### PR TITLE
partialidx: prove implication for comparisons with two variables

### DIFF
--- a/pkg/sql/opt/partialidx/testdata/implicator/atom
+++ b/pkg/sql/opt/partialidx/testdata/implicator/atom
@@ -130,15 +130,29 @@ predtest vars=(int, int)
 true
 └── remaining filters: none
 
-# TODO(mgartner): This filter should imply the predicate. The current logic does
-# not support this because it relies solely on constraints which can only
-# represent variable constraints in relation to constants.
 predtest vars=(int, int)
-@1 > @2
+@1 = @2
+=>
+@2 = @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 = @2
+=>
+@1 <= @2
+----
+true
+└── remaining filters: @1 = @2
+
+predtest vars=(int, int)
+@1 = @2
 =>
 @1 >= @2
 ----
-false
+true
+└── remaining filters: @1 = @2
 
 predtest vars=(int)
 @1 = 1
@@ -169,6 +183,110 @@ predtest vars=(int, int)
 @1 > @2
 =>
 @1 > @2
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 < @2
+=>
+@2 > @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 < @2
+=>
+@1 <= @2
+----
+true
+└── remaining filters: @1 < @2
+
+predtest vars=(int, int)
+@1 < @2
+=>
+@2 >= @1
+----
+true
+└── remaining filters: @1 < @2
+
+predtest vars=(int, int)
+@1 < @2
+=>
+@1 != @2
+----
+true
+└── remaining filters: @1 < @2
+
+predtest vars=(int, int)
+@1 < @2
+=>
+@2 != @1
+----
+true
+└── remaining filters: @1 < @2
+
+predtest vars=(int, int)
+@1 <= @2
+=>
+@2 >= @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 > @2
+=>
+@2 < @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 > @2
+=>
+@1 >= @2
+----
+true
+└── remaining filters: @1 > @2
+
+predtest vars=(int, int)
+@1 > @2
+=>
+@2 <= @1
+----
+true
+└── remaining filters: @1 > @2
+
+predtest vars=(int, int)
+@1 > @2
+=>
+@1 != @2
+----
+true
+└── remaining filters: @1 > @2
+
+predtest vars=(int, int)
+@1 > @2
+=>
+@2 != @1
+----
+true
+└── remaining filters: @1 > @2
+
+predtest vars=(int, int)
+@1 >= @2
+=>
+@2 <= @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, int)
+@1 != @2
+=>
+@2 != @1
 ----
 true
 └── remaining filters: none
@@ -389,6 +507,22 @@ predtest vars=(bool, bool)
 ----
 true
 └── remaining filters: @2
+
+predtest vars=(string, string, string)
+@1 = @2 AND @3 = 'foo'
+=>
+@2 = @1
+----
+true
+└── remaining filters: @3 = 'foo'
+
+predtest vars=(string, string, string)
+@1 = @2 AND @3 = @1
+=>
+@1 = @3
+----
+true
+└── remaining filters: @1 = @2
 
 predtest vars=(bool, bool)
 @1 AND NOT @2


### PR DESCRIPTION
This commit adds support for proving partial index predicates are
implied by query filters when they contain comparison expressions with
two variables and they are not identical expressions.

Below are some examples where the left expression implies (=>) the right
expression. The right is guaranteed to contain the left despite both
expressions having no constant values.

    a > b  =>  a >= b
    a = b  =>  a >= b
    b < a  =>  a >= b
    a > b  =>  a != b

Release note: None