### PR TITLE
backupccl: run scheduled backups as owner of schedule

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -328,7 +328,7 @@ func doCreateBackupSchedules(
 		}
 
 		if err := createBackupSchedule(
-			ctx, env, fullScheduleName, fullRecurrence,
+			ctx, env, p.User(), fullScheduleName, fullRecurrence,
 			fullFirstRun, details, backupNode, resultsCh, ex, txn,
 		); err != nil {
 			return err
@@ -339,7 +339,7 @@ func doCreateBackupSchedules(
 			backupNode.AppendToLatest = true
 
 			if err := createBackupSchedule(
-				ctx, env, fullScheduleName+": INCREMENTAL", incRecurrence,
+				ctx, env, p.User(), fullScheduleName+": INCREMENTAL", incRecurrence,
 				firstRun, details, backupNode, resultsCh, ex, txn,
 			); err != nil {
 				return err
@@ -354,6 +354,7 @@ func doCreateBackupSchedules(
 func createBackupSchedule(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
+	owner string,
 	name string,
 	recurrence *scheduleRecurrence,
 	firstRun *time.Time,
@@ -365,6 +366,7 @@ func createBackupSchedule(
 ) error {
 	sj := jobs.NewScheduledJob(env)
 	sj.SetScheduleName(name)
+	sj.SetOwner(owner)
 
 	// Prepare arguments for scheduled backup execution.
 	args := &ScheduledBackupExecutionArgs{}

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -85,8 +84,7 @@ func (e *scheduledBackupExecutor) executeBackup(
 	}
 
 	// Invoke backup plan hook.
-	// TODO(yevgeniy): Invoke backup as the owner of the schedule.
-	hook, cleanup := cfg.PlanHookMaker("exec-backup", txn, security.RootUser)
+	hook, cleanup := cfg.PlanHookMaker("exec-backup", txn, sj.Owner())
 	defer cleanup()
 	planBackup, cols, _, _, err := backupPlanHook(ctx, backupStmt, hook.(sql.PlanHookState))
 

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -88,6 +88,17 @@ func (j *ScheduledJob) SetScheduleName(name string) {
 	j.markDirty("schedule_name")
 }
 
+// Owner returns schedule owner.
+func (j *ScheduledJob) Owner() string {
+	return j.rec.Owner
+}
+
+// SetOwner updates schedule owner.
+func (j *ScheduledJob) SetOwner(owner string) {
+	j.rec.Owner = owner
+	j.markDirty("owner")
+}
+
 // NextRun returns the next time this schedule supposed to execute.
 // A sentinel value of time.Time{} indicates this schedule is paused.
 func (j *ScheduledJob) NextRun() time.Time {


### PR DESCRIPTION
This changes the user uses to spawn the BACKUP to be the
owner of the schedule instead of hard-coded as root.

Fixes #52946.
Informs #52776.

Release note: none.