### PR TITLE
rowexec: skip TestUncertaintyErrorIsReturned/vectorize=true

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -852,6 +852,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "vectorize", func(t *testing.T, vectorize bool) {
 		vectorizeOpt := "off"
 		if vectorize {
+			skip.WithIssue(t, 52948)
 			vectorizeOpt = "on"
 		}
 		for _, testCase := range testCases {


### PR DESCRIPTION
The test is flaky. Skip until the issue is resolved.

Release note: None (testing change)

Addresses #52948 