### PR TITLE
sql: introduce a command to convert a database into a schema

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -743,6 +743,7 @@ unreserved_keyword ::=
 	| 'CONSTRAINTS'
 	| 'CONTROLJOB'
 	| 'CONVERSION'
+	| 'CONVERT'
 	| 'COPY'
 	| 'COVERING'
 	| 'CREATEROLE'
@@ -1117,6 +1118,7 @@ alter_database_stmt ::=
 	alter_rename_database_stmt
 	| alter_zone_database_stmt
 	| alter_database_owner
+	| alter_database_to_schema_stmt
 
 alter_range_stmt ::=
 	alter_zone_range_stmt
@@ -1530,6 +1532,9 @@ alter_zone_database_stmt ::=
 
 alter_database_owner ::=
 	'ALTER' 'DATABASE' database_name 'OWNER' 'TO' role_spec
+
+alter_database_to_schema_stmt ::=
+	'ALTER' 'DATABASE' database_name 'CONVERT' 'TO' 'SCHEMA' 'WITH' 'PARENT' database_name
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' zone_name set_zone_config

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -129,8 +129,7 @@ func (*createSchemaNode) Next(runParams) (bool, error) { return false, nil }
 func (*createSchemaNode) Values() tree.Datums          { return tree.Datums{} }
 func (n *createSchemaNode) Close(ctx context.Context)  {}
 
-// CreateSchema creates a schema. Currently only works in IF NOT EXISTS mode,
-// for schemas that do in fact already exist.
+// CreateSchema creates a schema.
 func (p *planner) CreateSchema(ctx context.Context, n *tree.CreateSchema) (planNode, error) {
 	return &createSchemaNode{
 		n: n,

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -70,7 +70,7 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			ctx,
 			tree.ObjectLookupFlags{
 				// Note we set required to be false here in order to not error out
-				// if we don't find the object,
+				// if we don't find the object.
 				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
 				RequireMutable:    true,
 				IncludeOffline:    true,

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -164,7 +164,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		p.Descriptors().AddUncommittedDatabaseDeprecated(n.dbDesc.GetName(), n.dbDesc.GetID(), descs.DBDropped)
 
 	} else {
-		n.dbDesc.DrainingNames = append(n.dbDesc.DrainingNames, descpb.NameInfo{
+		n.dbDesc.AddDrainingName(descpb.NameInfo{
 			ParentID:       keys.RootNamespaceID,
 			ParentSchemaID: keys.RootNamespaceID,
 			Name:           n.dbDesc.Name,

--- a/pkg/sql/logictest/testdata/logic_test/reparent_database
+++ b/pkg/sql/logictest/testdata/logic_test/reparent_database
@@ -1,0 +1,74 @@
+statement ok
+SET experimental_enable_user_defined_schemas = true;
+SET experimental_enable_enums = true;
+
+statement ok
+CREATE DATABASE pgdatabase;
+CREATE TABLE pgdatabase.t1 (x INT PRIMARY KEY);
+CREATE DATABASE pgschema;
+CREATE TABLE pgschema.t1 (x INT);
+CREATE TABLE pgschema.t2 (x INT);
+CREATE TABLE pgschema.t3 (x INT PRIMARY KEY);
+ALTER TABLE pgschema.t3 ADD FOREIGN KEY (x) REFERENCES pgdatabase.t1 (x); -- references shouldn't be affected by reparenting.
+CREATE TYPE pgschema.typ AS ENUM ('schema');
+
+let $db_id
+SELECT id FROM system.namespace WHERE name = 'pgschema'
+
+statement ok
+ALTER DATABASE pgschema CONVERT TO SCHEMA WITH PARENT pgdatabase
+
+query I
+SELECT * FROM pgdatabase.pgschema.t1
+
+query I
+SELECT * FROM pgdatabase.pgschema.t2
+
+query T
+SELECT 'schema'::pgdatabase.pgschema.typ
+----
+schema
+
+statement error pq: insert on table "t3" violates foreign key constraint "fk_x_ref_t1"
+INSERT INTO pgdatabase.pgschema.t3 VALUES (1)
+
+# Assert there aren't any namespace entries left with the old parentID.
+query T
+SELECT name FROM system.namespace WHERE "parentID" = $db_id
+
+# We can't reparent a database that has any child schemas.
+statement ok
+CREATE DATABASE parent;
+USE parent;
+CREATE SCHEMA child;
+USE test;
+
+statement error pq: cannot convert database with schemas into schema
+ALTER DATABASE parent CONVERT TO SCHEMA WITH PARENT pgdatabase
+
+# We can't reparent a database if it causes a name conflict.
+statement ok
+CREATE DATABASE pgschema
+
+statement error pq: schema "pgschema" already exists
+ALTER DATABASE pgschema CONVERT TO SCHEMA WITH PARENT pgdatabase
+
+statement ok
+DROP DATABASE pgschema
+
+# We can't convert a database with an invalid schema name into a schema.
+statement ok
+CREATE DATABASE pg_temp
+
+statement error pq: unacceptable schema name "pg_temp"
+ALTER DATABASE pg_temp CONVERT TO SCHEMA WITH PARENT pgdatabase
+
+# We can't reparent a database that has any tables in use by views,
+# because we aren't able to rewrite those references.
+statement ok
+CREATE DATABASE with_views;
+CREATE TABLE with_views.t (x INT);
+CREATE VIEW with_views.v AS SELECT x FROM with_views.t
+
+statement error pq: could not convert database "with_views" into schema because "with_views.public.t" has dependent objects \[with_views.public.v\]
+ALTER DATABASE with_views CONVERT TO SCHEMA WITH PARENT pgdatabase

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -119,6 +119,8 @@ func buildOpaque(
 		plan, err = p.RenameColumn(ctx, n)
 	case *tree.RenameDatabase:
 		plan, err = p.RenameDatabase(ctx, n)
+	case *tree.ReparentDatabase:
+		plan, err = p.ReparentDatabase(ctx, n)
 	case *tree.RenameIndex:
 		plan, err = p.RenameIndex(ctx, n)
 	case *tree.RenameTable:
@@ -216,6 +218,7 @@ func init() {
 		&tree.RenameDatabase{},
 		&tree.RenameIndex{},
 		&tree.RenameTable{},
+		&tree.ReparentDatabase{},
 		&tree.Revoke{},
 		&tree.RevokeRole{},
 		&tree.Scatter{},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -576,7 +576,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %token <str> CHARACTER CHARACTERISTICS CHECK CLOSE
 %token <str> CLUSTER COALESCE COLLATE COLLATION COLUMN COLUMNS COMMENT COMMENTS COMMIT
 %token <str> COMMITTED COMPACT COMPLETE CONCAT CONCURRENTLY CONFIGURATION CONFIGURATIONS CONFIGURE
-%token <str> CONFLICT CONSTRAINT CONSTRAINTS CONTAINS CONTROLJOB CONVERSION COPY COVERING CREATE CREATEROLE
+%token <str> CONFLICT CONSTRAINT CONSTRAINTS CONTAINS CONTROLJOB CONVERSION CONVERT COPY COVERING CREATE CREATEROLE
 %token <str> CROSS CUBE CURRENT CURRENT_CATALOG CURRENT_DATE CURRENT_SCHEMA
 %token <str> CURRENT_ROLE CURRENT_TIME CURRENT_TIMESTAMP
 %token <str> CURRENT_USER CYCLE
@@ -714,6 +714,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 
 // ALTER DATABASE
 %type <tree.Statement> alter_rename_database_stmt
+%type <tree.Statement> alter_database_to_schema_stmt
 %type <tree.Statement> alter_zone_database_stmt
 %type <tree.Statement> alter_database_owner
 
@@ -1387,6 +1388,7 @@ alter_database_stmt:
   alter_rename_database_stmt
 |  alter_zone_database_stmt
 |  alter_database_owner
+| alter_database_to_schema_stmt
 // ALTER DATABASE has its error help token here because the ALTER DATABASE
 // prefix is spread over multiple non-terminals.
 | ALTER DATABASE error // SHOW HELP: ALTER DATABASE
@@ -6597,6 +6599,12 @@ opt_asc_desc:
     $$.val = tree.DefaultDirection
   }
 
+alter_database_to_schema_stmt:
+  ALTER DATABASE database_name CONVERT TO SCHEMA WITH PARENT database_name
+  {
+    $$.val = &tree.ReparentDatabase{Name: tree.Name($3), Parent: tree.Name($9)}
+  }
+
 alter_rename_database_stmt:
   ALTER DATABASE database_name RENAME TO database_name
   {
@@ -11173,6 +11181,7 @@ unreserved_keyword:
 | CONSTRAINTS
 | CONTROLJOB
 | CONVERSION
+| CONVERT
 | COPY
 | COVERING
 | CREATEROLE

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -192,6 +192,7 @@ var _ planNode = &renameColumnNode{}
 var _ planNode = &renameDatabaseNode{}
 var _ planNode = &renameIndexNode{}
 var _ planNode = &renameTableNode{}
+var _ planNode = &reparentDatabaseNode{}
 var _ planNode = &renderNode{}
 var _ planNode = &RevokeRoleNode{}
 var _ planNode = &rowCountNode{}
@@ -237,6 +238,7 @@ var _ planNodeReadingOwnWrites = &changePrivilegesNode{}
 var _ planNodeReadingOwnWrites = &dropSchemaNode{}
 var _ planNodeReadingOwnWrites = &dropTypeNode{}
 var _ planNodeReadingOwnWrites = &refreshMaterializedViewNode{}
+var _ planNodeReadingOwnWrites = &reparentDatabaseNode{}
 var _ planNodeReadingOwnWrites = &setZoneConfigNode{}
 
 // planNodeRequireSpool serves as marker for nodes whose parent must

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -1,0 +1,275 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+type reparentDatabaseNode struct {
+	n         *tree.ReparentDatabase
+	db        *sqlbase.MutableDatabaseDescriptor
+	newParent *sqlbase.MutableDatabaseDescriptor
+}
+
+func (p *planner) ReparentDatabase(
+	ctx context.Context, n *tree.ReparentDatabase,
+) (planNode, error) {
+	// We'll only allow the admin to perform this reparenting action.
+	if err := p.RequireAdminRole(ctx, "ALTER DATABASE ... CONVERT TO SCHEMA"); err != nil {
+		return nil, err
+	}
+
+	// Ensure that the cluster version is high enough to create the schema.
+	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.VersionUserDefinedSchemas) {
+		return nil, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			`creating schemas requires all nodes to be upgraded to %s`,
+			clusterversion.VersionByKey(clusterversion.VersionUserDefinedSchemas))
+	}
+
+	// Check that creation of schemas is enabled.
+	if !p.EvalContext().SessionData.UserDefinedSchemasEnabled {
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+			"session variable experimental_enable_user_defined_schemas is set to false, cannot create a schema")
+	}
+
+	db, err := p.ResolveMutableDatabaseDescriptor(ctx, string(n.Name), true /* required */)
+	if err != nil {
+		return nil, err
+	}
+
+	parent, err := p.ResolveMutableDatabaseDescriptor(ctx, string(n.Parent), true /* required */)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that this database wouldn't collide with a name under the new database.
+	exists, err := p.schemaExists(ctx, parent.ID, db.Name)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, pgerror.Newf(pgcode.DuplicateSchema, "schema %q already exists", db.Name)
+	}
+
+	// Ensure the database has a valid schema name.
+	if err := sqlbase.IsSchemaNameValid(db.Name); err != nil {
+		return nil, err
+	}
+
+	// We can't reparent a database that has any child schemas other than public.
+	if len(db.Schemas) > 0 {
+		return nil, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "cannot convert database with schemas into schema")
+	}
+
+	return &reparentDatabaseNode{
+		n:         n,
+		db:        db,
+		newParent: parent,
+	}, nil
+}
+
+func (n *reparentDatabaseNode) startExec(params runParams) error {
+	ctx, p, codec := params.ctx, params.p, params.ExecCfg().Codec
+
+	// Make a new schema corresponding to the target db.
+	id, err := catalogkv.GenerateUniqueDescID(ctx, p.ExecCfg().DB, codec)
+	if err != nil {
+		return err
+	}
+	schema := sqlbase.NewMutableCreatedSchemaDescriptor(descpb.SchemaDescriptor{
+		ParentID:   n.newParent.ID,
+		Name:       n.db.Name,
+		ID:         id,
+		Privileges: protoutil.Clone(n.db.Privileges).(*descpb.PrivilegeDescriptor),
+	})
+	// Add the new schema to the parent database's name map.
+	if n.newParent.Schemas == nil {
+		n.newParent.Schemas = make(map[string]descpb.DatabaseDescriptor_SchemaInfo)
+	}
+	n.newParent.Schemas[n.db.Name] = descpb.DatabaseDescriptor_SchemaInfo{
+		ID:      schema.ID,
+		Dropped: false,
+	}
+
+	if err := p.createDescriptorWithID(
+		ctx,
+		sqlbase.NewSchemaKey(n.newParent.ID, schema.Name).Key(p.ExecCfg().Codec),
+		id,
+		schema,
+		params.ExecCfg().Settings,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	); err != nil {
+		return err
+	}
+
+	b := p.txn.NewBatch()
+
+	// Get all objects under the target database.
+	objNames, err := resolver.GetObjectNames(ctx, p.txn, p, codec, n.db, tree.PublicSchema, true /* explicitPrefix */)
+	if err != nil {
+		return err
+	}
+
+	// For each object, adjust the ParentID and ParentSchemaID fields to point
+	// to the new parent DB and schema.
+	for _, objName := range objNames {
+		// First try looking up objName as a table.
+		found, desc, err := p.LookupObject(
+			ctx,
+			tree.ObjectLookupFlags{
+				// Note we set required to be false here in order to not error out
+				// if we don't find the object.
+				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
+				RequireMutable:    true,
+				IncludeOffline:    true,
+				DesiredObjectKind: tree.TableObject,
+			},
+			objName.Catalog(),
+			objName.Schema(),
+			objName.Object(),
+		)
+		if err != nil {
+			return err
+		}
+		if found {
+			// Remap the ID's on the table.
+			tbl, ok := desc.(*sqlbase.MutableTableDescriptor)
+			if !ok {
+				return errors.AssertionFailedf("%q was not a MutableTableDescriptor", objName.Object())
+			}
+
+			// If this table has any dependents, then we can't proceed (similar to the
+			// restrictions around renaming tables). See #10083.
+			if len(tbl.GetDependedOnBy()) > 0 {
+				var names []string
+				const errStr = "cannot convert database %q into schema because %q has dependent objects"
+				tblName, err := p.getQualifiedTableName(ctx, tbl)
+				if err != nil {
+					return errors.Wrapf(err, errStr, n.db.Name, tbl.Name)
+				}
+				for _, ref := range tbl.GetDependedOnBy() {
+					dep, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ID, p.txn)
+					if err != nil {
+						return errors.Wrapf(err, errStr, n.db.Name, tblName.String())
+					}
+					fqName, err := p.getQualifiedTableName(ctx, dep)
+					if err != nil {
+						return errors.Wrapf(err, errStr, n.db.Name, dep.Name)
+					}
+					names = append(names, fqName.String())
+				}
+				return sqlbase.NewDependentObjectErrorf(
+					"could not convert database %q into schema because %q has dependent objects %v",
+					n.db.Name,
+					tblName.String(),
+					names,
+				)
+			}
+
+			tbl.AddDrainingName(descpb.NameInfo{
+				ParentID:       tbl.ParentID,
+				ParentSchemaID: tbl.GetParentSchemaID(),
+				Name:           tbl.Name,
+			})
+			tbl.ParentID = n.newParent.ID
+			tbl.UnexposedParentSchemaID = schema.ID
+			objKey := catalogkv.MakeObjectNameKey(ctx, p.ExecCfg().Settings, tbl.ParentID, tbl.GetParentSchemaID(), tbl.Name).Key(codec)
+			b.CPut(objKey, tbl.ID, nil /* expected */)
+			if err := p.writeSchemaChange(ctx, tbl, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann())); err != nil {
+				return err
+			}
+		} else {
+			// If we couldn't resolve objName as a table, try a type.
+			found, desc, err := p.LookupObject(
+				ctx,
+				tree.ObjectLookupFlags{
+					CommonLookupFlags: tree.CommonLookupFlags{Required: true},
+					RequireMutable:    true,
+					IncludeOffline:    true,
+					DesiredObjectKind: tree.TypeObject,
+				},
+				objName.Catalog(),
+				objName.Schema(),
+				objName.Object(),
+			)
+			if err != nil {
+				return err
+			}
+			// If we couldn't find the object at all, then continue.
+			if !found {
+				continue
+			}
+			// Remap the ID's on the type.
+			typ, ok := desc.(*sqlbase.MutableTypeDescriptor)
+			if !ok {
+				return errors.AssertionFailedf("%q was not a MutableTypeDescriptor", objName.Object())
+			}
+			typ.AddDrainingName(descpb.NameInfo{
+				ParentID:       typ.ParentID,
+				ParentSchemaID: typ.ParentSchemaID,
+				Name:           typ.Name,
+			})
+			typ.ParentID = n.newParent.ID
+			typ.ParentSchemaID = schema.ID
+			objKey := catalogkv.MakeObjectNameKey(ctx, p.ExecCfg().Settings, typ.ParentID, typ.ParentSchemaID, typ.Name).Key(codec)
+			b.CPut(objKey, typ.ID, nil /* expected */)
+			if err := p.writeTypeSchemaChange(ctx, typ, tree.AsStringWithFQNames(n.n, params.Ann())); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Delete the public schema namespace entry for this database. Per our check
+	// during initialization, this is the only schema present under n.db.
+	b.Del(catalogkv.MakeObjectNameKey(ctx, p.ExecCfg().Settings, n.db.ID, keys.RootNamespaceID, tree.PublicSchema).Key(codec))
+
+	// This command can only be run when database leasing is supported, so we don't
+	// have to handle the case where it isn't.
+	n.db.AddDrainingName(descpb.NameInfo{
+		ParentID:       keys.RootNamespaceID,
+		ParentSchemaID: keys.RootNamespaceID,
+		Name:           n.db.Name,
+	})
+	n.db.State = descpb.DatabaseDescriptor_DROP
+	if err := p.writeDatabaseChangeToBatch(ctx, n.db, b); err != nil {
+		return err
+	}
+
+	if err := p.txn.Run(ctx, b); err != nil {
+		return err
+	}
+
+	return p.createDropDatabaseJob(
+		ctx,
+		n.db.ID,
+		nil, /* tableDropDetails */
+		nil, /* typesToDrop */
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
+}
+
+func (n *reparentDatabaseNode) Next(params runParams) (bool, error) { return false, nil }
+func (n *reparentDatabaseNode) Values() tree.Datums                 { return tree.Datums{} }
+func (n *reparentDatabaseNode) Close(ctx context.Context)           {}
+func (n *reparentDatabaseNode) ReadingOwnWrites()                   {}

--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -33,6 +33,20 @@ func (node *RenameDatabase) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.NewName)
 }
 
+// ReparentDatabase represents a database reparenting as a schema operation.
+type ReparentDatabase struct {
+	Name   Name
+	Parent Name
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ReparentDatabase) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER DATABASE ")
+	node.Name.Format(ctx)
+	ctx.WriteString(" CONVERT TO SCHEMA WITH PARENT ")
+	node.Parent.Format(ctx)
+}
+
 // RenameTable represents a RENAME TABLE or RENAME VIEW or RENAME SEQUENCE
 // statement. Whether the user has asked to rename a view or a sequence
 // is indicated by the IsView and IsSequence fields.

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -593,6 +593,12 @@ func (*RenameDatabase) StatementType() StatementType { return DDL }
 func (*RenameDatabase) StatementTag() string { return "RENAME DATABASE" }
 
 // StatementType implements the Statement interface.
+func (*ReparentDatabase) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ReparentDatabase) StatementTag() string { return "TODO (rohany): Implement" }
+
+// StatementType implements the Statement interface.
 func (*RenameIndex) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -1051,6 +1057,7 @@ func (n *Relocate) String() string                       { return AsString(n) }
 func (n *RefreshMaterializedView) String() string        { return AsString(n) }
 func (n *RenameColumn) String() string                   { return AsString(n) }
 func (n *RenameDatabase) String() string                 { return AsString(n) }
+func (n *ReparentDatabase) String() string               { return AsString(n) }
 func (n *RenameIndex) String() string                    { return AsString(n) }
 func (n *RenameTable) String() string                    { return AsString(n) }
 func (n *Restore) String() string                        { return AsString(n) }

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -233,3 +233,9 @@ func (desc *MutableDatabaseDescriptor) Immutable() Descriptor {
 func (desc *MutableDatabaseDescriptor) IsNew() bool {
 	return desc.ClusterVersion == nil
 }
+
+// AddDrainingName adds a draining name to the DatabaseDescriptor's slice of
+// draining names.
+func (desc *MutableDatabaseDescriptor) AddDrainingName(name descpb.NameInfo) {
+	desc.DrainingNames = append(desc.DrainingNames, name)
+}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -403,6 +403,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&renameDatabaseNode{}):          "rename database",
 	reflect.TypeOf(&renameIndexNode{}):             "rename index",
 	reflect.TypeOf(&renameTableNode{}):             "rename table",
+	reflect.TypeOf(&reparentDatabaseNode{}):        "TODO (rohany): fill out",
 	reflect.TypeOf(&renderNode{}):                  "render",
 	reflect.TypeOf(&RevokeRoleNode{}):              "revoke role",
 	reflect.TypeOf(&rowCountNode{}):                "count",


### PR DESCRIPTION
Fixes #50885.

This commit introduces a command to convert a database into a user
defined schema under a desired database. This command can be used by
users who are currently emulating a Postgres style set of schemas in
CockroachDB with separate databases.

Release note (sql change): Users can now convert existing databases into
schemas under other databases through the
`ALTER DATABASE ... CONVERT TO SCHEMA UNDER PARENT ...` command. This
command can only be run by `admin` and is only valid for databases that
don't already have any child schemas other than `public`.