### PR TITLE
sql: move schema resolution by ID into the descs.Collection

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1188,9 +1188,7 @@ func (p *planner) alterTableOwner(
 	}
 
 	// Ensure the new owner has CREATE privilege on the table's schema.
-	if err := p.canCreateOnSchema(
-		ctx, desc.GetParentSchemaID(), newOwner,
-	); err != nil {
+	if err := p.canCreateOnSchema(ctx, desc.GetParentSchemaID(), newOwner); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -467,7 +466,7 @@ const ConnAuditingClusterSettingName = "server.auth_log.sql_connections.enabled"
 const AuthAuditingClusterSettingName = "server.auth_log.sql_sessions.enabled"
 
 func (p *planner) canCreateOnSchema(ctx context.Context, schemaID descpb.ID, user string) error {
-	resolvedSchema, err := resolver.ResolveSchemaByID(ctx, p.Txn(), p.ExecCfg().Codec, schemaID)
+	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -130,18 +131,20 @@ func MakeCollection(
 	settings *cluster.Settings,
 	dbCache *database.Cache,
 	dbCacheSubscriber DatabaseCacheSubscriber,
+	sessionData *sessiondata.SessionData,
 ) Collection {
 	return Collection{
 		leaseMgr:          leaseMgr,
 		settings:          settings,
 		databaseCache:     dbCache,
 		dbCacheSubscriber: dbCacheSubscriber,
+		sessionData:       sessionData,
 	}
 }
 
 // NewCollection constructs a new *Collection.
 func NewCollection(leaseMgr *lease.Manager, settings *cluster.Settings) *Collection {
-	tc := MakeCollection(leaseMgr, settings, nil, nil)
+	tc := MakeCollection(leaseMgr, settings, nil, nil, nil)
 	return &tc
 }
 
@@ -211,6 +214,11 @@ type Collection struct {
 	// mixed version (19.2/20.1) clusters.
 	// TODO(solon): This field could maybe be removed in 20.2.
 	settings *cluster.Settings
+
+	// sessionData is the SessionData of the current session, if this Collection
+	// is being used in the context of a session. It is stored so that the Collection
+	// knows about state of temporary schemas (name and ID) for resolution.
+	sessionData *sessiondata.SessionData
 }
 
 // GetMutableTableDescriptor returns a mutable table descriptor.
@@ -614,6 +622,58 @@ func (tc *Collection) GetMutableSchemaDescriptorByID(
 	return desc.(*sqlbase.MutableSchemaDescriptor), nil
 }
 
+// ResolveSchemaByID looks up a schema by ID.
+func (tc *Collection) ResolveSchemaByID(
+	ctx context.Context, txn *kv.Txn, schemaID descpb.ID,
+) (sqlbase.ResolvedSchema, error) {
+	if schemaID == keys.PublicSchemaID {
+		return sqlbase.ResolvedSchema{
+			Kind: sqlbase.SchemaPublic,
+			ID:   schemaID,
+			Name: tree.PublicSchema,
+		}, nil
+	}
+
+	// We have already considered if the schemaID is PublicSchemaID,
+	// if the id appears in staticSchemaIDMap, it must map to a virtual schema.
+	if scName, ok := resolver.StaticSchemaIDMap[schemaID]; ok {
+		return sqlbase.ResolvedSchema{
+			Kind: sqlbase.SchemaVirtual,
+			ID:   schemaID,
+			Name: scName,
+		}, nil
+	}
+
+	// If this collection is attached to a session and the session has created
+	// a temporary schema, then check if the schema ID matches.
+	if tc.sessionData != nil && tc.sessionData.TemporarySchemaID == uint32(schemaID) {
+		return sqlbase.ResolvedSchema{
+			Kind: sqlbase.SchemaTemporary,
+			ID:   schemaID,
+			Name: tc.sessionData.SearchPath.GetTemporarySchemaName(),
+		}, nil
+	}
+
+	// Otherwise, fall back to looking up the descriptor with the desired ID.
+	desc, err := tc.getDescriptorVersionByID(
+		ctx, txn, schemaID, tree.ObjectLookupFlagsWithRequired(), true /* setTxnDeadline */)
+	if err != nil {
+		return sqlbase.ResolvedSchema{}, err
+	}
+
+	schemaDesc, ok := desc.(*sqlbase.ImmutableSchemaDescriptor)
+	if !ok {
+		return sqlbase.ResolvedSchema{}, pgerror.Newf(pgcode.WrongObjectType, "descriptor %d was not a schema", schemaID)
+	}
+
+	return sqlbase.ResolvedSchema{
+		Kind: sqlbase.SchemaUserDefined,
+		ID:   schemaID,
+		Desc: schemaDesc,
+		Name: schemaDesc.Name,
+	}, nil
+}
+
 // hydrateTypesInTableDesc installs user defined type metadata in all types.T
 // present in the input TableDescriptor. It always returns the same type of
 // TableDescriptor that was passed in. It ensures that ImmutableTableDescriptors
@@ -636,9 +696,11 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
-			// TODO (rohany): Once we can lookup schemas by ID in the collection,
-			//  resolve the correct schema name here.
-			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, tree.PublicSchema, desc.Name)
+			sc, err := tc.ResolveSchemaByID(ctx, txn, desc.ParentSchemaID)
+			if err != nil {
+				return tree.TypeName{}, nil, err
+			}
+			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, sc.Name, desc.Name)
 			return name, desc, nil
 		}
 
@@ -666,9 +728,11 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
-			// TODO (rohany): Once we can lookup schemas by ID in the collection,
-			//  resolve the correct schema name here.
-			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, tree.PublicSchema, desc.Name)
+			sc, err := tc.ResolveSchemaByID(ctx, txn, desc.ParentSchemaID)
+			if err != nil {
+				return tree.TypeName{}, nil, err
+			}
+			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, sc.Name, desc.Name)
 			return name, desc, nil
 		}
 
@@ -1029,12 +1093,15 @@ func (tc *Collection) GetAllDescriptors(
 		// so collect the needed information to set up metadata in those types.
 		dbDescs := make(map[descpb.ID]*sqlbase.ImmutableDatabaseDescriptor)
 		typDescs := make(map[descpb.ID]*sqlbase.ImmutableTypeDescriptor)
+		schemaDescs := make(map[descpb.ID]*sqlbase.ImmutableSchemaDescriptor)
 		for _, desc := range descs {
 			switch desc := desc.(type) {
 			case *sqlbase.ImmutableDatabaseDescriptor:
 				dbDescs[desc.GetID()] = desc
 			case *sqlbase.ImmutableTypeDescriptor:
 				typDescs[desc.GetID()] = desc
+			case *sqlbase.ImmutableSchemaDescriptor:
+				schemaDescs[desc.GetID()] = desc
 			}
 		}
 		// If we found any type descriptors, that means that some of the tables we
@@ -1054,11 +1121,19 @@ func (tc *Collection) GetAllDescriptors(
 					//  be performed.
 					return tree.TypeName{}, nil, errors.Newf("database id %d not found", typDesc.ParentID)
 				}
-				schemaName, err := resolver.ResolveSchemaNameByID(ctx, txn, tc.codec(), dbDesc.GetID(), typDesc.ParentSchemaID)
-				if err != nil {
-					return tree.TypeName{}, nil, err
+
+				// We don't use the collection's ResolveSchemaByID method here because
+				// we already have all of the descriptors. User defined types are only
+				// members of the public schema or a user defined schema, so those are
+				// the only cases we have to consider here.
+				var scName string
+				switch typDesc.ParentSchemaID {
+				case keys.PublicSchemaID:
+					scName = tree.PublicSchema
+				default:
+					scName = schemaDescs[typDesc.ParentSchemaID].Name
 				}
-				name := tree.MakeNewQualifiedTypeName(dbDesc.GetName(), schemaName, typDesc.GetName())
+				name := tree.MakeNewQualifiedTypeName(dbDesc.GetName(), scName, typDesc.GetName())
 				return name, typDesc, nil
 			}
 			// Now hydrate all table descriptors.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -642,7 +642,7 @@ func (s *Server) newConnExecutor(
 	}
 	ex.extraTxnState.prepStmtsNamespaceMemAcc = ex.sessionMon.MakeBoundAccount()
 	ex.extraTxnState.descCollection = descs.MakeCollection(s.cfg.LeaseManager,
-		s.cfg.Settings, s.dbCache.getDatabaseCache(), s.dbCache)
+		s.cfg.Settings, s.dbCache.getDatabaseCache(), s.dbCache, sd)
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobsCache = make(map[descpb.ID]*jobs.Job)
 	ex.mu.ActiveQueries = make(map[ClusterWideID]*queryMeta)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2030,6 +2030,10 @@ func (m *sessionDataMutator) SetTemporarySchemaName(scName string) {
 	m.data.SearchPath = m.data.SearchPath.WithTemporarySchemaName(scName)
 }
 
+func (m *sessionDataMutator) SetTemporarySchemaID(id uint32) {
+	m.data.TemporarySchemaID = id
+}
+
 func (m *sessionDataMutator) SetDefaultIntSize(size int) {
 	m.data.DefaultIntSize = size
 }

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1399,11 +1399,11 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 				if err != nil || desc == nil {
 					return false, err
 				}
-				schemaName, err := resolver.ResolveSchemaNameByID(ctx, p.txn, p.ExecCfg().Codec, db.GetID(), desc.GetParentSchemaID())
+				sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, desc.GetParentSchemaID())
 				if err != nil {
 					return false, err
 				}
-				return true, addTablesTableRow(addRow)(db, schemaName, desc)
+				return true, addTablesTableRow(addRow)(db, sc.Name, desc)
 			},
 		},
 	},

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -71,6 +71,10 @@ type SessionData struct {
 	SerialNormalizationMode SerialNormalizationMode
 	// SearchPath is a list of namespaces to search builtins in.
 	SearchPath SearchPath
+	// TemporarySchemaID is the ID of the current session's temporary schema,
+	// if it exists. It is a descpb.ID, but cannot be stored as one due to
+	// packaging dependencies.
+	TemporarySchemaID uint32
 	// StmtTimeout is the duration a query is permitted to run before it is
 	// canceled by the session. If set to 0, there is no timeout.
 	StmtTimeout time.Duration

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -103,6 +103,7 @@ func (p *planner) getOrCreateTemporarySchema(
 			return descpb.InvalidID, err
 		}
 		p.sessionDataMutator.SetTemporarySchemaName(sKey.Name())
+		p.sessionDataMutator.SetTemporarySchemaID(uint32(id))
 		return id, nil
 	}
 	return schemaID, nil


### PR DESCRIPTION
Fixes #52904.

This commit moves logic to resolve schemas by ID into the
descs.Collection to make use of the cache there. It also removes other
methods that provide similar functionality and updates their users to
use this method if possible.

Release note: None