### PR TITLE
backupccl: write checkpoint in resuming instead of planning

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -406,6 +406,22 @@ func (b *backupResumer) Resume(
 	details := b.job.Details().(jobspb.BackupDetails)
 	p := phs.(sql.PlanHookState)
 
+	// For all backups, partitioned or not, the main BACKUP manifest is stored at
+	// details.URI.
+	defaultConf, err := cloudimpl.ExternalStorageConfFromURI(details.URI, p.User())
+	if err != nil {
+		return errors.Wrapf(err, "export configuration")
+	}
+	defaultStore, err := p.ExecCfg().DistSQLSrv.ExternalStorage(ctx, defaultConf)
+	if err != nil {
+		return errors.Wrapf(err, "make storage")
+	}
+	defer defaultStore.Close()
+
+	if err := createCheckpointIfNotExists(ctx, p.ExecCfg().Settings, defaultStore, details.Encryption); err != nil {
+		return errors.Wrapf(err, "creating checkpoint to %s", details.URI)
+	}
+
 	ptsID := details.ProtectedTimestampRecord
 	if ptsID != nil && !b.testingKnobs.ignoreProtectedTimestamps {
 		if err := p.ExecCfg().ProtectedTimestampProvider.Verify(ctx, *ptsID); err != nil {
@@ -428,17 +444,7 @@ func (b *backupResumer) Resume(
 		return pgerror.Wrapf(err, pgcode.DataCorrupted,
 			"unmarshal backup descriptor")
 	}
-	// For all backups, partitioned or not, the main BACKUP manifest is stored at
-	// details.URI.
-	defaultConf, err := cloudimpl.ExternalStorageConfFromURI(details.URI, p.User())
-	if err != nil {
-		return errors.Wrapf(err, "export configuration")
-	}
-	defaultStore, err := p.ExecCfg().DistSQLSrv.ExternalStorage(ctx, defaultConf)
-	if err != nil {
-		return errors.Wrapf(err, "make storage")
-	}
-	defer defaultStore.Close()
+
 	storageByLocalityKV := make(map[string]*roachpb.ExternalStorage)
 	for kv, uri := range details.URIsByLocalityKV {
 		conf, err := cloudimpl.ExternalStorageConfFromURI(uri, p.User())

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -977,11 +977,12 @@ func backupPlanHook(
 		}
 		defer defaultStore.Close()
 
-		// TODO (lucy): For partitioned backups, also add verification for other
+		if err := checkForPreviousBackup(ctx, defaultStore, defaultURI); err != nil {
+			return err
+		}
+		// TODO (pbardea): For partitioned backups, also add verification for other
 		// stores we are writing to in addition to the default.
-		if err := VerifyUsableExportTarget(
-			ctx, p.ExecCfg().Settings, defaultStore, defaultURI, encryption,
-		); err != nil {
+		if err := verifyWriteableDestination(ctx, defaultStore, defaultURI); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4413,6 +4413,10 @@ func TestDetachedBackup(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tx.Rollback())
 	sqlDB.CheckQueryResults(t, allJobsQuery, allJobs)
+
+	// Ensure that we can backup again to the same location as the backup that was
+	// rolledback.
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1`, LocalFoo+"/2")
 }
 
 func TestDetachedRestore(t *testing.T) {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -684,7 +684,7 @@ type restoreResumer struct {
 	execCfg            *sql.ExecutorConfig
 
 	testingKnobs struct {
-		// duringSystemTableResotration is called once for every system table we
+		// duringSystemTableRestoration is called once for every system table we
 		// restore. It is used to simulate any errors that we may face at this point
 		// of the restore.
 		duringSystemTableRestoration func() error


### PR DESCRIPTION
Previously, BACKUP would write its CHECKPOINT file during planning. This
means that DETACHED BACKUPS would have the side-effect of leaving behind
a checkpoint file. This is particularly problematic if the transaction
in which the DETACHED BACKUP was created is rolledback or not yet
committed.

This change keeps the check for any existing backup manifests (both
complete and checkpoint) inside planning, but moves the writing of the
checkpoint file to only happen when the job starts. This makes an
existing race between reading and writing this checkpoint file more
evident, although not new:
- BACKUP 1 checks for the checkpoint, doesn't find it
- BACKUP 2 checks for the checkpoint, doesn't find it
- BACKUP 1 writes their checkpoint
- BACKUP 2 writes their checkpoint

Fixes #52922.

Release note (bug fix): Fix bug where non-committed DETACHED BACKUPS
left files which falsely indicated that a BACKUP was in-progress.