### PR TITLE
jobs: run runable scheduled jobs in random order

### DIFF
--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -79,15 +79,15 @@ func getFindSchedulesStatement(env scheduledjobs.JobSchedulerEnv, maxSchedules i
 	return fmt.Sprintf(
 		`
 SELECT
-  (SELECT count(*) 
+  (SELECT count(*)
    FROM %s J
-   WHERE 
-      J.created_by_type = '%s' AND J.created_by_id = S.schedule_id AND 
+   WHERE
+      J.created_by_type = '%s' AND J.created_by_id = S.schedule_id AND
       J.status NOT IN ('%s', '%s', '%s')
   ) AS num_running, S.*
 FROM %s S
 WHERE next_run < %s
-ORDER BY next_run
+ORDER BY random()
 %s`, env.SystemJobsTableName(), CreatedByScheduledJobs,
 		StatusSucceeded, StatusCanceled, StatusFailed,
 		env.ScheduledJobsTableName(), env.NowExpr(), limitClause)


### PR DESCRIPTION
Previously we would start runnable scheduled jobs in scheduled time order.
This changes it to be in random order.

In steady state, there should be very few runnable jobs so the difference
between these should be minimal. However if for some reason the job at the
front of the queue is bad in a way that prevents it moving from the front
of the queue, we would rather it not prevent other jobs making progress.

Fixes #52917 .

Release note: none.