### PR TITLE
bulkio: Dry run backup when creating schedules.

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -244,24 +244,8 @@ func doCreateBackupSchedules(
 		AppendToLatest: false,
 	}
 
-	if backupNode.Options.CaptureRevisionHistory && !eval.isEnterpriseUser {
-		// TODO(yevgeniy): Pull license check logic into a common helper.
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(),
-			"revision_history"); err != nil {
-			return err
-		}
-	}
-
 	// Evaluate encryption passphrase if set.
 	if eval.encryptionPassphrase != nil {
-		if !eval.isEnterpriseUser {
-			if err := utilccl.CheckEnterpriseEnabled(
-				p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(),
-				"encryption"); err != nil {
-				return err
-			}
-		}
 		pw, err := eval.encryptionPassphrase()
 		if err != nil {
 			return errors.Wrapf(err, "failed to evaluate backup encryption_passphrase")
@@ -275,20 +259,17 @@ func doCreateBackupSchedules(
 		return errors.Wrapf(err, "failed to evaluate backup destination paths")
 	}
 
-	if len(destinations) > 1 {
-		if !eval.isEnterpriseUser {
-			if err := utilccl.CheckEnterpriseEnabled(
-				p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(),
-				"partitioned destinations"); err != nil {
-				return err
-			}
-		}
-	}
 	for _, dest := range destinations {
 		backupNode.To = append(backupNode.To, tree.NewDString(dest))
 	}
 
 	backupNode.Targets = eval.Targets
+
+	// Run full backup in dry-run mode.  This will do all of the sanity checks
+	// and validation we need to make in order to ensure the schedule is sane.
+	if err := dryRunBackup(ctx, p, backupNode); err != nil {
+		return errors.Wrapf(err, "failed to dry run backup")
+	}
 
 	var fullScheduleName string
 	if eval.scheduleName != nil {
@@ -389,10 +370,6 @@ func createBackupSchedule(
 		sj.SetNextRun(*firstRun)
 	}
 
-	// TODO(yevgeniy): Validate backup schedule:
-	//  * Verify targets exist.  Provide a way for user to override this via option.
-	//  * Verify destination paths sane (i.e. valid schema://, etc)
-
 	// We do not set backupNode.AsOf: this is done when the scheduler kicks off the backup.
 	// Serialize backup statement and set schedule executor and its args.
 	args.BackupStatement = tree.AsString(backupNode)
@@ -429,6 +406,28 @@ func createBackupSchedule(
 		tree.NewDString(tree.AsString(backupNode)),
 	}
 	return nil
+}
+
+// dryRunBackup executes backup in dry-run mode: we simply execute backup
+// under transaction savepoint, and then rollback to that save point.
+func dryRunBackup(ctx context.Context, p sql.PlanHookState, backupNode *tree.Backup) error {
+	sp, err := p.ExtendedEvalContext().Txn.CreateSavepoint(ctx)
+	if err != nil {
+		return err
+	}
+	err = dryRunInvokeBackup(ctx, p, backupNode)
+	if rollbackErr := p.ExtendedEvalContext().Txn.RollbackToSavepoint(ctx, sp); rollbackErr != nil {
+		return rollbackErr
+	}
+	return err
+}
+
+func dryRunInvokeBackup(ctx context.Context, p sql.PlanHookState, backupNode *tree.Backup) error {
+	backupFn, err := planBackup(ctx, p, backupNode)
+	if err != nil {
+		return err
+	}
+	return invokeBackup(ctx, backupFn)
 }
 
 // makeScheduleBackupEval prepares helper scheduledBackupEval struct to assist in evaluation
@@ -530,10 +529,6 @@ func createBackupScheduleHook(
 	return fn, scheduledBackupHeader, nil, false, nil
 }
 
-func init() {
-	sql.AddPlanHook(createBackupScheduleHook)
-}
-
 // MarshalJSONPB provides a custom Marshaller for jsonpb that redacts secrets in
 // URI fields.
 func (m ScheduledBackupExecutionArgs) MarshalJSONPB(x *jsonpb.Marshaler) ([]byte, error) {
@@ -590,4 +585,8 @@ func (m ScheduledBackupExecutionArgs) MarshalJSONPB(x *jsonpb.Marshaler) ([]byte
 
 	m.BackupStatement = backup.String()
 	return json.Marshal(m)
+}
+
+func init() {
+	sql.AddPlanHook(createBackupScheduleHook)
 }

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -193,54 +193,54 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 	}{
 		{
 			name:  "full-cluster",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'somewhere?AWS_SECRET_ACCESS_KEY=neverappars' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=neverappears' RECURRING '@hourly'",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'somewhere?AWS_SECRET_ACCESS_KEY=neverappars' WITH detached",
-					shownStmt:  "BACKUP INTO 'somewhere?AWS_SECRET_ACCESS_KEY=redacted' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=neverappears' WITH detached",
+					shownStmt:  "BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=redacted' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster-with-name",
-			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'somewhere' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "my-backup",
-					backupStmt: "BACKUP INTO 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster-always",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'somewhere' RECURRING '@hourly' FULL BACKUP ALWAYS",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly' FULL BACKUP ALWAYS",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'somewhere' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .*: INCREMENTAL",
-					backupStmt: "BACKUP INTO LATEST IN 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 				},
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
 					period:     24 * time.Hour,
 					runsNow:    true,
 				},
@@ -248,17 +248,17 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:  "full-cluster-with-name",
-			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'somewhere' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "my-backup: INCREMENTAL",
-					backupStmt: "BACKUP INTO LATEST IN 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 				},
 				{
 					nameRe:     "my-backup",
-					backupStmt: "BACKUP INTO 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
 					period:     24 * time.Hour,
 					runsNow:    true,
 				},
@@ -266,48 +266,48 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:  "full-cluster-always",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'somewhere' RECURRING '@hourly' FULL BACKUP ALWAYS",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly' FULL BACKUP ALWAYS",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'somewhere' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:   "enterprise-license-required-for-incremental",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'somewhere' RECURRING '@hourly' FULL BACKUP '@weekly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly' FULL BACKUP '@weekly'",
 			user:   freeUser,
 			errMsg: "use of BACKUP INTO LATEST requires an enterprise license",
 		},
 		{
 			name:   "enterprise-license-required-for-revision-history",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'somewhere' WITH revision_history RECURRING '@hourly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history RECURRING '@hourly'",
 			user:   freeUser,
-			errMsg: "use of revision_history requires an enterprise license",
+			errMsg: "use of BACKUP with revision_history requires an enterprise license",
 		},
 		{
 			name:   "enterprise-license-required-for-encryption",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'somewhere'  WITH encryption_passphrase='secret' RECURRING '@hourly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup'  WITH encryption_passphrase='secret' RECURRING '@hourly'",
 			user:   freeUser,
-			errMsg: "use of encryption requires an enterprise license",
+			errMsg: "use of BACKUP with encryption requires an enterprise license",
 		},
 		{
 			name:      "full-cluster-with-name-arg",
-			query:     `CREATE SCHEDULE $1 FOR BACKUP INTO 'somewhere' WITH revision_history, detached RECURRING '@hourly'`,
+			query:     `CREATE SCHEDULE $1 FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history, detached RECURRING '@hourly'`,
 			queryArgs: []interface{}{"my_backup_name"},
 			user:      enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "my_backup_name: INCREMENTAL",
-					backupStmt: "BACKUP INTO LATEST IN 'somewhere' WITH revision_history, detached",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH revision_history, detached",
 					period:     time.Hour,
 				},
 				{
 					nameRe:     "my_backup_name",
-					backupStmt: "BACKUP INTO 'somewhere' WITH revision_history, detached",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH revision_history, detached",
 					period:     24 * time.Hour,
 					runsNow:    true,
 				},
@@ -317,13 +317,13 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "multiple-tables-with-encryption",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP TABLE db.*, other_db.foo INTO 'somewhere'
+		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://0/backup'
 		WITH encryption_passphrase='secret' RECURRING '@weekly'`,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .*",
-					backupStmt: "BACKUP TABLE db.*, other_db.foo INTO 'somewhere' WITH encryption_passphrase='secret', detached",
-					shownStmt:  "BACKUP TABLE db.*, other_db.foo INTO 'somewhere' WITH encryption_passphrase='redacted', detached",
+					backupStmt: "BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://0/backup' WITH encryption_passphrase='secret', detached",
+					shownStmt:  "BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://0/backup' WITH encryption_passphrase='redacted', detached",
 					period:     7 * 24 * time.Hour,
 				},
 			},
@@ -332,7 +332,8 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "partitioned-backup",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP DATABASE db1, db2 INTO ('somewhere', 'anywhere')
+		CREATE SCHEDULE FOR BACKUP DATABASE system 
+    INTO ('nodelocal://0/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://0/backup2?COCKROACH_LOCALITY=default')
 		WITH revision_history
     RECURRING '1 2 * * *'
     FULL BACKUP ALWAYS
@@ -341,9 +342,11 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			queryArgs: []interface{}{th.env.Now().Add(time.Minute)},
 			expectedSchedules: []expectedSchedule{
 				{
-					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP DATABASE db1, db2 INTO ('somewhere', 'anywhere') WITH revision_history, detached",
-					period:     24 * time.Hour,
+					nameRe: "BACKUP .+",
+					backupStmt: "BACKUP DATABASE system INTO " +
+						"('nodelocal://0/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://0/backup2?COCKROACH_LOCALITY=default') " +
+						"WITH revision_history, detached",
+					period: 24 * time.Hour,
 				},
 			},
 		},

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -375,9 +375,6 @@ func TestJobSchedulerDaemonProcessesJobs(t *testing.T) {
 		expectedRun{scheduleIDs[4], nil},
 	)
 	stopper.Stop(ctx)
-
-	require.EqualValues(t, numJobs, daemon.metrics.ReadyToRun.Value())
-	require.EqualValues(t, numJobs, daemon.metrics.NumStarted.Value())
 }
 
 func TestJobSchedulerDaemonHonorsMaxJobsLimit(t *testing.T) {
@@ -422,9 +419,6 @@ func TestJobSchedulerDaemonHonorsMaxJobsLimit(t *testing.T) {
 		return nil
 	})
 	stopper.Stop(ctx)
-
-	require.EqualValues(t, numJobs, daemon.metrics.ReadyToRun.Value())
-	require.EqualValues(t, jobsPerIteration, daemon.metrics.NumStarted.Value())
 }
 
 func TestJobSchedulerDaemonUsesSystemTables(t *testing.T) {


### PR DESCRIPTION
Fixes #52924

Dry run execution of the scheduled backup.

Invoking backup planning and execution in dry run ensures
that the scheduled backup is sane since all of the required
sanity checks are performed when attempting to run the backup.
The actual effects of this dry run are removed by rolling back
to the safepoint.

Release Notes: None