### PR TITLE
tree: allow resolution of spatial builtins with "public" schema

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4300,3 +4300,13 @@ POINT EMPTY                                            POINT EMPTY
 POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+
+subtest public_schema_resolution
+
+query T
+SELECT public.ST_AsText('POINT(10.5 20.25)'::geometry)
+----
+POINT (10.5 20.25)
+
+statement error unknown function: public.log\(\), but log\(\) exists
+SELECT public.log(10)

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -359,7 +359,11 @@ var aggregates = map[string]builtinDefinition{
 	),
 
 	"st_makeline": makeBuiltin(
-		aggPropsNullableArgs(),
+		tree.FunctionProperties{
+			Class:                   tree.AggregateClass,
+			NullableArgs:            true,
+			AvailableOnPublicSchema: true,
+		},
 		makeAggOverload(
 			[]*types.T{types.Geometry},
 			types.Geometry,

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4188,6 +4188,7 @@ func initGeoBuiltins() {
 			panic("duplicate builtin: " + k)
 		}
 		v.props.Category = categoryGeospatial
+		v.props.AvailableOnPublicSchema = true
 		builtins[k] = v
 	}
 }

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -73,6 +73,10 @@ type FunctionProperties struct {
 	// Category is used to generate documentation strings.
 	Category string
 
+	// AvailableOnPublicSchema indicates whether the function can be resolved
+	// if it is found on the public schema.
+	AvailableOnPublicSchema bool
+
 	// ReturnLabels can be used to override the return column name of a
 	// function in a FROM clause.
 	// This satisfies a Postgres quirk where some json functions have

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -512,6 +512,14 @@ func (n *UnresolvedName) ResolveFunction(
 		// it in the global namespace.
 		prefix = ""
 	}
+	if prefix == sessiondata.PublicSchemaName {
+		// If the user specified public, it may be from a PostgreSQL extension.
+		// Double check the function definition allows resolution on the public
+		// schema, and resolve as such if appropriate.
+		if d, ok := FunDefs[function]; ok && d.AvailableOnPublicSchema {
+			return d, nil
+		}
+	}
 
 	if prefix != "" {
 		fullName = prefix + "." + function


### PR DESCRIPTION
Release note (sql change): Add the ability to resolve the spatial-backed
builtins in the public schema. For example, `public.st_x` works the same
as `st_x`.