### PR TITLE
cli: command to deserialize descriptors

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -487,6 +487,27 @@ Decode and print a hexadecimal-encoded key-value pair.
 	},
 }
 
+var debugDecodeProtoName string
+var debugDecodeProtoCmd = &cobra.Command{
+	Use:   "decode-proto",
+	Short: "decode-proto <proto> --name=<fully qualified proto name>",
+	Long: `
+Read from stdin and attempt to decode any hex or base64 encoded proto fields and
+output them as JSON. All other fields will be outputted unchanged. Output fields
+will be separated by tabs.
+	
+The default value for --schema is 'cockroach.sql.sqlbase.Descriptor'.
+For example:
+
+$ decode-proto < cat debug/system.decsriptor.txt
+id	descriptor	hex_descriptor
+1	\022!\012\006system\020\001\032\025\012\011\012\005admin\0200\012\010\012\004root\0200	{"database": {"id": 1, "modificationTime": {}, "name": "system", "privileges": {"users": [{"privileges": 48, "user": "admin"}, {"privileges": 48, "user": "root"}]}}}
+...	
+`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runDebugDecodeProto,
+}
+
 var debugRaftLogCmd = &cobra.Command{
 	Use:   "raft-log <directory> <range id>",
 	Short: "print the raft log for a range",
@@ -1222,6 +1243,7 @@ var debugCmds = append(DebugCmdsForRocksDB,
 	debugBallastCmd,
 	debugDecodeKeyCmd,
 	debugDecodeValueCmd,
+	debugDecodeProtoCmd,
 	debugRocksDBCmd,
 	debugSSTDumpCmd,
 	debugGossipValuesCmd,
@@ -1316,4 +1338,8 @@ func init() {
 		"keep the output log file redactable")
 	f.BoolVar(&debugMergeLogsOpts.redactInput, "redact", debugMergeLogsOpts.redactInput,
 		"redact the input files to remove sensitive information")
+
+	f = debugDecodeProtoCmd.Flags()
+	f.StringVar(&debugDecodeProtoName, "schema", "cockroach.sql.sqlbase.Descriptor",
+		"fully qualified name of the proto to decode")
 }

--- a/pkg/cli/decode.go
+++ b/pkg/cli/decode.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bufio"
+	"encoding/base64"
+	gohex "encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/errors"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+func runDebugDecodeProto(_ *cobra.Command, _ []string) error {
+	if isatty.IsTerminal(stdin.Fd()) {
+		fmt.Fprintln(stderr,
+			`# Reading proto-encoded pieces of data from stdin.
+# Press Ctrl+C or Ctrl+D to terminate.`,
+		)
+	}
+	return streamMap(os.Stdout, stdin,
+		func(s string) (bool, string, error) { return tryDecodeValue(s, debugDecodeProtoName) })
+}
+
+// streamMap applies `fn` to all the scanned fields in `in`, and reports
+// the result of `fn` on `out`.
+// Errors returned by `fn` are emitted on `out` with a "warning" prefix.
+func streamMap(out io.Writer, in io.Reader, fn func(string) (bool, string, error)) error {
+	for sc := bufio.NewScanner(in); sc.Scan(); {
+		for _, field := range strings.Fields(sc.Text()) {
+			ok, value, err := fn(field)
+			if err != nil {
+				fmt.Fprintf(out, "warning:  %v", err)
+				continue
+			}
+			if !ok {
+				fmt.Fprintf(out, "%s\t", field)
+				// Skip since it doesn't appear that this field is an encoded proto.
+				continue
+			}
+			fmt.Fprintf(out, "%s\t", value)
+		}
+		fmt.Fprintln(out, "")
+	}
+	return nil
+}
+
+// tryDecodeValue tries to decode the given string with the given proto name
+// reports ok=false if the data was not valid proto-encoded.
+func tryDecodeValue(s, protoName string) (ok bool, val string, err error) {
+	bytes, err := gohex.DecodeString(s)
+	if err != nil {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return false, "", nil //nolint:returnerrcheck
+		}
+		bytes = b
+	}
+	msg, err := protoreflect.DecodeMessage(protoName, bytes)
+	if err != nil {
+		return false, "", nil //nolint:returnerrcheck
+	}
+	j, err := protoreflect.MessageToJSON(msg)
+	if err != nil {
+		// Unexpected error: the data was valid protobuf, but does not
+		// reflect back to JSON. We report the protobuf struct in the
+		// error message nonetheless.
+		return false, "", errors.Wrapf(err, "while JSON-encoding %#v", msg)
+	}
+	return true, j.String(), nil
+}

--- a/pkg/cli/decode_test.go
+++ b/pkg/cli/decode_test.go
@@ -1,0 +1,128 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	gohex "encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name    string
+		in      string
+		fn      func(string) (bool, string, error)
+		wantOut string
+		wantErr bool
+	}{
+		{
+			name:    "id map",
+			in:      "\na\n  b\tc\nd  e \t f",
+			wantOut: "\na\t\nb\tc\t\nd\te\tf\t\n",
+			fn:      func(s string) (bool, string, error) { return true, s, nil },
+		},
+		{
+			name:    "mixed",
+			in:      "a  b   c",
+			wantOut: "x\tb\twarning:  error\n",
+			fn: func(s string) (bool, string, error) {
+				switch s {
+				case "a":
+					return true, "x", nil
+				case "b":
+					return false, "y", nil
+				default:
+					return false, "z", errors.New("error")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := streamMap(&out, strings.NewReader(tt.in), tt.fn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("streamMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.wantOut, out.String())
+		})
+	}
+}
+
+func TestTryDecodeValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	protoName := "cockroach.sql.sqlbase.TableDescriptor"
+	marshal := func(pb protoutil.Message) []byte {
+		s, err := protoutil.Marshal(pb)
+		require.NoError(t, err)
+		return s
+	}
+	toJSON := func(pb protoutil.Message) string {
+		j, err := protoreflect.MessageToJSON(pb)
+		require.NoError(t, err)
+		return j.String()
+	}
+	tableDesc := &descpb.TableDescriptor{ID: 42, ParentID: 7, Name: "foo"}
+
+	tests := []struct {
+		name    string
+		s       string
+		wantOK  bool
+		wantVal string
+	}{
+		{
+			name:    "from hex",
+			s:       gohex.EncodeToString(marshal(tableDesc)),
+			wantOK:  true,
+			wantVal: toJSON(tableDesc),
+		},
+		{
+			name:    "from base64",
+			s:       base64.StdEncoding.EncodeToString(marshal(tableDesc)),
+			wantOK:  true,
+			wantVal: toJSON(tableDesc),
+		},
+		{
+			name: "junk",
+			s:    "@#$@#%$%@",
+		},
+		{
+			name: "hex not proto",
+			s:    gohex.EncodeToString([]byte("@#$@#%$%@")),
+		},
+		{
+			name: "base64 not proto",
+			s:    base64.StdEncoding.EncodeToString([]byte("@#$@#%$%@")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOk, gotVal, err := tryDecodeValue(tt.s, protoName)
+			require.Equal(t, tt.wantOK, gotOk)
+			require.NoError(t, err)
+			require.Equal(t, gotVal, tt.wantVal)
+		})
+	}
+}


### PR DESCRIPTION
We currently export the descriptors and job payloads in debug zips with
hex encoding.  It is often very valuable to decode these protos into
JSON for inspection.

Fixes #52063.

Release note (cli change):
The new debug command `decode-proto` reads descriptor from stdin in hex
or base64 format (auto-detected) and a flag --schema=\<fully qualified name to decode\>
with default value `cockroach.sql.sqlbase.Descriptor` and outputs to stdout the
deserialized proto in JSON format.