### PR TITLE
kvserver: Replace multiTestContext with TestCluster in client_lease_test

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -588,7 +588,7 @@ func (r *Replica) leaseStatus(
 // including the node liveness table must use expiration leases to avoid
 // circular dependencies on the node liveness table.
 func (r *Replica) requiresExpiringLeaseRLocked() bool {
-	return r.store.cfg.NodeLiveness == nil || !r.store.cfg.EnableEpochRangeLeases ||
+	return r.store.cfg.NodeLiveness == nil ||
 		r.mu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -181,7 +181,6 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		CoalescedHeartbeatsInterval: 50 * time.Millisecond,
 		ScanInterval:                10 * time.Minute,
 		HistogramWindowInterval:     metric.TestSampleInterval,
-		EnableEpochRangeLeases:      true,
 		ClosedTimestamp:             container.NoopContainer(),
 		ProtectedTimestampCache:     protectedts.EmptyCache(clock),
 	}
@@ -698,9 +697,6 @@ type StoreConfig struct {
 
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval
 	HistogramWindowInterval time.Duration
-
-	// EnableEpochRangeLeases controls whether epoch-based range leases are used.
-	EnableEpochRangeLeases bool
 
 	// GossipWhenCapacityDeltaExceedsFraction specifies the fraction from the last
 	// gossiped store capacity values which need be exceeded before the store will

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -513,7 +513,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			Dialer: nodeDialer.CTDialer(),
 		}),
 
-		EnableEpochRangeLeases:  true,
 		ExternalStorage:         externalStorage,
 		ExternalStorageFromURI:  externalStorageFromURI,
 		ProtectedTimestampCache: protectedtsProvider,

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -943,6 +943,16 @@ func (tc *TestCluster) WaitForValues(t testing.TB, key roachpb.Key, expected []i
 	})
 }
 
+// GetFirstStoreFromServer get the first store from the specified server.
+func (tc *TestCluster) GetFirstStoreFromServer(t testing.TB, server int) *kvserver.Store {
+	ts := tc.Servers[server]
+	store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+	return store
+}
+
 type testClusterFactoryImpl struct{}
 
 // TestClusterFactory can be passed to serverutils.InitTestClusterFactory


### PR DESCRIPTION
Makes progress on #8299

multiTestContext is a legacy construct that is deprecated in favor of running tests via TestCluster. This is one PR out of many to remove the usage of multiTestContext in the client_lease test cases.

Removes the EnableEpochRangeLeases flag from StoreConfig, as it was only used in a single test case, which has also been removed in this change.

Release note: none