### PR TITLE
builtins: implement ST_ClipByBox2D

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1068,6 +1068,8 @@ from the given Geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>
+<tr><td><a name="st_clipbybox2d"></a><code>st_clipbybox2d(geometry: geometry, box2d: box2d) &rarr; geometry</code></td><td><span class="funcdesc"><p>Clips the geometry to conform to the bounding box specified by box2d.</p>
+</span></td></tr>
 <tr><td><a name="st_combinebbox"></a><code>st_combinebbox(box2d: box2d, geometry: geometry) &rarr; box2d</code></td><td><span class="funcdesc"><p>Combines the current bounding box with the bounding box of the Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_contains"></a><code>st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>

--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -276,7 +276,7 @@ func (s *s2GeometryIndex) convertToGeomTAndTryClip(g *geo.Geometry) (geom.T, boo
 	if s.geomExceedsBounds(gt) {
 		clipped = true
 		clippedEWKB, err :=
-			geos.ClipEWKBByRect(g.EWKB(), s.minX+s.deltaX, s.minY+s.deltaY, s.maxX-s.deltaX, s.maxY-s.deltaY)
+			geos.ClipByRect(g.EWKB(), s.minX+s.deltaX, s.minY+s.deltaY, s.maxX-s.deltaX, s.maxY-s.deltaY)
 		if err != nil {
 			return nil, false, err
 		}

--- a/pkg/geo/geoindex/s2_geometry_index_test.go
+++ b/pkg/geo/geoindex/s2_geometry_index_test.go
@@ -78,7 +78,7 @@ func TestS2GeometryIndexBasic(t *testing.T) {
 	})
 }
 
-func TestClipEWKBByRect(t *testing.T) {
+func TestClipByRect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var g *geo.Geometry
@@ -97,8 +97,13 @@ func TestClipEWKBByRect(t *testing.T) {
 			d.ScanArgs(t, "ymin", &yMin)
 			d.ScanArgs(t, "xmax", &xMax)
 			d.ScanArgs(t, "ymax", &yMax)
-			ewkb, err := geos.ClipEWKBByRect(
-				g.EWKB(), float64(xMin), float64(yMin), float64(xMax), float64(yMax))
+			ewkb, err := geos.ClipByRect(
+				g.EWKB(),
+				float64(xMin),
+				float64(yMin),
+				float64(xMax),
+				float64(yMax),
+			)
 			if err != nil {
 				return err.Error()
 			}

--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -13,6 +13,7 @@ package geomfn
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+	"github.com/cockroachdb/errors"
 )
 
 // Centroid returns the Centroid of a given Geometry.
@@ -22,6 +23,21 @@ func Centroid(g *geo.Geometry) (*geo.Geometry, error) {
 		return nil, err
 	}
 	return geo.ParseGeometryFromEWKB(centroidEWKB)
+}
+
+// ClipByRect clips a given Geometry by the given BoundingBox.
+func ClipByRect(g *geo.Geometry, b *geo.CartesianBoundingBox) (*geo.Geometry, error) {
+	if g.Empty() {
+		return g, nil
+	}
+	if b == nil {
+		return nil, errors.Newf("expected not null bounding box")
+	}
+	clipByRectEWKB, err := geos.ClipByRect(g.EWKB(), b.LoX, b.LoY, b.HiX, b.HiY)
+	if err != nil {
+		return nil, err
+	}
+	return geo.ParseGeometryFromEWKB(clipByRectEWKB)
 }
 
 // ConvexHull returns the convex hull of a given Geometry.

--- a/pkg/geo/geos/geos.cc
+++ b/pkg/geo/geos/geos.cc
@@ -423,8 +423,8 @@ CR_GEOS_Status CR_GEOS_WKTToEWKB(CR_GEOS* lib, CR_GEOS_Slice wkt, int srid, CR_G
   return toGEOSString(error.data(), error.length());
 }
 
-CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice ewkb, double xmin, double ymin,
-                                      double xmax, double ymax, CR_GEOS_String* clippedEWKB) {
+CR_GEOS_Status CR_GEOS_ClipByRect(CR_GEOS* lib, CR_GEOS_Slice ewkb, double xmin, double ymin,
+                                  double xmax, double ymax, CR_GEOS_String* clippedEWKB) {
   std::string error;
   auto handle = initHandleWithErrorBuffer(lib, &error);
   *clippedEWKB = {.data = NULL, .len = 0};

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -438,8 +438,8 @@ func MinDistance(a geopb.EWKB, b geopb.EWKB) (float64, error) {
 	return float64(distance), nil
 }
 
-// ClipEWKBByRect clips a EWKB to the specified rectangle.
-func ClipEWKBByRect(
+// ClipByRect clips a EWKB to the specified rectangle.
+func ClipByRect(
 	ewkb geopb.EWKB, xMin float64, yMin float64, xMax float64, yMax float64,
 ) (geopb.EWKB, error) {
 	g, err := ensureInitInternal()
@@ -447,7 +447,7 @@ func ClipEWKBByRect(
 		return nil, err
 	}
 	var cEWKB C.CR_GEOS_String
-	if err := statusToError(C.CR_GEOS_ClipEWKBByRect(g, goToCSlice(ewkb), C.double(xMin),
+	if err := statusToError(C.CR_GEOS_ClipByRect(g, goToCSlice(ewkb), C.double(xMin),
 		C.double(yMin), C.double(xMax), C.double(yMax), &cEWKB)); err != nil {
 		return nil, err
 	}

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -62,9 +62,9 @@ CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice geoscLoc, CR_GEOS_Slice geosLoc, CR_GEO
 // convertible to a NUL character terminated C string.
 CR_GEOS_Status CR_GEOS_WKTToEWKB(CR_GEOS* lib, CR_GEOS_Slice wkt, int srid, CR_GEOS_String* ewkb);
 
-// CR_GEOS_ClipEWKBByRect clips a given EWKB by the given rectangle.
-CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice ewkb, double xmin, double ymin,
-                                      double xmax, double ymax, CR_GEOS_String* clippedEWKB);
+// CR_GEOS_ClipByRect clips a given EWKB by the given rectangle.
+CR_GEOS_Status CR_GEOS_ClipByRect(CR_GEOS* lib, CR_GEOS_Slice ewkb, double xmin, double ymin,
+                                  double xmax, double ymax, CR_GEOS_String* clippedEWKB);
 // CR_GEOS_Buffer buffers a given EWKB by the given distance and params.
 CR_GEOS_Status CR_GEOS_Buffer(CR_GEOS* lib, CR_GEOS_Slice ewkb, CR_GEOS_BufferParamsInput params,
                               double distance, CR_GEOS_String* ret);

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1261,6 +1261,26 @@ Square (left)                             POINT (-0.5 0.5)  POINT (-0.5 0.5)  PO
 Square (right)                            POINT (0.5 0.5)   POINT (0.5 0.5)   POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
 Square overlapping left and right square  POINT (0.45 0.5)  POINT (0.45 0.5)  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 
+query TT
+SELECT
+  a.dsc,
+  ST_AsEWKT(ST_ClipByBox2D(a.geom, 'box(0 0, 0.5 0.5)'))
+FROM geom_operators_test a
+ORDER BY a.dsc
+----
+Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY
+Empty LineString                          LINESTRING EMPTY
+Empty Point                               POINT EMPTY
+Faraway point                             GEOMETRYCOLLECTION EMPTY
+Line going through left and right square  GEOMETRYCOLLECTION EMPTY
+NULL                                      NULL
+Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY
+Point middle of Left Square               GEOMETRYCOLLECTION EMPTY
+Point middle of Right Square              GEOMETRYCOLLECTION EMPTY
+Square (left)                             GEOMETRYCOLLECTION EMPTY
+Square (right)                            POLYGON ((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0))
+Square overlapping left and right square  POLYGON ((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0))
+
 # Functions which take in strings as input as well.
 query TT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2815,6 +2815,26 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 			),
 		)...,
 	),
+	"st_clipbybox2d": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"box2d", types.Box2D}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				bbox := tree.MustBeDBox2D(args[1])
+				ret, err := geomfn.ClipByRect(g.Geometry, bbox.CartesianBoundingBox)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: "Clips the geometry to conform to the bounding box specified by box2d.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_convexhull": makeBuiltin(
 		defProps(),
 		geometryOverload1(


### PR DESCRIPTION
Also renamed ClipEWKBByRect to ClipByRect, which seems a little more
consistent with all our other naming for GEOS.

Resolves #52898.

Release note (sql change): Implement the ST_ClipByBox2D builtin.