### PR TITLE
sql: add WHERE condition to control scheduled jobs logic

### DIFF
--- a/pkg/jobs/schedule_control_test.go
+++ b/pkg/jobs/schedule_control_test.go
@@ -182,14 +182,16 @@ func TestJobsControlForSchedules(t *testing.T) {
 					Name: CreatedByScheduledJobs,
 					ID:   scheduleID,
 				}
-				require.NoError(t, registry.NewJob(record).Created(context.Background()))
+				newJob := registry.NewJob(record)
+				require.NoError(t, newJob.Created(context.Background()))
 
 				if tc.command == "resume" {
 					// Job has to be in paused state in order for it to be resumable;
 					// Alas, because we don't actually run real jobs (see comment above),
 					// We can't just pause the job (since it will stay in pause-requested state forever).
 					// So, just force set job status to paused.
-					th.sqlDB.Exec(t, "UPDATE system.jobs SET status=$1 WHERE id=$2", StatusPaused, scheduleID)
+					th.sqlDB.Exec(t, "UPDATE system.jobs SET status=$1 WHERE id=$2", StatusPaused,
+						*newJob.ID())
 				}
 			}
 		}
@@ -214,5 +216,82 @@ func TestJobsControlForSchedules(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, numJobs*tc.numSchedules, numEffected)
 		})
+	}
+}
+
+// TestFilterJobsControlForSchedules tests that a ControlJobsForSchedules query
+// does not error out even if the schedule contains a job in a state which is
+// invalid to apply the control command to. This is done by filtering out such
+// jobs prior to executing the control command.
+func TestFilterJobsControlForSchedules(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer ResetConstructors()()
+	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables)
+	defer cleanup()
+
+	registry := th.server.JobRegistry().(*Registry)
+	blockResume := make(chan struct{})
+	defer close(blockResume)
+
+	// Our resume never completes any jobs, until this test completes.
+	RegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
+		return FakeResumer{
+			OnResume: func(_ context.Context, _ chan<- tree.Datums) error {
+				<-blockResume
+				return nil
+			},
+		}
+	})
+
+	record := Record{
+		Description: "fake job",
+		Username:    "test",
+		Details:     jobspb.ImportDetails{},
+		Progress:    jobspb.ImportProgress{},
+	}
+
+	allJobStates := []Status{StatusPending, StatusRunning, StatusPaused, StatusFailed,
+		StatusReverting, StatusSucceeded, StatusCanceled, StatusCancelRequested, StatusPauseRequested}
+
+	var scheduleID int64 = 123
+	for _, tc := range []struct {
+		command             string
+		validStartingStates []Status
+	}{
+		{"pause", []Status{StatusPending, StatusRunning, StatusReverting}},
+		{"resume", []Status{StatusPaused}},
+		{"cancel", []Status{StatusPending, StatusRunning, StatusPaused}},
+	} {
+		scheduleID++
+		// Create one job of every Status.
+		for _, status := range allJobStates {
+			record.CreatedBy = &CreatedByInfo{
+				Name: CreatedByScheduledJobs,
+				ID:   scheduleID,
+			}
+			newJob := registry.NewJob(record)
+			require.NoError(t, newJob.Created(context.Background()))
+			th.sqlDB.Exec(t, "UPDATE system.jobs SET status=$1 WHERE id=$2", status, *newJob.ID())
+		}
+
+		jobControl := fmt.Sprintf(tc.command+" JOBS FOR SCHEDULE %d", scheduleID)
+		t.Run(jobControl, func(t *testing.T) {
+			// Go through internal executor to execute job control command. This
+			// correctly reports the number of effected rows which should only be
+			// equal to the number of validStartingStates as all the other states are
+			// invalid/no-ops.
+			numEffected, err := th.cfg.InternalExecutor.ExecEx(
+				context.Background(),
+				"test-num-effected",
+				nil,
+				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+				jobControl,
+			)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.validStartingStates), numEffected)
+		})
+
+		// Clear the system.jobs table for the next test run.
+		th.sqlDB.Exec(t, "DELETE FROM system.jobs")
 	}
 }

--- a/pkg/sql/delegate/job_control.go
+++ b/pkg/sql/delegate/job_control.go
@@ -12,19 +12,45 @@ package delegate
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 func (d *delegator) delegateJobControl(stmt *tree.ControlJobsForSchedules) (tree.Statement, error) {
-	// TODO(yevgeniy): it is very unfornate that we have to use the IN() clause
+	// We filter out the jobs which have a status on which it is invalid to apply
+	// the specified Command. This prevents the whole ControlJobsForSchedules
+	// query from erring out if any job is in such a state that cannot be
+	// controlled.
+	// The valid statuses prior to application of the Command have been derived
+	// from the control specific methods in pkg/jobs/jobs.go. All other states are
+	// either invalid starting states or result in no-ops.
+	validStartStatusForCommand := map[tree.JobCommand][]jobs.Status{
+		tree.PauseJob:  {jobs.StatusPending, jobs.StatusRunning, jobs.StatusReverting},
+		tree.ResumeJob: {jobs.StatusPaused},
+		tree.CancelJob: {jobs.StatusPending, jobs.StatusRunning, jobs.StatusPaused},
+	}
+
+	var filterExprs []string
+	var filterClause string
+	if statuses, ok := validStartStatusForCommand[stmt.Command]; ok {
+		for _, status := range statuses {
+			filterExprs = append(filterExprs, fmt.Sprintf("'%s'", status))
+		}
+		filterClause = fmt.Sprint(strings.Join(filterExprs, ", "))
+	} else {
+		return nil, errors.New("unexpected Command encountered in schedule job control")
+	}
+
+	// TODO(yevgeniy): it is very unfortunate that we have to use the IN() clause
 	// in order to select matching jobs.
-	// It would be better if the job control statement had a better (planNode) implementation,
-	// so that we can rely on the optimizer to select relevant nodes.
-	return parse(fmt.Sprintf(`
-%s JOBS
-SELECT id FROM system.jobs
-WHERE jobs.created_by_type = '%s' AND jobs.created_by_id IN (%s)
-`, tree.JobCommandToStatement[stmt.Command], jobs.CreatedByScheduledJobs, stmt.Schedules))
+	// It would be better if the job control statement had a better (planNode)
+	// implementation, so that we can rely on the optimizer to select relevant
+	// nodes.
+	return parse(fmt.Sprintf(`%s JOBS SELECT id FROM system.jobs WHERE jobs.created_by_type = '%s' 
+AND jobs.status IN (%s) AND jobs.created_by_id IN (%s)`,
+		tree.JobCommandToStatement[stmt.Command], jobs.CreatedByScheduledJobs, filterClause,
+		stmt.Schedules))
 }


### PR DESCRIPTION
Prior to this change, a `PAUSE/RESUME/CANCEL JOBS FOR SCHEDULE` query
would fail if any of the scheduled jobs were in a state from which it
could not be transitioned to the desired state.

This change filters out such jobs prior to executing the control
command, thereby guaranteeing we only execute on jobs which can be
"controlled", making for a better user experience.

Fixes: #52919

Release note: None