### PR TITLE
release-19.2: sql: allow DEALLOCATE ALL with a prepared statement

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -159,7 +159,11 @@ func (ex *connExecutor) execPortal(
 			// Note that the portal is considered exhausted regardless of
 			// the fact whether an error occurred or not - if it did, we
 			// still don't want to re-execute the portal from scratch.
-			ex.exhaustPortal(portalName)
+			// The current statement may have just closed and deleted the portal,
+			// so only exhaust it if it still exists.
+			if _, ok := ex.extraTxnState.prepStmtsNamespace.portals[portalName]; ok {
+				ex.exhaustPortal(portalName)
+			}
 		}
 	default:
 		ev, payload, err = ex.execStmt(stmtCtx, curStmt, stmtRes, pinfo)

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -1,0 +1,47 @@
+# deallocate_test checks that we can run DEALLOCATE ALL using a prepared
+# statement. See #52915.
+send
+Query {"String": "DROP TABLE IF EXISTS deallocate_test"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE deallocate_test (a INT)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+send
+Parse {"Name": "s1", "Query": "DEALLOCATE ALL"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"DEALLOCATE ALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DISCARD ALL"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DISCARD"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Backport 1/1 commits from #52940.

/cc @cockroachdb/release

---

PR #48842 added logic to exhaust portals after executing them. This had
issues when the portal being executed closes itself, which happens when
using DEALLOCATE in a prepared statement. Now we check if the portal
still exists before exhausting it.

There is no release note as this fixes a bug that only exists in
unreleased versions.

fixes #52915
fixes https://github.com/cockroachdb/cockroach/issues/52220
fixes https://github.com/cockroachdb/cockroach/issues/52880
fixes https://github.com/cockroachdb/cockroach/issues/52506

Release note: None
