### PR TITLE
sql: make RemoveIndexZoneConfigs a noop when run on behalf of a tenant

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(52558)
-
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1291,7 +1291,8 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 }
 
 // maybeUpdateZoneConfigsForPKChange moves zone configs for any rewritten
-// indexes from the old index over to the new index.
+// indexes from the old index over to the new index. Noop if run on behalf of a
+// tenant.
 func maybeUpdateZoneConfigsForPKChange(
 	ctx context.Context,
 	txn *kv.Txn,
@@ -1299,6 +1300,10 @@ func maybeUpdateZoneConfigsForPKChange(
 	table *sqlbase.MutableTableDescriptor,
 	swapInfo *descpb.PrimaryKeySwap,
 ) error {
+	if !execCfg.Codec.ForSystemTenant() {
+		// Tenants are agnostic to zone configs.
+		return nil
+	}
 	zone, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, table.ID)
 	if err != nil {
 		return err

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -901,7 +901,7 @@ func getZoneConfigRaw(
 
 // RemoveIndexZoneConfigs removes the zone configurations for some
 // indexs being dropped. It is a no-op if there is no zone
-// configuration.
+// configuration or run on behalf of a tenant.
 //
 // It operates entirely on the current goroutine and is thus able to
 // reuse an existing client.Txn safely.
@@ -912,6 +912,10 @@ func RemoveIndexZoneConfigs(
 	tableID descpb.ID,
 	indexDescs []descpb.IndexDescriptor,
 ) error {
+	if !execCfg.Codec.ForSystemTenant() {
+		// Tenants are agnostic to zone configs.
+		return nil
+	}
 	desc, err := catalogkv.GetDescriptorByID(ctx, txn, execCfg.Codec, tableID,
 		catalogkv.Mutable, catalogkv.TableDescriptorKind, true)
 	if err != nil {


### PR DESCRIPTION
RemoveIndexZoneConfigs would previously return an error when run on behalf of
a tenant because it attempts to write a zone config. This would cause some
operations like index truncation to fail unnecessarily.

Release note: None (multitenancy)

Fixes #52558