### PR TITLE
sql: gate certain box2d comparison ops by a cluster setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -56,6 +56,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.metrics.transaction_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-application transaction statistics</td></tr>
 <tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
+<tr><td><code>sql.spatial.experimental_box2d_comparison_operators.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enables the use of certain experimental box2d comparison operators</td></tr>
 <tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
@@ -1,3 +1,7 @@
+# LogicTest: local
+# Set to local as SET CLUSTER SETTING can take a while to propagate
+# on the fakedist and hence causing flakes.
+
 statement ok
 CREATE TABLE box2d_encoding_test(
   id int primary key,
@@ -70,6 +74,12 @@ INSERT INTO box2d_tbl VALUES
   ('NULL', NULL),
   ('box at origin', 'box(0 0, 0 0)'),
   ('box from origin to 1 1', 'box(0 0, 1 1)');
+
+statement error this box2d comparison operator is experimental
+SELECT 'box(0 0,1 1)'::box2d && 'box(1 1,2 2)'::box2d
+
+statement ok
+SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
 query TTBBBB
 SELECT


### PR DESCRIPTION
Release note (sql change): box2d comparison operators are now gated by
the cluster setting
`sql.spatial.experimental_box2d_comparison_operators.enabled`.

