### PR TITLE
sql: more EXPLAIN improvements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -388,7 +388,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i1] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i1
@@ -404,7 +403,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i2] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i2
@@ -420,7 +418,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i3] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i3
@@ -436,7 +433,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i4] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i4
@@ -452,7 +448,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i5] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i5
@@ -468,7 +463,6 @@ SELECT * FROM [EXPLAIN SELECT * FROM t@i7] OFFSET 2
 ----
 index join  ·              ·
  │          table          t@primary
- │          key columns    y
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          t@i7

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
@@ -33,7 +33,6 @@ filter                     ·                ·
  │                         filter           st_intersects('010100000000000000000008400000000000000840', geom)
  └── index join            ·                ·
       │                    table            geo_table2@primary
-      │                    key columns      k, k_plus_one
       └── inverted filter  ·                ·
            │               inverted column  geom_inverted_key
            │               num spans        31
@@ -51,7 +50,6 @@ filter                     ·                ·
  │                         filter           st_dfullywithin('010100000000000000000008400000000000000840', geom, 1.0)
  └── index join            ·                ·
       │                    table            geo_table2@primary
-      │                    key columns      k, k_plus_one
       └── inverted filter  ·                ·
            │               inverted column  geom_inverted_key
            │               num spans        20

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
@@ -35,13 +35,10 @@ lookup join         ·                      ·
  │                  type                   inner
  │                  equality               (rk1, rk2) = (rk1,rk2)
  │                  equality cols are key  ·
- │                  parallel               ·
  │                  pred                   st_intersects(geom1, geom)
  └── inverted join  ·                      ·
       │             table                  rtable@geom_index
       │             type                   inner
-      │             ·                      st_intersects(geom1, geom_inverted_key)
-      │             parallel               ·
       └── scan      ·                      ·
 ·                   missing stats          ·
 ·                   table                  ltable@primary
@@ -58,13 +55,10 @@ lookup join         ·                      ·
  │                  type                   inner
  │                  equality               (rk1, rk2) = (rk1,rk2)
  │                  equality cols are key  ·
- │                  parallel               ·
  │                  pred                   st_dwithin(geom1, geom, 5.0)
  └── inverted join  ·                      ·
       │             table                  rtable@geom_index
       │             type                   inner
-      │             ·                      st_dwithin(geom1, geom_inverted_key, 5.0)
-      │             parallel               ·
       └── scan      ·                      ·
 ·                   missing stats          ·
 ·                   table                  ltable@primary
@@ -86,7 +80,6 @@ project                                 ·                      ·              
            │                            type                   inner                                                                                 ·                                         ·
            │                            equality               (rk1, rk2) = (rk1,rk2)                                                                ·                                         ·
            │                            equality cols are key  ·                                                                                     ·                                         ·
-           │                            parallel               ·                                                                                     ·                                         ·
            │                            pred                   st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)                            ·                                         ·
            └── sort                     ·                      ·                                                                                     (lk, geom1, rk1, rk2)                     +lk,+rk1
                 │                       estimated row count    10000 (missing stats)                                                                 ·                                         ·
@@ -96,8 +89,7 @@ project                                 ·                      ·              
                      └── inverted join  ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom_inverted_key)  ·
                           │             table                  rtable@geom_index                                                                     ·                                         ·
                           │             type                   inner                                                                                 ·                                         ·
-                          │             ·                      st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
-                          │             parallel               ·                                                                                     ·                                         ·
+                          │             inverted expr          st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
                           └── scan      ·                      ·                                                                                     (lk, geom1)                               ·
 ·                                       estimated row count    1000 (missing stats)                                                                  ·                                         ·
 ·                                       table                  ltable@primary                                                                        ·                                         ·
@@ -122,15 +114,13 @@ sort                                    ·                      ·              
                 │                       type                   inner                                                                                  ·                                         ·
                 │                       equality               (rk1, rk2) = (rk1,rk2)                                                                 ·                                         ·
                 │                       equality cols are key  ·                                                                                      ·                                         ·
-                │                       parallel               ·                                                                                      ·                                         ·
                 │                       pred                   st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)                            ·                                         ·
                 └── project             ·                      ·                                                                                      (lk, geom1, rk1, rk2)                     ·
                      │                  estimated row count    10000 (missing stats)                                                                  ·                                         ·
                      └── inverted join  ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom_inverted_key)  ·
                           │             table                  rtable@geom_index                                                                      ·                                         ·
                           │             type                   inner                                                                                  ·                                         ·
-                          │             ·                      st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
-                          │             parallel               ·                                                                                      ·                                         ·
+                          │             inverted expr          st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
                           └── scan      ·                      ·                                                                                      (lk, geom1)                               ·
 ·                                       estimated row count    1000 (missing stats)                                                                   ·                                         ·
 ·                                       table                  ltable@primary                                                                         ·                                         ·
@@ -153,15 +143,13 @@ project                            ·                      ·                   
            │                       type                   inner                                                                                                                                                                                                                       ·                                                ·
            │                       equality               (rk1, rk2) = (rk1,rk2)                                                                                                                                                                                                      ·                                                ·
            │                       equality cols are key  ·                                                                                                                                                                                                                           ·                                                ·
-           │                       parallel               ·                                                                                                                                                                                                                           ·                                                ·
            │                       pred                   (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))                                                      ·                                                ·
            └── project             ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2)                     ·
                 │                  estimated row count    10000 (missing stats)                                                                                                                                                                                                       ·                                                ·
                 └── inverted join  ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom_inverted_key)  ·
                      │             table                  rtable@geom_index                                                                                                                                                                                                           ·                                                ·
                      │             type                   inner                                                                                                                                                                                                                       ·                                                ·
-                     │             ·                      (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))  ·                                                ·
-                     │             parallel               ·                                                                                                                                                                                                                           ·                                                ·
+                     │             inverted expr          (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))  ·                                                ·
                      └── scan      ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2)                               ·
 ·                                  estimated row count    1000 (missing stats)                                                                                                                                                                                                        ·                                                ·
 ·                                  table                  ltable@primary                                                                                                                                                                                                              ·                                                ·

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
@@ -32,13 +32,11 @@ FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom1, rtable.geom)
 ·                   vectorized             true
 lookup join         ·                      ·
  │                  table                  rtable@primary
- │                  type                   inner
  │                  equality               (rk1, rk2) = (rk1,rk2)
  │                  equality cols are key  ·
  │                  pred                   st_intersects(geom1, geom)
  └── inverted join  ·                      ·
       │             table                  rtable@geom_index
-      │             type                   inner
       └── scan      ·                      ·
 ·                   missing stats          ·
 ·                   table                  ltable@primary
@@ -52,13 +50,11 @@ FROM ltable JOIN rtable@geom_index ON ST_DWithin(ltable.geom1, rtable.geom, 5)
 ·                   vectorized             true
 lookup join         ·                      ·
  │                  table                  rtable@primary
- │                  type                   inner
  │                  equality               (rk1, rk2) = (rk1,rk2)
  │                  equality cols are key  ·
  │                  pred                   st_dwithin(geom1, geom, 5.0)
  └── inverted join  ·                      ·
       │             table                  rtable@geom_index
-      │             type                   inner
       └── scan      ·                      ·
 ·                   missing stats          ·
 ·                   table                  ltable@primary
@@ -75,9 +71,8 @@ project                                 ·                      ·              
  │                                      estimated row count    333333 (missing stats)                                                                ·                                         ·
  └── project                            ·                      ·                                                                                     (lk, geom1, rk1, geom)                    +lk,+rk1
       │                                 estimated row count    333333 (missing stats)                                                                ·                                         ·
-      └── lookup join                   ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom)               +lk,+rk1
+      └── lookup join (inner)           ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom)               +lk,+rk1
            │                            table                  rtable@primary                                                                        ·                                         ·
-           │                            type                   inner                                                                                 ·                                         ·
            │                            equality               (rk1, rk2) = (rk1,rk2)                                                                ·                                         ·
            │                            equality cols are key  ·                                                                                     ·                                         ·
            │                            pred                   st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)                            ·                                         ·
@@ -88,7 +83,6 @@ project                                 ·                      ·              
                      │                  estimated row count    10000 (missing stats)                                                                 ·                                         ·
                      └── inverted join  ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom_inverted_key)  ·
                           │             table                  rtable@geom_index                                                                     ·                                         ·
-                          │             type                   inner                                                                                 ·                                         ·
                           │             inverted expr          st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
                           └── scan      ·                      ·                                                                                     (lk, geom1)                               ·
 ·                                       estimated row count    1000 (missing stats)                                                                  ·                                         ·
@@ -109,9 +103,8 @@ sort                                    ·                      ·              
       │                                 estimated row count    10000 (missing stats)                                                                  ·                                         ·
       └── project                       ·                      ·                                                                                      (lk, geom1, rk1, geom)                    ·
            │                            estimated row count    10000 (missing stats)                                                                  ·                                         ·
-           └── lookup join              ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom)               ·
+           └── lookup join (inner)      ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom)               ·
                 │                       table                  rtable@primary                                                                         ·                                         ·
-                │                       type                   inner                                                                                  ·                                         ·
                 │                       equality               (rk1, rk2) = (rk1,rk2)                                                                 ·                                         ·
                 │                       equality cols are key  ·                                                                                      ·                                         ·
                 │                       pred                   st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)                            ·                                         ·
@@ -119,7 +112,6 @@ sort                                    ·                      ·              
                      │                  estimated row count    10000 (missing stats)                                                                  ·                                         ·
                      └── inverted join  ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom_inverted_key)  ·
                           │             table                  rtable@geom_index                                                                      ·                                         ·
-                          │             type                   inner                                                                                  ·                                         ·
                           │             inverted expr          st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
                           └── scan      ·                      ·                                                                                      (lk, geom1)                               ·
 ·                                       estimated row count    1000 (missing stats)                                                                   ·                                         ·
@@ -138,9 +130,8 @@ project                            ·                      ·                   
  │                                 estimated row count    3333 (missing stats)                                                                                                                                                                                                        ·                                                ·
  └── project                       ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, geom)                    ·
       │                            estimated row count    3333 (missing stats)                                                                                                                                                                                                        ·                                                ·
-      └── lookup join              ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom)               ·
+      └── lookup join (inner)      ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom)               ·
            │                       table                  rtable@primary                                                                                                                                                                                                              ·                                                ·
-           │                       type                   inner                                                                                                                                                                                                                       ·                                                ·
            │                       equality               (rk1, rk2) = (rk1,rk2)                                                                                                                                                                                                      ·                                                ·
            │                       equality cols are key  ·                                                                                                                                                                                                                           ·                                                ·
            │                       pred                   (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))                                                      ·                                                ·
@@ -148,7 +139,6 @@ project                            ·                      ·                   
                 │                  estimated row count    10000 (missing stats)                                                                                                                                                                                                       ·                                                ·
                 └── inverted join  ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom_inverted_key)  ·
                      │             table                  rtable@geom_index                                                                                                                                                                                                           ·                                                ·
-                     │             type                   inner                                                                                                                                                                                                                       ·                                                ·
                      │             inverted expr          (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))  ·                                                ·
                      └── scan      ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2)                               ·
 ·                                  estimated row count    1000 (missing stats)                                                                                                                                                                                                        ·                                                ·
@@ -161,40 +151,38 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT lk FROM ltable WHERE EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
-·                distribution         local                       ·            ·
-·                vectorized           true                        ·            ·
-project          ·                    ·                           (lk)         ·
- │               estimated row count  10 (missing stats)          ·            ·
- └── cross join  ·                    ·                           (lk, geom2)  ·
-      │          estimated row count  10 (missing stats)          ·            ·
-      │          type                 semi                        ·            ·
-      │          pred                 st_intersects(geom2, geom)  ·            ·
-      ├── scan   ·                    ·                           (lk, geom2)  ·
-      │          estimated row count  1000 (missing stats)        ·            ·
-      │          table                ltable@primary              ·            ·
-      │          spans                FULL SCAN                   ·            ·
-      └── scan   ·                    ·                           (geom)       ·
-·                estimated row count  1000 (missing stats)        ·            ·
-·                table                rtable@primary              ·            ·
-·                spans                FULL SCAN                   ·            ·
+·                       distribution         local                       ·            ·
+·                       vectorized           true                        ·            ·
+project                 ·                    ·                           (lk)         ·
+ │                      estimated row count  10 (missing stats)          ·            ·
+ └── cross join (semi)  ·                    ·                           (lk, geom2)  ·
+      │                 estimated row count  10 (missing stats)          ·            ·
+      │                 pred                 st_intersects(geom2, geom)  ·            ·
+      ├── scan          ·                    ·                           (lk, geom2)  ·
+      │                 estimated row count  1000 (missing stats)        ·            ·
+      │                 table                ltable@primary              ·            ·
+      │                 spans                FULL SCAN                   ·            ·
+      └── scan          ·                    ·                           (geom)       ·
+·                       estimated row count  1000 (missing stats)        ·            ·
+·                       table                rtable@primary              ·            ·
+·                       spans                FULL SCAN                   ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
 SELECT lk FROM ltable WHERE NOT EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
-·                distribution         local                       ·            ·
-·                vectorized           true                        ·            ·
-project          ·                    ·                           (lk)         ·
- │               estimated row count  990 (missing stats)         ·            ·
- └── cross join  ·                    ·                           (lk, geom2)  ·
-      │          estimated row count  990 (missing stats)         ·            ·
-      │          type                 anti                        ·            ·
-      │          pred                 st_intersects(geom2, geom)  ·            ·
-      ├── scan   ·                    ·                           (lk, geom2)  ·
-      │          estimated row count  1000 (missing stats)        ·            ·
-      │          table                ltable@primary              ·            ·
-      │          spans                FULL SCAN                   ·            ·
-      └── scan   ·                    ·                           (geom)       ·
-·                estimated row count  1000 (missing stats)        ·            ·
-·                table                rtable@primary              ·            ·
-·                spans                FULL SCAN                   ·            ·
+·                       distribution         local                       ·            ·
+·                       vectorized           true                        ·            ·
+project                 ·                    ·                           (lk)         ·
+ │                      estimated row count  990 (missing stats)         ·            ·
+ └── cross join (anti)  ·                    ·                           (lk, geom2)  ·
+      │                 estimated row count  990 (missing stats)         ·            ·
+      │                 pred                 st_intersects(geom2, geom)  ·            ·
+      ├── scan          ·                    ·                           (lk, geom2)  ·
+      │                 estimated row count  1000 (missing stats)        ·            ·
+      │                 table                ltable@primary              ·            ·
+      │                 spans                FULL SCAN                   ·            ·
+      └── scan          ·                    ·                           (geom)       ·
+·                       estimated row count  1000 (missing stats)        ·            ·
+·                       table                rtable@primary              ·            ·
+·                       spans                FULL SCAN                   ·            ·

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -21,7 +21,6 @@ EXPLAIN SELECT count(*) from small
 ·          distribution   full
 ·          vectorized     false
 group      ·              ·
- │         aggregate 0    count_rows()
  │         scalar         ·
  └── scan  ·              ·
 ·          missing stats  ·
@@ -39,7 +38,6 @@ EXPLAIN SELECT count(*) from small
 ·          distribution   full
 ·          vectorized     true
 group      ·              ·
- │         aggregate 0    count_rows()
  │         scalar         ·
  └── scan  ·              ·
 ·          missing stats  ·
@@ -66,7 +64,6 @@ EXPLAIN SELECT count(*) from small
 ·          distribution         full
 ·          vectorized           false
 group      ·                    ·
- │         aggregate 0          count_rows()
  │         scalar               ·
  └── scan  ·                    ·
 ·          estimated row count  100
@@ -84,7 +81,6 @@ EXPLAIN SELECT count(*) from small
 ·          distribution         full
 ·          vectorized           true
 group      ·                    ·
- │         aggregate 0          count_rows()
  │         scalar               ·
  └── scan  ·                    ·
 ·          estimated row count  100
@@ -114,7 +110,6 @@ EXPLAIN SELECT count(*) from large
 ·          distribution         full
 ·          vectorized           true
 group      ·                    ·
- │         aggregate 0          count_rows()
  │         scalar               ·
  └── scan  ·                    ·
 ·          estimated row count  100000
@@ -132,7 +127,6 @@ EXPLAIN SELECT count(*) from large
 ·          distribution         full
 ·          vectorized           false
 group      ·                    ·
- │         aggregate 0          count_rows()
  │         scalar               ·
  └── scan  ·                    ·
 ·          estimated row count  100000

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -18,14 +18,13 @@ SET vectorize_row_count_threshold = 1000
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distribution   full
-·          vectorized     false
-group      ·              ·
- │         scalar         ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          small@primary
-·          spans          FULL SCAN
+·               distribution   full
+·               vectorized     false
+group (scalar)  ·              ·
+ └── scan       ·              ·
+·               missing stats  ·
+·               table          small@primary
+·               spans          FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 0
@@ -35,14 +34,13 @@ SET vectorize_row_count_threshold = 0
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distribution   full
-·          vectorized     true
-group      ·              ·
- │         scalar         ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          small@primary
-·          spans          FULL SCAN
+·               distribution   full
+·               vectorized     true
+group (scalar)  ·              ·
+ └── scan       ·              ·
+·               missing stats  ·
+·               table          small@primary
+·               spans          FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -61,14 +59,13 @@ ALTER TABLE small INJECT STATISTICS '[
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distribution         full
-·          vectorized           false
-group      ·                    ·
- │         scalar               ·
- └── scan  ·                    ·
-·          estimated row count  100
-·          table                small@primary
-·          spans                FULL SCAN
+·               distribution         full
+·               vectorized           false
+group (scalar)  ·                    ·
+ └── scan       ·                    ·
+·               estimated row count  100
+·               table                small@primary
+·               spans                FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1
@@ -78,14 +75,13 @@ SET vectorize_row_count_threshold = 1
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distribution         full
-·          vectorized           true
-group      ·                    ·
- │         scalar               ·
- └── scan  ·                    ·
-·          estimated row count  100
-·          table                small@primary
-·          spans                FULL SCAN
+·               distribution         full
+·               vectorized           true
+group (scalar)  ·                    ·
+ └── scan       ·                    ·
+·               estimated row count  100
+·               table                small@primary
+·               spans                FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -107,14 +103,13 @@ ALTER TABLE large INJECT STATISTICS '[
 query TTT
 EXPLAIN SELECT count(*) from large
 ----
-·          distribution         full
-·          vectorized           true
-group      ·                    ·
- │         scalar               ·
- └── scan  ·                    ·
-·          estimated row count  100000
-·          table                large@primary
-·          spans                FULL SCAN
+·               distribution         full
+·               vectorized           true
+group (scalar)  ·                    ·
+ └── scan       ·                    ·
+·               estimated row count  100000
+·               table                large@primary
+·               spans                FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000000
@@ -124,11 +119,10 @@ SET vectorize_row_count_threshold = 1000000
 query TTT
 EXPLAIN SELECT count(*) from large
 ----
-·          distribution         full
-·          vectorized           false
-group      ·                    ·
- │         scalar               ·
- └── scan  ·                    ·
-·          estimated row count  100000
-·          table                large@primary
-·          spans                FULL SCAN
+·               distribution         full
+·               vectorized           false
+group (scalar)  ·                    ·
+ └── scan       ·                    ·
+·               estimated row count  100000
+·               table                large@primary
+·               spans                FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -13,7 +13,7 @@ EXPLAIN (TYPES) SELECT min(1), max(1), count(NULL), sum_int(1), avg(1), sum(1), 
 ----
 ·               distribution         local                 ·                                                                                                                                                   ·
 ·               vectorized           true                  ·                                                                                                                                                   ·
-group           ·                    ·                     (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
+group (scalar)  ·                    ·                     (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
  │              estimated row count  1 (missing stats)     ·                                                                                                                                                   ·
  │              aggregate 0          min(column6)          ·                                                                                                                                                   ·
  │              aggregate 1          max(column6)          ·                                                                                                                                                   ·
@@ -26,7 +26,6 @@ group           ·                    ·                     (min int, max int, 
  │              aggregate 8          bool_and(column16)    ·                                                                                                                                                   ·
  │              aggregate 9          bool_or(column18)     ·                                                                                                                                                   ·
  │              aggregate 10         xor_agg(column20)     ·                                                                                                                                                   ·
- │              scalar               ·                     ·                                                                                                                                                   ·
  └── render     ·                    ·                     (column6 int, column9 unknown, column16 bool, column18 bool, column20 bytes)                                                                        ·
       │         estimated row count  1000 (missing stats)  ·                                                                                                                                                   ·
       │         render 0             (1)[int]              ·                                                                                                                                                   ·
@@ -45,7 +44,7 @@ EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), std
 ·                    distribution         local                        ·                                                                                                                                                    ·
 ·                    vectorized           true                         ·                                                                                                                                                    ·
 project              ·                    ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
- └── group           ·                    ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)                 ·
+ └── group (scalar)  ·                    ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)                 ·
       │              estimated row count  1 (missing stats)            ·                                                                                                                                                    ·
       │              aggregate 0          min(v)                       ·                                                                                                                                                    ·
       │              aggregate 1          max(v)                       ·                                                                                                                                                    ·
@@ -57,7 +56,6 @@ project              ·                    ·                            (min in
       │              aggregate 7          variance(v)                  ·                                                                                                                                                    ·
       │              aggregate 8          bool_and(column15)           ·                                                                                                                                                    ·
       │              aggregate 9          xor_agg(column17)            ·                                                                                                                                                    ·
-      │              scalar               ·                            ·                                                                                                                                                    ·
       └── render     ·                    ·                            (column9 int, column15 bool, column17 bytes, v int)                                                                                                  ·
            │         estimated row count  1000 (missing stats)         ·                                                                                                                                                    ·
            │         render 0             (1)[int]                     ·                                                                                                                                                    ·
@@ -73,41 +71,40 @@ project              ·                    ·                            (min in
 query TTTTT
 EXPLAIN (TYPES) SELECT min(1), count(NULL), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
-·                 distribution         local                               ·                                                                                                                                                   ·
-·                 vectorized           false                               ·                                                                                                                                                   ·
-render            ·                    ·                                   (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)    ·
- │                estimated row count  1                                   ·                                                                                                                                                   ·
- │                render 0             ((avg)[decimal]::FLOAT8)[float]     ·                                                                                                                                                   ·
- │                render 1             (to_hex((xor_agg)[bytes]))[string]  ·                                                                                                                                                   ·
- │                render 2             (min)[int]                          ·                                                                                                                                                   ·
- │                render 3             (count)[int]                        ·                                                                                                                                                   ·
- │                render 4             (max)[int]                          ·                                                                                                                                                   ·
- │                render 5             (sum_int)[int]                      ·                                                                                                                                                   ·
- │                render 6             (sum)[decimal]                      ·                                                                                                                                                   ·
- │                render 7             (stddev)[decimal]                   ·                                                                                                                                                   ·
- │                render 8             (variance)[decimal]                 ·                                                                                                                                                   ·
- │                render 9             (bool_and)[bool]                    ·                                                                                                                                                   ·
- │                render 10            (bool_or)[bool]                     ·                                                                                                                                                   ·
- └── group        ·                    ·                                   (min int, count int, max int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
-      │           estimated row count  1                                   ·                                                                                                                                                   ·
-      │           aggregate 0          min(column1)                        ·                                                                                                                                                   ·
-      │           aggregate 1          count(column3)                      ·                                                                                                                                                   ·
-      │           aggregate 2          max(column1)                        ·                                                                                                                                                   ·
-      │           aggregate 3          sum_int(column1)                    ·                                                                                                                                                   ·
-      │           aggregate 4          avg(column1)                        ·                                                                                                                                                   ·
-      │           aggregate 5          sum(column1)                        ·                                                                                                                                                   ·
-      │           aggregate 6          stddev(column1)                     ·                                                                                                                                                   ·
-      │           aggregate 7          variance(column1)                   ·                                                                                                                                                   ·
-      │           aggregate 8          bool_and(column11)                  ·                                                                                                                                                   ·
-      │           aggregate 9          bool_or(column11)                   ·                                                                                                                                                   ·
-      │           aggregate 10         xor_agg(column14)                   ·                                                                                                                                                   ·
-      │           scalar               ·                                   ·                                                                                                                                                   ·
-      └── values  ·                    ·                                   (column1 int, column3 unknown, column11 bool, column14 bytes)                                                                                       ·
-·                 size                 4 columns, 1 row                    ·                                                                                                                                                   ·
-·                 row 0, expr 0        (1)[int]                            ·                                                                                                                                                   ·
-·                 row 0, expr 1        (NULL)[unknown]                     ·                                                                                                                                                   ·
-·                 row 0, expr 2        (true)[bool]                        ·                                                                                                                                                   ·
-·                 row 0, expr 3        ('\x01')[bytes]                     ·                                                                                                                                                   ·
+·                    distribution         local                               ·                                                                                                                                                   ·
+·                    vectorized           false                               ·                                                                                                                                                   ·
+render               ·                    ·                                   (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)    ·
+ │                   estimated row count  1                                   ·                                                                                                                                                   ·
+ │                   render 0             ((avg)[decimal]::FLOAT8)[float]     ·                                                                                                                                                   ·
+ │                   render 1             (to_hex((xor_agg)[bytes]))[string]  ·                                                                                                                                                   ·
+ │                   render 2             (min)[int]                          ·                                                                                                                                                   ·
+ │                   render 3             (count)[int]                        ·                                                                                                                                                   ·
+ │                   render 4             (max)[int]                          ·                                                                                                                                                   ·
+ │                   render 5             (sum_int)[int]                      ·                                                                                                                                                   ·
+ │                   render 6             (sum)[decimal]                      ·                                                                                                                                                   ·
+ │                   render 7             (stddev)[decimal]                   ·                                                                                                                                                   ·
+ │                   render 8             (variance)[decimal]                 ·                                                                                                                                                   ·
+ │                   render 9             (bool_and)[bool]                    ·                                                                                                                                                   ·
+ │                   render 10            (bool_or)[bool]                     ·                                                                                                                                                   ·
+ └── group (scalar)  ·                    ·                                   (min int, count int, max int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
+      │              estimated row count  1                                   ·                                                                                                                                                   ·
+      │              aggregate 0          min(column1)                        ·                                                                                                                                                   ·
+      │              aggregate 1          count(column3)                      ·                                                                                                                                                   ·
+      │              aggregate 2          max(column1)                        ·                                                                                                                                                   ·
+      │              aggregate 3          sum_int(column1)                    ·                                                                                                                                                   ·
+      │              aggregate 4          avg(column1)                        ·                                                                                                                                                   ·
+      │              aggregate 5          sum(column1)                        ·                                                                                                                                                   ·
+      │              aggregate 6          stddev(column1)                     ·                                                                                                                                                   ·
+      │              aggregate 7          variance(column1)                   ·                                                                                                                                                   ·
+      │              aggregate 8          bool_and(column11)                  ·                                                                                                                                                   ·
+      │              aggregate 9          bool_or(column11)                   ·                                                                                                                                                   ·
+      │              aggregate 10         xor_agg(column14)                   ·                                                                                                                                                   ·
+      └── values     ·                    ·                                   (column1 int, column3 unknown, column11 bool, column14 bytes)                                                                                       ·
+·                    size                 4 columns, 1 row                    ·                                                                                                                                                   ·
+·                    row 0, expr 0        (1)[int]                            ·                                                                                                                                                   ·
+·                    row 0, expr 1        (NULL)[unknown]                     ·                                                                                                                                                   ·
+·                    row 0, expr 2        (true)[bool]                        ·                                                                                                                                                   ·
+·                    row 0, expr 3        ('\x01')[bytes]                     ·                                                                                                                                                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k FROM kv GROUP BY 2
@@ -166,61 +163,57 @@ render          ·                    ·                                      (c
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k) FROM kv
 ----
-·          distribution         local                 ·            ·
-·          vectorized           true                  ·            ·
-group      ·                    ·                     (count int)  ·
- │         estimated row count  1 (missing stats)     ·            ·
- │         aggregate 0          count_rows()          ·            ·
- │         scalar               ·                     ·            ·
- └── scan  ·                    ·                     ()           ·
-·          estimated row count  1000 (missing stats)  ·            ·
-·          table                kv@primary            ·            ·
-·          spans                FULL SCAN             ·            ·
+·               distribution         local                 ·            ·
+·               vectorized           true                  ·            ·
+group (scalar)  ·                    ·                     (count int)  ·
+ │              estimated row count  1 (missing stats)     ·            ·
+ │              aggregate 0          count_rows()          ·            ·
+ └── scan       ·                    ·                     ()           ·
+·               estimated row count  1000 (missing stats)  ·            ·
+·               table                kv@primary            ·            ·
+·               spans                FULL SCAN             ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k), sum(k), max(k) FROM kv
 ----
-·          distribution         local                 ·                                  ·
-·          vectorized           true                  ·                                  ·
-group      ·                    ·                     (count int, sum decimal, max int)  ·
- │         estimated row count  1 (missing stats)     ·                                  ·
- │         aggregate 0          count_rows()          ·                                  ·
- │         aggregate 1          sum(k)                ·                                  ·
- │         aggregate 2          max(k)                ·                                  ·
- │         scalar               ·                     ·                                  ·
- └── scan  ·                    ·                     (k int)                            ·
-·          estimated row count  1000 (missing stats)  ·                                  ·
-·          table                kv@primary            ·                                  ·
-·          spans                FULL SCAN             ·                                  ·
+·               distribution         local                 ·                                  ·
+·               vectorized           true                  ·                                  ·
+group (scalar)  ·                    ·                     (count int, sum decimal, max int)  ·
+ │              estimated row count  1 (missing stats)     ·                                  ·
+ │              aggregate 0          count_rows()          ·                                  ·
+ │              aggregate 1          sum(k)                ·                                  ·
+ │              aggregate 2          max(k)                ·                                  ·
+ └── scan       ·                    ·                     (k int)                            ·
+·               estimated row count  1000 (missing stats)  ·                                  ·
+·               table                kv@primary            ·                                  ·
+·               spans                FULL SCAN             ·                                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
 ----
-·          distribution         local                 ·                                   ·
-·          vectorized           true                  ·                                   ·
-group      ·                    ·                     (count, count, sum, sum, min, min)  ·
- │         estimated row count  1 (missing stats)     ·                                   ·
- │         aggregate 0          count(v)              ·                                   ·
- │         aggregate 1          count(DISTINCT v)     ·                                   ·
- │         aggregate 2          sum(v)                ·                                   ·
- │         aggregate 3          sum(DISTINCT v)       ·                                   ·
- │         aggregate 4          min(v)                ·                                   ·
- │         aggregate 5          min(v)                ·                                   ·
- │         scalar               ·                     ·                                   ·
- └── scan  ·                    ·                     (v)                                 ·
-·          estimated row count  1000 (missing stats)  ·                                   ·
-·          table                kv@primary            ·                                   ·
-·          spans                FULL SCAN             ·                                   ·
+·               distribution         local                 ·                                   ·
+·               vectorized           true                  ·                                   ·
+group (scalar)  ·                    ·                     (count, count, sum, sum, min, min)  ·
+ │              estimated row count  1 (missing stats)     ·                                   ·
+ │              aggregate 0          count(v)              ·                                   ·
+ │              aggregate 1          count(DISTINCT v)     ·                                   ·
+ │              aggregate 2          sum(v)                ·                                   ·
+ │              aggregate 3          sum(DISTINCT v)       ·                                   ·
+ │              aggregate 4          min(v)                ·                                   ·
+ │              aggregate 5          min(v)                ·                                   ·
+ └── scan       ·                    ·                     (v)                                 ·
+·               estimated row count  1000 (missing stats)  ·                                   ·
+·               table                kv@primary            ·                                   ·
+·               spans                FULL SCAN             ·                                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
 ·                                  distribution         local                         ·             ·
 ·                                  vectorized           true                          ·             ·
-group                              ·                    ·                             (count)       ·
+group (scalar)                     ·                    ·                             (count)       ·
  │                                 estimated row count  1 (missing stats)             ·             ·
  │                                 aggregate 0          count(column11)               ·             ·
- │                                 scalar               ·                             ·             ·
  └── distinct                      ·                    ·                             (column11)    ·
       │                            estimated row count  1000 (missing stats)          ·             ·
       │                            distinct on          column11                      ·             ·
@@ -346,17 +339,16 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(a) FROM abc
 ----
-·          distribution         local              ·           ·
-·          vectorized           true               ·           ·
-group      ·                    ·                  (min char)  ·
- │         estimated row count  1 (missing stats)  ·           ·
- │         aggregate 0          any_not_null(a)    ·           ·
- │         scalar               ·                  ·           ·
- └── scan  ·                    ·                  (a char)    ·
-·          estimated row count  1 (missing stats)  ·           ·
-·          table                abc@primary        ·           ·
-·          spans                LIMITED SCAN       ·           ·
-·          limit                1                  ·           ·
+·               distribution         local              ·           ·
+·               vectorized           true               ·           ·
+group (scalar)  ·                    ·                  (min char)  ·
+ │              estimated row count  1 (missing stats)  ·           ·
+ │              aggregate 0          any_not_null(a)    ·           ·
+ └── scan       ·                    ·                  (a char)    ·
+·               estimated row count  1 (missing stats)  ·           ·
+·               table                abc@primary        ·           ·
+·               spans                LIMITED SCAN       ·           ·
+·               limit                1                  ·           ·
 
 statement ok
 CREATE TABLE xyz (
@@ -376,57 +368,53 @@ INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz
 ----
-·          distribution         local              ·          ·
-·          vectorized           true               ·          ·
-group      ·                    ·                  (min int)  ·
- │         estimated row count  1 (missing stats)  ·          ·
- │         aggregate 0          any_not_null(x)    ·          ·
- │         scalar               ·                  ·          ·
- └── scan  ·                    ·                  (x int)    ·
-·          estimated row count  1 (missing stats)  ·          ·
-·          table                xyz@xy             ·          ·
-·          spans                LIMITED SCAN       ·          ·
-·          limit                1                  ·          ·
+·               distribution         local              ·          ·
+·               vectorized           true               ·          ·
+group (scalar)  ·                    ·                  (min int)  ·
+ │              estimated row count  1 (missing stats)  ·          ·
+ │              aggregate 0          any_not_null(x)    ·          ·
+ └── scan       ·                    ·                  (x int)    ·
+·               estimated row count  1 (missing stats)  ·          ·
+·               table                xyz@xy             ·          ·
+·               spans                LIMITED SCAN       ·          ·
+·               limit                1                  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-·          distribution         local              ·          ·
-·          vectorized           true               ·          ·
-group      ·                    ·                  (min int)  ·
- │         estimated row count  1 (missing stats)  ·          ·
- │         aggregate 0          any_not_null(x)    ·          ·
- │         scalar               ·                  ·          ·
- └── scan  ·                    ·                  (x int)    ·
-·          estimated row count  1 (missing stats)  ·          ·
-·          table                xyz@xy             ·          ·
-·          spans                /0-/1 /4-/5 /7-/8  ·          ·
-·          limit                1                  ·          ·
+·               distribution         local              ·          ·
+·               vectorized           true               ·          ·
+group (scalar)  ·                    ·                  (min int)  ·
+ │              estimated row count  1 (missing stats)  ·          ·
+ │              aggregate 0          any_not_null(x)    ·          ·
+ └── scan       ·                    ·                  (x int)    ·
+·               estimated row count  1 (missing stats)  ·          ·
+·               table                xyz@xy             ·          ·
+·               spans                /0-/1 /4-/5 /7-/8  ·          ·
+·               limit                1                  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz
 ----
-·             distribution         local              ·          ·
-·             vectorized           true               ·          ·
-group         ·                    ·                  (max int)  ·
- │            estimated row count  1 (missing stats)  ·          ·
- │            aggregate 0          any_not_null(x)    ·          ·
- │            scalar               ·                  ·          ·
- └── revscan  ·                    ·                  (x int)    ·
-·             estimated row count  1 (missing stats)  ·          ·
-·             table                xyz@xy             ·          ·
-·             spans                LIMITED SCAN       ·          ·
-·             limit                1                  ·          ·
+·               distribution         local              ·          ·
+·               vectorized           true               ·          ·
+group (scalar)  ·                    ·                  (max int)  ·
+ │              estimated row count  1 (missing stats)  ·          ·
+ │              aggregate 0          any_not_null(x)    ·          ·
+ └── revscan    ·                    ·                  (x int)    ·
+·               estimated row count  1 (missing stats)  ·          ·
+·               table                xyz@xy             ·          ·
+·               spans                LIMITED SCAN       ·          ·
+·               limit                1                  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
 ----
 ·               distribution         local              ·               ·
 ·               vectorized           true               ·               ·
-group           ·                    ·                  (min int)       ·
+group (scalar)  ·                    ·                  (min int)       ·
  │              estimated row count  1 (missing stats)  ·               ·
  │              aggregate 0          any_not_null(y)    ·               ·
- │              scalar               ·                  ·               ·
  └── project    ·                    ·                  (y int)         ·
       └── scan  ·                    ·                  (x int, y int)  ·
 ·               estimated row count  1 (missing stats)  ·               ·
@@ -438,10 +426,9 @@ EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
 ·               distribution         local              ·               ·
 ·               vectorized           true               ·               ·
-group           ·                    ·                  (max int)       ·
+group (scalar)  ·                    ·                  (max int)       ·
  │              estimated row count  1 (missing stats)  ·               ·
  │              aggregate 0          any_not_null(y)    ·               ·
- │              scalar               ·                  ·               ·
  └── project    ·                    ·                  (y int)         ·
       └── scan  ·                    ·                  (x int, y int)  ·
 ·               estimated row count  1 (missing stats)  ·               ·
@@ -453,10 +440,9 @@ EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE z = 7
 ----
 ·               distribution         local                        ·                 ·
 ·               vectorized           true                         ·                 ·
-group           ·                    ·                            (min int)         ·
+group (scalar)  ·                    ·                            (min int)         ·
  │              estimated row count  1 (missing stats)            ·                 ·
  │              aggregate 0          any_not_null(y)              ·                 ·
- │              scalar               ·                            ·                 ·
  └── project    ·                    ·                            (y int)           ·
       └── scan  ·                    ·                            (y int, z float)  ·
 ·               estimated row count  1 (missing stats)            ·                 ·
@@ -469,10 +455,9 @@ EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
 ----
 ·                  distribution         local                        ·                 ·
 ·                  vectorized           true                         ·                 ·
-group              ·                    ·                            (max int)         ·
+group (scalar)     ·                    ·                            (max int)         ·
  │                 estimated row count  1 (missing stats)            ·                 ·
  │                 aggregate 0          any_not_null(y)              ·                 ·
- │                 scalar               ·                            ·                 ·
  └── project       ·                    ·                            (y int)           ·
       └── revscan  ·                    ·                            (y int, z float)  ·
 ·                  estimated row count  1 (missing stats)            ·                 ·
@@ -485,10 +470,9 @@ EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 ·               distribution         local              ·                        ·
 ·               vectorized           true               ·                        ·
-group           ·                    ·                  (min int)                ·
+group (scalar)  ·                    ·                  (min int)                ·
  │              estimated row count  1 (missing stats)  ·                        ·
  │              aggregate 0          min(x)             ·                        ·
- │              scalar               ·                  ·                        ·
  └── project    ·                    ·                  (x int)                  ·
       └── scan  ·                    ·                  (x int, y int, z float)  ·
 ·               estimated row count  1 (missing stats)  ·                        ·
@@ -511,10 +495,9 @@ EXPLAIN (TYPES) SELECT max(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 ·               distribution         local              ·                        ·
 ·               vectorized           true               ·                        ·
-group           ·                    ·                  (max int)                ·
+group (scalar)  ·                    ·                  (max int)                ·
  │              estimated row count  1 (missing stats)  ·                        ·
  │              aggregate 0          max(x)             ·                        ·
- │              scalar               ·                  ·                        ·
  └── project    ·                    ·                  (x int)                  ·
       └── scan  ·                    ·                  (x int, y int, z float)  ·
 ·               estimated row count  1 (missing stats)  ·                        ·
@@ -544,16 +527,15 @@ output row: [9 4.5 6.33333333333333]
 query TTTTT
 EXPLAIN (TYPES) SELECT variance(x) FROM xyz WHERE x = 1
 ----
-·          distribution         local              ·                   ·
-·          vectorized           true               ·                   ·
-group      ·                    ·                  (variance decimal)  ·
- │         estimated row count  1 (missing stats)  ·                   ·
- │         aggregate 0          variance(x)        ·                   ·
- │         scalar               ·                  ·                   ·
- └── scan  ·                    ·                  (x int)             ·
-·          estimated row count  1 (missing stats)  ·                   ·
-·          table                xyz@xy             ·                   ·
-·          spans                /1-/2              ·                   ·
+·               distribution         local              ·                   ·
+·               vectorized           true               ·                   ·
+group (scalar)  ·                    ·                  (variance decimal)  ·
+ │              estimated row count  1 (missing stats)  ·                   ·
+ │              aggregate 0          variance(x)        ·                   ·
+ └── scan       ·                    ·                  (x int)             ·
+·               estimated row count  1 (missing stats)  ·                   ·
+·               table                xyz@xy             ·                   ·
+·               spans                /1-/2              ·                   ·
 
 ## Tests for the single-row optimization.
 statement ok
@@ -791,17 +773,16 @@ CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test
 ----
-·          distribution         local              ·          ·
-·          vectorized           true               ·          ·
-group      ·                    ·                  (min int)  ·
- │         estimated row count  1 (missing stats)  ·          ·
- │         aggregate 0          any_not_null(v)    ·          ·
- │         scalar               ·                  ·          ·
- └── scan  ·                    ·                  (v int)    ·
-·          estimated row count  1 (missing stats)  ·          ·
-·          table                opt_test@v         ·          ·
-·          spans                /!NULL-            ·          ·
-·          limit                1                  ·          ·
+·               distribution         local              ·          ·
+·               vectorized           true               ·          ·
+group (scalar)  ·                    ·                  (min int)  ·
+ │              estimated row count  1 (missing stats)  ·          ·
+ │              aggregate 0          any_not_null(v)    ·          ·
+ └── scan       ·                    ·                  (v int)    ·
+·               estimated row count  1 (missing stats)  ·          ·
+·               table                opt_test@v         ·          ·
+·               spans                /!NULL-            ·          ·
+·               limit                1                  ·          ·
 
 # Repeat test when there is an existing filter.
 # TODO(radu): the best plan for this would be to use index v; in this case the scan
@@ -811,10 +792,9 @@ EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
 ·                         distribution         local                         ·               ·
 ·                         vectorized           true                          ·               ·
-group                     ·                    ·                             (min int)       ·
+group (scalar)            ·                    ·                             (min int)       ·
  │                        estimated row count  1 (missing stats)             ·               ·
  │                        aggregate 0          any_not_null(v)               ·               ·
- │                        scalar               ·                             ·               ·
  └── project              ·                    ·                             (v int)         ·
       └── limit           ·                    ·                             (k int, v int)  ·
            │              estimated row count  1 (missing stats)             ·               ·
@@ -834,10 +814,9 @@ EXPLAIN (TYPES) SELECT min(v+1) FROM opt_test
 ----
 ·               distribution         local                       ·              ·
 ·               vectorized           true                        ·              ·
-group           ·                    ·                           (min int)      ·
+group (scalar)  ·                    ·                           (min int)      ·
  │              estimated row count  1 (missing stats)           ·              ·
  │              aggregate 0          min(column4)                ·              ·
- │              scalar               ·                           ·              ·
  └── render     ·                    ·                           (column4 int)  ·
       │         estimated row count  1000 (missing stats)        ·              ·
       │         render 0             ((v)[int] + (1)[int])[int]  ·              ·
@@ -1092,10 +1071,9 @@ EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)
 ----
 ·               distribution         local                 ·            ·
 ·               vectorized           true                  ·            ·
-group           ·                    ·                     (array_agg)  ·
+group (scalar)  ·                    ·                     (array_agg)  ·
  │              estimated row count  1 (missing stats)     ·            ·
  │              aggregate 0          array_agg(v)          ·            ·
- │              scalar               ·                     ·            ·
  └── sort       ·                    ·                     (v)          +v
       │         estimated row count  1000 (missing stats)  ·            ·
       │         order                +v                    ·            ·
@@ -1121,26 +1099,24 @@ project         ·                    ·                     (k)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-group      ·                    ·                     (concat_agg)  ·
- │         estimated row count  1 (missing stats)     ·             ·
- │         aggregate 0          concat_agg(s)         ·             ·
- │         scalar               ·                     ·             ·
- └── scan  ·                    ·                     (k, s)        +k
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                kv@primary            ·             ·
-·          spans                FULL SCAN             ·             ·
+·               distribution         local                 ·             ·
+·               vectorized           true                  ·             ·
+group (scalar)  ·                    ·                     (concat_agg)  ·
+ │              estimated row count  1 (missing stats)     ·             ·
+ │              aggregate 0          concat_agg(s)         ·             ·
+ └── scan       ·                    ·                     (k, s)        +k
+·               estimated row count  1000 (missing stats)  ·             ·
+·               table                kv@primary            ·             ·
+·               spans                FULL SCAN             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
 ·               distribution         local                 ·            ·
 ·               vectorized           true                  ·            ·
-group           ·                    ·                     (array_agg)  ·
+group (scalar)  ·                    ·                     (array_agg)  ·
  │              estimated row count  1 (missing stats)     ·            ·
  │              aggregate 0          array_agg(k)          ·            ·
- │              scalar               ·                     ·            ·
  └── sort       ·                    ·                     (k, s)       +s
       │         estimated row count  1000 (missing stats)  ·            ·
       │         order                +s                    ·            ·
@@ -1154,10 +1130,9 @@ EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 ----
 ·               distribution         local                   ·                ·
 ·               vectorized           true                    ·                ·
-group           ·                    ·                       (string_agg)     ·
+group (scalar)  ·                    ·                       (string_agg)     ·
  │              estimated row count  1 (missing stats)       ·                ·
  │              aggregate 0          string_agg(s, column6)  ·                ·
- │              scalar               ·                       ·                ·
  └── render     ·                    ·                       (column6, k, s)  +k
       │         estimated row count  1000 (missing stats)    ·                ·
       │         render 0             ','                     ·                ·
@@ -1174,10 +1149,9 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM xyz JOIN kv ON y=v
 ----
 ·                            distribution         local                 ·        ·
 ·                            vectorized           true                  ·        ·
-group                        ·                    ·                     (count)  ·
+group (scalar)               ·                    ·                     (count)  ·
  │                           estimated row count  1 (missing stats)     ·        ·
  │                           aggregate 0          count_rows()          ·        ·
- │                           scalar               ·                     ·        ·
  └── project                 ·                    ·                     ()       ·
       └── hash join (inner)  ·                    ·                     (y, v)   ·
            │                 estimated row count  9801 (missing stats)  ·        ·
@@ -1217,10 +1191,9 @@ EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
 ----
 ·               distribution         local                   ·             ·
 ·               vectorized           true                    ·             ·
-group           ·                    ·                       (string_agg)  ·
+group (scalar)  ·                    ·                       (string_agg)  ·
  │              estimated row count  1 (missing stats)       ·             ·
  │              aggregate 0          string_agg(s, column6)  ·             ·
- │              scalar               ·                       ·             ·
  └── render     ·                    ·                       (column6, s)  ·
       │         estimated row count  1000 (missing stats)    ·             ·
       │         render 0             ', '                    ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -215,79 +215,76 @@ group      ·                    ·                     (count, count, sum, sum,
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-·                          distribution         local                         ·             ·
-·                          vectorized           true                          ·             ·
-group                      ·                    ·                             (count)       ·
- │                         estimated row count  1 (missing stats)             ·             ·
- │                         aggregate 0          count(column11)               ·             ·
- │                         scalar               ·                             ·             ·
- └── distinct              ·                    ·                             (column11)    ·
-      │                    estimated row count  1000 (missing stats)          ·             ·
-      │                    distinct on          column11                      ·             ·
-      └── render           ·                    ·                             (column11)    ·
-           │               estimated row count  1000000 (missing stats)       ·             ·
-           │               render 0             ((k, v, w, s) AS k, v, w, s)  ·             ·
-           └── cross join  ·                    ·                             (k, v, w, s)  ·
-                │          estimated row count  1000000 (missing stats)       ·             ·
-                │          type                 cross                         ·             ·
-                ├── scan   ·                    ·                             (k, v, w, s)  ·
-                │          estimated row count  1000 (missing stats)          ·             ·
-                │          table                kv@primary                    ·             ·
-                │          spans                FULL SCAN                     ·             ·
-                └── scan   ·                    ·                             ()            ·
-·                          estimated row count  1000 (missing stats)          ·             ·
-·                          table                kv@primary                    ·             ·
-·                          spans                FULL SCAN                     ·             ·
+·                                  distribution         local                         ·             ·
+·                                  vectorized           true                          ·             ·
+group                              ·                    ·                             (count)       ·
+ │                                 estimated row count  1 (missing stats)             ·             ·
+ │                                 aggregate 0          count(column11)               ·             ·
+ │                                 scalar               ·                             ·             ·
+ └── distinct                      ·                    ·                             (column11)    ·
+      │                            estimated row count  1000 (missing stats)          ·             ·
+      │                            distinct on          column11                      ·             ·
+      └── render                   ·                    ·                             (column11)    ·
+           │                       estimated row count  1000000 (missing stats)       ·             ·
+           │                       render 0             ((k, v, w, s) AS k, v, w, s)  ·             ·
+           └── cross join (inner)  ·                    ·                             (k, v, w, s)  ·
+                │                  estimated row count  1000000 (missing stats)       ·             ·
+                ├── scan           ·                    ·                             (k, v, w, s)  ·
+                │                  estimated row count  1000 (missing stats)          ·             ·
+                │                  table                kv@primary                    ·             ·
+                │                  spans                FULL SCAN                     ·             ·
+                └── scan           ·                    ·                             ()            ·
+·                                  estimated row count  1000 (missing stats)          ·             ·
+·                                  table                kv@primary                    ·             ·
+·                                  spans                FULL SCAN                     ·             ·
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
 ]
 ----
-·                     distribution         local
-·                     vectorized           true
-project               ·                    ·
- │                    estimated row count  1000 (missing stats)
- └── group            ·                    ·
-      │               estimated row count  1000 (missing stats)
-      │               aggregate 0          min(k)
-      │               group by             k
-      └── cross join  ·                    ·
-           │          estimated row count  1000000 (missing stats)
-           │          type                 cross
-           ├── scan   ·                    ·
-           │          estimated row count  1000 (missing stats)
-           │          table                kv@primary
-           │          spans                FULL SCAN
-           └── scan   ·                    ·
-·                     estimated row count  1000 (missing stats)
-·                     table                kv@primary
-·                     spans                FULL SCAN
+·                             distribution         local
+·                             vectorized           true
+project                       ·                    ·
+ │                            estimated row count  1000 (missing stats)
+ └── group                    ·                    ·
+      │                       estimated row count  1000 (missing stats)
+      │                       aggregate 0          min(k)
+      │                       group by             k
+      └── cross join (inner)  ·                    ·
+           │                  estimated row count  1000000 (missing stats)
+           ├── scan           ·                    ·
+           │                  estimated row count  1000 (missing stats)
+           │                  table                kv@primary
+           │                  spans                FULL SCAN
+           └── scan           ·                    ·
+·                             estimated row count  1000 (missing stats)
+·                             table                kv@primary
+·                             spans                FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
 ]
 ----
-·                     distribution         local
-·                     vectorized           true
-project               ·                    ·
- │                    estimated row count  1000 (missing stats)
- └── group            ·                    ·
-      │               estimated row count  1000 (missing stats)
-      │               aggregate 0          min(k)
-      │               group by             k
-      └── cross join  ·                    ·
-           │          estimated row count  1000000 (missing stats)
-           │          type                 cross
-           ├── scan   ·                    ·
-           │          estimated row count  1000 (missing stats)
-           │          table                kv@primary
-           │          spans                FULL SCAN
-           └── scan   ·                    ·
-·                     estimated row count  1000 (missing stats)
-·                     table                kv@primary
-·                     spans                FULL SCAN
+·                             distribution         local
+·                             vectorized           true
+project                       ·                    ·
+ │                            estimated row count  1000 (missing stats)
+ └── group                    ·                    ·
+      │                       estimated row count  1000 (missing stats)
+      │                       aggregate 0          min(k)
+      │                       group by             k
+      └── cross join (inner)  ·                    ·
+           │                  estimated row count  1000000 (missing stats)
+           ├── scan           ·                    ·
+           │                  estimated row count  1000 (missing stats)
+           │                  table                kv@primary
+           │                  spans                FULL SCAN
+           └── scan           ·                    ·
+·                             estimated row count  1000 (missing stats)
+·                             table                kv@primary
+·                             spans                FULL SCAN
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
 query TTT
@@ -295,25 +292,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
 ]
 ----
-·                     distribution         local
-·                     vectorized           true
-project               ·                    ·
- │                    estimated row count  1000 (missing stats)
- └── group            ·                    ·
-      │               estimated row count  1000 (missing stats)
-      │               aggregate 0          min(k)
-      │               group by             k
-      └── cross join  ·                    ·
-           │          estimated row count  1000000 (missing stats)
-           │          type                 cross
-           ├── scan   ·                    ·
-           │          estimated row count  1000 (missing stats)
-           │          table                kv@primary
-           │          spans                FULL SCAN
-           └── scan   ·                    ·
-·                     estimated row count  1000 (missing stats)
-·                     table                kv@primary
-·                     spans                FULL SCAN
+·                             distribution         local
+·                             vectorized           true
+project                       ·                    ·
+ │                            estimated row count  1000 (missing stats)
+ └── group                    ·                    ·
+      │                       estimated row count  1000 (missing stats)
+      │                       aggregate 0          min(k)
+      │                       group by             k
+      └── cross join (inner)  ·                    ·
+           │                  estimated row count  1000000 (missing stats)
+           ├── scan           ·                    ·
+           │                  estimated row count  1000 (missing stats)
+           │                  table                kv@primary
+           │                  spans                FULL SCAN
+           └── scan           ·                    ·
+·                             estimated row count  1000 (missing stats)
+·                             table                kv@primary
+·                             spans                FULL SCAN
 
 # Show reuse of renders expression inside an expansion.
 query TTT
@@ -321,24 +317,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT a.v FROM kv a, kv b GROUP BY a.v, a.w, a.s
 ]
 ----
-·                     distribution         local
-·                     vectorized           true
-project               ·                    ·
- │                    estimated row count  1000 (missing stats)
- └── distinct         ·                    ·
-      │               estimated row count  1000 (missing stats)
-      │               distinct on          v, w, s
-      └── cross join  ·                    ·
-           │          estimated row count  1000000 (missing stats)
-           │          type                 cross
-           ├── scan   ·                    ·
-           │          estimated row count  1000 (missing stats)
-           │          table                kv@primary
-           │          spans                FULL SCAN
-           └── scan   ·                    ·
-·                     estimated row count  1000 (missing stats)
-·                     table                kv@primary
-·                     spans                FULL SCAN
+·                             distribution         local
+·                             vectorized           true
+project                       ·                    ·
+ │                            estimated row count  1000 (missing stats)
+ └── distinct                 ·                    ·
+      │                       estimated row count  1000 (missing stats)
+      │                       distinct on          v, w, s
+      └── cross join (inner)  ·                    ·
+           │                  estimated row count  1000000 (missing stats)
+           ├── scan           ·                    ·
+           │                  estimated row count  1000 (missing stats)
+           │                  table                kv@primary
+           │                  spans                FULL SCAN
+           └── scan           ·                    ·
+·                             estimated row count  1000 (missing stats)
+·                             table                kv@primary
+·                             spans                FULL SCAN
 
 statement ok
 CREATE TABLE abc (
@@ -768,26 +763,25 @@ render     ·                    ·                     (a int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-·                     distribution         local                             ·                     ·
-·                     vectorized           true                              ·                     ·
-project               ·                    ·                                 (sum decimal)         ·
- │                    estimated row count  1000 (missing stats)              ·                     ·
- └── group            ·                    ·                                 (k int, sum decimal)  ·
-      │               estimated row count  1000 (missing stats)              ·                     ·
-      │               aggregate 0          sum(d)                            ·                     ·
-      │               group by             k                                 ·                     ·
-      └── cross join  ·                    ·                                 (k int, d decimal)    ·
-           │          estimated row count  330000 (missing stats)            ·                     ·
-           │          type                 cross                             ·                     ·
-           │          pred                 ((k)[int] >= (d)[decimal])[bool]  ·                     ·
-           ├── scan   ·                    ·                                 (k int)               ·
-           │          estimated row count  1000 (missing stats)              ·                     ·
-           │          table                kv@primary                        ·                     ·
-           │          spans                FULL SCAN                         ·                     ·
-           └── scan   ·                    ·                                 (d decimal)           ·
-·                     estimated row count  1000 (missing stats)              ·                     ·
-·                     table                abc@primary                       ·                     ·
-·                     spans                FULL SCAN                         ·                     ·
+·                             distribution         local                             ·                     ·
+·                             vectorized           true                              ·                     ·
+project                       ·                    ·                                 (sum decimal)         ·
+ │                            estimated row count  1000 (missing stats)              ·                     ·
+ └── group                    ·                    ·                                 (k int, sum decimal)  ·
+      │                       estimated row count  1000 (missing stats)              ·                     ·
+      │                       aggregate 0          sum(d)                            ·                     ·
+      │                       group by             k                                 ·                     ·
+      └── cross join (inner)  ·                    ·                                 (k int, d decimal)    ·
+           │                  estimated row count  330000 (missing stats)            ·                     ·
+           │                  pred                 ((k)[int] >= (d)[decimal])[bool]  ·                     ·
+           ├── scan           ·                    ·                                 (k int)               ·
+           │                  estimated row count  1000 (missing stats)              ·                     ·
+           │                  table                kv@primary                        ·                     ·
+           │                  spans                FULL SCAN                         ·                     ·
+           └── scan           ·                    ·                                 (d decimal)           ·
+·                             estimated row count  1000 (missing stats)              ·                     ·
+·                             table                abc@primary                       ·                     ·
+·                             spans                FULL SCAN                         ·                     ·
 
 # opt_test is used for tests around the single-row optimization for MIN/MAX.
 statement ok
@@ -889,28 +883,27 @@ render     ·                    ·                                        (r tu
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y), (b, a) r FROM ab, xy GROUP BY (x, (a, b))
 ----
-·                     distribution         local                                               ·                                                ·
-·                     vectorized           true                                                ·                                                ·
-render                ·                    ·                                                   (min string, r tuple{int, int})                  ·
- │                    estimated row count  100000 (missing stats)                              ·                                                ·
- │                    render 0             (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
- │                    render 1             (min)[string]                                       ·                                                ·
- └── group            ·                    ·                                                   (a int, x string, min string, any_not_null int)  ·
-      │               estimated row count  100000 (missing stats)                              ·                                                ·
-      │               aggregate 0          min(y)                                              ·                                                ·
-      │               aggregate 1          any_not_null(b)                                     ·                                                ·
-      │               group by             a, x                                                ·                                                ·
-      └── cross join  ·                    ·                                                   (a int, b int, x string, y string)               ·
-           │          estimated row count  1000000 (missing stats)                             ·                                                ·
-           │          type                 cross                                               ·                                                ·
-           ├── scan   ·                    ·                                                   (a int, b int)                                   ·
-           │          estimated row count  1000 (missing stats)                                ·                                                ·
-           │          table                ab@primary                                          ·                                                ·
-           │          spans                FULL SCAN                                           ·                                                ·
-           └── scan   ·                    ·                                                   (x string, y string)                             ·
-·                     estimated row count  1000 (missing stats)                                ·                                                ·
-·                     table                xy@primary                                          ·                                                ·
-·                     spans                FULL SCAN                                           ·                                                ·
+·                             distribution         local                                               ·                                                ·
+·                             vectorized           true                                                ·                                                ·
+render                        ·                    ·                                                   (min string, r tuple{int, int})                  ·
+ │                            estimated row count  100000 (missing stats)                              ·                                                ·
+ │                            render 0             (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
+ │                            render 1             (min)[string]                                       ·                                                ·
+ └── group                    ·                    ·                                                   (a int, x string, min string, any_not_null int)  ·
+      │                       estimated row count  100000 (missing stats)                              ·                                                ·
+      │                       aggregate 0          min(y)                                              ·                                                ·
+      │                       aggregate 1          any_not_null(b)                                     ·                                                ·
+      │                       group by             a, x                                                ·                                                ·
+      └── cross join (inner)  ·                    ·                                                   (a int, b int, x string, y string)               ·
+           │                  estimated row count  1000000 (missing stats)                             ·                                                ·
+           ├── scan           ·                    ·                                                   (a int, b int)                                   ·
+           │                  estimated row count  1000 (missing stats)                                ·                                                ·
+           │                  table                ab@primary                                          ·                                                ·
+           │                  spans                FULL SCAN                                           ·                                                ·
+           └── scan           ·                    ·                                                   (x string, y string)                             ·
+·                             estimated row count  1000 (missing stats)                                ·                                                ·
+·                             table                xy@primary                                          ·                                                ·
+·                             spans                FULL SCAN                                           ·                                                ·
 
 # Test that ordering on GROUP BY columns is maintained.
 # TODO(radu): Derive GROUP BY ordering in physicalPropsBuilder.
@@ -1179,25 +1172,24 @@ group           ·                    ·                       (string_agg)     
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM xyz JOIN kv ON y=v
 ----
-·                    distribution         local                 ·        ·
-·                    vectorized           true                  ·        ·
-group                ·                    ·                     (count)  ·
- │                   estimated row count  1 (missing stats)     ·        ·
- │                   aggregate 0          count_rows()          ·        ·
- │                   scalar               ·                     ·        ·
- └── project         ·                    ·                     ()       ·
-      └── hash join  ·                    ·                     (y, v)   ·
-           │         estimated row count  9801 (missing stats)  ·        ·
-           │         type                 inner                 ·        ·
-           │         equality             (y) = (v)             ·        ·
-           ├── scan  ·                    ·                     (y)      ·
-           │         estimated row count  1000 (missing stats)  ·        ·
-           │         table                xyz@xy                ·        ·
-           │         spans                FULL SCAN             ·        ·
-           └── scan  ·                    ·                     (v)      ·
-·                    estimated row count  1000 (missing stats)  ·        ·
-·                    table                kv@primary            ·        ·
-·                    spans                FULL SCAN             ·        ·
+·                            distribution         local                 ·        ·
+·                            vectorized           true                  ·        ·
+group                        ·                    ·                     (count)  ·
+ │                           estimated row count  1 (missing stats)     ·        ·
+ │                           aggregate 0          count_rows()          ·        ·
+ │                           scalar               ·                     ·        ·
+ └── project                 ·                    ·                     ()       ·
+      └── hash join (inner)  ·                    ·                     (y, v)   ·
+           │                 estimated row count  9801 (missing stats)  ·        ·
+           │                 equality             (y) = (v)             ·        ·
+           ├── scan          ·                    ·                     (y)      ·
+           │                 estimated row count  1000 (missing stats)  ·        ·
+           │                 table                xyz@xy                ·        ·
+           │                 spans                FULL SCAN             ·        ·
+           └── scan          ·                    ·                     (v)      ·
+·                            estimated row count  1000 (missing stats)  ·        ·
+·                            table                kv@primary            ·        ·
+·                            spans                FULL SCAN             ·        ·
 
 
 # Regression test for #31882: make sure we don't incorrectly advertise an

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -383,7 +383,6 @@ root                             ·                   ·
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
-                │                type                inner
                 │                equality            (id) = (pid)
                 │                left cols are key   ·
                 │                right cols are key  ·
@@ -432,7 +431,6 @@ root                             ·                   ·
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
-                │                type                inner
                 │                equality            (id) = (pid)
                 │                left cols are key   ·
                 │                right cols are key  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -26,7 +26,7 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 ·          distribution   full
 ·          vectorized     true
-append     ·              ·
+union all  ·              ·
  ├── scan  ·              ·
  │         missing stats  ·
  │         table          uniontest@primary
@@ -59,7 +59,7 @@ EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc OR
 sort                 ·                    ·                     (a)     +a
  │                   estimated row count  100 (missing stats)   ·       ·
  │                   order                +a                    ·       ·
- └── union           ·                    ·                     (a)     ·
+ └── intersect       ·                    ·                     (a)     ·
       │              estimated row count  100 (missing stats)   ·       ·
       ├── project    ·                    ·                     (a)     ·
       │    └── scan  ·                    ·                     (a, b)  ·
@@ -79,7 +79,7 @@ EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''
 ·                      distribution         full             ·                         ·
 ·                      vectorized           true             ·                         ·
 project                ·                    ·                (a)                       ·
- └── union             ·                    ·                (a, a)                    ·
+ └── except all        ·                    ·                (a, a)                    ·
       │                estimated row count  1                ·                         ·
       ├── project      ·                    ·                (a, a)                    ·
       │    └── values  ·                    ·                (a)                       ·
@@ -101,7 +101,7 @@ render                 ·                    ·                 ("?column?", "?c
  │                     render 0             "?column?"        ·                                     ·
  │                     render 1             "?column?"        ·                                     ·
  │                     render 2             "?column?"        ·                                     ·
- └── union             ·                    ·                 ("?column?", "?column?", "?column?")  ·
+ └── except            ·                    ·                 ("?column?", "?column?", "?column?")  ·
       │                estimated row count  1                 ·                                     ·
       ├── project      ·                    ·                 ("?column?", "?column?", "?column?")  ·
       │    └── values  ·                    ·                 ("?column?", "?column?")              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -273,31 +273,29 @@ distinct        ·                    ·                     (y, z, x)  +x
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
-·          distribution         local                 ·      ·
-·          vectorized           true                  ·      ·
-group      ·                    ·                     (max)  ·
- │         estimated row count  1 (missing stats)     ·      ·
- │         aggregate 0          max(x)                ·      ·
- │         scalar               ·                     ·      ·
- └── scan  ·                    ·                     (x)    ·
-·          estimated row count  1000 (missing stats)  ·      ·
-·          table                xyz@primary           ·      ·
-·          spans                FULL SCAN             ·      ·
+·               distribution         local                 ·      ·
+·               vectorized           true                  ·      ·
+group (scalar)  ·                    ·                     (max)  ·
+ │              estimated row count  1 (missing stats)     ·      ·
+ │              aggregate 0          max(x)                ·      ·
+ └── scan       ·                    ·                     (x)    ·
+·               estimated row count  1000 (missing stats)  ·      ·
+·               table                xyz@primary           ·      ·
+·               spans                FULL SCAN             ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
-·             distribution         local              ·      ·
-·             vectorized           true               ·      ·
-group         ·                    ·                  (max)  ·
- │            estimated row count  1 (missing stats)  ·      ·
- │            aggregate 0          any_not_null(a)    ·      ·
- │            scalar               ·                  ·      ·
- └── revscan  ·                    ·                  (a)    ·
-·             estimated row count  1 (missing stats)  ·      ·
-·             table                abc@primary        ·      ·
-·             spans                LIMITED SCAN       ·      ·
-·             limit                1                  ·      ·
+·               distribution         local              ·      ·
+·               vectorized           true               ·      ·
+group (scalar)  ·                    ·                  (max)  ·
+ │              estimated row count  1 (missing stats)  ·      ·
+ │              aggregate 0          any_not_null(a)    ·      ·
+ └── revscan    ·                    ·                  (a)    ·
+·               estimated row count  1 (missing stats)  ·      ·
+·               table                abc@primary        ·      ·
+·               spans                LIMITED SCAN       ·      ·
+·               limit                1                  ·      ·
 
 #################
 # With GROUP BY #
@@ -500,10 +498,9 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHE
 ----
 ·                              distribution         local                 ·        ·
 ·                              vectorized           true                  ·        ·
-group                          ·                    ·                     (count)  ·
+group (scalar)                 ·                    ·                     (count)  ·
  │                             estimated row count  1 (missing stats)     ·        ·
  │                             aggregate 0          count_rows()          ·        ·
- │                             scalar               ·                     ·        ·
  └── project                   ·                    ·                     ()       ·
       └── limit                ·                    ·                     (x, y)   ·
            │                   estimated row count  1 (missing stats)     ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -198,7 +198,6 @@ merge join  ·                  ·
  │          type               inner
  │          equality           (pid1) = (pid1)
  │          left cols are key  ·
- │          mergeJoinOrder     +"(pid1=pid1)"
  ├── scan   ·                  ·
  │          missing stats      ·
  │          table              parent1@primary
@@ -900,7 +899,7 @@ merge join      ·                    ·                        (pid1, v, pid1, 
  │              type                 inner                    ·                               ·
  │              equality             (pid1, v) = (pid1, v)    ·                               ·
  │              left cols are key    ·                        ·                               ·
- │              mergeJoinOrder       +"(pid1=pid1)",+"(v=v)"  ·                               ·
+ │              merge ordering       +"(pid1=pid1)",+"(v=v)"  ·                               ·
  ├── filter     ·                    ·                        (pid1, v)                       +pid1
  │    │         estimated row count  10 (missing stats)       ·                               ·
  │    │         filter               v = 1                    ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -195,7 +195,6 @@ EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ·           distribution       full
 ·           vectorized         true
 merge join  ·                  ·
- │          type               inner
  │          equality           (pid1) = (pid1)
  │          left cols are key  ·
  ├── scan   ·                  ·
@@ -216,7 +215,6 @@ EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ·                 distribution  full
 ·                 vectorized    true
 interleaved join  ·             ·
-·                 type          inner
 ·                 left table    parent1@primary
 ·                 left spans    FULL SCAN
 ·                 right table   child1@primary
@@ -231,18 +229,17 @@ interleaved join  ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
-·                      distribution         full                 ·                             ·
-·                      vectorized           true                 ·                             ·
-project                ·                    ·                    (pid1, pa1, cid1, ca1)        ·
- │                     estimated row count  30 (missing stats)   ·                             ·
- └── interleaved join  ·                    ·                    (pid1, pa1, pid1, cid1, ca1)  ·
-·                      estimated row count  30 (missing stats)   ·                             ·
-·                      type                 inner                ·                             ·
-·                      left table           parent1@primary      ·                             ·
-·                      left spans           /3-/5/#              ·                             ·
-·                      right table          child1@primary       ·                             ·
-·                      right spans          /3/#/55/1-/5/#/55/2  ·                             ·
-·                      ancestor             left                 ·                             ·
+·                              distribution         full                 ·                             ·
+·                              vectorized           true                 ·                             ·
+project                        ·                    ·                    (pid1, pa1, cid1, ca1)        ·
+ │                             estimated row count  30 (missing stats)   ·                             ·
+ └── interleaved join (inner)  ·                    ·                    (pid1, pa1, pid1, cid1, ca1)  ·
+·                              estimated row count  30 (missing stats)   ·                             ·
+·                              left table           parent1@primary      ·                             ·
+·                              left spans           /3-/5/#              ·                             ·
+·                              right table          child1@primary       ·                             ·
+·                              right spans          /3/#/55/1-/5/#/55/2  ·                             ·
+·                              ancestor             left                 ·                             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
@@ -253,18 +250,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMUsFu00AQvfMVq3eKYVC9Dr
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
-·                      distribution         full                 ·                             ·
-·                      vectorized           true                 ·                             ·
-project                ·                    ·                    (pid1, cid1, ca1, pa1)        ·
- │                     estimated row count  30 (missing stats)   ·                             ·
- └── interleaved join  ·                    ·                    (pid1, cid1, ca1, pid1, pa1)  ·
-·                      estimated row count  30 (missing stats)   ·                             ·
-·                      type                 inner                ·                             ·
-·                      left table           child1@primary       ·                             ·
-·                      left spans           /3/#/55/1-/5/#/55/2  ·                             ·
-·                      right table          parent1@primary      ·                             ·
-·                      right spans          /3-/5/#              ·                             ·
-·                      ancestor             right                ·                             ·
+·                              distribution         full                 ·                             ·
+·                              vectorized           true                 ·                             ·
+project                        ·                    ·                    (pid1, cid1, ca1, pa1)        ·
+ │                             estimated row count  30 (missing stats)   ·                             ·
+ └── interleaved join (inner)  ·                    ·                    (pid1, cid1, ca1, pid1, pa1)  ·
+·                              estimated row count  30 (missing stats)   ·                             ·
+·                              left table           child1@primary       ·                             ·
+·                              left spans           /3/#/55/1-/5/#/55/2  ·                             ·
+·                              right table          parent1@primary      ·                             ·
+·                              right spans          /3-/5/#              ·                             ·
+·                              ancestor             right                ·                             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
@@ -277,16 +273,15 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMUtFulEAUffcrJuep6DVlIH
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1
 ----
-·                 distribution         full                   ·                             ·
-·                 vectorized           true                   ·                             ·
-interleaved join  ·                    ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
-·                 estimated row count  30 (missing stats)     ·                             ·
-·                 type                 inner                  ·                             ·
-·                 left table           parent1@primary        ·                             ·
-·                 left spans           /29-/31/#              ·                             ·
-·                 right table          child1@primary         ·                             ·
-·                 right spans          /29/#/55/1-/31/#/55/2  ·                             ·
-·                 ancestor             left                   ·                             ·
+·                         distribution         full                   ·                             ·
+·                         vectorized           true                   ·                             ·
+interleaved join (inner)  ·                    ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
+·                         estimated row count  30 (missing stats)     ·                             ·
+·                         left table           parent1@primary        ·                             ·
+·                         left spans           /29-/31/#              ·                             ·
+·                         right table          child1@primary         ·                             ·
+·                         right spans          /29/#/55/1-/31/#/55/2  ·                             ·
+·                         ancestor             left                   ·                             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
@@ -303,18 +298,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUUdFu0zAUfecrru5TywyLU_
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1
 ----
-·                      distribution         full                 ·                                   ·
-·                      vectorized           true                 ·                                   ·
-project                ·                    ·                    (pid1, pa1, cid2, cid3, ca2)        +pid1
- │                     estimated row count  333 (missing stats)  ·                                   ·
- └── interleaved join  ·                    ·                    (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
-·                      estimated row count  333 (missing stats)  ·                                   ·
-·                      type                 inner                ·                                   ·
-·                      left table           parent1@primary      ·                                   ·
-·                      left spans           /12-                 ·                                   ·
-·                      right table          child2@primary       ·                                   ·
-·                      right spans          /12/#/56/1-          ·                                   ·
-·                      ancestor             left                 ·                                   ·
+·                              distribution         full                 ·                                   ·
+·                              vectorized           true                 ·                                   ·
+project                        ·                    ·                    (pid1, pa1, cid2, cid3, ca2)        +pid1
+ │                             estimated row count  333 (missing stats)  ·                                   ·
+ └── interleaved join (inner)  ·                    ·                    (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+·                              estimated row count  333 (missing stats)  ·                                   ·
+·                              left table           parent1@primary      ·                                   ·
+·                              left spans           /12-                 ·                                   ·
+·                              right table          child2@primary       ·                                   ·
+·                              right spans          /12/#/56/1-          ·                                   ·
+·                              ancestor             left                 ·                                   ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
@@ -325,18 +319,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlMFvlEAYxe_-FZN32rWfKc
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1
 ----
-·                      distribution         full                                                                                   ·                                   ·
-·                      vectorized           true                                                                                   ·                                   ·
-project                ·                    ·                                                                                      (pid1, pa1, cid2, cid3, ca2)        +pid1
- │                     estimated row count  40 (missing stats)                                                                     ·                                   ·
- └── interleaved join  ·                    ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
-·                      estimated row count  40 (missing stats)                                                                     ·                                   ·
-·                      type                 inner                                                                                  ·                                   ·
-·                      left table           parent1@primary                                                                        ·                                   ·
-·                      left spans           /1-/1/# /11-/11/# /21-/21/# /31-/31/#                                                  ·                                   ·
-·                      right table          child2@primary                                                                         ·                                   ·
-·                      right spans          /1/#/56/1-/1/#/56/2 /11/#/56/1-/11/#/56/2 /21/#/56/1-/21/#/56/2 /31/#/56/1-/31/#/56/2  ·                                   ·
-·                      ancestor             left                                                                                   ·                                   ·
+·                              distribution         full                                                                                   ·                                   ·
+·                              vectorized           true                                                                                   ·                                   ·
+project                        ·                    ·                                                                                      (pid1, pa1, cid2, cid3, ca2)        +pid1
+ │                             estimated row count  40 (missing stats)                                                                     ·                                   ·
+ └── interleaved join (inner)  ·                    ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+·                              estimated row count  40 (missing stats)                                                                     ·                                   ·
+·                              left table           parent1@primary                                                                        ·                                   ·
+·                              left spans           /1-/1/# /11-/11/# /21-/21/# /31-/31/#                                                  ·                                   ·
+·                              right table          child2@primary                                                                         ·                                   ·
+·                              right spans          /1/#/56/1-/1/#/56/2 /11/#/56/1-/11/#/56/2 /21/#/56/1-/21/#/56/2 /31/#/56/1-/31/#/56/2  ·                                   ·
+·                              ancestor             left                                                                                   ·                                   ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
@@ -353,19 +346,18 @@ EXPLAIN (VERBOSE)
     OR pid1 >= 31 AND pid1 <= 33
     OR pa1 > 0
 ----
-·                      distribution         full                                                                                                                    ·                                           ·
-·                      vectorized           true                                                                                                                    ·                                           ·
-project                ·                    ·                                                                                                                       (pid1, pa1, cid2, cid3, gcid2, gca2)        ·
- │                     estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
- └── interleaved join  ·                    ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
-·                      estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-·                      type                 inner                                                                                                                   ·                                           ·
-·                      left table           parent1@primary                                                                                                         ·                                           ·
-·                      left spans           FULL SCAN                                                                                                               ·                                           ·
-·                      left filter          ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
-·                      right table          grandchild2@primary                                                                                                     ·                                           ·
-·                      right spans          FULL SCAN                                                                                                               ·                                           ·
-·                      ancestor             left                                                                                                                    ·                                           ·
+·                              distribution         full                                                                                                                    ·                                           ·
+·                              vectorized           true                                                                                                                    ·                                           ·
+project                        ·                    ·                                                                                                                       (pid1, pa1, cid2, cid3, gcid2, gca2)        ·
+ │                             estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
+ └── interleaved join (inner)  ·                    ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
+·                              estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
+·                              left table           parent1@primary                                                                                                         ·                                           ·
+·                              left spans           FULL SCAN                                                                                                               ·                                           ·
+·                              left filter          ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
+·                              right table          grandchild2@primary                                                                                                     ·                                           ·
+·                              right spans          FULL SCAN                                                                                                               ·                                           ·
+·                              ancestor             left                                                                                                                    ·                                           ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -386,19 +378,18 @@ EXPLAIN (VERBOSE)
     OR pid1 >= 31 AND pid1 <= 33
     OR pa1 > 0
 ----
-·                      distribution         full                                                                                                                    ·                                           ·
-·                      vectorized           true                                                                                                                    ·                                           ·
-project                ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pa1)        ·
- │                     estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
- └── interleaved join  ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
-·                      estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-·                      type                 inner                                                                                                                   ·                                           ·
-·                      left table           grandchild2@primary                                                                                                     ·                                           ·
-·                      left spans           FULL SCAN                                                                                                               ·                                           ·
-·                      right table          parent1@primary                                                                                                         ·                                           ·
-·                      right spans          FULL SCAN                                                                                                               ·                                           ·
-·                      right filter         ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
-·                      ancestor             right                                                                                                                   ·                                           ·
+·                              distribution         full                                                                                                                    ·                                           ·
+·                              vectorized           true                                                                                                                    ·                                           ·
+project                        ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pa1)        ·
+ │                             estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
+ └── interleaved join (inner)  ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
+·                              estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
+·                              left table           grandchild2@primary                                                                                                     ·                                           ·
+·                              left spans           FULL SCAN                                                                                                               ·                                           ·
+·                              right table          parent1@primary                                                                                                         ·                                           ·
+·                              right spans          FULL SCAN                                                                                                               ·                                           ·
+·                              right filter         ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
+·                              ancestor             right                                                                                                                   ·                                           ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -421,7 +412,6 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
 ·                 distribution  full
 ·                 vectorized    true
 interleaved join  ·             ·
-·                 type          inner
 ·                 left table    grandchild2@primary
 ·                 left spans    FULL SCAN
 ·                 right table   parent1@primary
@@ -460,7 +450,6 @@ EXPLAIN
 ·                 distribution  full
 ·                 vectorized    true
 interleaved join  ·             ·
-·                 type          inner
 ·                 left table    child2@primary
 ·                 left spans    FULL SCAN
 ·                 right table   grandchild2@primary
@@ -549,23 +538,22 @@ NULL       /0       {5}       5
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)
 ----
-·                      distribution         full                  ·                                   ·
-·                      vectorized           true                  ·                                   ·
-render                 ·                    ·                     (pid1, pa1, cid1, cid2, ca1)        ·
- │                     estimated row count  1000 (missing stats)  ·                                   ·
- │                     render 0             COALESCE(pid1, pid1)  ·                                   ·
- │                     render 1             pa1                   ·                                   ·
- │                     render 2             cid1                  ·                                   ·
- │                     render 3             cid2                  ·                                   ·
- │                     render 4             ca1                   ·                                   ·
- └── interleaved join  ·                    ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
-·                      estimated row count  1000 (missing stats)  ·                                   ·
-·                      type                 full outer            ·                                   ·
-·                      left table           outer_p1@primary      ·                                   ·
-·                      left spans           FULL SCAN             ·                                   ·
-·                      right table          outer_c1@primary      ·                                   ·
-·                      right spans          FULL SCAN             ·                                   ·
-·                      ancestor             left                  ·                                   ·
+·                                   distribution         full                  ·                                   ·
+·                                   vectorized           true                  ·                                   ·
+render                              ·                    ·                     (pid1, pa1, cid1, cid2, ca1)        ·
+ │                                  estimated row count  1000 (missing stats)  ·                                   ·
+ │                                  render 0             COALESCE(pid1, pid1)  ·                                   ·
+ │                                  render 1             pa1                   ·                                   ·
+ │                                  render 2             cid1                  ·                                   ·
+ │                                  render 3             cid2                  ·                                   ·
+ │                                  render 4             ca1                   ·                                   ·
+ └── interleaved join (full outer)  ·                    ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
+·                                   estimated row count  1000 (missing stats)  ·                                   ·
+·                                   left table           outer_p1@primary      ·                                   ·
+·                                   left spans           FULL SCAN             ·                                   ·
+·                                   right table          outer_c1@primary      ·                                   ·
+·                                   right spans          FULL SCAN             ·                                   ·
+·                                   ancestor             left                  ·                                   ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
@@ -575,24 +563,23 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzclM9q20AQxu99imVOdjslXk
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)
 ----
-·                      distribution         full                  ·                                                       ·
-·                      vectorized           true                  ·                                                       ·
-render                 ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, ca1)                    ·
- │                     estimated row count  1999 (missing stats)  ·                                                       ·
- │                     render 0             COALESCE(pid1, pid1)  ·                                                       ·
- │                     render 1             COALESCE(cid1, cid1)  ·                                                       ·
- │                     render 2             COALESCE(cid2, cid2)  ·                                                       ·
- │                     render 3             gcid1                 ·                                                       ·
- │                     render 4             gca1                  ·                                                       ·
- │                     render 5             ca1                   ·                                                       ·
- └── interleaved join  ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
-·                      estimated row count  1999 (missing stats)  ·                                                       ·
-·                      type                 full outer            ·                                                       ·
-·                      left table           outer_gc1@primary     ·                                                       ·
-·                      left spans           FULL SCAN             ·                                                       ·
-·                      right table          outer_c1@primary      ·                                                       ·
-·                      right spans          FULL SCAN             ·                                                       ·
-·                      ancestor             right                 ·                                                       ·
+·                                   distribution         full                  ·                                                       ·
+·                                   vectorized           true                  ·                                                       ·
+render                              ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, ca1)                    ·
+ │                                  estimated row count  1999 (missing stats)  ·                                                       ·
+ │                                  render 0             COALESCE(pid1, pid1)  ·                                                       ·
+ │                                  render 1             COALESCE(cid1, cid1)  ·                                                       ·
+ │                                  render 2             COALESCE(cid2, cid2)  ·                                                       ·
+ │                                  render 3             gcid1                 ·                                                       ·
+ │                                  render 4             gca1                  ·                                                       ·
+ │                                  render 5             ca1                   ·                                                       ·
+ └── interleaved join (full outer)  ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
+·                                   estimated row count  1999 (missing stats)  ·                                                       ·
+·                                   left table           outer_gc1@primary     ·                                                       ·
+·                                   left spans           FULL SCAN             ·                                                       ·
+·                                   right table          outer_c1@primary      ·                                                       ·
+·                                   right spans          FULL SCAN             ·                                                       ·
+·                                   ancestor             right                 ·                                                       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
@@ -602,18 +589,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzklV-Lm0wUxu_fTzGcq-TNKZ
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40
 ----
-·                      distribution         full                  ·                                   ·
-·                      vectorized           true                  ·                                   ·
-project                ·                    ·                     (pid1, cid1, cid2, ca1, pa1)        ·
- │                     estimated row count  400 (missing stats)   ·                                   ·
- └── interleaved join  ·                    ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
-·                      estimated row count  400 (missing stats)   ·                                   ·
-·                      type                 left outer            ·                                   ·
-·                      left table           outer_c1@primary      ·                                   ·
-·                      left spans           /0/#/60/1-/39/#/60/2  ·                                   ·
-·                      right table          outer_p1@primary      ·                                   ·
-·                      right spans          /0-/39/#              ·                                   ·
-·                      ancestor             right                 ·                                   ·
+·                                   distribution         full                  ·                                   ·
+·                                   vectorized           true                  ·                                   ·
+project                             ·                    ·                     (pid1, cid1, cid2, ca1, pa1)        ·
+ │                                  estimated row count  400 (missing stats)   ·                                   ·
+ └── interleaved join (left outer)  ·                    ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
+·                                   estimated row count  400 (missing stats)   ·                                   ·
+·                                   left table           outer_c1@primary      ·                                   ·
+·                                   left spans           /0/#/60/1-/39/#/60/2  ·                                   ·
+·                                   right table          outer_p1@primary      ·                                   ·
+·                                   right spans          /0-/39/#              ·                                   ·
+·                                   ancestor             right                 ·                                   ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
@@ -623,18 +609,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUVF1rnEAUfe-vGM7T2k6Jo7
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20
 ----
-·                      distribution         full                  ·                                           ·
-·                      vectorized           true                  ·                                           ·
-project                ·                    ·                     (pid1, pa1, cid1, cid2, gcid1, gca1)        ·
- │                     estimated row count  200 (missing stats)   ·                                           ·
- └── interleaved join  ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
-·                      estimated row count  200 (missing stats)   ·                                           ·
-·                      type                 left outer            ·                                           ·
-·                      left table           outer_gc1@primary     ·                                           ·
-·                      left spans           /1/#/60/1-/20/#/60/2  ·                                           ·
-·                      right table          outer_p1@primary      ·                                           ·
-·                      right spans          /1-/20/#              ·                                           ·
-·                      ancestor             right                 ·                                           ·
+·                                   distribution         full                  ·                                           ·
+·                                   vectorized           true                  ·                                           ·
+project                             ·                    ·                     (pid1, pa1, cid1, cid2, gcid1, gca1)        ·
+ │                                  estimated row count  200 (missing stats)   ·                                           ·
+ └── interleaved join (left outer)  ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
+·                                   estimated row count  200 (missing stats)   ·                                           ·
+·                                   left table           outer_gc1@primary     ·                                           ·
+·                                   left spans           /1/#/60/1-/20/#/60/2  ·                                           ·
+·                                   right table          outer_p1@primary      ·                                           ·
+·                                   right spans          /1-/20/#              ·                                           ·
+·                                   ancestor             right                 ·                                           ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
@@ -705,14 +690,12 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM (SELECT * FROM parent1 ORDER BY pid1 LIMIT 2) AS parent1 INNER MERGE JOIN child1 USING(pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN (SELECT * FROM child1 ORDER BY pid1 LIMIT 10) AS child1 USING(pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 statement ok
 DROP TABLE grandchild2, grandchild1, child1, child2, parent1, parent2
@@ -742,21 +725,18 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 # Parent-grandchild cases.
 # parent1-grandchild1 share interleave prefix (pid1).
@@ -765,21 +745,18 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 # Multiple-column interleave prefix.
 # child1-grandchild1 share interleave prefix (pid1, cid1, cid2).
@@ -788,21 +765,18 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 # TODO(richardwu): update these once prefix/subset of
 # interleave prefixes are permitted.
@@ -811,70 +785,60 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 # Common ancestor example.
 # TODO(richardwu): update this when common ancestor interleaved joins are possible.
@@ -883,7 +847,6 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN child2 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge join
 
 # Case where the merge join ordering includes a non-interleaved column (this is
 # possible if that column is constrained to a constant value). We shouldn't
@@ -892,25 +855,24 @@ merge join
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 INNER MERGE JOIN child1 ON parent1.pid1 = child1.pid1 AND parent1.v = child1.v WHERE parent1.v=1
 ----
-·               distribution         full                     ·                               ·
-·               vectorized           true                     ·                               ·
-merge join      ·                    ·                        (pid1, v, pid1, cid1, cid2, v)  ·
- │              estimated row count  10 (missing stats)       ·                               ·
- │              type                 inner                    ·                               ·
- │              equality             (pid1, v) = (pid1, v)    ·                               ·
- │              left cols are key    ·                        ·                               ·
- │              merge ordering       +"(pid1=pid1)",+"(v=v)"  ·                               ·
- ├── filter     ·                    ·                        (pid1, v)                       +pid1
- │    │         estimated row count  10 (missing stats)       ·                               ·
- │    │         filter               v = 1                    ·                               ·
- │    └── scan  ·                    ·                        (pid1, v)                       +pid1
- │              estimated row count  1000 (missing stats)     ·                               ·
- │              table                parent1@primary          ·                               ·
- │              spans                FULL SCAN                ·                               ·
- └── filter     ·                    ·                        (pid1, cid1, cid2, v)           +pid1
-      │         estimated row count  10 (missing stats)       ·                               ·
-      │         filter               v = 1                    ·                               ·
-      └── scan  ·                    ·                        (pid1, cid1, cid2, v)           +pid1
-·               estimated row count  1000 (missing stats)     ·                               ·
-·               table                child1@primary           ·                               ·
-·               spans                FULL SCAN                ·                               ·
+·                   distribution         full                     ·                               ·
+·                   vectorized           true                     ·                               ·
+merge join (inner)  ·                    ·                        (pid1, v, pid1, cid1, cid2, v)  ·
+ │                  estimated row count  10 (missing stats)       ·                               ·
+ │                  equality             (pid1, v) = (pid1, v)    ·                               ·
+ │                  left cols are key    ·                        ·                               ·
+ │                  merge ordering       +"(pid1=pid1)",+"(v=v)"  ·                               ·
+ ├── filter         ·                    ·                        (pid1, v)                       +pid1
+ │    │             estimated row count  10 (missing stats)       ·                               ·
+ │    │             filter               v = 1                    ·                               ·
+ │    └── scan      ·                    ·                        (pid1, v)                       +pid1
+ │                  estimated row count  1000 (missing stats)     ·                               ·
+ │                  table                parent1@primary          ·                               ·
+ │                  spans                FULL SCAN                ·                               ·
+ └── filter         ·                    ·                        (pid1, cid1, cid2, v)           +pid1
+      │             estimated row count  10 (missing stats)       ·                               ·
+      │             filter               v = 1                    ·                               ·
+      └── scan      ·                    ·                        (pid1, cid1, cid2, v)           +pid1
+·                   estimated row count  1000 (missing stats)     ·                               ·
+·                   table                child1@primary           ·                               ·
+·                   spans                FULL SCAN                ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -32,23 +32,22 @@ NULL       /1       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-·                distribution         full                  ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b)        ·
- │               estimated row count  100 (missing stats)   ·             ·
- └── merge join  ·                    ·                     (a, b, a, b)  ·
-      │          estimated row count  100 (missing stats)   ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a, b) = (a, b)       ·             ·
-      │          merge ordering       +"(a=a)",+"(b=b)"     ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a,+b
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                data@primary          ·             ·
-      │          spans                FULL SCAN             ·             ·
-      └── scan   ·                    ·                     (a, b)        +a,+b
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                data@primary          ·             ·
-·                spans                FULL SCAN             ·             ·
+·                        distribution         full                  ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b)        ·
+ │                       estimated row count  100 (missing stats)   ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, b)  ·
+      │                  estimated row count  100 (missing stats)   ·             ·
+      │                  equality             (a, b) = (a, b)       ·             ·
+      │                  merge ordering       +"(a=a)",+"(b=b)"     ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a,+b
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                data@primary          ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      └── scan           ·                    ·                     (a, b)        +a,+b
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                data@primary          ·             ·
+·                        spans                FULL SCAN             ·             ·
 
 # TODO(radu): enable these tests when joins pass through orderings on equality
 # columns.
@@ -114,23 +113,22 @@ project          ·                    ·                     (a, b)        ·
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-·               distribution         full                  ·             ·
-·               vectorized           true                  ·             ·
-sort            ·                    ·                     (a, b, c, d)  +b,+a
- │              estimated row count  100 (missing stats)   ·             ·
- │              order                +b,+a                 ·             ·
- └── hash join  ·                    ·                     (a, b, c, d)  ·
-      │         estimated row count  100 (missing stats)   ·             ·
-      │         type                 inner                 ·             ·
-      │         equality             (a, b) = (c, d)       ·             ·
-      ├── scan  ·                    ·                     (a, b)        ·
-      │         estimated row count  1000 (missing stats)  ·             ·
-      │         table                data@primary          ·             ·
-      │         spans                FULL SCAN             ·             ·
-      └── scan  ·                    ·                     (c, d)        ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                data@primary          ·             ·
-·               spans                FULL SCAN             ·             ·
+·                       distribution         full                  ·             ·
+·                       vectorized           true                  ·             ·
+sort                    ·                    ·                     (a, b, c, d)  +b,+a
+ │                      estimated row count  100 (missing stats)   ·             ·
+ │                      order                +b,+a                 ·             ·
+ └── hash join (inner)  ·                    ·                     (a, b, c, d)  ·
+      │                 estimated row count  100 (missing stats)   ·             ·
+      │                 equality             (a, b) = (c, d)       ·             ·
+      ├── scan          ·                    ·                     (a, b)        ·
+      │                 estimated row count  1000 (missing stats)  ·             ·
+      │                 table                data@primary          ·             ·
+      │                 spans                FULL SCAN             ·             ·
+      └── scan          ·                    ·                     (c, d)        ·
+·                       estimated row count  1000 (missing stats)  ·             ·
+·                       table                data@primary          ·             ·
+·                       spans                FULL SCAN             ·             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -40,7 +40,7 @@ project          ·                    ·                     (a, b)        ·
       │          estimated row count  100 (missing stats)   ·             ·
       │          type                 inner                 ·             ·
       │          equality             (a, b) = (a, b)       ·             ·
-      │          mergeJoinOrder       +"(a=a)",+"(b=b)"     ·             ·
+      │          merge ordering       +"(a=a)",+"(b=b)"     ·             ·
       ├── scan   ·                    ·                     (a, b)        +a,+b
       │          estimated row count  1000 (missing stats)  ·             ·
       │          table                data@primary          ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -80,31 +80,30 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVFr2zwUhu-_XyHOVQsqsW
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-·                    distribution         full                  ·            ·
-·                    vectorized           true                  ·            ·
-project              ·                    ·                     (x, str)     ·
- │                   estimated row count  333 (missing stats)   ·            ·
- └── merge join      ·                    ·                     (x, y, str)  ·
-      │              estimated row count  333 (missing stats)   ·            ·
-      │              type                 inner                 ·            ·
-      │              equality             (x) = (y)             ·            ·
-      │              left cols are key    ·                     ·            ·
-      │              right cols are key   ·                     ·            ·
-      │              merge ordering       +"(x=y)"              ·            ·
-      ├── filter     ·                    ·                     (x)          +x
-      │    │         estimated row count  333 (missing stats)   ·            ·
-      │    │         filter               (x % 2) = 0           ·            ·
-      │    └── scan  ·                    ·                     (x)          +x
-      │              estimated row count  1000 (missing stats)  ·            ·
-      │              table                numtosquare@primary   ·            ·
-      │              spans                FULL SCAN             ·            ·
-      └── filter     ·                    ·                     (y, str)     +y
-           │         estimated row count  333 (missing stats)   ·            ·
-           │         filter               (y % 2) = 0           ·            ·
-           └── scan  ·                    ·                     (y, str)     +y
-·                    estimated row count  1000 (missing stats)  ·            ·
-·                    table                numtostr@primary      ·            ·
-·                    spans                FULL SCAN             ·            ·
+·                        distribution         full                  ·            ·
+·                        vectorized           true                  ·            ·
+project                  ·                    ·                     (x, str)     ·
+ │                       estimated row count  333 (missing stats)   ·            ·
+ └── merge join (inner)  ·                    ·                     (x, y, str)  ·
+      │                  estimated row count  333 (missing stats)   ·            ·
+      │                  equality             (x) = (y)             ·            ·
+      │                  left cols are key    ·                     ·            ·
+      │                  right cols are key   ·                     ·            ·
+      │                  merge ordering       +"(x=y)"              ·            ·
+      ├── filter         ·                    ·                     (x)          +x
+      │    │             estimated row count  333 (missing stats)   ·            ·
+      │    │             filter               (x % 2) = 0           ·            ·
+      │    └── scan      ·                    ·                     (x)          +x
+      │                  estimated row count  1000 (missing stats)  ·            ·
+      │                  table                numtosquare@primary   ·            ·
+      │                  spans                FULL SCAN             ·            ·
+      └── filter         ·                    ·                     (y, str)     +y
+           │             estimated row count  333 (missing stats)   ·            ·
+           │             filter               (y % 2) = 0           ·            ·
+           └── scan      ·                    ·                     (y, str)     +y
+·                        estimated row count  1000 (missing stats)  ·            ·
+·                        table                numtostr@primary      ·            ·
+·                        spans                FULL SCAN             ·            ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -90,7 +90,7 @@ project              ·                    ·                     (x, str)     �
       │              equality             (x) = (y)             ·            ·
       │              left cols are key    ·                     ·            ·
       │              right cols are key   ·                     ·            ·
-      │              mergeJoinOrder       +"(x=y)"              ·            ·
+      │              merge ordering       +"(x=y)"              ·            ·
       ├── filter     ·                    ·                     (x)          +x
       │    │         estimated row count  333 (missing stats)   ·            ·
       │    │         filter               (x % 2) = 0           ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -312,7 +312,6 @@ EXPLAIN SHOW COLUMNS FROM foo
 ·                                       vectorized    false
 render                                  ·             ·
  └── group                              ·             ·
-      │                                 aggregate 0   array_agg(index_name)
       │                                 group by      column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
       │                                 ordered       +ordinal_position
       └── sort                          ·             ·
@@ -372,7 +371,6 @@ sort                                      ·                      ·
                 │                         type                   inner
                 │                         equality               (oid) = (conrelid)
                 │                         equality cols are key  ·
-                │                         parallel               ·
                 └── filter                ·                      ·
                      │                    filter                 relname = 'foo'
                      └── virtual table    ·                      ·
@@ -387,9 +385,6 @@ sort                                                ·                  ·
  │                                                  order              +username
  └── render                                         ·                  ·
       └── group                                     ·                  ·
-           │                                        aggregate 0        array_agg(role)
-           │                                        aggregate 1        any_not_null(any_not_null)
-           │                                        aggregate 2        any_not_null(role)
            │                                        group by           username
            └── sort                                 ·                  ·
                 │                                   order              +role
@@ -398,7 +393,6 @@ sort                                                ·                  ·
                      │                              equality           (username) = (member)
                      │                              left cols are key  ·
                      ├── group                      ·                  ·
-                     │    │                         aggregate 0        any_not_null(string_agg)
                      │    │                         group by           username
                      │    └── window                ·                  ·
                      │         └── render           ·                  ·
@@ -406,7 +400,6 @@ sort                                                ·                  ·
                      │                   │          type               left outer
                      │                   │          equality           (username) = (username)
                      │                   │          left cols are key  ·
-                     │                   │          mergeJoinOrder     +"(username=username)"
                      │                   ├── scan   ·                  ·
                      │                   │          missing stats      ·
                      │                   │          table              users@primary
@@ -499,7 +492,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t@primary
 ·     spans          [/1 - /1] [/3 - /3]
-·     parallel       ·
 
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY)
@@ -514,7 +506,6 @@ lookup join  ·                      ·
  │           type                   inner
  │           equality               (k) = (x)
  │           equality cols are key  ·
- │           parallel               ·
  └── scan    ·                      ·
 ·            missing stats          ·
 ·            table                  t@primary
@@ -1086,7 +1077,6 @@ tree         field         description
 ·            distribution  local
 ·            vectorized    false
 group        ·             ·
- │           aggregate 0   string_agg(column1, column2)
  │           scalar        ·
  └── values  ·             ·
 ·            size          2 columns, 2 rows
@@ -1097,7 +1087,6 @@ EXPLAIN SELECT corr(a, b) FROM tc;
 ·          distribution   local
 ·          vectorized     true
 group      ·              ·
- │         aggregate 0    corr(a, b)
  │         scalar         ·
  └── scan  ·              ·
 ·          missing stats  ·
@@ -1146,4 +1135,3 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t@primary
 ·     spans          [/10 - /10] [/20 - /20] [/30 - /30] [/40 - /40] … (4 more)
-·     parallel       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1061,25 +1061,23 @@ sort
 query TTT colnames
 EXPLAIN SELECT string_agg(x, y) FROM (VALUES ('foo', 'foo'), ('bar', 'bar')) t(x, y)
 ----
-tree         field         description
-·            distribution  local
-·            vectorized    false
-group        ·             ·
- │           scalar        ·
- └── values  ·             ·
-·            size          2 columns, 2 rows
+tree            field         description
+·               distribution  local
+·               vectorized    false
+group (scalar)  ·             ·
+ └── values     ·             ·
+·               size          2 columns, 2 rows
 
 query TTT
 EXPLAIN SELECT corr(a, b) FROM tc;
 ----
-·          distribution   local
-·          vectorized     true
-group      ·              ·
- │         scalar         ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          tc@primary
-·          spans          FULL SCAN
+·               distribution   local
+·               vectorized     true
+group (scalar)  ·              ·
+ └── scan       ·              ·
+·               missing stats  ·
+·               table          tc@primary
+·               spans          FULL SCAN
 
 # Verify that subqueries are handled correctly, namely that we can have
 # subqueries outside of the EXPLAINed query.

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -184,21 +184,18 @@ SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 sort                                              ·                  ·
  │                                                order              +nspname,+relname
  └── render                                       ·                  ·
-      └── hash join                               ·                  ·
-           │                                      type               right outer
+      └── hash join (right outer)                 ·                  ·
            │                                      equality           (table_id) = (column44)
            ├── virtual table                      ·                  ·
            │                                      table              table_row_statistics@primary
            └── render                             ·                  ·
                 └── hash join                     ·                  ·
-                     │                            type               inner
                      │                            equality           (oid) = (relnamespace)
                      ├── filter                   ·                  ·
                      │    │                       filter             nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
                      │    └── virtual table       ·                  ·
                      │                            table              pg_namespace@primary
-                     └── hash join                ·                  ·
-                          │                       type               left outer
+                     └── hash join (left outer)   ·                  ·
                           │                       equality           (oid) = (objoid)
                           │                       left cols are key  ·
                           ├── filter              ·                  ·
@@ -219,21 +216,18 @@ SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 sort                                              ·                  ·
  │                                                order              +nspname,+relname
  └── render                                       ·                  ·
-      └── hash join                               ·                  ·
-           │                                      type               right outer
+      └── hash join (right outer)                 ·                  ·
            │                                      equality           (table_id) = (column44)
            ├── virtual table                      ·                  ·
            │                                      table              table_row_statistics@primary
            └── render                             ·                  ·
                 └── hash join                     ·                  ·
-                     │                            type               inner
                      │                            equality           (oid) = (relnamespace)
                      ├── filter                   ·                  ·
                      │    │                       filter             nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
                      │    └── virtual table       ·                  ·
                      │                            table              pg_namespace@primary
-                     └── hash join                ·                  ·
-                          │                       type               left outer
+                     └── hash join (left outer)   ·                  ·
                           │                       equality           (oid) = (objoid)
                           │                       left cols are key  ·
                           ├── filter              ·                  ·
@@ -316,8 +310,7 @@ render                                  ·             ·
       │                                 ordered       +ordinal_position
       └── sort                          ·             ·
            │                            order         +ordinal_position
-           └── hash join                ·             ·
-                │                       type          left outer
+           └── hash join (left outer)   ·             ·
                 │                       equality      (column_name) = (column_name)
                 ├── filter              ·             ·
                 │    │                  filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
@@ -360,7 +353,6 @@ sort                                      ·                      ·
  │                                        order                  +conname
  └── render                               ·                      ·
       └── hash join                       ·                      ·
-           │                              type                   inner
            │                              equality               (oid) = (relnamespace)
            ├── filter                     ·                      ·
            │    │                         filter                 nspname = 'public'
@@ -368,7 +360,6 @@ sort                                      ·                      ·
            │                              table                  pg_namespace@primary
            └── virtual table lookup join  ·                      ·
                 │                         table                  pg_constraint@pg_constraint_conrelid_idx
-                │                         type                   inner
                 │                         equality               (oid) = (conrelid)
                 │                         equality cols are key  ·
                 └── filter                ·                      ·
@@ -379,39 +370,37 @@ sort                                      ·                      ·
 query TTT
 EXPLAIN SHOW USERS
 ----
-·                                                   distribution       local
-·                                                   vectorized         true
-sort                                                ·                  ·
- │                                                  order              +username
- └── render                                         ·                  ·
-      └── group                                     ·                  ·
-           │                                        group by           username
-           └── sort                                 ·                  ·
-                │                                   order              +role
-                └── hash join                       ·                  ·
-                     │                              type               left outer
-                     │                              equality           (username) = (member)
-                     │                              left cols are key  ·
-                     ├── group                      ·                  ·
-                     │    │                         group by           username
-                     │    └── window                ·                  ·
-                     │         └── render           ·                  ·
-                     │              └── merge join  ·                  ·
-                     │                   │          type               left outer
-                     │                   │          equality           (username) = (username)
-                     │                   │          left cols are key  ·
-                     │                   ├── scan   ·                  ·
-                     │                   │          missing stats      ·
-                     │                   │          table              users@primary
-                     │                   │          spans              FULL SCAN
-                     │                   └── scan   ·                  ·
-                     │                              missing stats      ·
-                     │                              table              role_options@primary
-                     │                              spans              FULL SCAN
-                     └── scan                       ·                  ·
-·                                                   missing stats      ·
-·                                                   table              role_members@role_members_role_idx
-·                                                   spans              FULL SCAN
+·                                                                distribution       local
+·                                                                vectorized         true
+sort                                                             ·                  ·
+ │                                                               order              +username
+ └── render                                                      ·                  ·
+      └── group                                                  ·                  ·
+           │                                                     group by           username
+           └── sort                                              ·                  ·
+                │                                                order              +role
+                └── hash join (left outer)                       ·                  ·
+                     │                                           equality           (username) = (member)
+                     │                                           left cols are key  ·
+                     ├── group                                   ·                  ·
+                     │    │                                      group by           username
+                     │    └── window                             ·                  ·
+                     │         └── render                        ·                  ·
+                     │              └── merge join (left outer)  ·                  ·
+                     │                   │                       equality           (username) = (username)
+                     │                   │                       left cols are key  ·
+                     │                   ├── scan                ·                  ·
+                     │                   │                       missing stats      ·
+                     │                   │                       table              users@primary
+                     │                   │                       spans              FULL SCAN
+                     │                   └── scan                ·                  ·
+                     │                                           missing stats      ·
+                     │                                           table              role_options@primary
+                     │                                           spans              FULL SCAN
+                     └── scan                                    ·                  ·
+·                                                                missing stats      ·
+·                                                                table              role_members@role_members_role_idx
+·                                                                spans              FULL SCAN
 
 # EXPLAIN selecting from a sequence.
 statement ok
@@ -503,7 +492,6 @@ EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
 ·            vectorized             true
 lookup join  ·                      ·
  │           table                  t2@primary
- │           type                   inner
  │           equality               (k) = (x)
  │           equality cols are key  ·
  └── scan    ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -368,7 +368,7 @@ root                                  ·                   ·
  │              │                     equality            (p) = (p)
  │              │                     left cols are key   ·
  │              │                     right cols are key  ·
- │              ├── union             ·                   ·
+ │              ├── except            ·                   ·
  │              │    ├── scan buffer  ·                   ·
  │              │    │                label               buffer 1
  │              │    └── scan buffer  ·                   ·
@@ -386,7 +386,7 @@ root                                  ·                   ·
                 │                     equality            (p) = (p)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
-                ├── union             ·                   ·
+                ├── except            ·                   ·
                 │    ├── scan buffer  ·                   ·
                 │    │                label               buffer 1
                 │    └── scan buffer  ·                   ·
@@ -420,7 +420,7 @@ root                                  ·              ·
  │         └── lookup join (semi)     ·              ·
  │              │                     table          child@child_p_idx
  │              │                     equality       (p) = (p)
- │              └── union             ·              ·
+ │              └── except            ·              ·
  │                   ├── scan buffer  ·              ·
  │                   │                label          buffer 1
  │                   └── scan buffer  ·              ·
@@ -430,7 +430,7 @@ root                                  ·              ·
            └── lookup join (semi)     ·              ·
                 │                     table          child_nullable@child_nullable_p_idx
                 │                     equality       (p) = (p)
-                └── union             ·              ·
+                └── except            ·              ·
                      ├── scan buffer  ·              ·
                      │                label          buffer 1
                      └── scan buffer  ·              ·
@@ -461,7 +461,7 @@ root                                  ·                   ·
                 │                     equality            (c) = (c)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
-                ├── union             ·                   ·
+                ├── except            ·                   ·
                 │    ├── scan buffer  ·                   ·
                 │    │                label               buffer 1
                 │    └── scan buffer  ·                   ·
@@ -562,7 +562,7 @@ root                                  ·                   ·
                 │                     equality            (c) = (c)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
-                ├── union             ·                   ·
+                ├── except            ·                   ·
                 │    ├── scan buffer  ·                   ·
                 │    │                label               buffer 1
                 │    └── scan buffer  ·                   ·
@@ -659,7 +659,7 @@ root                                  ·                   ·
                 │                     equality            (x) = (y)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
-                ├── union             ·                   ·
+                ├── except            ·                   ·
                 │    ├── scan buffer  ·                   ·
                 │    │                label               buffer 1
                 │    └── scan buffer  ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -31,7 +31,6 @@ root                             ·                      ·
                 │                type                   anti
                 │                equality               (column2) = (p)
                 │                equality cols are key  ·
-                │                parallel               ·
                 └── scan buffer  ·                      ·
 ·                                label                  buffer 1
 
@@ -90,7 +89,6 @@ root                                  ·                      ·
                 │                     type                   anti
                 │                     equality               (column2) = (p)
                 │                     equality cols are key  ·
-                │                     parallel               ·
                 └── filter            ·                      ·
                      │                filter                 column2 IS NOT NULL
                      └── scan buffer  ·                      ·
@@ -127,7 +125,6 @@ root                                  ·                      ·
                 │                     type                   anti
                 │                     equality               (column2, column3, column4) = (p,q,r)
                 │                     equality cols are key  ·
-                │                     parallel               ·
                 └── filter            ·                      ·
                      │                filter                 (column2 IS NOT NULL) AND (column3 IS NOT NULL)
                      └── scan buffer  ·                      ·
@@ -168,7 +165,6 @@ root                                  ·                      ·
  │              │                     type                   anti
  │              │                     equality               (column2) = (a)
  │              │                     equality cols are key  ·
- │              │                     parallel               ·
  │              └── filter            ·                      ·
  │                   │                filter                 column2 IS NOT NULL
  │                   └── scan buffer  ·                      ·
@@ -180,7 +176,6 @@ root                                  ·                      ·
                 │                     type                   anti
                 │                     equality               (column3, column4) = (b,c)
                 │                     equality cols are key  ·
-                │                     parallel               ·
                 └── filter            ·                      ·
                      │                filter                 (column3 IS NOT NULL) AND (column4 IS NOT NULL)
                      └── scan buffer  ·                      ·
@@ -326,7 +321,6 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
- │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
@@ -356,7 +350,6 @@ root                             ·                      ·
  │                               missing stats          ·
  │                               table                  child@primary
  │                               spans                  [/10 - /10]
- │                               locking strength       for update
  └── fk-check                    ·                      ·
       └── error if rows          ·                      ·
            └── lookup join       ·                      ·
@@ -364,7 +357,6 @@ root                             ·                      ·
                 │                type                   anti
                 │                equality               (p_new) = (p)
                 │                equality cols are key  ·
-                │                parallel               ·
                 └── scan buffer  ·                      ·
 ·                                label                  buffer 1
 
@@ -384,7 +376,6 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               parent@primary
  │                                    spans               FULL SCAN
- │                                    locking strength    for update
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
  │         └── hash join              ·                   ·
@@ -427,42 +418,41 @@ root                                  ·                   ·
 query TTT
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
-·                                     distribution      local
-·                                     vectorized        false
-root                                  ·                 ·
- ├── update                           ·                 ·
- │    │                               table             parent
- │    │                               set               p
- │    └── buffer                      ·                 ·
- │         │                          label             buffer 1
- │         └── render                 ·                 ·
- │              └── scan              ·                 ·
- │                                    missing stats     ·
- │                                    table             parent@parent_other_key
- │                                    spans             [/10 - /10]
- │                                    locking strength  for update
- ├── fk-check                         ·                 ·
- │    └── error if rows               ·                 ·
- │         └── lookup join            ·                 ·
- │              │                     table             child@child_p_idx
- │              │                     type              semi
- │              │                     equality          (p) = (p)
- │              └── union             ·                 ·
- │                   ├── scan buffer  ·                 ·
- │                   │                label             buffer 1
- │                   └── scan buffer  ·                 ·
- │                                    label             buffer 1
- └── fk-check                         ·                 ·
-      └── error if rows               ·                 ·
-           └── lookup join            ·                 ·
-                │                     table             child_nullable@child_nullable_p_idx
-                │                     type              semi
-                │                     equality          (p) = (p)
-                └── union             ·                 ·
-                     ├── scan buffer  ·                 ·
-                     │                label             buffer 1
-                     └── scan buffer  ·                 ·
-·                                     label             buffer 1
+·                                     distribution   local
+·                                     vectorized     false
+root                                  ·              ·
+ ├── update                           ·              ·
+ │    │                               table          parent
+ │    │                               set            p
+ │    └── buffer                      ·              ·
+ │         │                          label          buffer 1
+ │         └── render                 ·              ·
+ │              └── scan              ·              ·
+ │                                    missing stats  ·
+ │                                    table          parent@parent_other_key
+ │                                    spans          [/10 - /10]
+ ├── fk-check                         ·              ·
+ │    └── error if rows               ·              ·
+ │         └── lookup join            ·              ·
+ │              │                     table          child@child_p_idx
+ │              │                     type           semi
+ │              │                     equality       (p) = (p)
+ │              └── union             ·              ·
+ │                   ├── scan buffer  ·              ·
+ │                   │                label          buffer 1
+ │                   └── scan buffer  ·              ·
+ │                                    label          buffer 1
+ └── fk-check                         ·              ·
+      └── error if rows               ·              ·
+           └── lookup join            ·              ·
+                │                     table          child_nullable@child_nullable_p_idx
+                │                     type           semi
+                │                     equality       (p) = (p)
+                └── union             ·              ·
+                     ├── scan buffer  ·              ·
+                     │                label          buffer 1
+                     └── scan buffer  ·              ·
+·                                     label          buffer 1
 
 statement ok
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
@@ -483,7 +473,6 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               child@primary
  │                                    spans               FULL SCAN
- │                                    locking strength    for update
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
@@ -520,7 +509,6 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
- │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
@@ -549,7 +537,6 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
- │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
@@ -579,7 +566,6 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               child@primary
  │                                    spans               FULL SCAN
- │                                    locking strength    for update
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
  │         └── hash join              ·                   ·
@@ -631,7 +617,6 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
- │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
@@ -664,7 +649,6 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               self@primary
  │                               spans               FULL SCAN
- │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join         ·                   ·
@@ -694,7 +678,6 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               self@primary
  │                                    spans               FULL SCAN
- │                                    locking strength    for update
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
@@ -899,7 +882,6 @@ filter               ·                   ·
       │              type                left outer
       │              equality            (a_z, a_y, a_x) = (z, y, x)
       │              right cols are key  ·
-      │              mergeJoinOrder      +"(a_z=z)",+"(a_y=y)",+"(a_x=x)"
       ├── filter     ·                   ·
       │    │         filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
       │    └── scan  ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -15,24 +15,23 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMI
 query TTT
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                                distribution           local
-·                                vectorized             false
-root                             ·                      ·
- ├── insert                      ·                      ·
- │    │                          into                   child(c, p)
- │    └── buffer                 ·                      ·
- │         │                     label                  buffer 1
- │         └── values            ·                      ·
- │                               size                   2 columns, 2 rows
- └── fk-check                    ·                      ·
-      └── error if rows          ·                      ·
-           └── lookup join       ·                      ·
-                │                table                  parent@primary
-                │                type                   anti
-                │                equality               (column2) = (p)
-                │                equality cols are key  ·
-                └── scan buffer  ·                      ·
-·                                label                  buffer 1
+·                                  distribution           local
+·                                  vectorized             false
+root                               ·                      ·
+ ├── insert                        ·                      ·
+ │    │                            into                   child(c, p)
+ │    └── buffer                   ·                      ·
+ │         │                       label                  buffer 1
+ │         └── values              ·                      ·
+ │                                 size                   2 columns, 2 rows
+ └── fk-check                      ·                      ·
+      └── error if rows            ·                      ·
+           └── lookup join (anti)  ·                      ·
+                │                  table                  parent@primary
+                │                  equality               (column2) = (p)
+                │                  equality cols are key  ·
+                └── scan buffer    ·                      ·
+·                                  label                  buffer 1
 
 # Use data from a different table as input.
 statement ok
@@ -54,8 +53,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (y) = (p)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -84,9 +82,8 @@ root                                  ·                      ·
  │                                    size                   2 columns, 2 rows
  └── fk-check                         ·                      ·
       └── error if rows               ·                      ·
-           └── lookup join            ·                      ·
+           └── lookup join (anti)     ·                      ·
                 │                     table                  parent@primary
-                │                     type                   anti
                 │                     equality               (column2) = (p)
                 │                     equality cols are key  ·
                 └── filter            ·                      ·
@@ -120,9 +117,8 @@ root                                  ·                      ·
  │                                    size                   4 columns, 2 rows
  └── fk-check                         ·                      ·
       └── error if rows               ·                      ·
-           └── lookup join            ·                      ·
+           └── lookup join (anti)     ·                      ·
                 │                     table                  multi_col_parent@primary
-                │                     type                   anti
                 │                     equality               (column2, column3, column4) = (p,q,r)
                 │                     equality cols are key  ·
                 └── filter            ·                      ·
@@ -160,9 +156,8 @@ root                                  ·                      ·
  │                                    size                   4 columns, 2 rows
  ├── fk-check                         ·                      ·
  │    └── error if rows               ·                      ·
- │         └── lookup join            ·                      ·
+ │         └── lookup join (anti)     ·                      ·
  │              │                     table                  multi_ref_parent_a@primary
- │              │                     type                   anti
  │              │                     equality               (column2) = (a)
  │              │                     equality cols are key  ·
  │              └── filter            ·                      ·
@@ -171,9 +166,8 @@ root                                  ·                      ·
  │                                    label                  buffer 1
  └── fk-check                         ·                      ·
       └── error if rows               ·                      ·
-           └── lookup join            ·                      ·
+           └── lookup join (anti)     ·                      ·
                 │                     table                  multi_ref_parent_bc@primary
-                │                     type                   anti
                 │                     equality               (column3, column4) = (b,c)
                 │                     equality cols are key  ·
                 └── filter            ·                      ·
@@ -198,33 +192,31 @@ insert       ·             ·
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                distribution   local
-·                                vectorized     false
-root                             ·              ·
- ├── delete                      ·              ·
- │    │                          from           parent
- │    └── buffer                 ·              ·
- │         │                     label          buffer 1
- │         └── scan              ·              ·
- │                               missing stats  ·
- │                               table          parent@primary
- │                               spans          [/3 - /3]
- ├── fk-check                    ·              ·
- │    └── error if rows          ·              ·
- │         └── lookup join       ·              ·
- │              │                table          child@child_p_idx
- │              │                type           semi
- │              │                equality       (p) = (p)
- │              └── scan buffer  ·              ·
- │                               label          buffer 1
- └── fk-check                    ·              ·
-      └── error if rows          ·              ·
-           └── lookup join       ·              ·
-                │                table          child_nullable@child_nullable_p_idx
-                │                type           semi
-                │                equality       (p) = (p)
-                └── scan buffer  ·              ·
-·                                label          buffer 1
+·                                  distribution   local
+·                                  vectorized     false
+root                               ·              ·
+ ├── delete                        ·              ·
+ │    │                            from           parent
+ │    └── buffer                   ·              ·
+ │         │                       label          buffer 1
+ │         └── scan                ·              ·
+ │                                 missing stats  ·
+ │                                 table          parent@primary
+ │                                 spans          [/3 - /3]
+ ├── fk-check                      ·              ·
+ │    └── error if rows            ·              ·
+ │         └── lookup join (semi)  ·              ·
+ │              │                  table          child@child_p_idx
+ │              │                  equality       (p) = (p)
+ │              └── scan buffer    ·              ·
+ │                                 label          buffer 1
+ └── fk-check                      ·              ·
+      └── error if rows            ·              ·
+           └── lookup join (semi)  ·              ·
+                │                  table          child_nullable@child_nullable_p_idx
+                │                  equality       (p) = (p)
+                └── scan buffer    ·              ·
+·                                  label          buffer 1
 
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other), INDEX (p))
@@ -232,41 +224,38 @@ CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other),
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                distribution   local
-·                                vectorized     false
-root                             ·              ·
- ├── delete                      ·              ·
- │    │                          from           parent
- │    └── buffer                 ·              ·
- │         │                     label          buffer 1
- │         └── scan              ·              ·
- │                               missing stats  ·
- │                               table          parent@primary
- │                               spans          [/3 - /3]
- ├── fk-check                    ·              ·
- │    └── error if rows          ·              ·
- │         └── lookup join       ·              ·
- │              │                table          child@child_p_idx
- │              │                type           semi
- │              │                equality       (p) = (p)
- │              └── scan buffer  ·              ·
- │                               label          buffer 1
- ├── fk-check                    ·              ·
- │    └── error if rows          ·              ·
- │         └── lookup join       ·              ·
- │              │                table          child_nullable@child_nullable_p_idx
- │              │                type           semi
- │              │                equality       (p) = (p)
- │              └── scan buffer  ·              ·
- │                               label          buffer 1
- └── fk-check                    ·              ·
-      └── error if rows          ·              ·
-           └── lookup join       ·              ·
-                │                table          child2@child2_p_idx
-                │                type           semi
-                │                equality       (other) = (p)
-                └── scan buffer  ·              ·
-·                                label          buffer 1
+·                                  distribution   local
+·                                  vectorized     false
+root                               ·              ·
+ ├── delete                        ·              ·
+ │    │                            from           parent
+ │    └── buffer                   ·              ·
+ │         │                       label          buffer 1
+ │         └── scan                ·              ·
+ │                                 missing stats  ·
+ │                                 table          parent@primary
+ │                                 spans          [/3 - /3]
+ ├── fk-check                      ·              ·
+ │    └── error if rows            ·              ·
+ │         └── lookup join (semi)  ·              ·
+ │              │                  table          child@child_p_idx
+ │              │                  equality       (p) = (p)
+ │              └── scan buffer    ·              ·
+ │                                 label          buffer 1
+ ├── fk-check                      ·              ·
+ │    └── error if rows            ·              ·
+ │         └── lookup join (semi)  ·              ·
+ │              │                  table          child_nullable@child_nullable_p_idx
+ │              │                  equality       (p) = (p)
+ │              └── scan buffer    ·              ·
+ │                                 label          buffer 1
+ └── fk-check                      ·              ·
+      └── error if rows            ·              ·
+           └── lookup join (semi)  ·              ·
+                │                  table          child2@child2_p_idx
+                │                  equality       (other) = (p)
+                └── scan buffer    ·              ·
+·                                  label          buffer 1
 
 statement ok
 CREATE TABLE doubleparent (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
@@ -283,25 +272,24 @@ CREATE TABLE doublechild (
 query TTT
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
-·                                distribution   local
-·                                vectorized     false
-root                             ·              ·
- ├── delete                      ·              ·
- │    │                          from           doubleparent
- │    └── buffer                 ·              ·
- │         │                     label          buffer 1
- │         └── scan              ·              ·
- │                               missing stats  ·
- │                               table          doubleparent@primary
- │                               spans          [/10 - /10]
- └── fk-check                    ·              ·
-      └── error if rows          ·              ·
-           └── lookup join       ·              ·
-                │                table          doublechild@doublechild_p1_p2_idx
-                │                type           semi
-                │                equality       (p1, p2) = (p1,p2)
-                └── scan buffer  ·              ·
-·                                label          buffer 1
+·                                  distribution   local
+·                                  vectorized     false
+root                               ·              ·
+ ├── delete                        ·              ·
+ │    │                            from           doubleparent
+ │    └── buffer                   ·              ·
+ │         │                       label          buffer 1
+ │         └── scan                ·              ·
+ │                                 missing stats  ·
+ │                                 table          doubleparent@primary
+ │                                 spans          [/10 - /10]
+ └── fk-check                      ·              ·
+      └── error if rows            ·              ·
+           └── lookup join (semi)  ·              ·
+                │                  table          doublechild@doublechild_p1_p2_idx
+                │                  equality       (p1, p2) = (p1,p2)
+                └── scan buffer    ·              ·
+·                                  label          buffer 1
 
 # -- Tests with UPDATE --
 
@@ -323,8 +311,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (p_new) = (p)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -337,28 +324,27 @@ root                             ·                   ·
 query TTT
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
-·                                distribution           local
-·                                vectorized             false
-root                             ·                      ·
- ├── update                      ·                      ·
- │    │                          table                  child
- │    │                          set                    p
- │    └── buffer                 ·                      ·
- │         │                     label                  buffer 1
- │         └── render            ·                      ·
- │              └── scan         ·                      ·
- │                               missing stats          ·
- │                               table                  child@primary
- │                               spans                  [/10 - /10]
- └── fk-check                    ·                      ·
-      └── error if rows          ·                      ·
-           └── lookup join       ·                      ·
-                │                table                  parent@primary
-                │                type                   anti
-                │                equality               (p_new) = (p)
-                │                equality cols are key  ·
-                └── scan buffer  ·                      ·
-·                                label                  buffer 1
+·                                  distribution           local
+·                                  vectorized             false
+root                               ·                      ·
+ ├── update                        ·                      ·
+ │    │                            table                  child
+ │    │                            set                    p
+ │    └── buffer                   ·                      ·
+ │         │                       label                  buffer 1
+ │         └── render              ·                      ·
+ │              └── scan           ·                      ·
+ │                                 missing stats          ·
+ │                                 table                  child@primary
+ │                                 spans                  [/10 - /10]
+ └── fk-check                      ·                      ·
+      └── error if rows            ·                      ·
+           └── lookup join (anti)  ·                      ·
+                │                  table                  parent@primary
+                │                  equality               (p_new) = (p)
+                │                  equality cols are key  ·
+                └── scan buffer    ·                      ·
+·                                  label                  buffer 1
 
 query TTT
 EXPLAIN UPDATE parent SET p = p+1
@@ -379,7 +365,6 @@ root                                  ·                   ·
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
  │         └── hash join              ·                   ·
- │              │                     type                inner
  │              │                     equality            (p) = (p)
  │              │                     left cols are key   ·
  │              │                     right cols are key  ·
@@ -398,7 +383,6 @@ root                                  ·                   ·
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
-                │                     type                inner
                 │                     equality            (p) = (p)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
@@ -433,9 +417,8 @@ root                                  ·              ·
  │                                    spans          [/10 - /10]
  ├── fk-check                         ·              ·
  │    └── error if rows               ·              ·
- │         └── lookup join            ·              ·
+ │         └── lookup join (semi)     ·              ·
  │              │                     table          child@child_p_idx
- │              │                     type           semi
  │              │                     equality       (p) = (p)
  │              └── union             ·              ·
  │                   ├── scan buffer  ·              ·
@@ -444,9 +427,8 @@ root                                  ·              ·
  │                                    label          buffer 1
  └── fk-check                         ·              ·
       └── error if rows               ·              ·
-           └── lookup join            ·              ·
+           └── lookup join (semi)     ·              ·
                 │                     table          child_nullable@child_nullable_p_idx
-                │                     type           semi
                 │                     equality       (p) = (p)
                 └── union             ·              ·
                      ├── scan buffer  ·              ·
@@ -476,7 +458,6 @@ root                                  ·                   ·
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
-                │                     type                inner
                 │                     equality            (c) = (c)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
@@ -511,8 +492,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (p_new) = (p)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -539,8 +519,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (p) = (p)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -568,8 +547,7 @@ root                                  ·                   ·
  │                                    spans               FULL SCAN
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
- │         └── hash join              ·                   ·
- │              │                     type                anti
+ │         └── hash join (anti)       ·                   ·
  │              │                     equality            (p_new) = (p)
  │              │                     right cols are key  ·
  │              ├── scan buffer       ·                   ·
@@ -581,7 +559,6 @@ root                                  ·                   ·
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
-                │                     type                inner
                 │                     equality            (c) = (c)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
@@ -619,8 +596,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (p_new) = (p)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -651,8 +627,7 @@ root                             ·                   ·
  │                               spans               FULL SCAN
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                type                anti
+           └── hash join (anti)  ·                   ·
                 │                equality            (y_new) = (x)
                 │                right cols are key  ·
                 ├── scan buffer  ·                   ·
@@ -681,7 +656,6 @@ root                                  ·                   ·
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
-                │                     type                inner
                 │                     equality            (x) = (y)
                 │                     left cols are key   ·
                 │                     right cols are key  ·
@@ -873,25 +847,24 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree                 field               description
-·                    distribution        local
-·                    vectorized          true
-filter               ·                   ·
- │                   filter              z IS NULL
- └── merge join      ·                   ·
-      │              type                left outer
-      │              equality            (a_z, a_y, a_x) = (z, y, x)
-      │              right cols are key  ·
-      ├── filter     ·                   ·
-      │    │         filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
-      │    └── scan  ·                   ·
-      │              missing stats       ·
-      │              table               b@idx
-      │              spans               (/NULL - ]
-      └── scan       ·                   ·
-·                    missing stats       ·
-·                    table               a@primary
-·                    spans               FULL SCAN
+tree                          field               description
+·                             distribution        local
+·                             vectorized          true
+filter                        ·                   ·
+ │                            filter              z IS NULL
+ └── merge join (left outer)  ·                   ·
+      │                       equality            (a_z, a_y, a_x) = (z, y, x)
+      │                       right cols are key  ·
+      ├── filter              ·                   ·
+      │    │                  filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
+      │    └── scan           ·                   ·
+      │                       missing stats       ·
+      │                       table               b@idx
+      │                       spans               (/NULL - ]
+      └── scan                ·                   ·
+·                             missing stats       ·
+·                             table               a@primary
+·                             spans               FULL SCAN
 
 statement ok
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -365,65 +365,62 @@ filter     ·              ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distribution           local                               ·       ·
-·                 vectorized             true                                ·       ·
-lookup join       ·                      ·                                   (a, b)  ·
- │                estimated row count    12 (missing stats)                  ·       ·
- │                table                  d@primary                           ·       ·
- │                type                   inner                               ·       ·
- │                equality               (a) = (a)                           ·       ·
- │                equality cols are key  ·                                   ·       ·
- │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag join  ·                      ·                                   (a)     ·
-·                 estimated row count    12 (missing stats)                  ·       ·
-·                 left table             d@foo_inv                           ·       ·
-·                 left columns           (a)                                 ·       ·
-·                 left fixed values      1 column                            ·       ·
-·                 right table            d@foo_inv                           ·       ·
-·                 right columns          ()                                  ·       ·
-·                 right fixed values     1 column                            ·       ·
+·                    distribution           local                               ·       ·
+·                    vectorized             true                                ·       ·
+lookup join (inner)  ·                      ·                                   (a, b)  ·
+ │                   estimated row count    12 (missing stats)                  ·       ·
+ │                   table                  d@primary                           ·       ·
+ │                   equality               (a) = (a)                           ·       ·
+ │                   equality cols are key  ·                                   ·       ·
+ │                   pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
+ └── zigzag join     ·                      ·                                   (a)     ·
+·                    estimated row count    12 (missing stats)                  ·       ·
+·                    left table             d@foo_inv                           ·       ·
+·                    left columns           (a)                                 ·       ·
+·                    left fixed values      1 column                            ·       ·
+·                    right table            d@foo_inv                           ·       ·
+·                    right columns          ()                                  ·       ·
+·                    right fixed values     1 column                            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                 distribution           local                                         ·       ·
-·                 vectorized             true                                          ·       ·
-lookup join       ·                      ·                                             (a, b)  ·
- │                estimated row count    1 (missing stats)                             ·       ·
- │                table                  d@primary                                     ·       ·
- │                type                   inner                                         ·       ·
- │                equality               (a) = (a)                                     ·       ·
- │                equality cols are key  ·                                             ·       ·
- │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag join  ·                      ·                                             (a)     ·
-·                 estimated row count    12 (missing stats)                            ·       ·
-·                 left table             d@foo_inv                                     ·       ·
-·                 left columns           (a)                                           ·       ·
-·                 left fixed values      1 column                                      ·       ·
-·                 right table            d@foo_inv                                     ·       ·
-·                 right columns          ()                                            ·       ·
-·                 right fixed values     1 column                                      ·       ·
+·                    distribution           local                                         ·       ·
+·                    vectorized             true                                          ·       ·
+lookup join (inner)  ·                      ·                                             (a, b)  ·
+ │                   estimated row count    1 (missing stats)                             ·       ·
+ │                   table                  d@primary                                     ·       ·
+ │                   equality               (a) = (a)                                     ·       ·
+ │                   equality cols are key  ·                                             ·       ·
+ │                   pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── zigzag join     ·                      ·                                             (a)     ·
+·                    estimated row count    12 (missing stats)                            ·       ·
+·                    left table             d@foo_inv                                     ·       ·
+·                    left columns           (a)                                           ·       ·
+·                    left fixed values      1 column                                      ·       ·
+·                    right table            d@foo_inv                                     ·       ·
+·                    right columns          ()                                            ·       ·
+·                    right fixed values     1 column                                      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                 distribution           local                              ·       ·
-·                 vectorized             true                               ·       ·
-lookup join       ·                      ·                                  (a, b)  ·
- │                estimated row count    12 (missing stats)                 ·       ·
- │                table                  d@primary                          ·       ·
- │                type                   inner                              ·       ·
- │                equality               (a) = (a)                          ·       ·
- │                equality cols are key  ·                                  ·       ·
- │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag join  ·                      ·                                  (a)     ·
-·                 estimated row count    12 (missing stats)                 ·       ·
-·                 left table             d@foo_inv                          ·       ·
-·                 left columns           (a)                                ·       ·
-·                 left fixed values      1 column                           ·       ·
-·                 right table            d@foo_inv                          ·       ·
-·                 right columns          ()                                 ·       ·
-·                 right fixed values     1 column                           ·       ·
+·                    distribution           local                              ·       ·
+·                    vectorized             true                               ·       ·
+lookup join (inner)  ·                      ·                                  (a, b)  ·
+ │                   estimated row count    12 (missing stats)                 ·       ·
+ │                   table                  d@primary                          ·       ·
+ │                   equality               (a) = (a)                          ·       ·
+ │                   equality cols are key  ·                                  ·       ·
+ │                   pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ └── zigzag join     ·                      ·                                  (a)     ·
+·                    estimated row count    12 (missing stats)                 ·       ·
+·                    left table             d@foo_inv                          ·       ·
+·                    left columns           (a)                                ·       ·
+·                    left fixed values      1 column                           ·       ·
+·                    right table            d@foo_inv                          ·       ·
+·                    right columns          ()                                 ·       ·
+·                    right fixed values     1 column                           ·       ·
 
 statement ok
 SET enable_zigzag_join = true
@@ -431,65 +428,62 @@ SET enable_zigzag_join = true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distribution           local                               ·       ·
-·                 vectorized             true                                ·       ·
-lookup join       ·                      ·                                   (a, b)  ·
- │                estimated row count    12 (missing stats)                  ·       ·
- │                table                  d@primary                           ·       ·
- │                type                   inner                               ·       ·
- │                equality               (a) = (a)                           ·       ·
- │                equality cols are key  ·                                   ·       ·
- │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag join  ·                      ·                                   (a)     ·
-·                 estimated row count    12 (missing stats)                  ·       ·
-·                 left table             d@foo_inv                           ·       ·
-·                 left columns           (a)                                 ·       ·
-·                 left fixed values      1 column                            ·       ·
-·                 right table            d@foo_inv                           ·       ·
-·                 right columns          ()                                  ·       ·
-·                 right fixed values     1 column                            ·       ·
+·                    distribution           local                               ·       ·
+·                    vectorized             true                                ·       ·
+lookup join (inner)  ·                      ·                                   (a, b)  ·
+ │                   estimated row count    12 (missing stats)                  ·       ·
+ │                   table                  d@primary                           ·       ·
+ │                   equality               (a) = (a)                           ·       ·
+ │                   equality cols are key  ·                                   ·       ·
+ │                   pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
+ └── zigzag join     ·                      ·                                   (a)     ·
+·                    estimated row count    12 (missing stats)                  ·       ·
+·                    left table             d@foo_inv                           ·       ·
+·                    left columns           (a)                                 ·       ·
+·                    left fixed values      1 column                            ·       ·
+·                    right table            d@foo_inv                           ·       ·
+·                    right columns          ()                                  ·       ·
+·                    right fixed values     1 column                            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                 distribution           local                                         ·       ·
-·                 vectorized             true                                          ·       ·
-lookup join       ·                      ·                                             (a, b)  ·
- │                estimated row count    1 (missing stats)                             ·       ·
- │                table                  d@primary                                     ·       ·
- │                type                   inner                                         ·       ·
- │                equality               (a) = (a)                                     ·       ·
- │                equality cols are key  ·                                             ·       ·
- │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag join  ·                      ·                                             (a)     ·
-·                 estimated row count    12 (missing stats)                            ·       ·
-·                 left table             d@foo_inv                                     ·       ·
-·                 left columns           (a)                                           ·       ·
-·                 left fixed values      1 column                                      ·       ·
-·                 right table            d@foo_inv                                     ·       ·
-·                 right columns          ()                                            ·       ·
-·                 right fixed values     1 column                                      ·       ·
+·                    distribution           local                                         ·       ·
+·                    vectorized             true                                          ·       ·
+lookup join (inner)  ·                      ·                                             (a, b)  ·
+ │                   estimated row count    1 (missing stats)                             ·       ·
+ │                   table                  d@primary                                     ·       ·
+ │                   equality               (a) = (a)                                     ·       ·
+ │                   equality cols are key  ·                                             ·       ·
+ │                   pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── zigzag join     ·                      ·                                             (a)     ·
+·                    estimated row count    12 (missing stats)                            ·       ·
+·                    left table             d@foo_inv                                     ·       ·
+·                    left columns           (a)                                           ·       ·
+·                    left fixed values      1 column                                      ·       ·
+·                    right table            d@foo_inv                                     ·       ·
+·                    right columns          ()                                            ·       ·
+·                    right fixed values     1 column                                      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                 distribution           local                              ·       ·
-·                 vectorized             true                               ·       ·
-lookup join       ·                      ·                                  (a, b)  ·
- │                estimated row count    12 (missing stats)                 ·       ·
- │                table                  d@primary                          ·       ·
- │                type                   inner                              ·       ·
- │                equality               (a) = (a)                          ·       ·
- │                equality cols are key  ·                                  ·       ·
- │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag join  ·                      ·                                  (a)     ·
-·                 estimated row count    12 (missing stats)                 ·       ·
-·                 left table             d@foo_inv                          ·       ·
-·                 left columns           (a)                                ·       ·
-·                 left fixed values      1 column                           ·       ·
-·                 right table            d@foo_inv                          ·       ·
-·                 right columns          ()                                 ·       ·
-·                 right fixed values     1 column                           ·       ·
+·                    distribution           local                              ·       ·
+·                    vectorized             true                               ·       ·
+lookup join (inner)  ·                      ·                                  (a, b)  ·
+ │                   estimated row count    12 (missing stats)                 ·       ·
+ │                   table                  d@primary                          ·       ·
+ │                   equality               (a) = (a)                          ·       ·
+ │                   equality cols are key  ·                                  ·       ·
+ │                   pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ └── zigzag join     ·                      ·                                  (a)     ·
+·                    estimated row count    12 (missing stats)                 ·       ·
+·                    left table             d@foo_inv                          ·       ·
+·                    left columns           (a)                                ·       ·
+·                    left fixed values      1 column                           ·       ·
+·                    right table            d@foo_inv                          ·       ·
+·                    right columns          ()                                 ·       ·
+·                    right fixed values     1 column                           ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
@@ -586,44 +580,42 @@ filter     ·                    ·                     (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ----
-·                 distribution           local                ·       ·
-·                 vectorized             true                 ·       ·
-lookup join       ·                      ·                    (a, b)  ·
- │                estimated row count    333 (missing stats)  ·       ·
- │                table                  e@primary            ·       ·
- │                type                   inner                ·       ·
- │                equality               (a) = (a)            ·       ·
- │                equality cols are key  ·                    ·       ·
- │                pred                   b @> ARRAY[1,2]      ·       ·
- └── zigzag join  ·                      ·                    (a)     ·
-·                 estimated row count    12 (missing stats)   ·       ·
-·                 left table             e@e_b_idx            ·       ·
-·                 left columns           (a)                  ·       ·
-·                 left fixed values      1 column             ·       ·
-·                 right table            e@e_b_idx            ·       ·
-·                 right columns          ()                   ·       ·
-·                 right fixed values     1 column             ·       ·
+·                    distribution           local                ·       ·
+·                    vectorized             true                 ·       ·
+lookup join (inner)  ·                      ·                    (a, b)  ·
+ │                   estimated row count    333 (missing stats)  ·       ·
+ │                   table                  e@primary            ·       ·
+ │                   equality               (a) = (a)            ·       ·
+ │                   equality cols are key  ·                    ·       ·
+ │                   pred                   b @> ARRAY[1,2]      ·       ·
+ └── zigzag join     ·                      ·                    (a)     ·
+·                    estimated row count    12 (missing stats)   ·       ·
+·                    left table             e@e_b_idx            ·       ·
+·                    left columns           (a)                  ·       ·
+·                    left fixed values      1 column             ·       ·
+·                    right table            e@e_b_idx            ·       ·
+·                    right columns          ()                   ·       ·
+·                    right fixed values     1 column             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ----
-·                 distribution           local                                ·       ·
-·                 vectorized             true                                 ·       ·
-lookup join       ·                      ·                                    (a, b)  ·
- │                estimated row count    111 (missing stats)                  ·       ·
- │                table                  e@primary                            ·       ·
- │                type                   inner                                ·       ·
- │                equality               (a) = (a)                            ·       ·
- │                equality cols are key  ·                                    ·       ·
- │                pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
- └── zigzag join  ·                      ·                                    (a)     ·
-·                 estimated row count    12 (missing stats)                   ·       ·
-·                 left table             e@e_b_idx                            ·       ·
-·                 left columns           (a)                                  ·       ·
-·                 left fixed values      1 column                             ·       ·
-·                 right table            e@e_b_idx                            ·       ·
-·                 right columns          ()                                   ·       ·
-·                 right fixed values     1 column                             ·       ·
+·                    distribution           local                                ·       ·
+·                    vectorized             true                                 ·       ·
+lookup join (inner)  ·                      ·                                    (a, b)  ·
+ │                   estimated row count    111 (missing stats)                  ·       ·
+ │                   table                  e@primary                            ·       ·
+ │                   equality               (a) = (a)                            ·       ·
+ │                   equality cols are key  ·                                    ·       ·
+ │                   pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
+ └── zigzag join     ·                      ·                                    (a)     ·
+·                    estimated row count    12 (missing stats)                   ·       ·
+·                    left table             e@e_b_idx                            ·       ·
+·                    left columns           (a)                                  ·       ·
+·                    left fixed values      1 column                             ·       ·
+·                    right table            e@e_b_idx                            ·       ·
+·                    right columns          ()                                   ·       ·
+·                    right fixed values     1 column                             ·       ·
 
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.
@@ -716,10 +708,9 @@ ON ST_Intersects(geo_table2.geom, geo_table.geom)
 ----
 ·                        distribution           local                                   ·                                ·
 ·                        vectorized             true                                    ·                                ·
-lookup join              ·                      ·                                       (k, geom, k, geom)               ·
+lookup join (inner)      ·                      ·                                       (k, geom, k, geom)               ·
  │                       estimated row count    10000 (missing stats)                   ·                                ·
  │                       table                  geo_table@primary                       ·                                ·
- │                       type                   inner                                   ·                                ·
  │                       equality               (k) = (k)                               ·                                ·
  │                       equality cols are key  ·                                       ·                                ·
  │                       pred                   st_intersects(geom, geom)               ·                                ·
@@ -727,7 +718,6 @@ lookup join              ·                      ·                             
       │                  estimated row count    10000 (missing stats)                   ·                                ·
       └── inverted join  ·                      ·                                       (k, geom, k, geom_inverted_key)  ·
            │             table                  geo_table@geom_index                    ·                                ·
-           │             type                   inner                                   ·                                ·
            │             inverted expr          st_intersects(geom, geom_inverted_key)  ·                                ·
            └── scan      ·                      ·                                       (k, geom)                        ·
 ·                        estimated row count    1000 (missing stats)                    ·                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -171,7 +171,7 @@ index join  ·                    ·                            (a, b)  ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
-·           estimated row count  111 (missing stats)          ·       ·
+·           estimated row count  110 (missing stats)          ·       ·
 ·           table                d@foo_inv                    ·       ·
 ·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
@@ -185,7 +185,7 @@ index join  ·                    ·                                        (a, 
  │          table                d@primary                                ·       ·
  │          key columns          a                                        ·       ·
  └── scan   ·                    ·                                        (a)     ·
-·           estimated row count  111 (missing stats)                      ·       ·
+·           estimated row count  110 (missing stats)                      ·       ·
 ·           table                d@foo_inv                                ·       ·
 ·           spans                /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
@@ -199,7 +199,7 @@ index join  ·                    ·                                            
  │          table                d@primary                                        ·       ·
  │          key columns          a                                                ·       ·
  └── scan   ·                    ·                                                (a)     ·
-·           estimated row count  111 (missing stats)                              ·       ·
+·           estimated row count  110 (missing stats)                              ·       ·
 ·           table                d@foo_inv                                        ·       ·
 ·           spans                /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
 
@@ -213,7 +213,7 @@ index join  ·                    ·                             (a, b)  ·
  │          table                d@primary                     ·       ·
  │          key columns          a                             ·       ·
  └── scan   ·                    ·                             (a)     ·
-·           estimated row count  111 (missing stats)           ·       ·
+·           estimated row count  110 (missing stats)           ·       ·
 ·           table                d@foo_inv                     ·       ·
 ·           spans                /"a"/"b"/True-/"a"/"b"/False  ·       ·
 
@@ -227,7 +227,7 @@ index join  ·                    ·                        (a, b)  ·
  │          table                d@primary                ·       ·
  │          key columns          a                        ·       ·
  └── scan   ·                    ·                        (a)     ·
-·           estimated row count  111 (missing stats)      ·       ·
+·           estimated row count  110 (missing stats)      ·       ·
 ·           table                d@foo_inv                ·       ·
 ·           spans                /Arr/1-/Arr/1/PrefixEnd  ·       ·
 
@@ -241,7 +241,7 @@ index join  ·                    ·                                            
  │          table                d@primary                                        ·       ·
  │          key columns          a                                                ·       ·
  └── scan   ·                    ·                                                (a)     ·
-·           estimated row count  111 (missing stats)                              ·       ·
+·           estimated row count  110 (missing stats)                              ·       ·
 ·           table                d@foo_inv                                        ·       ·
 ·           spans                /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
@@ -283,7 +283,7 @@ index join  ·                    ·                            (a, b)  ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
-·           estimated row count  111 (missing stats)          ·       ·
+·           estimated row count  110 (missing stats)          ·       ·
 ·           table                d@foo_inv                    ·       ·
 ·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
@@ -297,7 +297,7 @@ index join  ·                    ·                                    (a, b)  
  │          table                d@primary                            ·       ·
  │          key columns          a                                    ·       ·
  └── scan   ·                    ·                                    (a)     ·
-·           estimated row count  111 (missing stats)                  ·       ·
+·           estimated row count  110 (missing stats)                  ·       ·
 ·           table                d@foo_inv                            ·       ·
 ·           spans                /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
 
@@ -318,7 +318,7 @@ index join  ·                    ·                            (a, b)  ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
-·           estimated row count  111 (missing stats)          ·       ·
+·           estimated row count  110 (missing stats)          ·       ·
 ·           table                d@foo_inv                    ·       ·
 ·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
@@ -373,11 +373,9 @@ lookup join       ·                      ·                                   (
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
- │                parallel               ·                                   ·       ·
  │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag join  ·                      ·                                   (a)     ·
 ·                 estimated row count    12 (missing stats)                  ·       ·
-·                 type                   inner                               ·       ·
 ·                 left table             d@foo_inv                           ·       ·
 ·                 left columns           (a)                                 ·       ·
 ·                 left fixed values      1 column                            ·       ·
@@ -396,11 +394,9 @@ lookup join       ·                      ·                                    
  │                type                   inner                                         ·       ·
  │                equality               (a) = (a)                                     ·       ·
  │                equality cols are key  ·                                             ·       ·
- │                parallel               ·                                             ·       ·
  │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
  └── zigzag join  ·                      ·                                             (a)     ·
 ·                 estimated row count    12 (missing stats)                            ·       ·
-·                 type                   inner                                         ·       ·
 ·                 left table             d@foo_inv                                     ·       ·
 ·                 left columns           (a)                                           ·       ·
 ·                 left fixed values      1 column                                      ·       ·
@@ -419,11 +415,9 @@ lookup join       ·                      ·                                  (a
  │                type                   inner                              ·       ·
  │                equality               (a) = (a)                          ·       ·
  │                equality cols are key  ·                                  ·       ·
- │                parallel               ·                                  ·       ·
  │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
  └── zigzag join  ·                      ·                                  (a)     ·
 ·                 estimated row count    12 (missing stats)                 ·       ·
-·                 type                   inner                              ·       ·
 ·                 left table             d@foo_inv                          ·       ·
 ·                 left columns           (a)                                ·       ·
 ·                 left fixed values      1 column                           ·       ·
@@ -445,11 +439,9 @@ lookup join       ·                      ·                                   (
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
- │                parallel               ·                                   ·       ·
  │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag join  ·                      ·                                   (a)     ·
 ·                 estimated row count    12 (missing stats)                  ·       ·
-·                 type                   inner                               ·       ·
 ·                 left table             d@foo_inv                           ·       ·
 ·                 left columns           (a)                                 ·       ·
 ·                 left fixed values      1 column                            ·       ·
@@ -468,11 +460,9 @@ lookup join       ·                      ·                                    
  │                type                   inner                                         ·       ·
  │                equality               (a) = (a)                                     ·       ·
  │                equality cols are key  ·                                             ·       ·
- │                parallel               ·                                             ·       ·
  │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
  └── zigzag join  ·                      ·                                             (a)     ·
 ·                 estimated row count    12 (missing stats)                            ·       ·
-·                 type                   inner                                         ·       ·
 ·                 left table             d@foo_inv                                     ·       ·
 ·                 left columns           (a)                                           ·       ·
 ·                 left fixed values      1 column                                      ·       ·
@@ -491,11 +481,9 @@ lookup join       ·                      ·                                  (a
  │                type                   inner                              ·       ·
  │                equality               (a) = (a)                          ·       ·
  │                equality cols are key  ·                                  ·       ·
- │                parallel               ·                                  ·       ·
  │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
  └── zigzag join  ·                      ·                                  (a)     ·
 ·                 estimated row count    12 (missing stats)                 ·       ·
-·                 type                   inner                              ·       ·
 ·                 left table             d@foo_inv                          ·       ·
 ·                 left columns           (a)                                ·       ·
 ·                 left fixed values      1 column                           ·       ·
@@ -512,11 +500,11 @@ filter           ·                    ·                         (a, b)  ·
  │               estimated row count  12 (missing stats)        ·       ·
  │               filter               b @> '{"a": {}, "b": 2}'  ·       ·
  └── index join  ·                    ·                         (a, b)  ·
-      │          estimated row count  111 (missing stats)       ·       ·
+      │          estimated row count  110 (missing stats)       ·       ·
       │          table                d@primary                 ·       ·
       │          key columns          a                         ·       ·
       └── scan   ·                    ·                         (a)     ·
-·                estimated row count  111 (missing stats)       ·       ·
+·                estimated row count  110 (missing stats)       ·       ·
 ·                table                d@foo_inv                 ·       ·
 ·                spans                /"b"/2-/"b"/2/PrefixEnd   ·       ·
 
@@ -546,7 +534,7 @@ index join  ·                    ·                    (a, b)  ·
  │          table                e@primary            ·       ·
  │          key columns          a                    ·       ·
  └── scan   ·                    ·                    (a)     ·
-·           estimated row count  111 (missing stats)  ·       ·
+·           estimated row count  110 (missing stats)  ·       ·
 ·           table                e@e_b_idx            ·       ·
 ·           spans                /1-/2                ·       ·
 
@@ -606,11 +594,9 @@ lookup join       ·                      ·                    (a, b)  ·
  │                type                   inner                ·       ·
  │                equality               (a) = (a)            ·       ·
  │                equality cols are key  ·                    ·       ·
- │                parallel               ·                    ·       ·
  │                pred                   b @> ARRAY[1,2]      ·       ·
  └── zigzag join  ·                      ·                    (a)     ·
 ·                 estimated row count    12 (missing stats)   ·       ·
-·                 type                   inner                ·       ·
 ·                 left table             e@e_b_idx            ·       ·
 ·                 left columns           (a)                  ·       ·
 ·                 left fixed values      1 column             ·       ·
@@ -629,11 +615,9 @@ lookup join       ·                      ·                                    
  │                type                   inner                                ·       ·
  │                equality               (a) = (a)                            ·       ·
  │                equality cols are key  ·                                    ·       ·
- │                parallel               ·                                    ·       ·
  │                pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
  └── zigzag join  ·                      ·                                    (a)     ·
 ·                 estimated row count    12 (missing stats)                   ·       ·
-·                 type                   inner                                ·       ·
 ·                 left table             e@e_b_idx                            ·       ·
 ·                 left columns           (a)                                  ·       ·
 ·                 left fixed values      1 column                             ·       ·
@@ -738,15 +722,13 @@ lookup join              ·                      ·                             
  │                       type                   inner                                   ·                                ·
  │                       equality               (k) = (k)                               ·                                ·
  │                       equality cols are key  ·                                       ·                                ·
- │                       parallel               ·                                       ·                                ·
  │                       pred                   st_intersects(geom, geom)               ·                                ·
  └── project             ·                      ·                                       (k, geom, k)                     ·
       │                  estimated row count    10000 (missing stats)                   ·                                ·
       └── inverted join  ·                      ·                                       (k, geom, k, geom_inverted_key)  ·
            │             table                  geo_table@geom_index                    ·                                ·
            │             type                   inner                                   ·                                ·
-           │             ·                      st_intersects(geom, geom_inverted_key)  ·                                ·
-           │             parallel               ·                                       ·                                ·
+           │             inverted expr          st_intersects(geom, geom_inverted_key)  ·                                ·
            └── scan      ·                      ·                                       (k, geom)                        ·
 ·                        estimated row count    1000 (missing stats)                    ·                                ·
 ·                        table                  geo_table2@primary                      ·                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -14,7 +14,6 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ·          distribution   local
 ·          vectorized     true
 hash join  ·              ·
- │         type           inner
  │         equality       (x) = (x)
  ├── scan  ·              ·
  │         missing stats  ·
@@ -31,7 +30,6 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ·          distribution   local
 ·          vectorized     true
 hash join  ·              ·
- │         type           inner
  │         equality       (x) = (y)
  ├── scan  ·              ·
  │         missing stats  ·
@@ -48,7 +46,6 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ·               distribution   local
 ·               vectorized     true
 cross join      ·              ·
- │              type           cross
  ├── scan       ·              ·
  │              missing stats  ·
  │              table          twocolumn@primary
@@ -66,7 +63,6 @@ EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ·          distribution   local
 ·          vectorized     true
 hash join  ·              ·
- │         type           inner
  │         equality       (x) = (y)
  ├── scan  ·              ·
  │         missing stats  ·
@@ -83,7 +79,6 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ·          distribution   local
 ·          vectorized     true
 hash join  ·              ·
- │         type           inner
  │         equality       (x) = (y)
  ├── scan  ·              ·
  │         missing stats  ·
@@ -107,10 +102,8 @@ LIMIT 1
 limit                ·              ·
  │                   count          1
  └── hash join       ·              ·
-      │              type           inner
       │              equality       (x) = (x)
       ├── hash join  ·              ·
-      │    │         type           inner
       │    │         equality       (x) = (x)
       │    ├── scan  ·              ·
       │    │         missing stats  ·
@@ -121,7 +114,6 @@ limit                ·              ·
       │              table          twocolumn@primary
       │              spans          FULL SCAN
       └── hash join  ·              ·
-           │         type           inner
            │         equality       (x) = (x)
            ├── scan  ·              ·
            │         missing stats  ·
@@ -136,139 +128,133 @@ limit                ·              ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-·           distribution         local                    ·       ·
-·           vectorized           true                     ·       ·
-cross join  ·                    ·                        (x, y)  ·
- │          estimated row count  1000000 (missing stats)  ·       ·
- │          type                 cross                    ·       ·
- ├── scan   ·                    ·                        (x)     ·
- │          estimated row count  1000 (missing stats)     ·       ·
- │          table                twocolumn@primary        ·       ·
- │          spans                FULL SCAN                ·       ·
- └── scan   ·                    ·                        (y)     ·
-·           estimated row count  1000 (missing stats)     ·       ·
-·           table                twocolumn@primary        ·       ·
-·           spans                FULL SCAN                ·       ·
+·                   distribution         local                    ·       ·
+·                   vectorized           true                     ·       ·
+cross join (inner)  ·                    ·                        (x, y)  ·
+ │                  estimated row count  1000000 (missing stats)  ·       ·
+ ├── scan           ·                    ·                        (x)     ·
+ │                  estimated row count  1000 (missing stats)     ·       ·
+ │                  table                twocolumn@primary        ·       ·
+ │                  spans                FULL SCAN                ·       ·
+ └── scan           ·                    ·                        (y)     ·
+·                   estimated row count  1000 (missing stats)     ·       ·
+·                   table                twocolumn@primary        ·       ·
+·                   spans                FULL SCAN                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (y)        ·
- │              estimated row count  9801 (missing stats)  ·          ·
- └── hash join  ·                    ·                     (x, x, y)  ·
-      │         estimated row count  9801 (missing stats)  ·          ·
-      │         type                 inner                 ·          ·
-      │         equality             (x) = (x)             ·          ·
-      ├── scan  ·                    ·                     (x)        ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         table                twocolumn@primary     ·          ·
-      │         spans                FULL SCAN             ·          ·
-      └── scan  ·                    ·                     (x, y)     ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                twocolumn@primary     ·          ·
-·               spans                FULL SCAN             ·          ·
+·                       distribution         local                 ·          ·
+·                       vectorized           true                  ·          ·
+project                 ·                    ·                     (y)        ·
+ │                      estimated row count  9801 (missing stats)  ·          ·
+ └── hash join (inner)  ·                    ·                     (x, x, y)  ·
+      │                 estimated row count  9801 (missing stats)  ·          ·
+      │                 equality             (x) = (x)             ·          ·
+      ├── scan          ·                    ·                     (x)        ·
+      │                 estimated row count  1000 (missing stats)  ·          ·
+      │                 table                twocolumn@primary     ·          ·
+      │                 spans                FULL SCAN             ·          ·
+      └── scan          ·                    ·                     (x, y)     ·
+·                       estimated row count  1000 (missing stats)  ·          ·
+·                       table                twocolumn@primary     ·          ·
+·                       spans                FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (y)        ·
- │              estimated row count  9801 (missing stats)  ·          ·
- └── hash join  ·                    ·                     (x, x, y)  ·
-      │         estimated row count  9801 (missing stats)  ·          ·
-      │         type                 inner                 ·          ·
-      │         equality             (x) = (x)             ·          ·
-      ├── scan  ·                    ·                     (x)        ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         table                twocolumn@primary     ·          ·
-      │         spans                FULL SCAN             ·          ·
-      └── scan  ·                    ·                     (x, y)     ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                twocolumn@primary     ·          ·
-·               spans                FULL SCAN             ·          ·
+·                       distribution         local                 ·          ·
+·                       vectorized           true                  ·          ·
+project                 ·                    ·                     (y)        ·
+ │                      estimated row count  9801 (missing stats)  ·          ·
+ └── hash join (inner)  ·                    ·                     (x, x, y)  ·
+      │                 estimated row count  9801 (missing stats)  ·          ·
+      │                 equality             (x) = (x)             ·          ·
+      ├── scan          ·                    ·                     (x)        ·
+      │                 estimated row count  1000 (missing stats)  ·          ·
+      │                 table                twocolumn@primary     ·          ·
+      │                 spans                FULL SCAN             ·          ·
+      └── scan          ·                    ·                     (x, y)     ·
+·                       estimated row count  1000 (missing stats)  ·          ·
+·                       table                twocolumn@primary     ·          ·
+·                       spans                FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-·                distribution         local                   ·       ·
-·                vectorized           true                    ·       ·
-project          ·                    ·                       (x)     ·
- │               estimated row count  326700 (missing stats)  ·       ·
- └── cross join  ·                    ·                       (x, y)  ·
-      │          estimated row count  326700 (missing stats)  ·       ·
-      │          type                 cross                   ·       ·
-      │          pred                 x < y                   ·       ·
-      ├── scan   ·                    ·                       (x)     ·
-      │          estimated row count  1000 (missing stats)    ·       ·
-      │          table                twocolumn@primary       ·       ·
-      │          spans                FULL SCAN               ·       ·
-      └── scan   ·                    ·                       (y)     ·
-·                estimated row count  1000 (missing stats)    ·       ·
-·                table                twocolumn@primary       ·       ·
-·                spans                FULL SCAN               ·       ·
+·                        distribution         local                   ·       ·
+·                        vectorized           true                    ·       ·
+project                  ·                    ·                       (x)     ·
+ │                       estimated row count  326700 (missing stats)  ·       ·
+ └── cross join (inner)  ·                    ·                       (x, y)  ·
+      │                  estimated row count  326700 (missing stats)  ·       ·
+      │                  pred                 x < y                   ·       ·
+      ├── scan           ·                    ·                       (x)     ·
+      │                  estimated row count  1000 (missing stats)    ·       ·
+      │                  table                twocolumn@primary       ·       ·
+      │                  spans                FULL SCAN               ·       ·
+      └── scan           ·                    ·                       (y)     ·
+·                        estimated row count  1000 (missing stats)    ·       ·
+·                        table                twocolumn@primary       ·       ·
+·                        spans                FULL SCAN               ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
 ----
-·                    distribution         local                  ·                   ·
-·                    vectorized           true                   ·                   ·
-render               ·                    ·                      (x, two, plus1)     ·
- │                   estimated row count  10000 (missing stats)  ·                   ·
- │                   render 0             COALESCE(x, x)         ·                   ·
- │                   render 1             two                    ·                   ·
- │                   render 2             plus1                  ·                   ·
- └── hash join       ·                    ·                      (two, x, plus1, x)  ·
-      │              estimated row count  10000 (missing stats)  ·                   ·
-      │              type                 full outer             ·                   ·
-      │              equality             (x) = (x)              ·                   ·
-      ├── render     ·                    ·                      (two, x)            ·
-      │    │         estimated row count  1000 (missing stats)   ·                   ·
-      │    │         render 0             2                      ·                   ·
-      │    │         render 1             x                      ·                   ·
-      │    └── scan  ·                    ·                      (x)                 ·
-      │              estimated row count  1000 (missing stats)   ·                   ·
-      │              table                onecolumn@primary      ·                   ·
-      │              spans                FULL SCAN              ·                   ·
-      └── render     ·                    ·                      (plus1, x)          ·
-           │         estimated row count  1000 (missing stats)   ·                   ·
-           │         render 0             y + 1                  ·                   ·
-           │         render 1             x                      ·                   ·
-           └── scan  ·                    ·                      (x, y)              ·
-·                    estimated row count  1000 (missing stats)   ·                   ·
-·                    table                twocolumn@primary      ·                   ·
-·                    spans                FULL SCAN              ·                   ·
+·                            distribution         local                  ·                   ·
+·                            vectorized           true                   ·                   ·
+render                       ·                    ·                      (x, two, plus1)     ·
+ │                           estimated row count  10000 (missing stats)  ·                   ·
+ │                           render 0             COALESCE(x, x)         ·                   ·
+ │                           render 1             two                    ·                   ·
+ │                           render 2             plus1                  ·                   ·
+ └── hash join (full outer)  ·                    ·                      (two, x, plus1, x)  ·
+      │                      estimated row count  10000 (missing stats)  ·                   ·
+      │                      equality             (x) = (x)              ·                   ·
+      ├── render             ·                    ·                      (two, x)            ·
+      │    │                 estimated row count  1000 (missing stats)   ·                   ·
+      │    │                 render 0             2                      ·                   ·
+      │    │                 render 1             x                      ·                   ·
+      │    └── scan          ·                    ·                      (x)                 ·
+      │                      estimated row count  1000 (missing stats)   ·                   ·
+      │                      table                onecolumn@primary      ·                   ·
+      │                      spans                FULL SCAN              ·                   ·
+      └── render             ·                    ·                      (plus1, x)          ·
+           │                 estimated row count  1000 (missing stats)   ·                   ·
+           │                 render 0             y + 1                  ·                   ·
+           │                 render 1             x                      ·                   ·
+           └── scan          ·                    ·                      (x, y)              ·
+·                            estimated row count  1000 (missing stats)   ·                   ·
+·                            table                twocolumn@primary      ·                   ·
+·                            spans                FULL SCAN              ·                   ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-·                      distribution         local                  ·                                     ·
-·                      vectorized           false                  ·                                     ·
-sort                   ·                    ·                      (k, u, w)                             +u
- │                     estimated row count  2                      ·                                     ·
- │                     order                +column1               ·                                     ·
- └── project           ·                    ·                      (column1, column2, column2)           ·
-      │                estimated row count  2                      ·                                     ·
-      └── hash join    ·                    ·                      (column1, column2, column1, column2)  ·
-           │           estimated row count  2                      ·                                     ·
-           │           type                 inner                  ·                                     ·
-           │           equality             (column2) = (column1)  ·                                     ·
-           ├── values  ·                    ·                      (column1, column2)                    ·
-           │           size                 2 columns, 2 rows      ·                                     ·
-           │           row 0, expr 0        9                      ·                                     ·
-           │           row 0, expr 1        1                      ·                                     ·
-           │           row 1, expr 0        8                      ·                                     ·
-           │           row 1, expr 1        2                      ·                                     ·
-           └── values  ·                    ·                      (column1, column2)                    ·
-·                      size                 2 columns, 2 rows      ·                                     ·
-·                      row 0, expr 0        1                      ·                                     ·
-·                      row 0, expr 1        1                      ·                                     ·
-·                      row 1, expr 0        2                      ·                                     ·
-·                      row 1, expr 1        2                      ·                                     ·
+·                            distribution         local                  ·                                     ·
+·                            vectorized           false                  ·                                     ·
+sort                         ·                    ·                      (k, u, w)                             +u
+ │                           estimated row count  2                      ·                                     ·
+ │                           order                +column1               ·                                     ·
+ └── project                 ·                    ·                      (column1, column2, column2)           ·
+      │                      estimated row count  2                      ·                                     ·
+      └── hash join (inner)  ·                    ·                      (column1, column2, column1, column2)  ·
+           │                 estimated row count  2                      ·                                     ·
+           │                 equality             (column2) = (column1)  ·                                     ·
+           ├── values        ·                    ·                      (column1, column2)                    ·
+           │                 size                 2 columns, 2 rows      ·                                     ·
+           │                 row 0, expr 0        9                      ·                                     ·
+           │                 row 0, expr 1        1                      ·                                     ·
+           │                 row 1, expr 0        8                      ·                                     ·
+           │                 row 1, expr 1        2                      ·                                     ·
+           └── values        ·                    ·                      (column1, column2)                    ·
+·                            size                 2 columns, 2 rows      ·                                     ·
+·                            row 0, expr 0        1                      ·                                     ·
+·                            row 0, expr 1        1                      ·                                     ·
+·                            row 1, expr 0        2                      ·                                     ·
+·                            row 1, expr 1        2                      ·                                     ·
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
@@ -339,101 +325,92 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
            pos.n
   ] WHERE node_type <> 'values' AND field <> 'size'
 ----
-0   ·                          distribution           local
-0   ·                          vectorized             false
-0   project                    ·                      ·
-1   sort                       ·                      ·
-1   ·                          estimated row count    106 (missing stats)
-1   ·                          order                  +nspname,+relname,+conname,+generate_series
-2   render                     ·                      ·
-2   ·                          estimated row count    106 (missing stats)
-2   ·                          render 0               CAST(NULL AS STRING)
-2   ·                          render 1               CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-2   ·                          render 2               CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-2   ·                          render 3               CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
-2   ·                          render 4               nspname
-2   ·                          render 5               relname
-2   ·                          render 6               attname
-2   ·                          render 7               nspname
-2   ·                          render 8               relname
-2   ·                          render 9               attname
-2   ·                          render 10              conname
-2   ·                          render 11              generate_series
-2   ·                          render 12              relname
-3   hash join                  ·                      ·
-3   ·                          estimated row count    106 (missing stats)
-3   ·                          type                   inner
-3   ·                          equality               (oid) = (objid)
-4   hash join                  ·                      ·
-4   ·                          estimated row count    109 (missing stats)
-4   ·                          type                   inner
-4   ·                          equality               (oid) = (relnamespace)
-5   virtual table              ·                      ·
-5   ·                          estimated row count    1000 (missing stats)
-5   ·                          table                  pg_namespace@primary
-5   hash join                  ·                      ·
-5   ·                          estimated row count    11 (missing stats)
-5   ·                          type                   inner
-5   ·                          equality               (relnamespace) = (oid)
-6   cross join                 ·                      ·
-6   ·                          estimated row count    11 (missing stats)
-6   ·                          type                   cross
-6   ·                          pred                   (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
-7   project set                ·                      ·
-7   ·                          estimated row count    10
-7   ·                          render 0               generate_series(1, 32)
-8   emptyrow                   ·                      ·
-7   virtual table lookup join  ·                      ·
-7   ·                          estimated row count    10 (missing stats)
-7   ·                          table                  pg_attribute@pg_attribute_attrelid_idx
-7   ·                          type                   inner
-7   ·                          equality               (oid) = (attrelid)
-7   ·                          equality cols are key  ·
-8   virtual table lookup join  ·                      ·
-8   ·                          estimated row count    10 (missing stats)
-8   ·                          table                  pg_class@pg_class_oid_idx
-8   ·                          type                   inner
-8   ·                          equality               (attrelid) = (oid)
-8   ·                          equality cols are key  ·
-9   virtual table lookup join  ·                      ·
-9   ·                          estimated row count    10 (missing stats)
-9   ·                          table                  pg_attribute@pg_attribute_attrelid_idx
-9   ·                          type                   inner
-9   ·                          equality               (confrelid) = (attrelid)
-9   ·                          equality cols are key  ·
-10  virtual table lookup join  ·                      ·
-10  ·                          estimated row count    10 (missing stats)
-10  ·                          table                  pg_constraint@pg_constraint_conrelid_idx
-10  ·                          type                   inner
-10  ·                          equality               (oid) = (conrelid)
-10  ·                          equality cols are key  ·
-10  ·                          pred                   contype = 'f'
-11  filter                     ·                      ·
-11  ·                          estimated row count    10 (missing stats)
-11  ·                          filter                 relname = 'orders'
-12  virtual table              ·                      ·
-12  ·                          estimated row count    1000 (missing stats)
-12  ·                          table                  pg_class@primary
-6   filter                     ·                      ·
-6   ·                          estimated row count    10 (missing stats)
-6   ·                          filter                 nspname = 'public'
-7   virtual table              ·                      ·
-7   ·                          estimated row count    1000 (missing stats)
-7   ·                          table                  pg_namespace@primary
-4   hash join                  ·                      ·
-4   ·                          estimated row count    99 (missing stats)
-4   ·                          type                   inner
-4   ·                          equality               (refobjid) = (oid)
-4   ·                          right cols are key     ·
-5   virtual table              ·                      ·
-5   ·                          estimated row count    1000 (missing stats)
-5   ·                          table                  pg_depend@primary
-5   filter                     ·                      ·
-5   ·                          estimated row count    10 (missing stats)
-5   ·                          filter                 relkind = 'i'
-6   virtual table              ·                      ·
-6   ·                          estimated row count    1000 (missing stats)
-6   ·                          table                  pg_class@primary
+0   ·                                  distribution           local
+0   ·                                  vectorized             false
+0   project                            ·                      ·
+1   sort                               ·                      ·
+1   ·                                  estimated row count    106 (missing stats)
+1   ·                                  order                  +nspname,+relname,+conname,+generate_series
+2   render                             ·                      ·
+2   ·                                  estimated row count    106 (missing stats)
+2   ·                                  render 0               CAST(NULL AS STRING)
+2   ·                                  render 1               CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+2   ·                                  render 2               CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+2   ·                                  render 3               CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
+2   ·                                  render 4               nspname
+2   ·                                  render 5               relname
+2   ·                                  render 6               attname
+2   ·                                  render 7               nspname
+2   ·                                  render 8               relname
+2   ·                                  render 9               attname
+2   ·                                  render 10              conname
+2   ·                                  render 11              generate_series
+2   ·                                  render 12              relname
+3   hash join (inner)                  ·                      ·
+3   ·                                  estimated row count    106 (missing stats)
+3   ·                                  equality               (oid) = (objid)
+4   hash join (inner)                  ·                      ·
+4   ·                                  estimated row count    109 (missing stats)
+4   ·                                  equality               (oid) = (relnamespace)
+5   virtual table                      ·                      ·
+5   ·                                  estimated row count    1000 (missing stats)
+5   ·                                  table                  pg_namespace@primary
+5   hash join (inner)                  ·                      ·
+5   ·                                  estimated row count    11 (missing stats)
+5   ·                                  equality               (relnamespace) = (oid)
+6   cross join (inner)                 ·                      ·
+6   ·                                  estimated row count    11 (missing stats)
+6   ·                                  pred                   (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
+7   project set                        ·                      ·
+7   ·                                  estimated row count    10
+7   ·                                  render 0               generate_series(1, 32)
+8   emptyrow                           ·                      ·
+7   virtual table lookup join (inner)  ·                      ·
+7   ·                                  estimated row count    10 (missing stats)
+7   ·                                  table                  pg_attribute@pg_attribute_attrelid_idx
+7   ·                                  equality               (oid) = (attrelid)
+7   ·                                  equality cols are key  ·
+8   virtual table lookup join (inner)  ·                      ·
+8   ·                                  estimated row count    10 (missing stats)
+8   ·                                  table                  pg_class@pg_class_oid_idx
+8   ·                                  equality               (attrelid) = (oid)
+8   ·                                  equality cols are key  ·
+9   virtual table lookup join (inner)  ·                      ·
+9   ·                                  estimated row count    10 (missing stats)
+9   ·                                  table                  pg_attribute@pg_attribute_attrelid_idx
+9   ·                                  equality               (confrelid) = (attrelid)
+9   ·                                  equality cols are key  ·
+10  virtual table lookup join (inner)  ·                      ·
+10  ·                                  estimated row count    10 (missing stats)
+10  ·                                  table                  pg_constraint@pg_constraint_conrelid_idx
+10  ·                                  equality               (oid) = (conrelid)
+10  ·                                  equality cols are key  ·
+10  ·                                  pred                   contype = 'f'
+11  filter                             ·                      ·
+11  ·                                  estimated row count    10 (missing stats)
+11  ·                                  filter                 relname = 'orders'
+12  virtual table                      ·                      ·
+12  ·                                  estimated row count    1000 (missing stats)
+12  ·                                  table                  pg_class@primary
+6   filter                             ·                      ·
+6   ·                                  estimated row count    10 (missing stats)
+6   ·                                  filter                 nspname = 'public'
+7   virtual table                      ·                      ·
+7   ·                                  estimated row count    1000 (missing stats)
+7   ·                                  table                  pg_namespace@primary
+4   hash join (inner)                  ·                      ·
+4   ·                                  estimated row count    99 (missing stats)
+4   ·                                  equality               (refobjid) = (oid)
+4   ·                                  right cols are key     ·
+5   virtual table                      ·                      ·
+5   ·                                  estimated row count    1000 (missing stats)
+5   ·                                  table                  pg_depend@primary
+5   filter                             ·                      ·
+5   ·                                  estimated row count    10 (missing stats)
+5   ·                                  filter                 relkind = 'i'
+6   virtual table                      ·                      ·
+6   ·                                  estimated row count    1000 (missing stats)
+6   ·                                  table                  pg_class@primary
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok
@@ -445,7 +422,6 @@ EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cu
 ·           distribution        local
 ·           vectorized          true
 merge join  ·                   ·
- │          type                inner
  │          equality            (cust) = (id)
  │          right cols are key  ·
  ├── scan   ·                   ·
@@ -472,7 +448,6 @@ EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ·          distribution        local
 ·          vectorized          true
 hash join  ·                   ·
- │         type                inner
  │         equality            (b) = (n)
  │         right cols are key  ·
  ├── scan  ·                   ·
@@ -488,112 +463,108 @@ hash join  ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-·                    distribution         local                 ·                       ·
-·                    vectorized           true                  ·                       ·
-project              ·                    ·                     (a, b, n, sq)           ·
- │                   estimated row count  990 (missing stats)   ·                       ·
- └── hash join       ·                    ·                     (column8, a, b, n, sq)  ·
-      │              estimated row count  990 (missing stats)   ·                       ·
-      │              type                 inner                 ·                       ·
-      │              equality             (column8) = (sq)      ·                       ·
-      ├── render     ·                    ·                     (column8, a, b)         ·
-      │    │         estimated row count  1000 (missing stats)  ·                       ·
-      │    │         render 0             a + b                 ·                       ·
-      │    │         render 1             a                     ·                       ·
-      │    │         render 2             b                     ·                       ·
-      │    └── scan  ·                    ·                     (a, b)                  ·
-      │              estimated row count  1000 (missing stats)  ·                       ·
-      │              table                pairs@primary         ·                       ·
-      │              spans                FULL SCAN             ·                       ·
-      └── scan       ·                    ·                     (n, sq)                 ·
-·                    estimated row count  1000 (missing stats)  ·                       ·
-·                    table                square@primary        ·                       ·
-·                    spans                FULL SCAN             ·                       ·
+·                       distribution         local                 ·                       ·
+·                       vectorized           true                  ·                       ·
+project                 ·                    ·                     (a, b, n, sq)           ·
+ │                      estimated row count  990 (missing stats)   ·                       ·
+ └── hash join (inner)  ·                    ·                     (column8, a, b, n, sq)  ·
+      │                 estimated row count  990 (missing stats)   ·                       ·
+      │                 equality             (column8) = (sq)      ·                       ·
+      ├── render        ·                    ·                     (column8, a, b)         ·
+      │    │            estimated row count  1000 (missing stats)  ·                       ·
+      │    │            render 0             a + b                 ·                       ·
+      │    │            render 1             a                     ·                       ·
+      │    │            render 2             b                     ·                       ·
+      │    └── scan     ·                    ·                     (a, b)                  ·
+      │                 estimated row count  1000 (missing stats)  ·                       ·
+      │                 table                pairs@primary         ·                       ·
+      │                 spans                FULL SCAN             ·                       ·
+      └── scan          ·                    ·                     (n, sq)                 ·
+·                       estimated row count  1000 (missing stats)  ·                       ·
+·                       table                square@primary        ·                       ·
+·                       spans                FULL SCAN             ·                       ·
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a * b / 2 AS div, n, sq FROM pairs, square) WHERE div = sq
 ----
-·                          distribution         local                    ·                   ·
-·                          vectorized           true                     ·                   ·
-project                    ·                    ·                        (a, b, n, sq)       ·
- │                         estimated row count  990 (missing stats)      ·                   ·
- └── filter                ·                    ·                        (div, a, b, n, sq)  ·
-      │                    estimated row count  990 (missing stats)      ·                   ·
-      │                    filter               div = sq                 ·                   ·
-      └── render           ·                    ·                        (div, a, b, n, sq)  ·
-           │               estimated row count  1000000 (missing stats)  ·                   ·
-           │               render 0             (a * b) / 2              ·                   ·
-           │               render 1             a                        ·                   ·
-           │               render 2             b                        ·                   ·
-           │               render 3             n                        ·                   ·
-           │               render 4             sq                       ·                   ·
-           └── cross join  ·                    ·                        (a, b, n, sq)       ·
-                │          estimated row count  1000000 (missing stats)  ·                   ·
-                │          type                 cross                    ·                   ·
-                ├── scan   ·                    ·                        (a, b)              ·
-                │          estimated row count  1000 (missing stats)     ·                   ·
-                │          table                pairs@primary            ·                   ·
-                │          spans                FULL SCAN                ·                   ·
-                └── scan   ·                    ·                        (n, sq)             ·
-·                          estimated row count  1000 (missing stats)     ·                   ·
-·                          table                square@primary           ·                   ·
-·                          spans                FULL SCAN                ·                   ·
+·                                  distribution         local                    ·                   ·
+·                                  vectorized           true                     ·                   ·
+project                            ·                    ·                        (a, b, n, sq)       ·
+ │                                 estimated row count  990 (missing stats)      ·                   ·
+ └── filter                        ·                    ·                        (div, a, b, n, sq)  ·
+      │                            estimated row count  990 (missing stats)      ·                   ·
+      │                            filter               div = sq                 ·                   ·
+      └── render                   ·                    ·                        (div, a, b, n, sq)  ·
+           │                       estimated row count  1000000 (missing stats)  ·                   ·
+           │                       render 0             (a * b) / 2              ·                   ·
+           │                       render 1             a                        ·                   ·
+           │                       render 2             b                        ·                   ·
+           │                       render 3             n                        ·                   ·
+           │                       render 4             sq                       ·                   ·
+           └── cross join (inner)  ·                    ·                        (a, b, n, sq)       ·
+                │                  estimated row count  1000000 (missing stats)  ·                   ·
+                ├── scan           ·                    ·                        (a, b)              ·
+                │                  estimated row count  1000 (missing stats)     ·                   ·
+                │                  table                pairs@primary            ·                   ·
+                │                  spans                FULL SCAN                ·                   ·
+                └── scan           ·                    ·                        (n, sq)             ·
+·                                  estimated row count  1000 (missing stats)     ·                   ·
+·                                  table                square@primary           ·                   ·
+·                                  spans                FULL SCAN                ·                   ·
 
 # The filter expression must stay on top of the outer join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-·                    distribution         local                 ·                       ·
-·                    vectorized           true                  ·                       ·
-project              ·                    ·                     (a, b, n, sq)           ·
- │                   estimated row count  1000 (missing stats)  ·                       ·
- └── hash join       ·                    ·                     (column8, a, b, n, sq)  ·
-      │              estimated row count  1000 (missing stats)  ·                       ·
-      │              type                 full outer            ·                       ·
-      │              equality             (column8) = (sq)      ·                       ·
-      ├── render     ·                    ·                     (column8, a, b)         ·
-      │    │         estimated row count  1000 (missing stats)  ·                       ·
-      │    │         render 0             a + b                 ·                       ·
-      │    │         render 1             a                     ·                       ·
-      │    │         render 2             b                     ·                       ·
-      │    └── scan  ·                    ·                     (a, b)                  ·
-      │              estimated row count  1000 (missing stats)  ·                       ·
-      │              table                pairs@primary         ·                       ·
-      │              spans                FULL SCAN             ·                       ·
-      └── scan       ·                    ·                     (n, sq)                 ·
-·                    estimated row count  1000 (missing stats)  ·                       ·
-·                    table                square@primary        ·                       ·
-·                    spans                FULL SCAN             ·                       ·
+·                            distribution         local                 ·                       ·
+·                            vectorized           true                  ·                       ·
+project                      ·                    ·                     (a, b, n, sq)           ·
+ │                           estimated row count  1000 (missing stats)  ·                       ·
+ └── hash join (full outer)  ·                    ·                     (column8, a, b, n, sq)  ·
+      │                      estimated row count  1000 (missing stats)  ·                       ·
+      │                      equality             (column8) = (sq)      ·                       ·
+      ├── render             ·                    ·                     (column8, a, b)         ·
+      │    │                 estimated row count  1000 (missing stats)  ·                       ·
+      │    │                 render 0             a + b                 ·                       ·
+      │    │                 render 1             a                     ·                       ·
+      │    │                 render 2             b                     ·                       ·
+      │    └── scan          ·                    ·                     (a, b)                  ·
+      │                      estimated row count  1000 (missing stats)  ·                       ·
+      │                      table                pairs@primary         ·                       ·
+      │                      spans                FULL SCAN             ·                       ·
+      └── scan               ·                    ·                     (n, sq)                 ·
+·                            estimated row count  1000 (missing stats)  ·                       ·
+·                            table                square@primary        ·                       ·
+·                            spans                FULL SCAN             ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-·                         distribution         local                 ·                       ·
-·                         vectorized           true                  ·                       ·
-project                   ·                    ·                     (a, b, n, sq)           ·
- │                        estimated row count  333 (missing stats)   ·                       ·
- └── filter               ·                    ·                     (column8, a, b, n, sq)  ·
-      │                   estimated row count  333 (missing stats)   ·                       ·
-      │                   filter               (b % 2) != (sq % 2)   ·                       ·
-      └── hash join       ·                    ·                     (column8, a, b, n, sq)  ·
-           │              estimated row count  1000 (missing stats)  ·                       ·
-           │              type                 full outer            ·                       ·
-           │              equality             (column8) = (sq)      ·                       ·
-           ├── render     ·                    ·                     (column8, a, b)         ·
-           │    │         estimated row count  1000 (missing stats)  ·                       ·
-           │    │         render 0             a + b                 ·                       ·
-           │    │         render 1             a                     ·                       ·
-           │    │         render 2             b                     ·                       ·
-           │    └── scan  ·                    ·                     (a, b)                  ·
-           │              estimated row count  1000 (missing stats)  ·                       ·
-           │              table                pairs@primary         ·                       ·
-           │              spans                FULL SCAN             ·                       ·
-           └── scan       ·                    ·                     (n, sq)                 ·
-·                         estimated row count  1000 (missing stats)  ·                       ·
-·                         table                square@primary        ·                       ·
-·                         spans                FULL SCAN             ·                       ·
+·                                 distribution         local                 ·                       ·
+·                                 vectorized           true                  ·                       ·
+project                           ·                    ·                     (a, b, n, sq)           ·
+ │                                estimated row count  333 (missing stats)   ·                       ·
+ └── filter                       ·                    ·                     (column8, a, b, n, sq)  ·
+      │                           estimated row count  333 (missing stats)   ·                       ·
+      │                           filter               (b % 2) != (sq % 2)   ·                       ·
+      └── hash join (full outer)  ·                    ·                     (column8, a, b, n, sq)  ·
+           │                      estimated row count  1000 (missing stats)  ·                       ·
+           │                      equality             (column8) = (sq)      ·                       ·
+           ├── render             ·                    ·                     (column8, a, b)         ·
+           │    │                 estimated row count  1000 (missing stats)  ·                       ·
+           │    │                 render 0             a + b                 ·                       ·
+           │    │                 render 1             a                     ·                       ·
+           │    │                 render 2             b                     ·                       ·
+           │    └── scan          ·                    ·                     (a, b)                  ·
+           │                      estimated row count  1000 (missing stats)  ·                       ·
+           │                      table                pairs@primary         ·                       ·
+           │                      spans                FULL SCAN             ·                       ·
+           └── scan               ·                    ·                     (n, sq)                 ·
+·                                 estimated row count  1000 (missing stats)  ·                       ·
+·                                 table                square@primary        ·                       ·
+·                                 spans                FULL SCAN             ·                       ·
 
 # Filter propagation through outer joins.
 
@@ -605,30 +576,29 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ]
 ----
-·                    distribution         local
-·                    vectorized           true
-filter               ·                    ·
- │                   estimated row count  115 (missing stats)
- │                   filter               ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash join       ·                    ·
-      │              estimated row count  1037 (missing stats)
-      │              type                 left outer
-      │              equality             (b) = (sq)
-      │              pred                 a > 1
-      ├── filter     ·                    ·
-      │    │         estimated row count  333 (missing stats)
-      │    │         filter               b > 1
-      │    └── scan  ·                    ·
-      │              estimated row count  1000 (missing stats)
-      │              table                pairs@primary
-      │              spans                FULL SCAN
-      └── filter     ·                    ·
-           │         estimated row count  311 (missing stats)
-           │         filter               sq > 1
-           └── scan  ·                    ·
-·                    estimated row count  333 (missing stats)
-·                    table                square@primary
-·                    spans                -/5/#
+·                            distribution         local
+·                            vectorized           true
+filter                       ·                    ·
+ │                           estimated row count  115 (missing stats)
+ │                           filter               ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+ └── hash join (left outer)  ·                    ·
+      │                      estimated row count  1037 (missing stats)
+      │                      equality             (b) = (sq)
+      │                      pred                 a > 1
+      ├── filter             ·                    ·
+      │    │                 estimated row count  333 (missing stats)
+      │    │                 filter               b > 1
+      │    └── scan          ·                    ·
+      │                      estimated row count  1000 (missing stats)
+      │                      table                pairs@primary
+      │                      spans                FULL SCAN
+      └── filter             ·                    ·
+           │                 estimated row count  311 (missing stats)
+           │                 filter               sq > 1
+           └── scan          ·                    ·
+·                            estimated row count  333 (missing stats)
+·                            table                square@primary
+·                            spans                -/5/#
 
 query TTT
 SELECT tree, field, description FROM [
@@ -638,27 +608,26 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·                    distribution         local
-·                    vectorized           true
-filter               ·                    ·
- │                   estimated row count  42 (missing stats)
- │                   filter               ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
- └── hash join       ·                    ·
-      │              estimated row count  377 (missing stats)
-      │              type                 left outer
-      │              equality             (sq) = (b)
-      │              pred                 n < 6
-      ├── scan       ·                    ·
-      │              estimated row count  333 (missing stats)
-      │              table                square@primary
-      │              spans                /2-
-      └── filter     ·                    ·
-           │         estimated row count  333 (missing stats)
-           │         filter               a > 1
-           └── scan  ·                    ·
-·                    estimated row count  1000 (missing stats)
-·                    table                pairs@primary
-·                    spans                FULL SCAN
+·                            distribution         local
+·                            vectorized           true
+filter                       ·                    ·
+ │                           estimated row count  42 (missing stats)
+ │                           filter               ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+ └── hash join (left outer)  ·                    ·
+      │                      estimated row count  377 (missing stats)
+      │                      equality             (sq) = (b)
+      │                      pred                 n < 6
+      ├── scan               ·                    ·
+      │                      estimated row count  333 (missing stats)
+      │                      table                square@primary
+      │                      spans                /2-
+      └── filter             ·                    ·
+           │                 estimated row count  333 (missing stats)
+           │                 filter               a > 1
+           └── scan          ·                    ·
+·                            estimated row count  1000 (missing stats)
+·                            table                pairs@primary
+·                            spans                FULL SCAN
 
 # The simpler plan for an inner join, to compare.
 query TTT
@@ -669,24 +638,23 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·               distribution         local
-·               vectorized           true
-hash join       ·                    ·
- │              estimated row count  6 (missing stats)
- │              type                 inner
- │              equality             (b) = (sq)
- ├── filter     ·                    ·
- │    │         estimated row count  111 (missing stats)
- │    │         filter               ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
- │    └── scan  ·                    ·
- │              estimated row count  1000 (missing stats)
- │              table                pairs@primary
- │              spans                FULL SCAN
- └── scan       ·                    ·
-·               estimated row count  4 (missing stats)
-·               table                square@primary
-·               spans                /2-/5/#
-·               parallel             ·
+·                  distribution         local
+·                  vectorized           true
+hash join (inner)  ·                    ·
+ │                 estimated row count  6 (missing stats)
+ │                 equality             (b) = (sq)
+ ├── filter        ·                    ·
+ │    │            estimated row count  111 (missing stats)
+ │    │            filter               ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+ │    └── scan     ·                    ·
+ │                 estimated row count  1000 (missing stats)
+ │                 table                pairs@primary
+ │                 spans                FULL SCAN
+ └── scan          ·                    ·
+·                  estimated row count  4 (missing stats)
+·                  table                square@primary
+·                  spans                /2-/5/#
+·                  parallel             ·
 
 
 statement ok
@@ -698,22 +666,21 @@ CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-project         ·                    ·                     (x)           ·
- │              estimated row count  96 (missing stats)    ·             ·
- └── hash join  ·                    ·                     (x, y, y, x)  ·
-      │         estimated row count  96 (missing stats)    ·             ·
-      │         type                 inner                 ·             ·
-      │         equality             (x, y) = (x, y)       ·             ·
-      ├── scan  ·                    ·                     (x, y)        ·
-      │         estimated row count  1000 (missing stats)  ·             ·
-      │         table                t1@primary            ·             ·
-      │         spans                FULL SCAN             ·             ·
-      └── scan  ·                    ·                     (y, x)        ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                t2@primary            ·             ·
-·               spans                FULL SCAN             ·             ·
+·                       distribution         local                 ·             ·
+·                       vectorized           true                  ·             ·
+project                 ·                    ·                     (x)           ·
+ │                      estimated row count  96 (missing stats)    ·             ·
+ └── hash join (inner)  ·                    ·                     (x, y, y, x)  ·
+      │                 estimated row count  96 (missing stats)    ·             ·
+      │                 equality             (x, y) = (x, y)       ·             ·
+      ├── scan          ·                    ·                     (x, y)        ·
+      │                 estimated row count  1000 (missing stats)  ·             ·
+      │                 table                t1@primary            ·             ·
+      │                 spans                FULL SCAN             ·             ·
+      └── scan          ·                    ·                     (y, x)        ·
+·                       estimated row count  1000 (missing stats)  ·             ·
+·                       table                t2@primary            ·             ·
+·                       spans                FULL SCAN             ·             ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -731,88 +698,84 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-·          distribution         local                  ·                         ·
-·          vectorized           true                   ·                         ·
-hash join  ·                    ·                      (a, b, c, d, a, b, c, d)  ·
- │         estimated row count  1 (missing stats)      ·                         ·
- │         type                 inner                  ·                         ·
- │         equality             (a, b, c) = (a, b, c)  ·                         ·
- │         left cols are key    ·                      ·                         ·
- │         right cols are key   ·                      ·                         ·
- ├── scan  ·                    ·                      (a, b, c, d)              ·
- │         estimated row count  1000 (missing stats)   ·                         ·
- │         table                pkba@primary           ·                         ·
- │         spans                FULL SCAN              ·                         ·
- └── scan  ·                    ·                      (a, b, c, d)              ·
-·          estimated row count  1000 (missing stats)   ·                         ·
-·          table                pkbc@primary           ·                         ·
-·          spans                FULL SCAN              ·                         ·
+·                  distribution         local                  ·                         ·
+·                  vectorized           true                   ·                         ·
+hash join (inner)  ·                    ·                      (a, b, c, d, a, b, c, d)  ·
+ │                 estimated row count  1 (missing stats)      ·                         ·
+ │                 equality             (a, b, c) = (a, b, c)  ·                         ·
+ │                 left cols are key    ·                      ·                         ·
+ │                 right cols are key   ·                      ·                         ·
+ ├── scan          ·                    ·                      (a, b, c, d)              ·
+ │                 estimated row count  1000 (missing stats)   ·                         ·
+ │                 table                pkba@primary           ·                         ·
+ │                 spans                FULL SCAN              ·                         ·
+ └── scan          ·                    ·                      (a, b, c, d)              ·
+·                  estimated row count  1000 (missing stats)   ·                         ·
+·                  table                pkbc@primary           ·                         ·
+·                  spans                FULL SCAN              ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-·               distribution         local                        ·                         ·
-·               vectorized           true                         ·                         ·
-project         ·                    ·                            (a, b, c, d)              ·
- │              estimated row count  0 (missing stats)            ·                         ·
- └── hash join  ·                    ·                            (a, b, c, d, a, b, c, d)  ·
-      │         estimated row count  0 (missing stats)            ·                         ·
-      │         type                 inner                        ·                         ·
-      │         equality             (a, b, c, d) = (a, b, c, d)  ·                         ·
-      │         left cols are key    ·                            ·                         ·
-      │         right cols are key   ·                            ·                         ·
-      ├── scan  ·                    ·                            (a, b, c, d)              ·
-      │         estimated row count  1000 (missing stats)         ·                         ·
-      │         table                pkba@primary                 ·                         ·
-      │         spans                FULL SCAN                    ·                         ·
-      └── scan  ·                    ·                            (a, b, c, d)              ·
-·               estimated row count  1000 (missing stats)         ·                         ·
-·               table                pkbad@primary                ·                         ·
-·               spans                FULL SCAN                    ·                         ·
+·                       distribution         local                        ·                         ·
+·                       vectorized           true                         ·                         ·
+project                 ·                    ·                            (a, b, c, d)              ·
+ │                      estimated row count  0 (missing stats)            ·                         ·
+ └── hash join (inner)  ·                    ·                            (a, b, c, d, a, b, c, d)  ·
+      │                 estimated row count  0 (missing stats)            ·                         ·
+      │                 equality             (a, b, c, d) = (a, b, c, d)  ·                         ·
+      │                 left cols are key    ·                            ·                         ·
+      │                 right cols are key   ·                            ·                         ·
+      ├── scan          ·                    ·                            (a, b, c, d)              ·
+      │                 estimated row count  1000 (missing stats)         ·                         ·
+      │                 table                pkba@primary                 ·                         ·
+      │                 spans                FULL SCAN                    ·                         ·
+      └── scan          ·                    ·                            (a, b, c, d)              ·
+·                       estimated row count  1000 (missing stats)         ·                         ·
+·                       table                pkbad@primary                ·                         ·
+·                       spans                FULL SCAN                    ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-·                distribution         local                       ·                         ·
-·                vectorized           true                        ·                         ·
-project          ·                    ·                           (a, b, c, d, d)           ·
- │               estimated row count  1 (missing stats)           ·                         ·
- └── merge join  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
-      │          estimated row count  1 (missing stats)           ·                         ·
-      │          type                 inner                       ·                         ·
-      │          equality             (b, a, c) = (b, a, c)       ·                         ·
-      │          left cols are key    ·                           ·                         ·
-      │          right cols are key   ·                           ·                         ·
-      │          merge ordering       +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
-      ├── scan   ·                    ·                           (a, b, c, d)              +b,+a,+c
-      │          estimated row count  1000 (missing stats)        ·                         ·
-      │          table                pkbac@primary               ·                         ·
-      │          spans                FULL SCAN                   ·                         ·
-      └── scan   ·                    ·                           (a, b, c, d)              +b,+a,+c
-·                estimated row count  1000 (missing stats)        ·                         ·
-·                table                pkbac@primary               ·                         ·
-·                spans                FULL SCAN                   ·                         ·
+·                        distribution         local                       ·                         ·
+·                        vectorized           true                        ·                         ·
+project                  ·                    ·                           (a, b, c, d, d)           ·
+ │                       estimated row count  1 (missing stats)           ·                         ·
+ └── merge join (inner)  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
+      │                  estimated row count  1 (missing stats)           ·                         ·
+      │                  equality             (b, a, c) = (b, a, c)       ·                         ·
+      │                  left cols are key    ·                           ·                         ·
+      │                  right cols are key   ·                           ·                         ·
+      │                  merge ordering       +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
+      ├── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
+      │                  estimated row count  1000 (missing stats)        ·                         ·
+      │                  table                pkbac@primary               ·                         ·
+      │                  spans                FULL SCAN                   ·                         ·
+      └── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
+·                        estimated row count  1000 (missing stats)        ·                         ·
+·                        table                pkbac@primary               ·                         ·
+·                        spans                FULL SCAN                   ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-·           distribution         local                       ·                         ·
-·           vectorized           true                        ·                         ·
-merge join  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
- │          estimated row count  1 (missing stats)           ·                         ·
- │          type                 inner                       ·                         ·
- │          equality             (b, a, c) = (b, a, d)       ·                         ·
- │          left cols are key    ·                           ·                         ·
- │          right cols are key   ·                           ·                         ·
- │          merge ordering       +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
- ├── scan   ·                    ·                           (a, b, c, d)              +b,+a,+c
- │          estimated row count  1000 (missing stats)        ·                         ·
- │          table                pkbac@primary               ·                         ·
- │          spans                FULL SCAN                   ·                         ·
- └── scan   ·                    ·                           (a, b, c, d)              +b,+a,+d
-·           estimated row count  1000 (missing stats)        ·                         ·
-·           table                pkbad@primary               ·                         ·
-·           spans                FULL SCAN                   ·                         ·
+·                   distribution         local                       ·                         ·
+·                   vectorized           true                        ·                         ·
+merge join (inner)  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
+ │                  estimated row count  1 (missing stats)           ·                         ·
+ │                  equality             (b, a, c) = (b, a, d)       ·                         ·
+ │                  left cols are key    ·                           ·                         ·
+ │                  right cols are key   ·                           ·                         ·
+ │                  merge ordering       +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+ ├── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
+ │                  estimated row count  1000 (missing stats)        ·                         ·
+ │                  table                pkbac@primary               ·                         ·
+ │                  spans                FULL SCAN                   ·                         ·
+ └── scan           ·                    ·                           (a, b, c, d)              +b,+a,+d
+·                   estimated row count  1000 (missing stats)        ·                         ·
+·                   table                pkbad@primary               ·                         ·
+·                   spans                FULL SCAN                   ·                         ·
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -824,112 +787,107 @@ CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (s, s, s)  ·
- └── hash join  ·                    ·                     (s, s)     ·
-      │         estimated row count  9801 (missing stats)  ·          ·
-      │         type                 inner                 ·          ·
-      │         equality             (s) = (s)             ·          ·
-      ├── scan  ·                    ·                     (s)        ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         table                str1@primary          ·          ·
-      │         spans                FULL SCAN             ·          ·
-      └── scan  ·                    ·                     (s)        ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                str2@primary          ·          ·
-·               spans                FULL SCAN             ·          ·
+·                       distribution         local                 ·          ·
+·                       vectorized           true                  ·          ·
+project                 ·                    ·                     (s, s, s)  ·
+ └── hash join (inner)  ·                    ·                     (s, s)     ·
+      │                 estimated row count  9801 (missing stats)  ·          ·
+      │                 equality             (s) = (s)             ·          ·
+      ├── scan          ·                    ·                     (s)        ·
+      │                 estimated row count  1000 (missing stats)  ·          ·
+      │                 table                str1@primary          ·          ·
+      │                 spans                FULL SCAN             ·          ·
+      └── scan          ·                    ·                     (s)        ·
+·                       estimated row count  1000 (missing stats)  ·          ·
+·                       table                str2@primary          ·          ·
+·                       spans                FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-·               distribution         local                  ·          ·
-·               vectorized           true                   ·          ·
-project         ·                    ·                      (s, s, s)  ·
- └── hash join  ·                    ·                      (s, s)     ·
-      │         estimated row count  10000 (missing stats)  ·          ·
-      │         type                 left outer             ·          ·
-      │         equality             (s) = (s)              ·          ·
-      ├── scan  ·                    ·                      (s)        ·
-      │         estimated row count  1000 (missing stats)   ·          ·
-      │         table                str1@primary           ·          ·
-      │         spans                FULL SCAN              ·          ·
-      └── scan  ·                    ·                      (s)        ·
-·               estimated row count  1000 (missing stats)   ·          ·
-·               table                str2@primary           ·          ·
-·               spans                FULL SCAN              ·          ·
+·                            distribution         local                  ·          ·
+·                            vectorized           true                   ·          ·
+project                      ·                    ·                      (s, s, s)  ·
+ └── hash join (left outer)  ·                    ·                      (s, s)     ·
+      │                      estimated row count  10000 (missing stats)  ·          ·
+      │                      equality             (s) = (s)              ·          ·
+      ├── scan               ·                    ·                      (s)        ·
+      │                      estimated row count  1000 (missing stats)   ·          ·
+      │                      table                str1@primary           ·          ·
+      │                      spans                FULL SCAN              ·          ·
+      └── scan               ·                    ·                      (s)        ·
+·                            estimated row count  1000 (missing stats)   ·          ·
+·                            table                str2@primary           ·          ·
+·                            spans                FULL SCAN              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-·               distribution         local                  ·          ·
-·               vectorized           true                   ·          ·
-render          ·                    ·                      (s, s, s)  ·
- │              estimated row count  10000 (missing stats)  ·          ·
- │              render 0             COALESCE(s, s)         ·          ·
- │              render 1             s                      ·          ·
- │              render 2             s                      ·          ·
- └── hash join  ·                    ·                      (s, s)     ·
-      │         estimated row count  10000 (missing stats)  ·          ·
-      │         type                 left outer             ·          ·
-      │         equality             (s) = (s)              ·          ·
-      ├── scan  ·                    ·                      (s)        ·
-      │         estimated row count  1000 (missing stats)   ·          ·
-      │         table                str2@primary           ·          ·
-      │         spans                FULL SCAN              ·          ·
-      └── scan  ·                    ·                      (s)        ·
-·               estimated row count  1000 (missing stats)   ·          ·
-·               table                str1@primary           ·          ·
-·               spans                FULL SCAN              ·          ·
+·                            distribution         local                  ·          ·
+·                            vectorized           true                   ·          ·
+render                       ·                    ·                      (s, s, s)  ·
+ │                           estimated row count  10000 (missing stats)  ·          ·
+ │                           render 0             COALESCE(s, s)         ·          ·
+ │                           render 1             s                      ·          ·
+ │                           render 2             s                      ·          ·
+ └── hash join (left outer)  ·                    ·                      (s, s)     ·
+      │                      estimated row count  10000 (missing stats)  ·          ·
+      │                      equality             (s) = (s)              ·          ·
+      ├── scan               ·                    ·                      (s)        ·
+      │                      estimated row count  1000 (missing stats)   ·          ·
+      │                      table                str2@primary           ·          ·
+      │                      spans                FULL SCAN              ·          ·
+      └── scan               ·                    ·                      (s)        ·
+·                            estimated row count  1000 (missing stats)   ·          ·
+·                            table                str1@primary           ·          ·
+·                            spans                FULL SCAN              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-·               distribution         local                  ·          ·
-·               vectorized           true                   ·          ·
-render          ·                    ·                      (s, s, s)  ·
- │              estimated row count  10000 (missing stats)  ·          ·
- │              render 0             COALESCE(s, s)         ·          ·
- │              render 1             s                      ·          ·
- │              render 2             s                      ·          ·
- └── hash join  ·                    ·                      (s, s)     ·
-      │         estimated row count  10000 (missing stats)  ·          ·
-      │         type                 full outer             ·          ·
-      │         equality             (s) = (s)              ·          ·
-      ├── scan  ·                    ·                      (s)        ·
-      │         estimated row count  1000 (missing stats)   ·          ·
-      │         table                str1@primary           ·          ·
-      │         spans                FULL SCAN              ·          ·
-      └── scan  ·                    ·                      (s)        ·
-·               estimated row count  1000 (missing stats)   ·          ·
-·               table                str2@primary           ·          ·
-·               spans                FULL SCAN              ·          ·
+·                            distribution         local                  ·          ·
+·                            vectorized           true                   ·          ·
+render                       ·                    ·                      (s, s, s)  ·
+ │                           estimated row count  10000 (missing stats)  ·          ·
+ │                           render 0             COALESCE(s, s)         ·          ·
+ │                           render 1             s                      ·          ·
+ │                           render 2             s                      ·          ·
+ └── hash join (full outer)  ·                    ·                      (s, s)     ·
+      │                      estimated row count  10000 (missing stats)  ·          ·
+      │                      equality             (s) = (s)              ·          ·
+      ├── scan               ·                    ·                      (s)        ·
+      │                      estimated row count  1000 (missing stats)   ·          ·
+      │                      table                str1@primary           ·          ·
+      │                      spans                FULL SCAN              ·          ·
+      └── scan               ·                    ·                      (s)        ·
+·                            estimated row count  1000 (missing stats)   ·          ·
+·                            table                str2@primary           ·          ·
+·                            spans                FULL SCAN              ·          ·
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-render          ·                    ·                     (a, s)        ·
- │              estimated row count  1000 (missing stats)  ·             ·
- │              render 0             COALESCE(s, s)        ·             ·
- │              render 1             a                     ·             ·
- └── hash join  ·                    ·                     (a, s, a, s)  ·
-      │         estimated row count  1000 (missing stats)  ·             ·
-      │         type                 left outer            ·             ·
-      │         equality             (a, s) = (a, s)       ·             ·
-      │         left cols are key    ·                     ·             ·
-      │         right cols are key   ·                     ·             ·
-      ├── scan  ·                    ·                     (a, s)        ·
-      │         estimated row count  1000 (missing stats)  ·             ·
-      │         table                str2@primary          ·             ·
-      │         spans                FULL SCAN             ·             ·
-      └── scan  ·                    ·                     (a, s)        ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                str1@primary          ·             ·
-·               spans                FULL SCAN             ·             ·
+·                            distribution         local                 ·             ·
+·                            vectorized           true                  ·             ·
+render                       ·                    ·                     (a, s)        ·
+ │                           estimated row count  1000 (missing stats)  ·             ·
+ │                           render 0             COALESCE(s, s)        ·             ·
+ │                           render 1             a                     ·             ·
+ └── hash join (left outer)  ·                    ·                     (a, s, a, s)  ·
+      │                      estimated row count  1000 (missing stats)  ·             ·
+      │                      equality             (a, s) = (a, s)       ·             ·
+      │                      left cols are key    ·                     ·             ·
+      │                      right cols are key   ·                     ·             ·
+      ├── scan               ·                    ·                     (a, s)        ·
+      │                      estimated row count  1000 (missing stats)  ·             ·
+      │                      table                str2@primary          ·             ·
+      │                      spans                FULL SCAN             ·             ·
+      └── scan               ·                    ·                     (a, s)        ·
+·                            estimated row count  1000 (missing stats)  ·             ·
+·                            table                str1@primary          ·             ·
+·                            spans                FULL SCAN             ·             ·
 
 
 statement ok
@@ -941,170 +899,162 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distribution         local                ·                   ·
-·                vectorized           true                 ·                   ·
-project          ·                    ·                    (x, y, u, v)        ·
- │               estimated row count  34 (missing stats)   ·                   ·
- └── merge join  ·                    ·                    (x, y, u, x, y, v)  ·
-      │          estimated row count  34 (missing stats)   ·                   ·
-      │          type                 inner                ·                   ·
-      │          equality             (x, y) = (x, y)      ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan   ·                    ·                    (x, y, u)           +x,+y
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          table                xyu@primary          ·                   ·
-      │          spans                /3-                  ·                   ·
-      └── scan   ·                    ·                    (x, y, v)           +x,+y
-·                estimated row count  333 (missing stats)  ·                   ·
-·                table                xyv@primary          ·                   ·
-·                spans                /3-                  ·                   ·
+·                        distribution         local                ·                   ·
+·                        vectorized           true                 ·                   ·
+project                  ·                    ·                    (x, y, u, v)        ·
+ │                       estimated row count  34 (missing stats)   ·                   ·
+ └── merge join (inner)  ·                    ·                    (x, y, u, x, y, v)  ·
+      │                  estimated row count  34 (missing stats)   ·                   ·
+      │                  equality             (x, y) = (x, y)      ·                   ·
+      │                  merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
+      ├── scan           ·                    ·                    (x, y, u)           +x,+y
+      │                  estimated row count  333 (missing stats)  ·                   ·
+      │                  table                xyu@primary          ·                   ·
+      │                  spans                /3-                  ·                   ·
+      └── scan           ·                    ·                    (x, y, v)           +x,+y
+·                        estimated row count  333 (missing stats)  ·                   ·
+·                        table                xyv@primary          ·                   ·
+·                        spans                /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distribution         local                ·                   ·
-·                vectorized           true                 ·                   ·
-project          ·                    ·                    (x, y, u, v)        ·
- │               estimated row count  333 (missing stats)  ·                   ·
- └── merge join  ·                    ·                    (x, y, u, x, y, v)  ·
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          type                 left outer           ·                   ·
-      │          equality             (x, y) = (x, y)      ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan   ·                    ·                    (x, y, u)           +x,+y
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          table                xyu@primary          ·                   ·
-      │          spans                /3-                  ·                   ·
-      └── scan   ·                    ·                    (x, y, v)           +x,+y
-·                estimated row count  333 (missing stats)  ·                   ·
-·                table                xyv@primary          ·                   ·
-·                spans                /3-                  ·                   ·
+·                             distribution         local                ·                   ·
+·                             vectorized           true                 ·                   ·
+project                       ·                    ·                    (x, y, u, v)        ·
+ │                            estimated row count  333 (missing stats)  ·                   ·
+ └── merge join (left outer)  ·                    ·                    (x, y, u, x, y, v)  ·
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       equality             (x, y) = (x, y)      ·                   ·
+      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
+      ├── scan                ·                    ·                    (x, y, u)           +x,+y
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       table                xyu@primary          ·                   ·
+      │                       spans                /3-                  ·                   ·
+      └── scan                ·                    ·                    (x, y, v)           +x,+y
+·                             estimated row count  333 (missing stats)  ·                   ·
+·                             table                xyv@primary          ·                   ·
+·                             spans                /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distribution         local                ·                   ·
-·                vectorized           true                 ·                   ·
-project          ·                    ·                    (x, y, u, v)        ·
- │               estimated row count  333 (missing stats)  ·                   ·
- └── merge join  ·                    ·                    (x, y, v, x, y, u)  ·
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          type                 left outer           ·                   ·
-      │          equality             (x, y) = (x, y)      ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan   ·                    ·                    (x, y, v)           +x,+y
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          table                xyv@primary          ·                   ·
-      │          spans                /3-                  ·                   ·
-      └── scan   ·                    ·                    (x, y, u)           +x,+y
-·                estimated row count  333 (missing stats)  ·                   ·
-·                table                xyu@primary          ·                   ·
-·                spans                /3-                  ·                   ·
+·                             distribution         local                ·                   ·
+·                             vectorized           true                 ·                   ·
+project                       ·                    ·                    (x, y, u, v)        ·
+ │                            estimated row count  333 (missing stats)  ·                   ·
+ └── merge join (left outer)  ·                    ·                    (x, y, v, x, y, u)  ·
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       equality             (x, y) = (x, y)      ·                   ·
+      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
+      ├── scan                ·                    ·                    (x, y, v)           +x,+y
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       table                xyv@primary          ·                   ·
+      │                       spans                /3-                  ·                   ·
+      └── scan                ·                    ·                    (x, y, u)           +x,+y
+·                             estimated row count  333 (missing stats)  ·                   ·
+·                             table                xyu@primary          ·                   ·
+·                             spans                /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                     distribution         local                 ·                   ·
-·                     vectorized           true                  ·                   ·
-filter                ·                    ·                     (x, y, u, v)        ·
- │                    estimated row count  633 (missing stats)   ·                   ·
- │                    filter               x > 2                 ·                   ·
- └── render           ·                    ·                     (x, y, u, v)        ·
-      │               estimated row count  1900 (missing stats)  ·                   ·
-      │               render 0             COALESCE(x, x)        ·                   ·
-      │               render 1             COALESCE(y, y)        ·                   ·
-      │               render 2             u                     ·                   ·
-      │               render 3             v                     ·                   ·
-      └── merge join  ·                    ·                     (x, y, u, x, y, v)  ·
-           │          estimated row count  1900 (missing stats)  ·                   ·
-           │          type                 full outer            ·                   ·
-           │          equality             (x, y) = (x, y)       ·                   ·
-           │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-           ├── scan   ·                    ·                     (x, y, u)           +x,+y
-           │          estimated row count  1000 (missing stats)  ·                   ·
-           │          table                xyu@primary           ·                   ·
-           │          spans                FULL SCAN             ·                   ·
-           └── scan   ·                    ·                     (x, y, v)           +x,+y
-·                     estimated row count  1000 (missing stats)  ·                   ·
-·                     table                xyv@primary           ·                   ·
-·                     spans                FULL SCAN             ·                   ·
+·                                  distribution         local                 ·                   ·
+·                                  vectorized           true                  ·                   ·
+filter                             ·                    ·                     (x, y, u, v)        ·
+ │                                 estimated row count  633 (missing stats)   ·                   ·
+ │                                 filter               x > 2                 ·                   ·
+ └── render                        ·                    ·                     (x, y, u, v)        ·
+      │                            estimated row count  1900 (missing stats)  ·                   ·
+      │                            render 0             COALESCE(x, x)        ·                   ·
+      │                            render 1             COALESCE(y, y)        ·                   ·
+      │                            render 2             u                     ·                   ·
+      │                            render 3             v                     ·                   ·
+      └── merge join (full outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+           │                       estimated row count  1900 (missing stats)  ·                   ·
+           │                       equality             (x, y) = (x, y)       ·                   ·
+           │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+           ├── scan                ·                    ·                     (x, y, u)           +x,+y
+           │                       estimated row count  1000 (missing stats)  ·                   ·
+           │                       table                xyu@primary           ·                   ·
+           │                       spans                FULL SCAN             ·                   ·
+           └── scan                ·                    ·                     (x, y, v)           +x,+y
+·                                  estimated row count  1000 (missing stats)  ·                   ·
+·                                  table                xyv@primary           ·                   ·
+·                                  spans                FULL SCAN             ·                   ·
 
 # Verify that we transfer constraints between the two sides.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local              ·                   ·
-·           vectorized           true               ·                   ·
-merge join  ·                    ·                  (x, y, u, x, y, v)  ·
- │          estimated row count  9 (missing stats)  ·                   ·
- │          type                 inner              ·                   ·
- │          equality             (x, y) = (x, y)    ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan   ·                    ·                  (x, y, u)           +y
- │          estimated row count  9 (missing stats)  ·                   ·
- │          table                xyu@primary        ·                   ·
- │          spans                /1-/1/10           ·                   ·
- └── scan   ·                    ·                  (x, y, v)           +y
-·           estimated row count  9 (missing stats)  ·                   ·
-·           table                xyv@primary        ·                   ·
-·           spans                /1-/1/10           ·                   ·
+·                   distribution         local              ·                   ·
+·                   vectorized           true               ·                   ·
+merge join (inner)  ·                    ·                  (x, y, u, x, y, v)  ·
+ │                  estimated row count  9 (missing stats)  ·                   ·
+ │                  equality             (x, y) = (x, y)    ·                   ·
+ │                  merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan           ·                    ·                  (x, y, u)           +y
+ │                  estimated row count  9 (missing stats)  ·                   ·
+ │                  table                xyu@primary        ·                   ·
+ │                  spans                /1-/1/10           ·                   ·
+ └── scan           ·                    ·                  (x, y, v)           +y
+·                   estimated row count  9 (missing stats)  ·                   ·
+·                   table                xyv@primary        ·                   ·
+·                   spans                /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local              ·                   ·
-·           vectorized           true               ·                   ·
-merge join  ·                    ·                  (x, y, u, x, y, v)  ·
- │          estimated row count  9 (missing stats)  ·                   ·
- │          type                 inner              ·                   ·
- │          equality             (x, y) = (x, y)    ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan   ·                    ·                  (x, y, u)           +y
- │          estimated row count  9 (missing stats)  ·                   ·
- │          table                xyu@primary        ·                   ·
- │          spans                /1-/1/10           ·                   ·
- └── scan   ·                    ·                  (x, y, v)           +y
-·           estimated row count  9 (missing stats)  ·                   ·
-·           table                xyv@primary        ·                   ·
-·           spans                /1-/1/10           ·                   ·
+·                   distribution         local              ·                   ·
+·                   vectorized           true               ·                   ·
+merge join (inner)  ·                    ·                  (x, y, u, x, y, v)  ·
+ │                  estimated row count  9 (missing stats)  ·                   ·
+ │                  equality             (x, y) = (x, y)    ·                   ·
+ │                  merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan           ·                    ·                  (x, y, u)           +y
+ │                  estimated row count  9 (missing stats)  ·                   ·
+ │                  table                xyu@primary        ·                   ·
+ │                  spans                /1-/1/10           ·                   ·
+ └── scan           ·                    ·                  (x, y, v)           +y
+·                   estimated row count  9 (missing stats)  ·                   ·
+·                   table                xyv@primary        ·                   ·
+·                   spans                /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local                 ·                   ·
-·           vectorized           true                  ·                   ·
-merge join  ·                    ·                     (x, y, u, x, y, v)  ·
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          type                 left outer            ·                   ·
- │          equality             (x, y) = (x, y)       ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan   ·                    ·                     (x, y, u)           +x,+y
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          table                xyu@primary           ·                   ·
- │          spans                FULL SCAN             ·                   ·
- └── scan   ·                    ·                     (x, y, v)           +y
-·           estimated row count  9 (missing stats)     ·                   ·
-·           table                xyv@primary           ·                   ·
-·           spans                /1-/1/10              ·                   ·
+·                        distribution         local                 ·                   ·
+·                        vectorized           true                  ·                   ·
+merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       equality             (x, y) = (x, y)       ·                   ·
+ │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+ ├── scan                ·                    ·                     (x, y, u)           +x,+y
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       table                xyu@primary           ·                   ·
+ │                       spans                FULL SCAN             ·                   ·
+ └── scan                ·                    ·                     (x, y, v)           +y
+·                        estimated row count  9 (missing stats)     ·                   ·
+·                        table                xyv@primary           ·                   ·
+·                        spans                /1-/1/10              ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local                 ·                   ·
-·           vectorized           true                  ·                   ·
-merge join  ·                    ·                     (x, y, u, x, y, v)  ·
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          type                 left outer            ·                   ·
- │          equality             (x, y) = (x, y)       ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan   ·                    ·                     (x, y, v)           +x,+y
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          table                xyv@primary           ·                   ·
- │          spans                FULL SCAN             ·                   ·
- └── scan   ·                    ·                     (x, y, u)           +y
-·           estimated row count  9 (missing stats)     ·                   ·
-·           table                xyu@primary           ·                   ·
-·           spans                /1-/1/10              ·                   ·
+·                        distribution         local                 ·                   ·
+·                        vectorized           true                  ·                   ·
+merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       equality             (x, y) = (x, y)       ·                   ·
+ │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+ ├── scan                ·                    ·                     (x, y, v)           +x,+y
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       table                xyv@primary           ·                   ·
+ │                       spans                FULL SCAN             ·                   ·
+ └── scan                ·                    ·                     (x, y, u)           +y
+·                        estimated row count  9 (missing stats)     ·                   ·
+·                        table                xyu@primary           ·                   ·
+·                        spans                /1-/1/10              ·                   ·
 
 
 # Test OUTER joins that are run in the distSQL merge joiner
@@ -1112,132 +1062,126 @@ merge join  ·                    ·                     (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                distribution         local                ·                   ·
-·                vectorized           true                 ·                   ·
-project          ·                    ·                    (x, y, u, v)        ·
- │               estimated row count  333 (missing stats)  ·                   ·
- └── merge join  ·                    ·                    (x, y, u, x, y, v)  ·
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          type                 left outer           ·                   ·
-      │          equality             (x, y) = (x, y)      ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan   ·                    ·                    (x, y, u)           +x,+y
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          table                xyu@primary          ·                   ·
-      │          spans                /3-                  ·                   ·
-      └── scan   ·                    ·                    (x, y, v)           +x,+y
-·                estimated row count  333 (missing stats)  ·                   ·
-·                table                xyv@primary          ·                   ·
-·                spans                /3-                  ·                   ·
+·                             distribution         local                ·                   ·
+·                             vectorized           true                 ·                   ·
+project                       ·                    ·                    (x, y, u, v)        ·
+ │                            estimated row count  333 (missing stats)  ·                   ·
+ └── merge join (left outer)  ·                    ·                    (x, y, u, x, y, v)  ·
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       equality             (x, y) = (x, y)      ·                   ·
+      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
+      ├── scan                ·                    ·                    (x, y, u)           +x,+y
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       table                xyu@primary          ·                   ·
+      │                       spans                /3-                  ·                   ·
+      └── scan                ·                    ·                    (x, y, v)           +x,+y
+·                             estimated row count  333 (missing stats)  ·                   ·
+·                             table                xyv@primary          ·                   ·
+·                             spans                /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                distribution         local                ·                   ·
-·                vectorized           true                 ·                   ·
-project          ·                    ·                    (x, y, u, v)        ·
- │               estimated row count  333 (missing stats)  ·                   ·
- └── merge join  ·                    ·                    (x, y, v, x, y, u)  ·
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          type                 left outer           ·                   ·
-      │          equality             (x, y) = (x, y)      ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan   ·                    ·                    (x, y, v)           +x,+y
-      │          estimated row count  333 (missing stats)  ·                   ·
-      │          table                xyv@primary          ·                   ·
-      │          spans                /3-                  ·                   ·
-      └── scan   ·                    ·                    (x, y, u)           +x,+y
-·                estimated row count  333 (missing stats)  ·                   ·
-·                table                xyu@primary          ·                   ·
-·                spans                /3-                  ·                   ·
+·                             distribution         local                ·                   ·
+·                             vectorized           true                 ·                   ·
+project                       ·                    ·                    (x, y, u, v)        ·
+ │                            estimated row count  333 (missing stats)  ·                   ·
+ └── merge join (left outer)  ·                    ·                    (x, y, v, x, y, u)  ·
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       equality             (x, y) = (x, y)      ·                   ·
+      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
+      ├── scan                ·                    ·                    (x, y, v)           +x,+y
+      │                       estimated row count  333 (missing stats)  ·                   ·
+      │                       table                xyv@primary          ·                   ·
+      │                       spans                /3-                  ·                   ·
+      └── scan                ·                    ·                    (x, y, u)           +x,+y
+·                             estimated row count  333 (missing stats)  ·                   ·
+·                             table                xyu@primary          ·                   ·
+·                             spans                /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                     distribution         local                 ·                   ·
-·                     vectorized           true                  ·                   ·
-filter                ·                    ·                     (x, y, u, v)        ·
- │                    estimated row count  633 (missing stats)   ·                   ·
- │                    filter               x > 2                 ·                   ·
- └── render           ·                    ·                     (x, y, u, v)        ·
-      │               estimated row count  1900 (missing stats)  ·                   ·
-      │               render 0             COALESCE(x, x)        ·                   ·
-      │               render 1             COALESCE(y, y)        ·                   ·
-      │               render 2             u                     ·                   ·
-      │               render 3             v                     ·                   ·
-      └── merge join  ·                    ·                     (x, y, u, x, y, v)  ·
-           │          estimated row count  1900 (missing stats)  ·                   ·
-           │          type                 full outer            ·                   ·
-           │          equality             (x, y) = (x, y)       ·                   ·
-           │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-           ├── scan   ·                    ·                     (x, y, u)           +x,+y
-           │          estimated row count  1000 (missing stats)  ·                   ·
-           │          table                xyu@primary           ·                   ·
-           │          spans                FULL SCAN             ·                   ·
-           └── scan   ·                    ·                     (x, y, v)           +x,+y
-·                     estimated row count  1000 (missing stats)  ·                   ·
-·                     table                xyv@primary           ·                   ·
-·                     spans                FULL SCAN             ·                   ·
+·                                  distribution         local                 ·                   ·
+·                                  vectorized           true                  ·                   ·
+filter                             ·                    ·                     (x, y, u, v)        ·
+ │                                 estimated row count  633 (missing stats)   ·                   ·
+ │                                 filter               x > 2                 ·                   ·
+ └── render                        ·                    ·                     (x, y, u, v)        ·
+      │                            estimated row count  1900 (missing stats)  ·                   ·
+      │                            render 0             COALESCE(x, x)        ·                   ·
+      │                            render 1             COALESCE(y, y)        ·                   ·
+      │                            render 2             u                     ·                   ·
+      │                            render 3             v                     ·                   ·
+      └── merge join (full outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+           │                       estimated row count  1900 (missing stats)  ·                   ·
+           │                       equality             (x, y) = (x, y)       ·                   ·
+           │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+           ├── scan                ·                    ·                     (x, y, u)           +x,+y
+           │                       estimated row count  1000 (missing stats)  ·                   ·
+           │                       table                xyu@primary           ·                   ·
+           │                       spans                FULL SCAN             ·                   ·
+           └── scan                ·                    ·                     (x, y, v)           +x,+y
+·                                  estimated row count  1000 (missing stats)  ·                   ·
+·                                  table                xyv@primary           ·                   ·
+·                                  spans                FULL SCAN             ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local                 ·                   ·
-·           vectorized           true                  ·                   ·
-merge join  ·                    ·                     (x, y, u, x, y, v)  ·
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          type                 left outer            ·                   ·
- │          equality             (x, y) = (x, y)       ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan   ·                    ·                     (x, y, u)           +x,+y
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          table                xyu@primary           ·                   ·
- │          spans                FULL SCAN             ·                   ·
- └── scan   ·                    ·                     (x, y, v)           +y
-·           estimated row count  9 (missing stats)     ·                   ·
-·           table                xyv@primary           ·                   ·
-·           spans                /1-/1/10              ·                   ·
+·                        distribution         local                 ·                   ·
+·                        vectorized           true                  ·                   ·
+merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       equality             (x, y) = (x, y)       ·                   ·
+ │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+ ├── scan                ·                    ·                     (x, y, u)           +x,+y
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       table                xyu@primary           ·                   ·
+ │                       spans                FULL SCAN             ·                   ·
+ └── scan                ·                    ·                     (x, y, v)           +y
+·                        estimated row count  9 (missing stats)     ·                   ·
+·                        table                xyv@primary           ·                   ·
+·                        spans                /1-/1/10              ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distribution         local                 ·                   ·
-·           vectorized           true                  ·                   ·
-merge join  ·                    ·                     (x, y, u, x, y, v)  ·
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          type                 left outer            ·                   ·
- │          equality             (x, y) = (x, y)       ·                   ·
- │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan   ·                    ·                     (x, y, v)           +x,+y
- │          estimated row count  1000 (missing stats)  ·                   ·
- │          table                xyv@primary           ·                   ·
- │          spans                FULL SCAN             ·                   ·
- └── scan   ·                    ·                     (x, y, u)           +y
-·           estimated row count  9 (missing stats)     ·                   ·
-·           table                xyu@primary           ·                   ·
-·           spans                /1-/1/10              ·                   ·
+·                        distribution         local                 ·                   ·
+·                        vectorized           true                  ·                   ·
+merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       equality             (x, y) = (x, y)       ·                   ·
+ │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+ ├── scan                ·                    ·                     (x, y, v)           +x,+y
+ │                       estimated row count  1000 (missing stats)  ·                   ·
+ │                       table                xyv@primary           ·                   ·
+ │                       spans                FULL SCAN             ·                   ·
+ └── scan                ·                    ·                     (x, y, u)           +y
+·                        estimated row count  9 (missing stats)     ·                   ·
+·                        table                xyu@primary           ·                   ·
+·                        spans                /1-/1/10              ·                   ·
 
 # Regression test for #20472: break up tuple inequalities.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-·                distribution         local                 ·                   ·
-·                vectorized           true                  ·                   ·
-project          ·                    ·                     (x, y, u, v)        ·
- │               estimated row count  33 (missing stats)    ·                   ·
- └── merge join  ·                    ·                     (x, y, u, x, y, v)  ·
-      │          estimated row count  33 (missing stats)    ·                   ·
-      │          type                 inner                 ·                   ·
-      │          equality             (x, y) = (x, y)       ·                   ·
-      │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-      ├── scan   ·                    ·                     (x, y, u)           +x,+y
-      │          estimated row count  333 (missing stats)   ·                   ·
-      │          table                xyu@primary           ·                   ·
-      │          spans                /1/2/4-               ·                   ·
-      └── scan   ·                    ·                     (x, y, v)           +x,+y
-·                estimated row count  1000 (missing stats)  ·                   ·
-·                table                xyv@primary           ·                   ·
-·                spans                FULL SCAN             ·                   ·
+·                        distribution         local                 ·                   ·
+·                        vectorized           true                  ·                   ·
+project                  ·                    ·                     (x, y, u, v)        ·
+ │                       estimated row count  33 (missing stats)    ·                   ·
+ └── merge join (inner)  ·                    ·                     (x, y, u, x, y, v)  ·
+      │                  estimated row count  33 (missing stats)    ·                   ·
+      │                  equality             (x, y) = (x, y)       ·                   ·
+      │                  merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
+      ├── scan           ·                    ·                     (x, y, u)           +x,+y
+      │                  estimated row count  333 (missing stats)   ·                   ·
+      │                  table                xyu@primary           ·                   ·
+      │                  spans                /1/2/4-               ·                   ·
+      └── scan           ·                    ·                     (x, y, v)           +x,+y
+·                        estimated row count  1000 (missing stats)  ·                   ·
+·                        table                xyv@primary           ·                   ·
+·                        spans                FULL SCAN             ·                   ·
 
 
 # Regression test for #20765/27431.
@@ -1253,90 +1197,86 @@ CREATE TABLE r (a INT PRIMARY KEY, b2 INT, FAMILY (a))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                distribution         local              ·               ·
-·                vectorized           true               ·               ·
-project          ·                    ·                  (a, b1, b2)     ·
- │               estimated row count  1 (missing stats)  ·               ·
- └── merge join  ·                    ·                  (a, b1, a, b2)  ·
-      │          estimated row count  1 (missing stats)  ·               ·
-      │          type                 left outer         ·               ·
-      │          equality             (a) = (a)          ·               ·
-      │          left cols are key    ·                  ·               ·
-      │          right cols are key   ·                  ·               ·
-      │          merge ordering       +"(a=a)"           ·               ·
-      ├── scan   ·                    ·                  (a, b1)         ·
-      │          estimated row count  1 (missing stats)  ·               ·
-      │          table                l@primary          ·               ·
-      │          spans                /3-/3/#            ·               ·
-      └── scan   ·                    ·                  (a, b2)         ·
-·                estimated row count  1 (missing stats)  ·               ·
-·                table                r@primary          ·               ·
-·                spans                /3-/3/#            ·               ·
+·                             distribution         local              ·               ·
+·                             vectorized           true               ·               ·
+project                       ·                    ·                  (a, b1, b2)     ·
+ │                            estimated row count  1 (missing stats)  ·               ·
+ └── merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
+      │                       estimated row count  1 (missing stats)  ·               ·
+      │                       equality             (a) = (a)          ·               ·
+      │                       left cols are key    ·                  ·               ·
+      │                       right cols are key   ·                  ·               ·
+      │                       merge ordering       +"(a=a)"           ·               ·
+      ├── scan                ·                    ·                  (a, b1)         ·
+      │                       estimated row count  1 (missing stats)  ·               ·
+      │                       table                l@primary          ·               ·
+      │                       spans                /3-/3/#            ·               ·
+      └── scan                ·                    ·                  (a, b2)         ·
+·                             estimated row count  1 (missing stats)  ·               ·
+·                             table                r@primary          ·               ·
+·                             spans                /3-/3/#            ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-·           distribution         local              ·               ·
-·           vectorized           true               ·               ·
-merge join  ·                    ·                  (a, b1, a, b2)  ·
- │          estimated row count  1 (missing stats)  ·               ·
- │          type                 left outer         ·               ·
- │          equality             (a) = (a)          ·               ·
- │          left cols are key    ·                  ·               ·
- │          right cols are key   ·                  ·               ·
- │          merge ordering       +"(a=a)"           ·               ·
- ├── scan   ·                    ·                  (a, b1)         ·
- │          estimated row count  1 (missing stats)  ·               ·
- │          table                l@primary          ·               ·
- │          spans                /3-/3/#            ·               ·
- └── scan   ·                    ·                  (a, b2)         ·
-·           estimated row count  1 (missing stats)  ·               ·
-·           table                r@primary          ·               ·
-·           spans                /3-/3/#            ·               ·
+·                        distribution         local              ·               ·
+·                        vectorized           true               ·               ·
+merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
+ │                       estimated row count  1 (missing stats)  ·               ·
+ │                       equality             (a) = (a)          ·               ·
+ │                       left cols are key    ·                  ·               ·
+ │                       right cols are key   ·                  ·               ·
+ │                       merge ordering       +"(a=a)"           ·               ·
+ ├── scan                ·                    ·                  (a, b1)         ·
+ │                       estimated row count  1 (missing stats)  ·               ·
+ │                       table                l@primary          ·               ·
+ │                       spans                /3-/3/#            ·               ·
+ └── scan                ·                    ·                  (a, b2)         ·
+·                        estimated row count  1 (missing stats)  ·               ·
+·                        table                r@primary          ·               ·
+·                        spans                /3-/3/#            ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                distribution         local              ·               ·
-·                vectorized           true               ·               ·
-project          ·                    ·                  (a, b1, b2)     ·
- │               estimated row count  1 (missing stats)  ·               ·
- └── merge join  ·                    ·                  (a, b2, a, b1)  ·
-      │          estimated row count  1 (missing stats)  ·               ·
-      │          type                 left outer         ·               ·
-      │          equality             (a) = (a)          ·               ·
-      │          left cols are key    ·                  ·               ·
-      │          right cols are key   ·                  ·               ·
-      │          merge ordering       +"(a=a)"           ·               ·
-      ├── scan   ·                    ·                  (a, b2)         ·
-      │          estimated row count  1 (missing stats)  ·               ·
-      │          table                r@primary          ·               ·
-      │          spans                /3-/3/#            ·               ·
-      └── scan   ·                    ·                  (a, b1)         ·
-·                estimated row count  1 (missing stats)  ·               ·
-·                table                l@primary          ·               ·
-·                spans                /3-/3/#            ·               ·
+·                             distribution         local              ·               ·
+·                             vectorized           true               ·               ·
+project                       ·                    ·                  (a, b1, b2)     ·
+ │                            estimated row count  1 (missing stats)  ·               ·
+ └── merge join (left outer)  ·                    ·                  (a, b2, a, b1)  ·
+      │                       estimated row count  1 (missing stats)  ·               ·
+      │                       equality             (a) = (a)          ·               ·
+      │                       left cols are key    ·                  ·               ·
+      │                       right cols are key   ·                  ·               ·
+      │                       merge ordering       +"(a=a)"           ·               ·
+      ├── scan                ·                    ·                  (a, b2)         ·
+      │                       estimated row count  1 (missing stats)  ·               ·
+      │                       table                r@primary          ·               ·
+      │                       spans                /3-/3/#            ·               ·
+      └── scan                ·                    ·                  (a, b1)         ·
+·                             estimated row count  1 (missing stats)  ·               ·
+·                             table                l@primary          ·               ·
+·                             spans                /3-/3/#            ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-·           distribution         local              ·               ·
-·           vectorized           true               ·               ·
-merge join  ·                    ·                  (a, b1, a, b2)  ·
- │          estimated row count  1 (missing stats)  ·               ·
- │          type                 left outer         ·               ·
- │          equality             (a) = (a)          ·               ·
- │          left cols are key    ·                  ·               ·
- │          right cols are key   ·                  ·               ·
- │          merge ordering       +"(a=a)"           ·               ·
- ├── scan   ·                    ·                  (a, b2)         ·
- │          estimated row count  1 (missing stats)  ·               ·
- │          table                r@primary          ·               ·
- │          spans                /3-/3/#            ·               ·
- └── scan   ·                    ·                  (a, b1)         ·
-·           estimated row count  1 (missing stats)  ·               ·
-·           table                l@primary          ·               ·
-·           spans                /3-/3/#            ·               ·
+·                        distribution         local              ·               ·
+·                        vectorized           true               ·               ·
+merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
+ │                       estimated row count  1 (missing stats)  ·               ·
+ │                       equality             (a) = (a)          ·               ·
+ │                       left cols are key    ·                  ·               ·
+ │                       right cols are key   ·                  ·               ·
+ │                       merge ordering       +"(a=a)"           ·               ·
+ ├── scan                ·                    ·                  (a, b2)         ·
+ │                       estimated row count  1 (missing stats)  ·               ·
+ │                       table                r@primary          ·               ·
+ │                       spans                /3-/3/#            ·               ·
+ └── scan                ·                    ·                  (a, b1)         ·
+·                        estimated row count  1 (missing stats)  ·               ·
+·                        table                l@primary          ·               ·
+·                        spans                /3-/3/#            ·               ·
 
 # Regression tests for #21243
 statement ok
@@ -1364,7 +1304,6 @@ EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(
 ·           distribution        local
 ·           vectorized          true
 merge join  ·                   ·
- │          type                inner
  │          equality            (a, b) = (a, b)
  │          right cols are key  ·
  ├── scan   ·                   ·
@@ -1399,23 +1338,22 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo NATURAL JOIN bar
 ]
 ----
-·               distribution         local
-·               vectorized           true
-project         ·                    ·
- │              estimated row count  0 (missing stats)
- └── hash join  ·                    ·
-      │         estimated row count  0 (missing stats)
-      │         type                 inner
-      │         equality             (a, c) = (a, c)
-      │         pred                 (b = b) AND (d = d)
-      ├── scan  ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         table                foo@primary
-      │         spans                FULL SCAN
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                bar@primary
-·               spans                FULL SCAN
+·                       distribution         local
+·                       vectorized           true
+project                 ·                    ·
+ │                      estimated row count  0 (missing stats)
+ └── hash join (inner)  ·                    ·
+      │                 estimated row count  0 (missing stats)
+      │                 equality             (a, c) = (a, c)
+      │                 pred                 (b = b) AND (d = d)
+      ├── scan          ·                    ·
+      │                 estimated row count  1000 (missing stats)
+      │                 table                foo@primary
+      │                 spans                FULL SCAN
+      └── scan          ·                    ·
+·                       estimated row count  1000 (missing stats)
+·                       table                bar@primary
+·                       spans                FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1423,22 +1361,21 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (b)
 ]
 ----
-·                distribution         local
-·                vectorized           true
-project          ·                    ·
- │               estimated row count  9801 (missing stats)
- └── cross join  ·                    ·
-      │          estimated row count  9801 (missing stats)
-      │          type                 cross
-      │          pred                 b = b
-      ├── scan   ·                    ·
-      │          estimated row count  1000 (missing stats)
-      │          table                foo@primary
-      │          spans                FULL SCAN
-      └── scan   ·                    ·
-·                estimated row count  1000 (missing stats)
-·                table                bar@primary
-·                spans                FULL SCAN
+·                        distribution         local
+·                        vectorized           true
+project                  ·                    ·
+ │                       estimated row count  9801 (missing stats)
+ └── cross join (inner)  ·                    ·
+      │                  estimated row count  9801 (missing stats)
+      │                  pred                 b = b
+      ├── scan           ·                    ·
+      │                  estimated row count  1000 (missing stats)
+      │                  table                foo@primary
+      │                  spans                FULL SCAN
+      └── scan           ·                    ·
+·                        estimated row count  1000 (missing stats)
+·                        table                bar@primary
+·                        spans                FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1446,23 +1383,22 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b)
 ]
 ----
-·               distribution         local
-·               vectorized           true
-project         ·                    ·
- │              estimated row count  96 (missing stats)
- └── hash join  ·                    ·
-      │         estimated row count  96 (missing stats)
-      │         type                 inner
-      │         equality             (a) = (a)
-      │         pred                 b = b
-      ├── scan  ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         table                foo@primary
-      │         spans                FULL SCAN
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                bar@primary
-·               spans                FULL SCAN
+·                       distribution         local
+·                       vectorized           true
+project                 ·                    ·
+ │                      estimated row count  96 (missing stats)
+ └── hash join (inner)  ·                    ·
+      │                 estimated row count  96 (missing stats)
+      │                 equality             (a) = (a)
+      │                 pred                 b = b
+      ├── scan          ·                    ·
+      │                 estimated row count  1000 (missing stats)
+      │                 table                foo@primary
+      │                 spans                FULL SCAN
+      └── scan          ·                    ·
+·                       estimated row count  1000 (missing stats)
+·                       table                bar@primary
+·                       spans                FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
@@ -1470,23 +1406,22 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b, c)
 ]
 ----
-·               distribution         local
-·               vectorized           true
-project         ·                    ·
- │              estimated row count  1 (missing stats)
- └── hash join  ·                    ·
-      │         estimated row count  1 (missing stats)
-      │         type                 inner
-      │         equality             (a, c) = (a, c)
-      │         pred                 b = b
-      ├── scan  ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         table                foo@primary
-      │         spans                FULL SCAN
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                bar@primary
-·               spans                FULL SCAN
+·                       distribution         local
+·                       vectorized           true
+project                 ·                    ·
+ │                      estimated row count  1 (missing stats)
+ └── hash join (inner)  ·                    ·
+      │                 estimated row count  1 (missing stats)
+      │                 equality             (a, c) = (a, c)
+      │                 pred                 b = b
+      ├── scan          ·                    ·
+      │                 estimated row count  1000 (missing stats)
+      │                 table                foo@primary
+      │                 spans                FULL SCAN
+      └── scan          ·                    ·
+·                       estimated row count  1000 (missing stats)
+·                       table                bar@primary
+·                       spans                FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1494,20 +1429,19 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ]
 ----
-·           distribution         local
-·           vectorized           true
-cross join  ·                    ·
- │          estimated row count  9801 (missing stats)
- │          type                 cross
- │          pred                 b = b
- ├── scan   ·                    ·
- │          estimated row count  1000 (missing stats)
- │          table                foo@primary
- │          spans                FULL SCAN
- └── scan   ·                    ·
-·           estimated row count  1000 (missing stats)
-·           table                bar@primary
-·           spans                FULL SCAN
+·                   distribution         local
+·                   vectorized           true
+cross join (inner)  ·                    ·
+ │                  estimated row count  9801 (missing stats)
+ │                  pred                 b = b
+ ├── scan           ·                    ·
+ │                  estimated row count  1000 (missing stats)
+ │                  table                foo@primary
+ │                  spans                FULL SCAN
+ └── scan           ·                    ·
+·                   estimated row count  1000 (missing stats)
+·                   table                bar@primary
+·                   spans                FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1515,41 +1449,39 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-·          distribution         local
-·          vectorized           true
-hash join  ·                    ·
- │         estimated row count  96 (missing stats)
- │         type                 inner
- │         equality             (a) = (a)
- │         pred                 b = b
- ├── scan  ·                    ·
- │         estimated row count  1000 (missing stats)
- │         table                foo@primary
- │         spans                FULL SCAN
- └── scan  ·                    ·
-·          estimated row count  1000 (missing stats)
-·          table                bar@primary
-·          spans                FULL SCAN
+·                  distribution         local
+·                  vectorized           true
+hash join (inner)  ·                    ·
+ │                 estimated row count  96 (missing stats)
+ │                 equality             (a) = (a)
+ │                 pred                 b = b
+ ├── scan          ·                    ·
+ │                 estimated row count  1000 (missing stats)
+ │                 table                foo@primary
+ │                 spans                FULL SCAN
+ └── scan          ·                    ·
+·                  estimated row count  1000 (missing stats)
+·                  table                bar@primary
+·                  spans                FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
 ]
 ----
-·           distribution         local
-·           vectorized           true
-cross join  ·                    ·
- │          estimated row count  9801 (missing stats)
- │          type                 cross
- │          pred                 b = b
- ├── scan   ·                    ·
- │          estimated row count  1000 (missing stats)
- │          table                foo@primary
- │          spans                FULL SCAN
- └── scan   ·                    ·
-·           estimated row count  1000 (missing stats)
-·           table                bar@primary
-·           spans                FULL SCAN
+·                   distribution         local
+·                   vectorized           true
+cross join (inner)  ·                    ·
+ │                  estimated row count  9801 (missing stats)
+ │                  pred                 b = b
+ ├── scan           ·                    ·
+ │                  estimated row count  1000 (missing stats)
+ │                  table                foo@primary
+ │                  spans                FULL SCAN
+ └── scan           ·                    ·
+·                   estimated row count  1000 (missing stats)
+·                   table                bar@primary
+·                   spans                FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1557,21 +1489,20 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-·          distribution         local
-·          vectorized           true
-hash join  ·                    ·
- │         estimated row count  96 (missing stats)
- │         type                 inner
- │         equality             (a) = (a)
- │         pred                 b = b
- ├── scan  ·                    ·
- │         estimated row count  1000 (missing stats)
- │         table                foo@primary
- │         spans                FULL SCAN
- └── scan  ·                    ·
-·          estimated row count  1000 (missing stats)
-·          table                bar@primary
-·          spans                FULL SCAN
+·                  distribution         local
+·                  vectorized           true
+hash join (inner)  ·                    ·
+ │                 estimated row count  96 (missing stats)
+ │                 equality             (a) = (a)
+ │                 pred                 b = b
+ ├── scan          ·                    ·
+ │                 estimated row count  1000 (missing stats)
+ │                 table                foo@primary
+ │                 spans                FULL SCAN
+ └── scan          ·                    ·
+·                  estimated row count  1000 (missing stats)
+·                  table                bar@primary
+·                  spans                FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
@@ -1580,7 +1511,6 @@ EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = b
 ·          distribution   local
 ·          vectorized     true
 hash join  ·              ·
- │         type           inner
  │         equality       (a, c) = (a, c)
  │         pred           (b = b) AND (d = d)
  ├── scan  ·              ·
@@ -1649,7 +1579,6 @@ EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ·                 vectorized             true
 lookup join       ·                      ·
  │                table                  zigzag@primary
- │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
  └── zigzag join  ·                      ·
@@ -1669,7 +1598,6 @@ EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ·                 vectorized             true
 lookup join       ·                      ·
  │                table                  zigzag@primary
- │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
  │                pred                   d > 4.0
@@ -1717,7 +1645,6 @@ EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ·               distribution   local
 ·               vectorized     true
 merge join      ·              ·
- │              type           inner
  │              equality       (x) = (x)
  ├── sort       ·              ·
  │    │         order          +x
@@ -1739,7 +1666,6 @@ EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ·               distribution   local
 ·               vectorized     true
 merge join      ·              ·
- │              type           inner
  │              equality       (x) = (x)
  ├── sort       ·              ·
  │    │         order          +x
@@ -1761,7 +1687,6 @@ EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = t
 ·               distribution   local
 ·               vectorized     true
 merge join      ·              ·
- │              type           inner
  │              equality       (x) = (x)
  ├── sort       ·              ·
  │    │         order          +x
@@ -1792,7 +1717,6 @@ EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = car
 ·          distribution        local
 ·          vectorized          true
 hash join  ·                   ·
- │         type                inner
  │         equality            (cust) = (id)
  │         right cols are key  ·
  ├── scan  ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -389,28 +389,24 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 7   ·                          type                   inner
 7   ·                          equality               (oid) = (attrelid)
 7   ·                          equality cols are key  ·
-7   ·                          parallel               ·
 8   virtual table lookup join  ·                      ·
 8   ·                          estimated row count    10 (missing stats)
 8   ·                          table                  pg_class@pg_class_oid_idx
 8   ·                          type                   inner
 8   ·                          equality               (attrelid) = (oid)
 8   ·                          equality cols are key  ·
-8   ·                          parallel               ·
 9   virtual table lookup join  ·                      ·
 9   ·                          estimated row count    10 (missing stats)
 9   ·                          table                  pg_attribute@pg_attribute_attrelid_idx
 9   ·                          type                   inner
 9   ·                          equality               (confrelid) = (attrelid)
 9   ·                          equality cols are key  ·
-9   ·                          parallel               ·
 10  virtual table lookup join  ·                      ·
 10  ·                          estimated row count    10 (missing stats)
 10  ·                          table                  pg_constraint@pg_constraint_conrelid_idx
 10  ·                          type                   inner
 10  ·                          equality               (oid) = (conrelid)
 10  ·                          equality cols are key  ·
-10  ·                          parallel               ·
 10  ·                          pred                   contype = 'f'
 11  filter                     ·                      ·
 11  ·                          estimated row count    10 (missing stats)
@@ -452,7 +448,6 @@ merge join  ·                   ·
  │          type                inner
  │          equality            (cust) = (id)
  │          right cols are key  ·
- │          mergeJoinOrder      +"(cust=id)"
  ├── scan   ·                   ·
  │          missing stats       ·
  │          table               cards@cards_cust_idx
@@ -788,7 +783,7 @@ project          ·                    ·                           (a, b, c, d,
       │          equality             (b, a, c) = (b, a, c)       ·                         ·
       │          left cols are key    ·                           ·                         ·
       │          right cols are key   ·                           ·                         ·
-      │          mergeJoinOrder       +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
+      │          merge ordering       +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
       ├── scan   ·                    ·                           (a, b, c, d)              +b,+a,+c
       │          estimated row count  1000 (missing stats)        ·                         ·
       │          table                pkbac@primary               ·                         ·
@@ -809,7 +804,7 @@ merge join  ·                    ·                           (a, b, c, d, a, b
  │          equality             (b, a, c) = (b, a, d)       ·                         ·
  │          left cols are key    ·                           ·                         ·
  │          right cols are key   ·                           ·                         ·
- │          mergeJoinOrder       +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+ │          merge ordering       +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
  ├── scan   ·                    ·                           (a, b, c, d)              +b,+a,+c
  │          estimated row count  1000 (missing stats)        ·                         ·
  │          table                pkbac@primary               ·                         ·
@@ -954,7 +949,7 @@ project          ·                    ·                    (x, y, u, v)       
       │          estimated row count  34 (missing stats)   ·                   ·
       │          type                 inner                ·                   ·
       │          equality             (x, y) = (x, y)      ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"    ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
       ├── scan   ·                    ·                    (x, y, u)           +x,+y
       │          estimated row count  333 (missing stats)  ·                   ·
       │          table                xyu@primary          ·                   ·
@@ -975,7 +970,7 @@ project          ·                    ·                    (x, y, u, v)       
       │          estimated row count  333 (missing stats)  ·                   ·
       │          type                 left outer           ·                   ·
       │          equality             (x, y) = (x, y)      ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"    ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
       ├── scan   ·                    ·                    (x, y, u)           +x,+y
       │          estimated row count  333 (missing stats)  ·                   ·
       │          table                xyu@primary          ·                   ·
@@ -996,7 +991,7 @@ project          ·                    ·                    (x, y, u, v)       
       │          estimated row count  333 (missing stats)  ·                   ·
       │          type                 left outer           ·                   ·
       │          equality             (x, y) = (x, y)      ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"    ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
       ├── scan   ·                    ·                    (x, y, v)           +x,+y
       │          estimated row count  333 (missing stats)  ·                   ·
       │          table                xyv@primary          ·                   ·
@@ -1024,7 +1019,7 @@ filter                ·                    ·                     (x, y, u, v) 
            │          estimated row count  1900 (missing stats)  ·                   ·
            │          type                 full outer            ·                   ·
            │          equality             (x, y) = (x, y)       ·                   ·
-           │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+           │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
            ├── scan   ·                    ·                     (x, y, u)           +x,+y
            │          estimated row count  1000 (missing stats)  ·                   ·
            │          table                xyu@primary           ·                   ·
@@ -1044,7 +1039,7 @@ merge join  ·                    ·                  (x, y, u, x, y, v)  ·
  │          estimated row count  9 (missing stats)  ·                   ·
  │          type                 inner              ·                   ·
  │          equality             (x, y) = (x, y)    ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"  ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
  ├── scan   ·                    ·                  (x, y, u)           +y
  │          estimated row count  9 (missing stats)  ·                   ·
  │          table                xyu@primary        ·                   ·
@@ -1063,7 +1058,7 @@ merge join  ·                    ·                  (x, y, u, x, y, v)  ·
  │          estimated row count  9 (missing stats)  ·                   ·
  │          type                 inner              ·                   ·
  │          equality             (x, y) = (x, y)    ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"  ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
  ├── scan   ·                    ·                  (x, y, u)           +y
  │          estimated row count  9 (missing stats)  ·                   ·
  │          table                xyu@primary        ·                   ·
@@ -1082,7 +1077,7 @@ merge join  ·                    ·                     (x, y, u, x, y, v)  ·
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          type                 left outer            ·                   ·
  │          equality             (x, y) = (x, y)       ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
  ├── scan   ·                    ·                     (x, y, u)           +x,+y
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          table                xyu@primary           ·                   ·
@@ -1101,7 +1096,7 @@ merge join  ·                    ·                     (x, y, u, x, y, v)  ·
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          type                 left outer            ·                   ·
  │          equality             (x, y) = (x, y)       ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
  ├── scan   ·                    ·                     (x, y, v)           +x,+y
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          table                xyv@primary           ·                   ·
@@ -1125,7 +1120,7 @@ project          ·                    ·                    (x, y, u, v)       
       │          estimated row count  333 (missing stats)  ·                   ·
       │          type                 left outer           ·                   ·
       │          equality             (x, y) = (x, y)      ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"    ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
       ├── scan   ·                    ·                    (x, y, u)           +x,+y
       │          estimated row count  333 (missing stats)  ·                   ·
       │          table                xyu@primary          ·                   ·
@@ -1146,7 +1141,7 @@ project          ·                    ·                    (x, y, u, v)       
       │          estimated row count  333 (missing stats)  ·                   ·
       │          type                 left outer           ·                   ·
       │          equality             (x, y) = (x, y)      ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"    ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
       ├── scan   ·                    ·                    (x, y, v)           +x,+y
       │          estimated row count  333 (missing stats)  ·                   ·
       │          table                xyv@primary          ·                   ·
@@ -1174,7 +1169,7 @@ filter                ·                    ·                     (x, y, u, v) 
            │          estimated row count  1900 (missing stats)  ·                   ·
            │          type                 full outer            ·                   ·
            │          equality             (x, y) = (x, y)       ·                   ·
-           │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+           │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
            ├── scan   ·                    ·                     (x, y, u)           +x,+y
            │          estimated row count  1000 (missing stats)  ·                   ·
            │          table                xyu@primary           ·                   ·
@@ -1193,7 +1188,7 @@ merge join  ·                    ·                     (x, y, u, x, y, v)  ·
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          type                 left outer            ·                   ·
  │          equality             (x, y) = (x, y)       ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
  ├── scan   ·                    ·                     (x, y, u)           +x,+y
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          table                xyu@primary           ·                   ·
@@ -1212,7 +1207,7 @@ merge join  ·                    ·                     (x, y, u, x, y, v)  ·
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          type                 left outer            ·                   ·
  │          equality             (x, y) = (x, y)       ·                   ·
- │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+ │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
  ├── scan   ·                    ·                     (x, y, v)           +x,+y
  │          estimated row count  1000 (missing stats)  ·                   ·
  │          table                xyv@primary           ·                   ·
@@ -1234,7 +1229,7 @@ project          ·                    ·                     (x, y, u, v)      
       │          estimated row count  33 (missing stats)    ·                   ·
       │          type                 inner                 ·                   ·
       │          equality             (x, y) = (x, y)       ·                   ·
-      │          mergeJoinOrder       +"(x=x)",+"(y=y)"     ·                   ·
+      │          merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
       ├── scan   ·                    ·                     (x, y, u)           +x,+y
       │          estimated row count  333 (missing stats)   ·                   ·
       │          table                xyu@primary           ·                   ·
@@ -1268,7 +1263,7 @@ project          ·                    ·                  (a, b1, b2)     ·
       │          equality             (a) = (a)          ·               ·
       │          left cols are key    ·                  ·               ·
       │          right cols are key   ·                  ·               ·
-      │          mergeJoinOrder       +"(a=a)"           ·               ·
+      │          merge ordering       +"(a=a)"           ·               ·
       ├── scan   ·                    ·                  (a, b1)         ·
       │          estimated row count  1 (missing stats)  ·               ·
       │          table                l@primary          ·               ·
@@ -1289,7 +1284,7 @@ merge join  ·                    ·                  (a, b1, a, b2)  ·
  │          equality             (a) = (a)          ·               ·
  │          left cols are key    ·                  ·               ·
  │          right cols are key   ·                  ·               ·
- │          mergeJoinOrder       +"(a=a)"           ·               ·
+ │          merge ordering       +"(a=a)"           ·               ·
  ├── scan   ·                    ·                  (a, b1)         ·
  │          estimated row count  1 (missing stats)  ·               ·
  │          table                l@primary          ·               ·
@@ -1312,7 +1307,7 @@ project          ·                    ·                  (a, b1, b2)     ·
       │          equality             (a) = (a)          ·               ·
       │          left cols are key    ·                  ·               ·
       │          right cols are key   ·                  ·               ·
-      │          mergeJoinOrder       +"(a=a)"           ·               ·
+      │          merge ordering       +"(a=a)"           ·               ·
       ├── scan   ·                    ·                  (a, b2)         ·
       │          estimated row count  1 (missing stats)  ·               ·
       │          table                r@primary          ·               ·
@@ -1333,7 +1328,7 @@ merge join  ·                    ·                  (a, b1, a, b2)  ·
  │          equality             (a) = (a)          ·               ·
  │          left cols are key    ·                  ·               ·
  │          right cols are key   ·                  ·               ·
- │          mergeJoinOrder       +"(a=a)"           ·               ·
+ │          merge ordering       +"(a=a)"           ·               ·
  ├── scan   ·                    ·                  (a, b2)         ·
  │          estimated row count  1 (missing stats)  ·               ·
  │          table                r@primary          ·               ·
@@ -1372,7 +1367,6 @@ merge join  ·                   ·
  │          type                inner
  │          equality            (a, b) = (a, b)
  │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)",+"(b=b)"
  ├── scan   ·                   ·
  │          missing stats       ·
  │          table               abcdef@primary
@@ -1622,7 +1616,6 @@ filter           ·              ·
  │               filter         c = 6.0
  └── index join  ·              ·
       │          table          zigzag@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          zigzag@b_idx
@@ -1639,7 +1632,6 @@ EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ·            distribution        local
 ·            vectorized          true
 zigzag join  ·                   ·
-·            type                inner
 ·            pred                (b = 5) AND (c = 6.0)
 ·            left table          zigzag@b_idx
 ·            left columns        (a, b)
@@ -1660,9 +1652,7 @@ lookup join       ·                      ·
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
- │                parallel               ·
  └── zigzag join  ·                      ·
-·                 type                   inner
 ·                 pred                   (b = 5) AND (c = 6.0)
 ·                 left table             zigzag@b_idx
 ·                 left columns           (a, b)
@@ -1682,10 +1672,8 @@ lookup join       ·                      ·
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
- │                parallel               ·
  │                pred                   d > 4.0
  └── zigzag join  ·                      ·
-·                 type                   inner
 ·                 pred                   (b = 5) AND (c = 6.0)
 ·                 left table             zigzag@b_idx
 ·                 left columns           (a, b)
@@ -1717,7 +1705,6 @@ filter           ·              ·
  │               filter         c IS NULL
  └── index join  ·              ·
       │          table          zigzag2@primary
-      │          key columns    rowid
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          zigzag2@a_b_idx
@@ -1727,70 +1714,67 @@ filter           ·              ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
-·               distribution    local
-·               vectorized      true
-merge join      ·               ·
- │              type            inner
- │              equality        (x) = (x)
- │              mergeJoinOrder  +"(x=x)"
- ├── sort       ·               ·
- │    │         order           +x
- │    └── scan  ·               ·
- │              missing stats   ·
- │              table           onecolumn@primary
- │              spans           FULL SCAN
- └── sort       ·               ·
-      │         order           +x
-      └── scan  ·               ·
-·               missing stats   ·
-·               table           twocolumn@primary
-·               spans           FULL SCAN
+·               distribution   local
+·               vectorized     true
+merge join      ·              ·
+ │              type           inner
+ │              equality       (x) = (x)
+ ├── sort       ·              ·
+ │    │         order          +x
+ │    └── scan  ·              ·
+ │              missing stats  ·
+ │              table          onecolumn@primary
+ │              spans          FULL SCAN
+ └── sort       ·              ·
+      │         order          +x
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          twocolumn@primary
+·               spans          FULL SCAN
 
 # Test that we can force a merge join using the NATURAL syntax.
 query TTT
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
-·               distribution    local
-·               vectorized      true
-merge join      ·               ·
- │              type            inner
- │              equality        (x) = (x)
- │              mergeJoinOrder  +"(x=x)"
- ├── sort       ·               ·
- │    │         order           +x
- │    └── scan  ·               ·
- │              missing stats   ·
- │              table           onecolumn@primary
- │              spans           FULL SCAN
- └── sort       ·               ·
-      │         order           +x
-      └── scan  ·               ·
-·               missing stats   ·
-·               table           twocolumn@primary
-·               spans           FULL SCAN
+·               distribution   local
+·               vectorized     true
+merge join      ·              ·
+ │              type           inner
+ │              equality       (x) = (x)
+ ├── sort       ·              ·
+ │    │         order          +x
+ │    └── scan  ·              ·
+ │              missing stats  ·
+ │              table          onecolumn@primary
+ │              spans          FULL SCAN
+ └── sort       ·              ·
+      │         order          +x
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          twocolumn@primary
+·               spans          FULL SCAN
 
 # Test that we can force a merge join using the CROSS syntax.
 query TTT
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
-·               distribution    local
-·               vectorized      true
-merge join      ·               ·
- │              type            inner
- │              equality        (x) = (x)
- │              mergeJoinOrder  +"(x=x)"
- ├── sort       ·               ·
- │    │         order           +x
- │    └── scan  ·               ·
- │              missing stats   ·
- │              table           onecolumn@primary
- │              spans           FULL SCAN
- └── sort       ·               ·
-      │         order           +x
-      └── scan  ·               ·
-·               missing stats   ·
-·               table           twocolumn@primary
-·               spans           FULL SCAN
+·               distribution   local
+·               vectorized     true
+merge join      ·              ·
+ │              type           inner
+ │              equality       (x) = (x)
+ ├── sort       ·              ·
+ │    │         order          +x
+ │    └── scan  ·              ·
+ │              missing stats  ·
+ │              table          onecolumn@primary
+ │              spans          FULL SCAN
+ └── sort       ·              ·
+      │         order          +x
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          twocolumn@primary
+·               spans          FULL SCAN
 
 statement error LOOKUP can only be used with INNER or LEFT joins
 EXPLAIN SELECT * FROM onecolumn RIGHT LOOKUP JOIN twocolumn USING(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -47,14 +47,12 @@ lookup join       ·                      ·                  (a, b, c, d, b, x,
  │                type                   inner              ·                         ·
  │                equality               (c) = (c)          ·                         ·
  │                equality cols are key  ·                  ·                         ·
- │                parallel               ·                  ·                         ·
  └── lookup join  ·                      ·                  (a, b, c, d, b, x)        ·
       │           estimated row count    1 (missing stats)  ·                         ·
       │           table                  bx@primary         ·                         ·
       │           type                   inner              ·                         ·
       │           equality               (b) = (b)          ·                         ·
       │           equality cols are key  ·                  ·                         ·
-      │           parallel               ·                  ·                         ·
       └── scan    ·                      ·                  (a, b, c, d)              ·
 ·                 estimated row count    1 (missing stats)  ·                         ·
 ·                 table                  abc@primary        ·                         ·
@@ -74,14 +72,12 @@ lookup join       ·                      ·                  (a, b, c, d, b, x,
  │                type                   inner              ·                         ·
  │                equality               (c) = (c)          ·                         ·
  │                equality cols are key  ·                  ·                         ·
- │                parallel               ·                  ·                         ·
  └── lookup join  ·                      ·                  (a, b, c, d, b, x)        ·
       │           estimated row count    1 (missing stats)  ·                         ·
       │           table                  bx@primary         ·                         ·
       │           type                   inner              ·                         ·
       │           equality               (b) = (b)          ·                         ·
       │           equality cols are key  ·                  ·                         ·
-      │           parallel               ·                  ·                         ·
       └── scan    ·                      ·                  (a, b, c, d)              ·
 ·                 estimated row count    1 (missing stats)  ·                         ·
 ·                 table                  abc@primary        ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -39,24 +39,22 @@ SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 65
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                 distribution           local              ·                         ·
-·                 vectorized             true               ·                         ·
-lookup join       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
- │                estimated row count    1 (missing stats)  ·                         ·
- │                table                  cy@primary         ·                         ·
- │                type                   inner              ·                         ·
- │                equality               (c) = (c)          ·                         ·
- │                equality cols are key  ·                  ·                         ·
- └── lookup join  ·                      ·                  (a, b, c, d, b, x)        ·
-      │           estimated row count    1 (missing stats)  ·                         ·
-      │           table                  bx@primary         ·                         ·
-      │           type                   inner              ·                         ·
-      │           equality               (b) = (b)          ·                         ·
-      │           equality cols are key  ·                  ·                         ·
-      └── scan    ·                      ·                  (a, b, c, d)              ·
-·                 estimated row count    1 (missing stats)  ·                         ·
-·                 table                  abc@primary        ·                         ·
-·                 spans                  /1-/1/#            ·                         ·
+·                         distribution           local              ·                         ·
+·                         vectorized             true               ·                         ·
+lookup join (inner)       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
+ │                        estimated row count    1 (missing stats)  ·                         ·
+ │                        table                  cy@primary         ·                         ·
+ │                        equality               (c) = (c)          ·                         ·
+ │                        equality cols are key  ·                  ·                         ·
+ └── lookup join (inner)  ·                      ·                  (a, b, c, d, b, x)        ·
+      │                   estimated row count    1 (missing stats)  ·                         ·
+      │                   table                  bx@primary         ·                         ·
+      │                   equality               (b) = (b)          ·                         ·
+      │                   equality cols are key  ·                  ·                         ·
+      └── scan            ·                      ·                  (a, b, c, d)              ·
+·                         estimated row count    1 (missing stats)  ·                         ·
+·                         table                  abc@primary        ·                         ·
+·                         spans                  /1-/1/#            ·                         ·
 
 statement ok
 SET reorder_joins_limit = 3
@@ -64,21 +62,19 @@ SET reorder_joins_limit = 3
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                 distribution           local              ·                         ·
-·                 vectorized             true               ·                         ·
-lookup join       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
- │                estimated row count    1 (missing stats)  ·                         ·
- │                table                  cy@primary         ·                         ·
- │                type                   inner              ·                         ·
- │                equality               (c) = (c)          ·                         ·
- │                equality cols are key  ·                  ·                         ·
- └── lookup join  ·                      ·                  (a, b, c, d, b, x)        ·
-      │           estimated row count    1 (missing stats)  ·                         ·
-      │           table                  bx@primary         ·                         ·
-      │           type                   inner              ·                         ·
-      │           equality               (b) = (b)          ·                         ·
-      │           equality cols are key  ·                  ·                         ·
-      └── scan    ·                      ·                  (a, b, c, d)              ·
-·                 estimated row count    1 (missing stats)  ·                         ·
-·                 table                  abc@primary        ·                         ·
-·                 spans                  /1-/1/#            ·                         ·
+·                         distribution           local              ·                         ·
+·                         vectorized             true               ·                         ·
+lookup join (inner)       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
+ │                        estimated row count    1 (missing stats)  ·                         ·
+ │                        table                  cy@primary         ·                         ·
+ │                        equality               (c) = (c)          ·                         ·
+ │                        equality cols are key  ·                  ·                         ·
+ └── lookup join (inner)  ·                      ·                  (a, b, c, d, b, x)        ·
+      │                   estimated row count    1 (missing stats)  ·                         ·
+      │                   table                  bx@primary         ·                         ·
+      │                   equality               (b) = (b)          ·                         ·
+      │                   equality cols are key  ·                  ·                         ·
+      └── scan            ·                      ·                  (a, b, c, d)              ·
+·                         estimated row count    1 (missing stats)  ·                         ·
+·                         table                  abc@primary        ·                         ·
+·                         spans                  /1-/1/#            ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -56,7 +56,6 @@ lookup join  ·                      ·               (a, b, c, d, e, f)  ·
  │           type                   inner           ·                   ·
  │           equality               (b, c) = (f,e)  ·                   ·
  │           equality cols are key  ·               ·                   ·
- │           parallel               ·               ·                   ·
  └── scan    ·                      ·               (a, b, c)           ·
 ·            estimated row count    100             ·                   ·
 ·            table                  abc@primary     ·                   ·
@@ -185,7 +184,6 @@ project              ·                      ·                         (a, b, c
       │              type                   inner                     ·                         ·
       │              equality               (a, b, c, d) = (a,b,c,d)  ·                         ·
       │              equality cols are key  ·                         ·                         ·
-      │              parallel               ·                         ·                         ·
       │              pred                   c > 0                     ·                         ·
       └── filter     ·                      ·                         (a, b, c, d)              ·
            │         estimated row count    10                        ·                         ·
@@ -424,7 +422,6 @@ project                     ·                      ·               (a, d)     
            │                type                   inner           ·             ·
            │                equality               (a, b) = (a,b)  ·             ·
            │                equality cols are key  ·               ·             ·
-           │                parallel               ·               ·             ·
            └── lookup join  ·                      ·               (a, a, b)     ·
                 │           estimated row count    1000            ·             ·
                 │           table                  large@bc        ·             ·
@@ -512,7 +509,6 @@ project                     ·                      ·               (c, d)     
            │                type                   left outer      ·             ·
            │                equality               (a, b) = (a,b)  ·             ·
            │                equality cols are key  ·               ·             ·
-           │                parallel               ·               ·             ·
            └── lookup join  ·                      ·               (c, a, b)     ·
                 │           estimated row count    1000            ·             ·
                 │           table                  large@bc        ·             ·
@@ -622,7 +618,6 @@ project              ·                      ·                     (a)         
       │              type                   inner                 ·                ·
       │              equality               (d) = (d)             ·                ·
       │              equality cols are key  ·                     ·                ·
-      │              parallel               ·                     ·                ·
       │              pred                   a = a                 ·                ·
       └── filter     ·                      ·                     (a, d, e)        ·
            │         estimated row count    10 (missing stats)    ·                ·
@@ -739,7 +734,7 @@ merge join  ·                    ·            (d, e, f, a, b, c)  +f
  │          estimated row count  100          ·                   ·
  │          type                 inner        ·                   ·
  │          equality             (f) = (a)    ·                   ·
- │          mergeJoinOrder       +"(f=a)"     ·                   ·
+ │          merge ordering       +"(f=a)"     ·                   ·
  ├── scan   ·                    ·            (d, e, f)           +f
  │          estimated row count  10000        ·                   ·
  │          table                def@primary  ·                   ·
@@ -813,7 +808,6 @@ lookup join  ·                      ·               (a, b, c)  ·
  │           type                   semi            ·          ·
  │           equality               (a, c) = (f,e)  ·          ·
  │           equality cols are key  ·               ·          ·
- │           parallel               ·               ·          ·
  └── scan    ·                      ·               (a, b, c)  ·
 ·            estimated row count    100             ·          ·
 ·            table                  abc@primary     ·          ·
@@ -830,7 +824,6 @@ lookup join  ·                      ·               (a, b, c)  ·
  │           type                   anti            ·          ·
  │           equality               (a, c) = (f,e)  ·          ·
  │           equality cols are key  ·               ·          ·
- │           parallel               ·               ·          ·
  └── scan    ·                      ·               (a, b, c)  ·
 ·            estimated row count    100             ·          ·
 ·            table                  abc@primary     ·          ·
@@ -904,7 +897,6 @@ EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
 ·                 distribution   full
 ·                 vectorized     true
 group             ·              ·
- │                aggregate 0    count_rows()
  │                scalar         ·
  └── lookup join  ·              ·
       │           table          a@primary
@@ -1497,7 +1489,6 @@ limit                                                        ·                 
  └── sort                                                    ·                      ·
       │                                                      order                  -count_rows,+s_name
       └── group                                              ·                      ·
-           │                                                 aggregate 0            count_rows()
            │                                                 group by               s_name
            └── lookup join                                   ·                      ·
                 │                                            table                  lineitem@primary
@@ -1509,7 +1500,6 @@ limit                                                        ·                 
                      │                                       type                   inner
                      │                                       equality               (l_orderkey) = (o_orderkey)
                      │                                       equality cols are key  ·
-                     │                                       parallel               ·
                      │                                       pred                   o_orderstatus = 'F'
                      └── lookup join                         ·                      ·
                           │                                  table                  lineitem@primary
@@ -1521,7 +1511,6 @@ limit                                                        ·                 
                                │                             type                   inner
                                │                             equality               (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
                                │                             equality cols are key  ·
-                               │                             parallel               ·
                                │                             pred                   l_receiptdate > l_commitdate
                                └── lookup join               ·                      ·
                                     │                        table                  lineitem@l_sk
@@ -1532,7 +1521,6 @@ limit                                                        ·                 
                                          │                   type                   inner
                                          │                   equality               (s_suppkey) = (s_suppkey)
                                          │                   equality cols are key  ·
-                                         │                   parallel               ·
                                          └── lookup join     ·                      ·
                                               │              table                  supplier@s_nk
                                               │              type                   inner
@@ -1566,7 +1554,6 @@ project                         ·                      ·                      
            │                    type                   semi                                         ·                                          ·
            │                    equality               (col0, project_const_col_@14) = (col3,col4)  ·                                          ·
            │                    equality cols are key  ·                                            ·                                          ·
-           │                    parallel               ·                                            ·                                          ·
            └── render           ·                      ·                                            ("project_const_col_@14", pk, col0, col3)  ·
                 │               estimated row count    10 (missing stats)                           ·                                          ·
                 │               render 0               495.6                                        ·                                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -31,103 +31,97 @@ ALTER TABLE def INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
-tree         field                description  columns             ordering
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (a, b, c, d, e, f)  ·
- │           estimated row count  99           ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (b) = (f)    ·                   ·
- └── scan    ·                    ·            (a, b, c)           ·
-·            estimated row count  100          ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                FULL SCAN    ·                   ·
+tree                 field                description  columns             ordering
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
+ │                   estimated row count  99           ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (b) = (f)    ·                   ·
+ └── scan            ·                    ·            (a, b, c)           ·
+·                    estimated row count  100          ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 ----
-tree         field                  description     columns             ordering
-·            distribution           full            ·                   ·
-·            vectorized             true            ·                   ·
-lookup join  ·                      ·               (a, b, c, d, e, f)  ·
- │           estimated row count    0               ·                   ·
- │           table                  def@primary     ·                   ·
- │           type                   inner           ·                   ·
- │           equality               (b, c) = (f,e)  ·                   ·
- │           equality cols are key  ·               ·                   ·
- └── scan    ·                      ·               (a, b, c)           ·
-·            estimated row count    100             ·                   ·
-·            table                  abc@primary     ·                   ·
-·            spans                  FULL SCAN       ·                   ·
+tree                 field                  description     columns             ordering
+·                    distribution           full            ·                   ·
+·                    vectorized             true            ·                   ·
+lookup join (inner)  ·                      ·               (a, b, c, d, e, f)  ·
+ │                   estimated row count    0               ·                   ·
+ │                   table                  def@primary     ·                   ·
+ │                   equality               (b, c) = (f,e)  ·                   ·
+ │                   equality cols are key  ·               ·                   ·
+ └── scan            ·                      ·               (a, b, c)           ·
+·                    estimated row count    100             ·                   ·
+·                    table                  abc@primary     ·                   ·
+·                    spans                  FULL SCAN       ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 ----
-tree         field                description  columns             ordering
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (a, b, c, d, e, f)  ·
- │           estimated row count  33           ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (b) = (f)    ·                   ·
- │           pred                 e > 1        ·                   ·
- └── scan    ·                    ·            (a, b, c)           ·
-·            estimated row count  33           ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                /2-          ·                   ·
+tree                 field                description  columns             ordering
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
+ │                   estimated row count  33           ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (b) = (f)    ·                   ·
+ │                   pred                 e > 1        ·                   ·
+ └── scan            ·                    ·            (a, b, c)           ·
+·                    estimated row count  33           ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
-tree         field                description  columns             ordering
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (a, b, c, d, e, f)  ·
- │           estimated row count  33           ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (a) = (f)    ·                   ·
- │           pred                 f > 1        ·                   ·
- └── scan    ·                    ·            (a, b, c)           ·
-·            estimated row count  33           ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                /2-          ·                   ·
+tree                 field                description  columns             ordering
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
+ │                   estimated row count  33           ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (a) = (f)    ·                   ·
+ │                   pred                 f > 1        ·                   ·
+ └── scan            ·                    ·            (a, b, c)           ·
+·                    estimated row count  33           ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 ----
-tree         field                description  columns             ordering
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (a, b, c, d, e, f)  ·
- │           estimated row count  33           ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (b) = (f)    ·                   ·
- │           pred                 a >= e       ·                   ·
- └── scan    ·                    ·            (a, b, c)           ·
-·            estimated row count  100          ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                FULL SCAN    ·                   ·
+tree                 field                description  columns             ordering
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
+ │                   estimated row count  33           ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (b) = (f)    ·                   ·
+ │                   pred                 a >= e       ·                   ·
+ └── scan            ·                    ·            (a, b, c)           ·
+·                    estimated row count  100          ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 ----
-tree         field                description  columns             ordering
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (a, b, c, d, e, f)  ·
- │           estimated row count  33           ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (b) = (f)    ·                   ·
- │           pred                 a >= e       ·                   ·
- └── scan    ·                    ·            (a, b, c)           ·
-·            estimated row count  100          ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                FULL SCAN    ·                   ·
+tree                 field                description  columns             ordering
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
+ │                   estimated row count  33           ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (b) = (f)    ·                   ·
+ │                   pred                 a >= e       ·                   ·
+ └── scan            ·                    ·            (a, b, c)           ·
+·                    estimated row count  100          ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                FULL SCAN    ·                   ·
 
 # Verify a distsql plan.
 statement ok
@@ -174,24 +168,23 @@ SELECT *
 FROM (SELECT * FROM data WHERE c = 1) AS l
 NATURAL JOIN (SELECT * FROM data WHERE c > 0) AS r
 ----
-·                    distribution           full                      ·                         ·
-·                    vectorized             true                      ·                         ·
-project              ·                      ·                         (a, b, c, d)              ·
- │                   estimated row count    0                         ·                         ·
- └── lookup join     ·                      ·                         (a, b, c, d, a, b, c, d)  ·
-      │              estimated row count    0                         ·                         ·
-      │              table                  data@primary              ·                         ·
-      │              type                   inner                     ·                         ·
-      │              equality               (a, b, c, d) = (a,b,c,d)  ·                         ·
-      │              equality cols are key  ·                         ·                         ·
-      │              pred                   c > 0                     ·                         ·
-      └── filter     ·                      ·                         (a, b, c, d)              ·
-           │         estimated row count    10                        ·                         ·
-           │         filter                 c = 1                     ·                         ·
-           └── scan  ·                      ·                         (a, b, c, d)              ·
-·                    estimated row count    100000                    ·                         ·
-·                    table                  data@primary              ·                         ·
-·                    spans                  FULL SCAN                 ·                         ·
+·                         distribution           full                      ·                         ·
+·                         vectorized             true                      ·                         ·
+project                   ·                      ·                         (a, b, c, d)              ·
+ │                        estimated row count    0                         ·                         ·
+ └── lookup join (inner)  ·                      ·                         (a, b, c, d, a, b, c, d)  ·
+      │                   estimated row count    0                         ·                         ·
+      │                   table                  data@primary              ·                         ·
+      │                   equality               (a, b, c, d) = (a,b,c,d)  ·                         ·
+      │                   equality cols are key  ·                         ·                         ·
+      │                   pred                   c > 0                     ·                         ·
+      └── filter          ·                      ·                         (a, b, c, d)              ·
+           │              estimated row count    10                        ·                         ·
+           │              filter                 c = 1                     ·                         ·
+           └── scan       ·                      ·                         (a, b, c, d)              ·
+·                         estimated row count    100000                    ·                         ·
+·                         table                  data@primary              ·                         ·
+·                         spans                  FULL SCAN                 ·                         ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -230,24 +223,23 @@ ALTER TABLE books2 INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
-tree                   field                description        columns                       ordering
-·                      distribution         full               ·                             ·
-·                      vectorized           true               ·                             ·
-distinct               ·                    ·                  (title)                       ·
- │                     estimated row count  100                ·                             ·
- │                     distinct on          title              ·                             ·
- │                     order key            title              ·                             ·
- └── project           ·                    ·                  (title)                       +title
-      └── lookup join  ·                    ·                  (title, shelf, title, shelf)  +title
-           │           estimated row count  327                ·                             ·
-           │           table                books2@primary     ·                             ·
-           │           type                 inner              ·                             ·
-           │           equality             (title) = (title)  ·                             ·
-           │           pred                 shelf != shelf     ·                             ·
-           └── scan    ·                    ·                  (title, shelf)                +title
-·                      estimated row count  100                ·                             ·
-·                      table                books@primary      ·                             ·
-·                      spans                FULL SCAN          ·                             ·
+tree                           field                description        columns                       ordering
+·                              distribution         full               ·                             ·
+·                              vectorized           true               ·                             ·
+distinct                       ·                    ·                  (title)                       ·
+ │                             estimated row count  100                ·                             ·
+ │                             distinct on          title              ·                             ·
+ │                             order key            title              ·                             ·
+ └── project                   ·                    ·                  (title)                       +title
+      └── lookup join (inner)  ·                    ·                  (title, shelf, title, shelf)  +title
+           │                   estimated row count  327                ·                             ·
+           │                   table                books2@primary     ·                             ·
+           │                   equality             (title) = (title)  ·                             ·
+           │                   pred                 shelf != shelf     ·                             ·
+           └── scan            ·                    ·                  (title, shelf)                +title
+·                              estimated row count  100                ·                             ·
+·                              table                books@primary      ·                             ·
+·                              spans                FULL SCAN          ·                             ·
 
 statement ok
 CREATE TABLE authors (name STRING, book STRING)
@@ -265,31 +257,29 @@ ALTER TABLE authors INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
-tree                      field                description       columns                                   ordering
-·                         distribution         full              ·                                         ·
-·                         vectorized           true              ·                                         ·
-distinct                  ·                    ·                 (name)                                    ·
- │                        estimated row count  96                ·                                         ·
- │                        distinct on          name              ·                                         ·
- └── project              ·                    ·                 (name)                                    ·
-      └── lookup join     ·                    ·                 (title, shelf, name, book, title, shelf)  ·
-           │              estimated row count  323               ·                                         ·
-           │              table                books2@primary    ·                                         ·
-           │              type                 inner             ·                                         ·
-           │              equality             (book) = (title)  ·                                         ·
-           │              pred                 shelf != shelf    ·                                         ·
-           └── hash join  ·                    ·                 (title, shelf, name, book)                ·
-                │         estimated row count  99                ·                                         ·
-                │         type                 inner             ·                                         ·
-                │         equality             (title) = (book)  ·                                         ·
-                ├── scan  ·                    ·                 (title, shelf)                            ·
-                │         estimated row count  100               ·                                         ·
-                │         table                books@primary     ·                                         ·
-                │         spans                FULL SCAN         ·                                         ·
-                └── scan  ·                    ·                 (name, book)                              ·
-·                         estimated row count  100               ·                                         ·
-·                         table                authors@primary   ·                                         ·
-·                         spans                FULL SCAN         ·                                         ·
+tree                              field                description       columns                                   ordering
+·                                 distribution         full              ·                                         ·
+·                                 vectorized           true              ·                                         ·
+distinct                          ·                    ·                 (name)                                    ·
+ │                                estimated row count  96                ·                                         ·
+ │                                distinct on          name              ·                                         ·
+ └── project                      ·                    ·                 (name)                                    ·
+      └── lookup join (inner)     ·                    ·                 (title, shelf, name, book, title, shelf)  ·
+           │                      estimated row count  323               ·                                         ·
+           │                      table                books2@primary    ·                                         ·
+           │                      equality             (book) = (title)  ·                                         ·
+           │                      pred                 shelf != shelf    ·                                         ·
+           └── hash join (inner)  ·                    ·                 (title, shelf, name, book)                ·
+                │                 estimated row count  99                ·                                         ·
+                │                 equality             (title) = (book)  ·                                         ·
+                ├── scan          ·                    ·                 (title, shelf)                            ·
+                │                 estimated row count  100               ·                                         ·
+                │                 table                books@primary     ·                                         ·
+                │                 spans                FULL SCAN         ·                                         ·
+                └── scan          ·                    ·                 (name, book)                              ·
+·                                 estimated row count  100               ·                                         ·
+·                                 table                authors@primary   ·                                         ·
+·                                 spans                FULL SCAN         ·                                         ·
 
 # Verify data placement.
 query TTTI colnames
@@ -306,42 +296,40 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyck1Fv2jAQx9_3Kbx7SiS34C
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
-tree                 field                description       columns              ordering
-·                    distribution         full              ·                    ·
-·                    vectorized           true              ·                    ·
-project              ·                    ·                 (name)               +name
- │                   estimated row count  990               ·                    ·
- └── lookup join     ·                    ·                 (name, book, title)  +name
-      │              estimated row count  990               ·                    ·
-      │              table                books2@primary    ·                    ·
-      │              type                 inner             ·                    ·
-      │              equality             (book) = (title)  ·                    ·
-      └── sort       ·                    ·                 (name, book)         +name
-           │         estimated row count  100               ·                    ·
-           │         order                +name             ·                    ·
-           └── scan  ·                    ·                 (name, book)         ·
-·                    estimated row count  100               ·                    ·
-·                    table                authors@primary   ·                    ·
-·                    spans                FULL SCAN         ·                    ·
+tree                      field                description       columns              ordering
+·                         distribution         full              ·                    ·
+·                         vectorized           true              ·                    ·
+project                   ·                    ·                 (name)               +name
+ │                        estimated row count  990               ·                    ·
+ └── lookup join (inner)  ·                    ·                 (name, book, title)  +name
+      │                   estimated row count  990               ·                    ·
+      │                   table                books2@primary    ·                    ·
+      │                   equality             (book) = (title)  ·                    ·
+      └── sort            ·                    ·                 (name, book)         +name
+           │              estimated row count  100               ·                    ·
+           │              order                +name             ·                    ·
+           └── scan       ·                    ·                 (name, book)         ·
+·                         estimated row count  100               ·                    ·
+·                         table                authors@primary   ·                    ·
+·                         spans                FULL SCAN         ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM books CROSS JOIN books2
 ----
-tree        field                description     columns                                         ordering
-·           distribution         full            ·                                               ·
-·           vectorized           true            ·                                               ·
-cross join  ·                    ·               (title, edition, shelf, title, edition, shelf)  ·
- │          estimated row count  1000000         ·                                               ·
- │          type                 cross           ·                                               ·
- ├── scan   ·                    ·               (title, edition, shelf)                         ·
- │          estimated row count  10000           ·                                               ·
- │          table                books2@primary  ·                                               ·
- │          spans                FULL SCAN       ·                                               ·
- └── scan   ·                    ·               (title, edition, shelf)                         ·
-·           estimated row count  100             ·                                               ·
-·           table                books@primary   ·                                               ·
-·           spans                FULL SCAN       ·                                               ·
+tree                field                description     columns                                         ordering
+·                   distribution         full            ·                                               ·
+·                   vectorized           true            ·                                               ·
+cross join (inner)  ·                    ·               (title, edition, shelf, title, edition, shelf)  ·
+ │                  estimated row count  1000000         ·                                               ·
+ ├── scan           ·                    ·               (title, edition, shelf)                         ·
+ │                  estimated row count  10000           ·                                               ·
+ │                  table                books2@primary  ·                                               ·
+ │                  spans                FULL SCAN       ·                                               ·
+ └── scan           ·                    ·               (title, edition, shelf)                         ·
+·                   estimated row count  100             ·                                               ·
+·                   table                books@primary   ·                                               ·
+·                   spans                FULL SCAN       ·                                               ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
@@ -393,44 +381,41 @@ ALTER TABLE large INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
 ----
-·                 distribution         full           ·          ·
-·                 vectorized           true           ·          ·
-project           ·                    ·              (a, c)     ·
- │                estimated row count  1000           ·          ·
- └── lookup join  ·                    ·              (a, b, c)  ·
-      │           estimated row count  1000           ·          ·
-      │           table                large@bc       ·          ·
-      │           type                 inner          ·          ·
-      │           equality             (a) = (b)      ·          ·
-      └── scan    ·                    ·              (a)        ·
-·                 estimated row count  100            ·          ·
-·                 table                small@primary  ·          ·
-·                 spans                FULL SCAN      ·          ·
+·                         distribution         full           ·          ·
+·                         vectorized           true           ·          ·
+project                   ·                    ·              (a, c)     ·
+ │                        estimated row count  1000           ·          ·
+ └── lookup join (inner)  ·                    ·              (a, b, c)  ·
+      │                   estimated row count  1000           ·          ·
+      │                   table                large@bc       ·          ·
+      │                   equality             (a) = (b)      ·          ·
+      └── scan            ·                    ·              (a)        ·
+·                         estimated row count  100            ·          ·
+·                         table                small@primary  ·          ·
+·                         spans                FULL SCAN      ·          ·
 
 # Lookup join on non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
 ----
-·                           distribution           full            ·             ·
-·                           vectorized             true            ·             ·
-project                     ·                      ·               (a, d)        ·
- │                          estimated row count    1000            ·             ·
- └── project                ·                      ·               (a, b, d)     ·
-      │                     estimated row count    1000            ·             ·
-      └── lookup join       ·                      ·               (a, a, b, d)  ·
-           │                table                  large@primary   ·             ·
-           │                type                   inner           ·             ·
-           │                equality               (a, b) = (a,b)  ·             ·
-           │                equality cols are key  ·               ·             ·
-           └── lookup join  ·                      ·               (a, a, b)     ·
-                │           estimated row count    1000            ·             ·
-                │           table                  large@bc        ·             ·
-                │           type                   inner           ·             ·
-                │           equality               (a) = (b)       ·             ·
-                └── scan    ·                      ·               (a)           ·
-·                           estimated row count    100             ·             ·
-·                           table                  small@primary   ·             ·
-·                           spans                  FULL SCAN       ·             ·
+·                                   distribution           full            ·             ·
+·                                   vectorized             true            ·             ·
+project                             ·                      ·               (a, d)        ·
+ │                                  estimated row count    1000            ·             ·
+ └── project                        ·                      ·               (a, b, d)     ·
+      │                             estimated row count    1000            ·             ·
+      └── lookup join (inner)       ·                      ·               (a, a, b, d)  ·
+           │                        table                  large@primary   ·             ·
+           │                        equality               (a, b) = (a,b)  ·             ·
+           │                        equality cols are key  ·               ·             ·
+           └── lookup join (inner)  ·                      ·               (a, a, b)     ·
+                │                   estimated row count    1000            ·             ·
+                │                   table                  large@bc        ·             ·
+                │                   equality               (a) = (b)       ·             ·
+                └── scan            ·                      ·               (a)           ·
+·                                   estimated row count    100             ·             ·
+·                                   table                  small@primary   ·             ·
+·                                   spans                  FULL SCAN       ·             ·
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
@@ -440,36 +425,34 @@ project                     ·                      ·               (a, d)     
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
 ----
-·            distribution         full           ·       ·
-·            vectorized           true           ·       ·
-lookup join  ·                    ·              (b, a)  ·
- │           estimated row count  100            ·       ·
- │           table                large@primary  ·       ·
- │           type                 left outer     ·       ·
- │           equality             (b) = (a)      ·       ·
- └── scan    ·                    ·              (b)     ·
-·            estimated row count  100            ·       ·
-·            table                small@primary  ·       ·
-·            spans                FULL SCAN      ·       ·
+·                         distribution         full           ·       ·
+·                         vectorized           true           ·       ·
+lookup join (left outer)  ·                    ·              (b, a)  ·
+ │                        estimated row count  100            ·       ·
+ │                        table                large@primary  ·       ·
+ │                        equality             (b) = (a)      ·       ·
+ └── scan                 ·                    ·              (b)     ·
+·                         estimated row count  100            ·       ·
+·                         table                small@primary  ·       ·
+·                         spans                FULL SCAN      ·       ·
 
 # Left join should preserve input order.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a
 ----
-·                 distribution         full           ·          ·
-·                 vectorized           true           ·          ·
-project           ·                    ·              (a, b)     +a
- │                estimated row count  100            ·          ·
- └── lookup join  ·                    ·              (a, a, b)  +a
-      │           estimated row count  100            ·          ·
-      │           table                large@primary  ·          ·
-      │           type                 left outer     ·          ·
-      │           equality             (a) = (a)      ·          ·
-      │           pred                 (b % 6) = 0    ·          ·
-      └── scan    ·                    ·              (a)        +a
-·                 estimated row count  100            ·          ·
-·                 table                small@primary  ·          ·
-·                 spans                FULL SCAN      ·          ·
+·                              distribution         full           ·          ·
+·                              vectorized           true           ·          ·
+project                        ·                    ·              (a, b)     +a
+ │                             estimated row count  100            ·          ·
+ └── lookup join (left outer)  ·                    ·              (a, a, b)  +a
+      │                        estimated row count  100            ·          ·
+      │                        table                large@primary  ·          ·
+      │                        equality             (a) = (a)      ·          ·
+      │                        pred                 (b % 6) = 0    ·          ·
+      └── scan                 ·                    ·              (a)        +a
+·                              estimated row count  100            ·          ·
+·                              table                small@primary  ·          ·
+·                              spans                FULL SCAN      ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -480,63 +463,59 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlV9r2zwUxu_fT3E48ELClD
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                 distribution         full           ·          ·
-·                 vectorized           true           ·          ·
-project           ·                    ·              (c, c)     ·
- │                estimated row count  1000           ·          ·
- └── lookup join  ·                    ·              (c, b, c)  ·
-      │           estimated row count  1000           ·          ·
-      │           table                large@bc       ·          ·
-      │           type                 left outer     ·          ·
-      │           equality             (c) = (b)      ·          ·
-      └── scan    ·                    ·              (c)        ·
-·                 estimated row count  100            ·          ·
-·                 table                small@primary  ·          ·
-·                 spans                FULL SCAN      ·          ·
+·                              distribution         full           ·          ·
+·                              vectorized           true           ·          ·
+project                        ·                    ·              (c, c)     ·
+ │                             estimated row count  1000           ·          ·
+ └── lookup join (left outer)  ·                    ·              (c, b, c)  ·
+      │                        estimated row count  1000           ·          ·
+      │                        table                large@bc       ·          ·
+      │                        equality             (c) = (b)      ·          ·
+      └── scan                 ·                    ·              (c)        ·
+·                              estimated row count  100            ·          ·
+·                              table                small@primary  ·          ·
+·                              spans                FULL SCAN      ·          ·
 
 # Left join against non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                           distribution           full            ·             ·
-·                           vectorized             true            ·             ·
-project                     ·                      ·               (c, d)        ·
- │                          estimated row count    1000            ·             ·
- └── project                ·                      ·               (c, b, d)     ·
-      │                     estimated row count    1000            ·             ·
-      └── lookup join       ·                      ·               (c, a, b, d)  ·
-           │                table                  large@primary   ·             ·
-           │                type                   left outer      ·             ·
-           │                equality               (a, b) = (a,b)  ·             ·
-           │                equality cols are key  ·               ·             ·
-           └── lookup join  ·                      ·               (c, a, b)     ·
-                │           estimated row count    1000            ·             ·
-                │           table                  large@bc        ·             ·
-                │           type                   left outer      ·             ·
-                │           equality               (c) = (b)       ·             ·
-                └── scan    ·                      ·               (c)           ·
-·                           estimated row count    100             ·             ·
-·                           table                  small@primary   ·             ·
-·                           spans                  FULL SCAN       ·             ·
+·                                        distribution           full            ·             ·
+·                                        vectorized             true            ·             ·
+project                                  ·                      ·               (c, d)        ·
+ │                                       estimated row count    1000            ·             ·
+ └── project                             ·                      ·               (c, b, d)     ·
+      │                                  estimated row count    1000            ·             ·
+      └── lookup join (left outer)       ·                      ·               (c, a, b, d)  ·
+           │                             table                  large@primary   ·             ·
+           │                             equality               (a, b) = (a,b)  ·             ·
+           │                             equality cols are key  ·               ·             ·
+           └── lookup join (left outer)  ·                      ·               (c, a, b)     ·
+                │                        estimated row count    1000            ·             ·
+                │                        table                  large@bc        ·             ·
+                │                        equality               (c) = (b)       ·             ·
+                └── scan                 ·                      ·               (c)           ·
+·                                        estimated row count    100             ·             ·
+·                                        table                  small@primary   ·             ·
+·                                        spans                  FULL SCAN       ·             ·
 
 # Left join with ON filter on covering index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
 ----
-·                 distribution         full           ·          ·
-·                 vectorized           true           ·          ·
-project           ·                    ·              (c, c)     ·
- │                estimated row count  336            ·          ·
- └── lookup join  ·                    ·              (c, b, c)  ·
-      │           estimated row count  336            ·          ·
-      │           table                large@bc       ·          ·
-      │           type                 left outer     ·          ·
-      │           equality             (c) = (b)      ·          ·
-      │           pred                 c < 20         ·          ·
-      └── scan    ·                    ·              (c)        ·
-·                 estimated row count  100            ·          ·
-·                 table                small@primary  ·          ·
-·                 spans                FULL SCAN      ·          ·
+·                              distribution         full           ·          ·
+·                              vectorized           true           ·          ·
+project                        ·                    ·              (c, c)     ·
+ │                             estimated row count  336            ·          ·
+ └── lookup join (left outer)  ·                    ·              (c, b, c)  ·
+      │                        estimated row count  336            ·          ·
+      │                        table                large@bc       ·          ·
+      │                        equality             (c) = (b)      ·          ·
+      │                        pred                 c < 20         ·          ·
+      └── scan                 ·                    ·              (c)        ·
+·                              estimated row count  100            ·          ·
+·                              table                small@primary  ·          ·
+·                              spans                FULL SCAN      ·          ·
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
@@ -544,25 +523,24 @@ project           ·                    ·              (c, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
 ----
-·                    distribution         full           ·          ·
-·                    vectorized           true           ·          ·
-project              ·                    ·              (c, d)     ·
- │                   estimated row count  336            ·          ·
- └── hash join       ·                    ·              (b, d, c)  ·
-      │              estimated row count  336            ·          ·
-      │              type                 right outer    ·          ·
-      │              equality             (b) = (c)      ·          ·
-      ├── filter     ·                    ·              (b, d)     ·
-      │    │         estimated row count  3303           ·          ·
-      │    │         filter               d < 30         ·          ·
-      │    └── scan  ·                    ·              (b, d)     ·
-      │              estimated row count  10000          ·          ·
-      │              table                large@primary  ·          ·
-      │              spans                FULL SCAN      ·          ·
-      └── scan       ·                    ·              (c)        ·
-·                    estimated row count  100            ·          ·
-·                    table                small@primary  ·          ·
-·                    spans                FULL SCAN      ·          ·
+·                             distribution         full           ·          ·
+·                             vectorized           true           ·          ·
+project                       ·                    ·              (c, d)     ·
+ │                            estimated row count  336            ·          ·
+ └── hash join (right outer)  ·                    ·              (b, d, c)  ·
+      │                       estimated row count  336            ·          ·
+      │                       equality             (b) = (c)      ·          ·
+      ├── filter              ·                    ·              (b, d)     ·
+      │    │                  estimated row count  3303           ·          ·
+      │    │                  filter               d < 30         ·          ·
+      │    └── scan           ·                    ·              (b, d)     ·
+      │                       estimated row count  10000          ·          ·
+      │                       table                large@primary  ·          ·
+      │                       spans                FULL SCAN      ·          ·
+      └── scan                ·                    ·              (c)        ·
+·                             estimated row count  100            ·          ·
+·                             table                small@primary  ·          ·
+·                             spans                FULL SCAN      ·          ·
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -581,22 +559,21 @@ CREATE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                    distribution         full                  ·                ·
-·                    vectorized           true                  ·                ·
-project              ·                    ·                     (a)              ·
- │                   estimated row count  1 (missing stats)     ·                ·
- └── lookup join     ·                    ·                     (a, d, e, a, d)  ·
-      │              estimated row count  1 (missing stats)     ·                ·
-      │              table                u@idx                 ·                ·
-      │              type                 inner                 ·                ·
-      │              equality             (d, a) = (d,a)        ·                ·
-      └── filter     ·                    ·                     (a, d, e)        ·
-           │         estimated row count  10 (missing stats)    ·                ·
-           │         filter               e = 5                 ·                ·
-           └── scan  ·                    ·                     (a, d, e)        ·
-·                    estimated row count  1000 (missing stats)  ·                ·
-·                    table                t@primary             ·                ·
-·                    spans                FULL SCAN             ·                ·
+·                         distribution         full                  ·                ·
+·                         vectorized           true                  ·                ·
+project                   ·                    ·                     (a)              ·
+ │                        estimated row count  1 (missing stats)     ·                ·
+ └── lookup join (inner)  ·                    ·                     (a, d, e, a, d)  ·
+      │                   estimated row count  1 (missing stats)     ·                ·
+      │                   table                u@idx                 ·                ·
+      │                   equality             (d, a) = (d,a)        ·                ·
+      └── filter          ·                    ·                     (a, d, e)        ·
+           │              estimated row count  10 (missing stats)    ·                ·
+           │              filter               e = 5                 ·                ·
+           └── scan       ·                    ·                     (a, d, e)        ·
+·                         estimated row count  1000 (missing stats)  ·                ·
+·                         table                t@primary             ·                ·
+·                         spans                FULL SCAN             ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -608,24 +585,23 @@ CREATE UNIQUE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                    distribution           full                  ·                ·
-·                    vectorized             true                  ·                ·
-project              ·                      ·                     (a)              ·
- │                   estimated row count    0 (missing stats)     ·                ·
- └── lookup join     ·                      ·                     (a, d, e, a, d)  ·
-      │              estimated row count    0 (missing stats)     ·                ·
-      │              table                  u@idx                 ·                ·
-      │              type                   inner                 ·                ·
-      │              equality               (d) = (d)             ·                ·
-      │              equality cols are key  ·                     ·                ·
-      │              pred                   a = a                 ·                ·
-      └── filter     ·                      ·                     (a, d, e)        ·
-           │         estimated row count    10 (missing stats)    ·                ·
-           │         filter                 e = 5                 ·                ·
-           └── scan  ·                      ·                     (a, d, e)        ·
-·                    estimated row count    1000 (missing stats)  ·                ·
-·                    table                  t@primary             ·                ·
-·                    spans                  FULL SCAN             ·                ·
+·                         distribution           full                  ·                ·
+·                         vectorized             true                  ·                ·
+project                   ·                      ·                     (a)              ·
+ │                        estimated row count    0 (missing stats)     ·                ·
+ └── lookup join (inner)  ·                      ·                     (a, d, e, a, d)  ·
+      │                   estimated row count    0 (missing stats)     ·                ·
+      │                   table                  u@idx                 ·                ·
+      │                   equality               (d) = (d)             ·                ·
+      │                   equality cols are key  ·                     ·                ·
+      │                   pred                   a = a                 ·                ·
+      └── filter          ·                      ·                     (a, d, e)        ·
+           │              estimated row count    10 (missing stats)    ·                ·
+           │              filter                 e = 5                 ·                ·
+           └── scan       ·                      ·                     (a, d, e)        ·
+·                         estimated row count    1000 (missing stats)  ·                ·
+·                         table                  t@primary             ·                ·
+·                         spans                  FULL SCAN             ·                ·
 
 # Test index with first primary key column explicit and the rest implicit.
 statement ok
@@ -637,22 +613,21 @@ CREATE INDEX idx ON u (d, a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                    distribution         full                  ·                      ·
-·                    vectorized           true                  ·                      ·
-project              ·                    ·                     (a)                    ·
- │                   estimated row count  0 (missing stats)     ·                      ·
- └── lookup join     ·                    ·                     (a, b, d, e, a, b, d)  ·
-      │              estimated row count  0 (missing stats)     ·                      ·
-      │              table                u@idx                 ·                      ·
-      │              type                 inner                 ·                      ·
-      │              equality             (d, a, b) = (d,a,b)   ·                      ·
-      └── filter     ·                    ·                     (a, b, d, e)           ·
-           │         estimated row count  10 (missing stats)    ·                      ·
-           │         filter               e = 5                 ·                      ·
-           └── scan  ·                    ·                     (a, b, d, e)           ·
-·                    estimated row count  1000 (missing stats)  ·                      ·
-·                    table                t@primary             ·                      ·
-·                    spans                FULL SCAN             ·                      ·
+·                         distribution         full                  ·                      ·
+·                         vectorized           true                  ·                      ·
+project                   ·                    ·                     (a)                    ·
+ │                        estimated row count  0 (missing stats)     ·                      ·
+ └── lookup join (inner)  ·                    ·                     (a, b, d, e, a, b, d)  ·
+      │                   estimated row count  0 (missing stats)     ·                      ·
+      │                   table                u@idx                 ·                      ·
+      │                   equality             (d, a, b) = (d,a,b)   ·                      ·
+      └── filter          ·                    ·                     (a, b, d, e)           ·
+           │              estimated row count  10 (missing stats)    ·                      ·
+           │              filter               e = 5                 ·                      ·
+           └── scan       ·                    ·                     (a, b, d, e)           ·
+·                         estimated row count  1000 (missing stats)  ·                      ·
+·                         table                t@primary             ·                      ·
+·                         spans                FULL SCAN             ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -664,22 +639,21 @@ CREATE INDEX idx ON u (d, b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                    distribution         full                  ·                      ·
-·                    vectorized           true                  ·                      ·
-project              ·                    ·                     (a)                    ·
- │                   estimated row count  0 (missing stats)     ·                      ·
- └── lookup join     ·                    ·                     (a, b, d, e, a, b, d)  ·
-      │              estimated row count  0 (missing stats)     ·                      ·
-      │              table                u@idx                 ·                      ·
-      │              type                 inner                 ·                      ·
-      │              equality             (d, b, a) = (d,b,a)   ·                      ·
-      └── filter     ·                    ·                     (a, b, d, e)           ·
-           │         estimated row count  10 (missing stats)    ·                      ·
-           │         filter               e = 5                 ·                      ·
-           └── scan  ·                    ·                     (a, b, d, e)           ·
-·                    estimated row count  1000 (missing stats)  ·                      ·
-·                    table                t@primary             ·                      ·
-·                    spans                FULL SCAN             ·                      ·
+·                         distribution         full                  ·                      ·
+·                         vectorized           true                  ·                      ·
+project                   ·                    ·                     (a)                    ·
+ │                        estimated row count  0 (missing stats)     ·                      ·
+ └── lookup join (inner)  ·                    ·                     (a, b, d, e, a, b, d)  ·
+      │                   estimated row count  0 (missing stats)     ·                      ·
+      │                   table                u@idx                 ·                      ·
+      │                   equality             (d, b, a) = (d,b,a)   ·                      ·
+      └── filter          ·                    ·                     (a, b, d, e)           ·
+           │              estimated row count  10 (missing stats)    ·                      ·
+           │              filter               e = 5                 ·                      ·
+           └── scan       ·                    ·                     (a, b, d, e)           ·
+·                         estimated row count  1000 (missing stats)  ·                      ·
+·                         table                t@primary             ·                      ·
+·                         spans                FULL SCAN             ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -691,175 +665,165 @@ CREATE INDEX idx ON u (d, c)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
-·                    distribution         full                  ·                ·
-·                    vectorized           true                  ·                ·
-project              ·                    ·                     (a)              ·
- │                   estimated row count  1 (missing stats)     ·                ·
- └── lookup join     ·                    ·                     (a, d, e, a, d)  ·
-      │              estimated row count  1 (missing stats)     ·                ·
-      │              table                u@idx                 ·                ·
-      │              type                 inner                 ·                ·
-      │              equality             (d) = (d)             ·                ·
-      │              pred                 a = a                 ·                ·
-      └── filter     ·                    ·                     (a, d, e)        ·
-           │         estimated row count  10 (missing stats)    ·                ·
-           │         filter               e = 5                 ·                ·
-           └── scan  ·                    ·                     (a, d, e)        ·
-·                    estimated row count  1000 (missing stats)  ·                ·
-·                    table                t@primary             ·                ·
-·                    spans                FULL SCAN             ·                ·
+·                         distribution         full                  ·                ·
+·                         vectorized           true                  ·                ·
+project                   ·                    ·                     (a)              ·
+ │                        estimated row count  1 (missing stats)     ·                ·
+ └── lookup join (inner)  ·                    ·                     (a, d, e, a, d)  ·
+      │                   estimated row count  1 (missing stats)     ·                ·
+      │                   table                u@idx                 ·                ·
+      │                   equality             (d) = (d)             ·                ·
+      │                   pred                 a = a                 ·                ·
+      └── filter          ·                    ·                     (a, d, e)        ·
+           │              estimated row count  10 (missing stats)    ·                ·
+           │              filter               e = 5                 ·                ·
+           └── scan       ·                    ·                     (a, d, e)        ·
+·                         estimated row count  1000 (missing stats)  ·                ·
+·                         table                t@primary             ·                ·
+·                         spans                FULL SCAN             ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
 ----
-·            distribution         full         ·                   ·
-·            vectorized           true         ·                   ·
-lookup join  ·                    ·            (d, e, f, a, b, c)  +a
- │           estimated row count  100          ·                   ·
- │           table                def@primary  ·                   ·
- │           type                 inner        ·                   ·
- │           equality             (a) = (f)    ·                   ·
- └── scan    ·                    ·            (a, b, c)           +a
-·            estimated row count  100          ·                   ·
-·            table                abc@primary  ·                   ·
-·            spans                FULL SCAN    ·                   ·
+·                    distribution         full         ·                   ·
+·                    vectorized           true         ·                   ·
+lookup join (inner)  ·                    ·            (d, e, f, a, b, c)  +a
+ │                   estimated row count  100          ·                   ·
+ │                   table                def@primary  ·                   ·
+ │                   equality             (a) = (f)    ·                   ·
+ └── scan            ·                    ·            (a, b, c)           +a
+·                    estimated row count  100          ·                   ·
+·                    table                abc@primary  ·                   ·
+·                    spans                FULL SCAN    ·                   ·
 
 # Test that we don't get a lookup join if we force a merge join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
-·           distribution         full         ·                   ·
-·           vectorized           true         ·                   ·
-merge join  ·                    ·            (d, e, f, a, b, c)  +f
- │          estimated row count  100          ·                   ·
- │          type                 inner        ·                   ·
- │          equality             (f) = (a)    ·                   ·
- │          merge ordering       +"(f=a)"     ·                   ·
- ├── scan   ·                    ·            (d, e, f)           +f
- │          estimated row count  10000        ·                   ·
- │          table                def@primary  ·                   ·
- │          spans                FULL SCAN    ·                   ·
- └── scan   ·                    ·            (a, b, c)           +a
-·           estimated row count  100          ·                   ·
-·           table                abc@primary  ·                   ·
-·           spans                FULL SCAN    ·                   ·
+·                   distribution         full         ·                   ·
+·                   vectorized           true         ·                   ·
+merge join (inner)  ·                    ·            (d, e, f, a, b, c)  +f
+ │                  estimated row count  100          ·                   ·
+ │                  equality             (f) = (a)    ·                   ·
+ │                  merge ordering       +"(f=a)"     ·                   ·
+ ├── scan           ·                    ·            (d, e, f)           +f
+ │                  estimated row count  10000        ·                   ·
+ │                  table                def@primary  ·                   ·
+ │                  spans                FULL SCAN    ·                   ·
+ └── scan           ·                    ·            (a, b, c)           +a
+·                   estimated row count  100          ·                   ·
+·                   table                abc@primary  ·                   ·
+·                   spans                FULL SCAN    ·                   ·
 
 # Test that we don't get a lookup join if we force a hash join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ----
-·               distribution         full         ·                   ·
-·               vectorized           true         ·                   ·
-sort            ·                    ·            (d, e, f, a, b, c)  +f
- │              estimated row count  100          ·                   ·
- │              order                +f           ·                   ·
- └── hash join  ·                    ·            (d, e, f, a, b, c)  ·
-      │         estimated row count  100          ·                   ·
-      │         type                 inner        ·                   ·
-      │         equality             (f) = (a)    ·                   ·
-      ├── scan  ·                    ·            (d, e, f)           ·
-      │         estimated row count  10000        ·                   ·
-      │         table                def@primary  ·                   ·
-      │         spans                FULL SCAN    ·                   ·
-      └── scan  ·                    ·            (a, b, c)           ·
-·               estimated row count  100          ·                   ·
-·               table                abc@primary  ·                   ·
-·               spans                FULL SCAN    ·                   ·
+·                       distribution         full         ·                   ·
+·                       vectorized           true         ·                   ·
+sort                    ·                    ·            (d, e, f, a, b, c)  +f
+ │                      estimated row count  100          ·                   ·
+ │                      order                +f           ·                   ·
+ └── hash join (inner)  ·                    ·            (d, e, f, a, b, c)  ·
+      │                 estimated row count  100          ·                   ·
+      │                 equality             (f) = (a)    ·                   ·
+      ├── scan          ·                    ·            (d, e, f)           ·
+      │                 estimated row count  10000        ·                   ·
+      │                 table                def@primary  ·                   ·
+      │                 spans                FULL SCAN    ·                   ·
+      └── scan          ·                    ·            (a, b, c)           ·
+·                       estimated row count  100          ·                   ·
+·                       table                abc@primary  ·                   ·
+·                       spans                FULL SCAN    ·                   ·
 
 # Test lookup semi and anti join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·            distribution         full         ·          ·
-·            vectorized           true         ·          ·
-lookup join  ·                    ·            (a, b, c)  ·
- │           estimated row count  100          ·          ·
- │           table                def@primary  ·          ·
- │           type                 semi         ·          ·
- │           equality             (a) = (f)    ·          ·
- └── scan    ·                    ·            (a, b, c)  ·
-·            estimated row count  100          ·          ·
-·            table                abc@primary  ·          ·
-·            spans                FULL SCAN    ·          ·
+·                   distribution         full         ·          ·
+·                   vectorized           true         ·          ·
+lookup join (semi)  ·                    ·            (a, b, c)  ·
+ │                  estimated row count  100          ·          ·
+ │                  table                def@primary  ·          ·
+ │                  equality             (a) = (f)    ·          ·
+ └── scan           ·                    ·            (a, b, c)  ·
+·                   estimated row count  100          ·          ·
+·                   table                abc@primary  ·          ·
+·                   spans                FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·            distribution         full         ·          ·
-·            vectorized           true         ·          ·
-lookup join  ·                    ·            (a, b, c)  ·
- │           estimated row count  0            ·          ·
- │           table                def@primary  ·          ·
- │           type                 anti         ·          ·
- │           equality             (a) = (f)    ·          ·
- └── scan    ·                    ·            (a, b, c)  ·
-·            estimated row count  100          ·          ·
-·            table                abc@primary  ·          ·
-·            spans                FULL SCAN    ·          ·
+·                   distribution         full         ·          ·
+·                   vectorized           true         ·          ·
+lookup join (anti)  ·                    ·            (a, b, c)  ·
+ │                  estimated row count  0            ·          ·
+ │                  table                def@primary  ·          ·
+ │                  equality             (a) = (f)    ·          ·
+ └── scan           ·                    ·            (a, b, c)  ·
+·                   estimated row count  100          ·          ·
+·                   table                abc@primary  ·          ·
+·                   spans                FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·            distribution           full            ·          ·
-·            vectorized             true            ·          ·
-lookup join  ·                      ·               (a, b, c)  ·
- │           estimated row count    100             ·          ·
- │           table                  def@primary     ·          ·
- │           type                   semi            ·          ·
- │           equality               (a, c) = (f,e)  ·          ·
- │           equality cols are key  ·               ·          ·
- └── scan    ·                      ·               (a, b, c)  ·
-·            estimated row count    100             ·          ·
-·            table                  abc@primary     ·          ·
-·            spans                  FULL SCAN       ·          ·
+·                   distribution           full            ·          ·
+·                   vectorized             true            ·          ·
+lookup join (semi)  ·                      ·               (a, b, c)  ·
+ │                  estimated row count    100             ·          ·
+ │                  table                  def@primary     ·          ·
+ │                  equality               (a, c) = (f,e)  ·          ·
+ │                  equality cols are key  ·               ·          ·
+ └── scan           ·                      ·               (a, b, c)  ·
+·                   estimated row count    100             ·          ·
+·                   table                  abc@primary     ·          ·
+·                   spans                  FULL SCAN       ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·            distribution           full            ·          ·
-·            vectorized             true            ·          ·
-lookup join  ·                      ·               (a, b, c)  ·
- │           estimated row count    0               ·          ·
- │           table                  def@primary     ·          ·
- │           type                   anti            ·          ·
- │           equality               (a, c) = (f,e)  ·          ·
- │           equality cols are key  ·               ·          ·
- └── scan    ·                      ·               (a, b, c)  ·
-·            estimated row count    100             ·          ·
-·            table                  abc@primary     ·          ·
-·            spans                  FULL SCAN       ·          ·
+·                   distribution           full            ·          ·
+·                   vectorized             true            ·          ·
+lookup join (anti)  ·                      ·               (a, b, c)  ·
+ │                  estimated row count    0               ·          ·
+ │                  table                  def@primary     ·          ·
+ │                  equality               (a, c) = (f,e)  ·          ·
+ │                  equality cols are key  ·               ·          ·
+ └── scan           ·                      ·               (a, b, c)  ·
+·                   estimated row count    100             ·          ·
+·                   table                  abc@primary     ·          ·
+·                   spans                  FULL SCAN       ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distribution         full         ·          ·
-·            vectorized           true         ·          ·
-lookup join  ·                    ·            (a, b, c)  ·
- │           estimated row count  33           ·          ·
- │           table                def@primary  ·          ·
- │           type                 semi         ·          ·
- │           equality             (a) = (f)    ·          ·
- │           pred                 (d + b) > 1  ·          ·
- └── scan    ·                    ·            (a, b, c)  ·
-·            estimated row count  100          ·          ·
-·            table                abc@primary  ·          ·
-·            spans                FULL SCAN    ·          ·
+·                   distribution         full         ·          ·
+·                   vectorized           true         ·          ·
+lookup join (semi)  ·                    ·            (a, b, c)  ·
+ │                  estimated row count  33           ·          ·
+ │                  table                def@primary  ·          ·
+ │                  equality             (a) = (f)    ·          ·
+ │                  pred                 (d + b) > 1  ·          ·
+ └── scan           ·                    ·            (a, b, c)  ·
+·                   estimated row count  100          ·          ·
+·                   table                abc@primary  ·          ·
+·                   spans                FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distribution         full         ·          ·
-·            vectorized           true         ·          ·
-lookup join  ·                    ·            (a, b, c)  ·
- │           estimated row count  67           ·          ·
- │           table                def@primary  ·          ·
- │           type                 anti         ·          ·
- │           equality             (a) = (f)    ·          ·
- │           pred                 (d + b) > 1  ·          ·
- └── scan    ·                    ·            (a, b, c)  ·
-·            estimated row count  100          ·          ·
-·            table                abc@primary  ·          ·
-·            spans                FULL SCAN    ·          ·
+·                   distribution         full         ·          ·
+·                   vectorized           true         ·          ·
+lookup join (anti)  ·                    ·            (a, b, c)  ·
+ │                  estimated row count  67           ·          ·
+ │                  table                def@primary  ·          ·
+ │                  equality             (a) = (f)    ·          ·
+ │                  pred                 (d + b) > 1  ·          ·
+ └── scan           ·                    ·            (a, b, c)  ·
+·                   estimated row count  100          ·          ·
+·                   table                abc@primary  ·          ·
+·                   spans                FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -900,7 +864,6 @@ group             ·              ·
  │                scalar         ·
  └── lookup join  ·              ·
       │           table          a@primary
-      │           type           inner
       │           equality       (a) = (a)
       └── scan    ·              ·
 ·                 missing stats  ·
@@ -1490,40 +1453,33 @@ limit                                                        ·                 
       │                                                      order                  -count_rows,+s_name
       └── group                                              ·                      ·
            │                                                 group by               s_name
-           └── lookup join                                   ·                      ·
+           └── lookup join (semi)                            ·                      ·
                 │                                            table                  lineitem@primary
-                │                                            type                   semi
                 │                                            equality               (l_orderkey) = (l_orderkey)
                 │                                            pred                   l_suppkey != l_suppkey
                 └── lookup join                              ·                      ·
                      │                                       table                  orders@primary
-                     │                                       type                   inner
                      │                                       equality               (l_orderkey) = (o_orderkey)
                      │                                       equality cols are key  ·
                      │                                       pred                   o_orderstatus = 'F'
-                     └── lookup join                         ·                      ·
+                     └── lookup join (anti)                  ·                      ·
                           │                                  table                  lineitem@primary
-                          │                                  type                   anti
                           │                                  equality               (l_orderkey) = (l_orderkey)
                           │                                  pred                   l_receiptdate > l_commitdate
                           └── lookup join                    ·                      ·
                                │                             table                  lineitem@primary
-                               │                             type                   inner
                                │                             equality               (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
                                │                             equality cols are key  ·
                                │                             pred                   l_receiptdate > l_commitdate
                                └── lookup join               ·                      ·
                                     │                        table                  lineitem@l_sk
-                                    │                        type                   inner
                                     │                        equality               (s_suppkey) = (l_suppkey)
                                     └── lookup join          ·                      ·
                                          │                   table                  supplier@primary
-                                         │                   type                   inner
                                          │                   equality               (s_suppkey) = (s_suppkey)
                                          │                   equality cols are key  ·
                                          └── lookup join     ·                      ·
                                               │              table                  supplier@s_nk
-                                              │              type                   inner
                                               │              equality               (n_nationkey) = (s_nationkey)
                                               └── filter     ·                      ·
                                                    │         filter                 n_name = 'SAUDI ARABIA'
@@ -1549,9 +1505,8 @@ project                         ·                      ·                      
  │                              estimated row count    10 (missing stats)                           ·                                          ·
  └── project                    ·                      ·                                            (pk, col0, col3)                           ·
       │                         estimated row count    10 (missing stats)                           ·                                          ·
-      └── lookup join           ·                      ·                                            ("project_const_col_@14", pk, col0, col3)  ·
+      └── lookup join (semi)    ·                      ·                                            ("project_const_col_@14", pk, col0, col3)  ·
            │                    table                  tab4@tab4_col3_col4_key                      ·                                          ·
-           │                    type                   semi                                         ·                                          ·
            │                    equality               (col0, project_const_col_@14) = (col3,col4)  ·                                          ·
            │                    equality cols are key  ·                                            ·                                          ·
            └── render           ·                      ·                                            ("project_const_col_@14", pk, col0, col3)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -860,8 +860,7 @@ EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
 ----
 ·                 distribution   full
 ·                 vectorized     true
-group             ·              ·
- │                scalar         ·
+group (scalar)    ·              ·
  └── lookup join  ·              ·
       │           table          a@primary
       │           equality       (a) = (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
+++ b/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
@@ -31,7 +31,6 @@ EXPLAIN SELECT * FROM v WHERE y = 3
 ·           vectorized     true
 index join  ·              ·
  │          table          v@primary
- │          key columns    rowid
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          v@i

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -893,48 +893,46 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-·                           distribution           local              ·                ·
-·                           vectorized             false              ·                ·
-project                     ·                      ·                  (k)              ·
- └── sort                   ·                      ·                  (k, v)           -v,+k
-      │                     estimated row count    2 (missing stats)  ·                ·
-      │                     order                  -v,+k              ·                ·
-      └── project           ·                      ·                  (k, v)           ·
-           │                estimated row count    2 (missing stats)  ·                ·
-           └── lookup join  ·                      ·                  (column1, k, v)  ·
-                │           estimated row count    2 (missing stats)  ·                ·
-                │           table                  kv@primary         ·                ·
-                │           type                   inner              ·                ·
-                │           equality               (column1) = (k)    ·                ·
-                │           equality cols are key  ·                  ·                ·
-                └── values  ·                      ·                  (column1)        ·
-·                           size                   1 column, 2 rows   ·                ·
-·                           row 0, expr 0          1                  ·                ·
-·                           row 1, expr 0          3                  ·                ·
+·                                   distribution           local              ·                ·
+·                                   vectorized             false              ·                ·
+project                             ·                      ·                  (k)              ·
+ └── sort                           ·                      ·                  (k, v)           -v,+k
+      │                             estimated row count    2 (missing stats)  ·                ·
+      │                             order                  -v,+k              ·                ·
+      └── project                   ·                      ·                  (k, v)           ·
+           │                        estimated row count    2 (missing stats)  ·                ·
+           └── lookup join (inner)  ·                      ·                  (column1, k, v)  ·
+                │                   estimated row count    2 (missing stats)  ·                ·
+                │                   table                  kv@primary         ·                ·
+                │                   equality               (column1) = (k)    ·                ·
+                │                   equality cols are key  ·                  ·                ·
+                └── values          ·                      ·                  (column1)        ·
+·                                   size                   1 column, 2 rows   ·                ·
+·                                   row 0, expr 0          1                  ·                ·
+·                                   row 1, expr 0          3                  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-·                     distribution         local                 ·             ·
-·                     vectorized           true                  ·             ·
-project               ·                    ·                     (k)           ·
- └── project          ·                    ·                     (k, k, v)     -v,+k
-      │               estimated row count  10 (missing stats)    ·             ·
-      └── merge join  ·                    ·                     (k, v, k, v)  -v,+k
-           │          estimated row count  10 (missing stats)    ·             ·
-           │          type                 inner                 ·             ·
-           │          equality             (v, k) = (v, k)       ·             ·
-           │          left cols are key    ·                     ·             ·
-           │          right cols are key   ·                     ·             ·
-           │          merge ordering       -"(v=v)",+"(k=k)"     ·             ·
-           ├── scan   ·                    ·                     (k, v)        -v,+k
-           │          estimated row count  1000 (missing stats)  ·             ·
-           │          table                kv@foo                ·             ·
-           │          spans                FULL SCAN             ·             ·
-           └── scan   ·                    ·                     (k, v)        -v,+k
-·                     estimated row count  1000 (missing stats)  ·             ·
-·                     table                kv@foo                ·             ·
-·                     spans                FULL SCAN             ·             ·
+·                             distribution         local                 ·             ·
+·                             vectorized           true                  ·             ·
+project                       ·                    ·                     (k)           ·
+ └── project                  ·                    ·                     (k, k, v)     -v,+k
+      │                       estimated row count  10 (missing stats)    ·             ·
+      └── merge join (inner)  ·                    ·                     (k, v, k, v)  -v,+k
+           │                  estimated row count  10 (missing stats)    ·             ·
+           │                  equality             (v, k) = (v, k)       ·             ·
+           │                  left cols are key    ·                     ·             ·
+           │                  right cols are key   ·                     ·             ·
+           │                  merge ordering       -"(v=v)",+"(k=k)"     ·             ·
+           ├── scan           ·                    ·                     (k, v)        -v,+k
+           │                  estimated row count  1000 (missing stats)  ·             ·
+           │                  table                kv@foo                ·             ·
+           │                  spans                FULL SCAN             ·             ·
+           └── scan           ·                    ·                     (k, v)        -v,+k
+·                             estimated row count  1000 (missing stats)  ·             ·
+·                             table                kv@foo                ·             ·
+·                             spans                FULL SCAN             ·             ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -293,7 +293,6 @@ sort             ·                ·
  │               already ordered  +b,+a
  └── index join  ·                ·
       │          table            abc@primary
-      │          key columns      a, b, c
       └── scan   ·                ·
 ·                missing stats    ·
 ·                table            abc@ba
@@ -908,7 +907,6 @@ project                     ·                      ·                  (k)     
                 │           type                   inner              ·                ·
                 │           equality               (column1) = (k)    ·                ·
                 │           equality cols are key  ·                  ·                ·
-                │           parallel               ·                  ·                ·
                 └── values  ·                      ·                  (column1)        ·
 ·                           size                   1 column, 2 rows   ·                ·
 ·                           row 0, expr 0          1                  ·                ·
@@ -928,7 +926,7 @@ project               ·                    ·                     (k)          
            │          equality             (v, k) = (v, k)       ·             ·
            │          left cols are key    ·                     ·             ·
            │          right cols are key   ·                     ·             ·
-           │          mergeJoinOrder       -"(v=v)",+"(k=k)"     ·             ·
+           │          merge ordering       -"(v=v)",+"(k=k)"     ·             ·
            ├── scan   ·                    ·                     (k, v)        -v,+k
            │          estimated row count  1000 (missing stats)  ·             ·
            │          table                kv@foo                ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -8,10 +8,9 @@ EXPLAIN (VERBOSE) SELECT max(ordinality) FROM foo WITH ORDINALITY
 ----
 ·                distribution         local                 ·               ·
 ·                vectorized           true                  ·               ·
-group            ·                    ·                     (max)           ·
+group (scalar)   ·                    ·                     (max)           ·
  │               estimated row count  1 (missing stats)     ·               ·
  │               aggregate 0          max(ordinality)       ·               ·
- │               scalar               ·                     ·               ·
  └── ordinality  ·                    ·                     ("ordinality")  ·
       │          estimated row count  1000 (missing stats)  ·               ·
       └── scan   ·                    ·                     ()              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -61,7 +61,6 @@ EXECUTE change_stats
 ·           distribution        full
 ·           vectorized          true
 merge join  ·                   ·
- │          type                inner
  │          equality            (a) = (c)
  │          left cols are key   ·
  │          right cols are key  ·
@@ -87,7 +86,6 @@ EXECUTE change_stats
 ·            vectorized             true
 lookup join  ·                      ·
  │           table                  cd@primary
- │           type                   inner
  │           equality               (a) = (c)
  │           equality cols are key  ·
  └── scan    ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -65,7 +65,6 @@ merge join  ·                   ·
  │          equality            (a) = (c)
  │          left cols are key   ·
  │          right cols are key  ·
- │          mergeJoinOrder      +"(a=c)"
  ├── scan   ·                   ·
  │          missing stats       ·
  │          table               ab@primary
@@ -91,7 +90,6 @@ lookup join  ·                      ·
  │           type                   inner
  │           equality               (a) = (c)
  │           equality cols are key  ·
- │           parallel               ·
  └── scan    ·                      ·
 ·            estimated row count    1
 ·            table                  ab@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1571,7 +1571,6 @@ limit                     ·              ·
       │                   order          +z
       └── project set     ·              ·
            └── hash join  ·              ·
-                │         type           inner
                 │         equality       (y) = (y)
                 ├── scan  ·              ·
                 │         missing stats  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1335,7 +1335,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          a@primary
 ·     spans          [/10 - /10] [/20 - /20]
-·     parallel       ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
@@ -1346,7 +1345,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          a@primary
 ·     spans          [/10 - /10] [/20 - /20]
-·     parallel       ·
 
 # Verify that consolidated point spans are still parallelized.
 query TTT
@@ -1358,7 +1356,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          a@primary
 ·     spans          [/10 - /11]
-·     parallel       ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a > 10 AND a < 20
@@ -1369,7 +1366,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          a@primary
 ·     spans          [/11 - /19]
-·     parallel       ·
 
 # This ticks all the boxes for parallelization apart from the fact that there
 # is no end key in the span.
@@ -1393,12 +1389,10 @@ EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ·           vectorized     true
 index join  ·              ·
  │          table          a@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          a@item
 ·           spans          [/'ball' - /'ball'] [/'sock' - /'sock']
-·           parallel       ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
@@ -1409,7 +1403,6 @@ EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND pric
 ·           vectorized     true
 index join  ·              ·
  │          table          a@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          a@p
@@ -1424,7 +1417,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          b@primary
 ·     spans          [/10/10 - /10/10] [/20/20 - /20/20]
-·     parallel       ·
 
 # This one isn't parallelizable because it's not a point lookup - only part of
 # the primary key is specified.
@@ -1478,7 +1470,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          b@b_c_key
 ·     spans          [/10 - /10] [/20 - /20]
-·     parallel       ·
 
 query TTT
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c < 2
@@ -1536,7 +1527,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          b@b_b_key
 ·     spans          [/10 - /10] [/20 - /20]
-·     parallel       ·
 
 statement ok
 ALTER TABLE a SPLIT AT VALUES(5)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -581,88 +581,84 @@ root                 ·                    ·                                  (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ----
-·                    distribution           local                 ·          ·
-·                    vectorized             true                  ·          ·
-project              ·                      ·                     (a, b)     ·
- │                   estimated row count    100 (missing stats)   ·          ·
- └── lookup join     ·                      ·                     (b, a, b)  ·
-      │              estimated row count    99 (missing stats)    ·          ·
-      │              table                  t@primary             ·          ·
-      │              type                   inner                 ·          ·
-      │              equality               (b) = (a)             ·          ·
-      │              equality cols are key  ·                     ·          ·
-      └── distinct   ·                      ·                     (b)        ·
-           │         estimated row count    100 (missing stats)   ·          ·
-           │         distinct on            b                     ·          ·
-           └── scan  ·                      ·                     (b)        ·
-·                    estimated row count    1000 (missing stats)  ·          ·
-·                    table                  t@primary             ·          ·
-·                    spans                  FULL SCAN             ·          ·
+·                         distribution           local                 ·          ·
+·                         vectorized             true                  ·          ·
+project                   ·                      ·                     (a, b)     ·
+ │                        estimated row count    100 (missing stats)   ·          ·
+ └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
+      │                   estimated row count    99 (missing stats)    ·          ·
+      │                   table                  t@primary             ·          ·
+      │                   equality               (b) = (a)             ·          ·
+      │                   equality cols are key  ·                     ·          ·
+      └── distinct        ·                      ·                     (b)        ·
+           │              estimated row count    100 (missing stats)   ·          ·
+           │              distinct on            b                     ·          ·
+           └── scan       ·                      ·                     (b)        ·
+·                         estimated row count    1000 (missing stats)  ·          ·
+·                         table                  t@primary             ·          ·
+·                         spans                  FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
 ----
-·                    distribution           local                 ·          ·
-·                    vectorized             true                  ·          ·
-project              ·                      ·                     (a, b)     ·
- │                   estimated row count    100 (missing stats)   ·          ·
- └── lookup join     ·                      ·                     (b, a, b)  ·
-      │              estimated row count    99 (missing stats)    ·          ·
-      │              table                  t@primary             ·          ·
-      │              type                   inner                 ·          ·
-      │              equality               (b) = (a)             ·          ·
-      │              equality cols are key  ·                     ·          ·
-      └── distinct   ·                      ·                     (b)        ·
-           │         estimated row count    100 (missing stats)   ·          ·
-           │         distinct on            b                     ·          ·
-           └── scan  ·                      ·                     (b)        ·
-·                    estimated row count    1000 (missing stats)  ·          ·
-·                    table                  t@primary             ·          ·
-·                    spans                  FULL SCAN             ·          ·
-·                    locking strength       for update            ·          ·
+·                         distribution           local                 ·          ·
+·                         vectorized             true                  ·          ·
+project                   ·                      ·                     (a, b)     ·
+ │                        estimated row count    100 (missing stats)   ·          ·
+ └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
+      │                   estimated row count    99 (missing stats)    ·          ·
+      │                   table                  t@primary             ·          ·
+      │                   equality               (b) = (a)             ·          ·
+      │                   equality cols are key  ·                     ·          ·
+      └── distinct        ·                      ·                     (b)        ·
+           │              estimated row count    100 (missing stats)   ·          ·
+           │              distinct on            b                     ·          ·
+           └── scan       ·                      ·                     (b)        ·
+·                         estimated row count    1000 (missing stats)  ·          ·
+·                         table                  t@primary             ·          ·
+·                         spans                  FULL SCAN             ·          ·
+·                         locking strength       for update            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
 ----
-·                    distribution           local                 ·          ·
-·                    vectorized             true                  ·          ·
-project              ·                      ·                     (a, b)     ·
- │                   estimated row count    100 (missing stats)   ·          ·
- └── lookup join     ·                      ·                     (b, a, b)  ·
-      │              estimated row count    99 (missing stats)    ·          ·
-      │              table                  t@primary             ·          ·
-      │              type                   inner                 ·          ·
-      │              equality               (b) = (a)             ·          ·
-      │              equality cols are key  ·                     ·          ·
-      └── distinct   ·                      ·                     (b)        ·
-           │         estimated row count    100 (missing stats)   ·          ·
-           │         distinct on            b                     ·          ·
-           └── scan  ·                      ·                     (b)        ·
-·                    estimated row count    1000 (missing stats)  ·          ·
-·                    table                  t@primary             ·          ·
-·                    spans                  FULL SCAN             ·          ·
+·                         distribution           local                 ·          ·
+·                         vectorized             true                  ·          ·
+project                   ·                      ·                     (a, b)     ·
+ │                        estimated row count    100 (missing stats)   ·          ·
+ └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
+      │                   estimated row count    99 (missing stats)    ·          ·
+      │                   table                  t@primary             ·          ·
+      │                   equality               (b) = (a)             ·          ·
+      │                   equality cols are key  ·                     ·          ·
+      └── distinct        ·                      ·                     (b)        ·
+           │              estimated row count    100 (missing stats)   ·          ·
+           │              distinct on            b                     ·          ·
+           └── scan       ·                      ·                     (b)        ·
+·                         estimated row count    1000 (missing stats)  ·          ·
+·                         table                  t@primary             ·          ·
+·                         spans                  FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
 ----
-·                    distribution           local                 ·          ·
-·                    vectorized             true                  ·          ·
-project              ·                      ·                     (a, b)     ·
- │                   estimated row count    100 (missing stats)   ·          ·
- └── lookup join     ·                      ·                     (b, a, b)  ·
-      │              estimated row count    99 (missing stats)    ·          ·
-      │              table                  t@primary             ·          ·
-      │              type                   inner                 ·          ·
-      │              equality               (b) = (a)             ·          ·
-      │              equality cols are key  ·                     ·          ·
-      └── distinct   ·                      ·                     (b)        ·
-           │         estimated row count    100 (missing stats)   ·          ·
-           │         distinct on            b                     ·          ·
-           └── scan  ·                      ·                     (b)        ·
-·                    estimated row count    1000 (missing stats)  ·          ·
-·                    table                  t@primary             ·          ·
-·                    spans                  FULL SCAN             ·          ·
-·                    locking strength       for update            ·          ·
+·                         distribution           local                 ·          ·
+·                         vectorized             true                  ·          ·
+project                   ·                      ·                     (a, b)     ·
+ │                        estimated row count    100 (missing stats)   ·          ·
+ └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
+      │                   estimated row count    99 (missing stats)    ·          ·
+      │                   table                  t@primary             ·          ·
+      │                   equality               (b) = (a)             ·          ·
+      │                   equality cols are key  ·                     ·          ·
+      └── distinct        ·                      ·                     (b)        ·
+           │              estimated row count    100 (missing stats)   ·          ·
+           │              distinct on            b                     ·          ·
+           └── scan       ·                      ·                     (b)        ·
+·                         estimated row count    1000 (missing stats)  ·          ·
+·                         table                  t@primary             ·          ·
+·                         spans                  FULL SCAN             ·          ·
+·                         locking strength       for update            ·          ·
 
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
@@ -775,125 +771,120 @@ root                 ·                    ·                           (c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for share             ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for share             ·             ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
@@ -901,102 +892,98 @@ EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for share             ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for share             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for no key update     ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for key share         ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for no key update     ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for key share         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for no key update     ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for no key update     ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
@@ -1005,27 +992,26 @@ project          ·                    ·                     (a, b, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
@@ -1039,75 +1025,72 @@ EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 # Postgres doesn't support applying locking clauses to joins. The following
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
@@ -1116,27 +1099,26 @@ project          ·                    ·                     (a, b, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
@@ -1150,27 +1132,26 @@ EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ----
-·                distribution         local                 ·             ·
-·                vectorized           true                  ·             ·
-project          ·                    ·                     (a, b, c)     ·
- │               estimated row count  1000 (missing stats)  ·             ·
- └── merge join  ·                    ·                     (a, b, a, c)  ·
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          type                 inner                 ·             ·
-      │          equality             (a) = (a)             ·             ·
-      │          left cols are key    ·                     ·             ·
-      │          right cols are key   ·                     ·             ·
-      │          merge ordering       +"(a=a)"              ·             ·
-      ├── scan   ·                    ·                     (a, b)        +a
-      │          estimated row count  1000 (missing stats)  ·             ·
-      │          table                t@primary             ·             ·
-      │          spans                FULL SCAN             ·             ·
-      │          locking strength     for update            ·             ·
-      └── scan   ·                    ·                     (a, c)        +a
-·                estimated row count  1000 (missing stats)  ·             ·
-·                table                u@primary             ·             ·
-·                spans                FULL SCAN             ·             ·
-·                locking strength     for update            ·             ·
+·                        distribution         local                 ·             ·
+·                        vectorized           true                  ·             ·
+project                  ·                    ·                     (a, b, c)     ·
+ │                       estimated row count  1000 (missing stats)  ·             ·
+ └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  equality             (a) = (a)             ·             ·
+      │                  left cols are key    ·                     ·             ·
+      │                  right cols are key   ·                     ·             ·
+      │                  merge ordering       +"(a=a)"              ·             ·
+      ├── scan           ·                    ·                     (a, b)        +a
+      │                  estimated row count  1000 (missing stats)  ·             ·
+      │                  table                t@primary             ·             ·
+      │                  spans                FULL SCAN             ·             ·
+      │                  locking strength     for update            ·             ·
+      └── scan           ·                    ·                     (a, c)        +a
+·                        estimated row count  1000 (missing stats)  ·             ·
+·                        table                u@primary             ·             ·
+·                        spans                FULL SCAN             ·             ·
+·                        locking strength     for update            ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
@@ -1179,77 +1160,73 @@ project          ·                    ·                     (a, b, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE
 ----
-·           distribution         local                    ·             ·
-·           vectorized           true                     ·             ·
-cross join  ·                    ·                        (a, b, a, c)  ·
- │          estimated row count  1000000 (missing stats)  ·             ·
- │          type                 cross                    ·             ·
- ├── scan   ·                    ·                        (a, b)        ·
- │          estimated row count  1000 (missing stats)     ·             ·
- │          table                t@primary                ·             ·
- │          spans                FULL SCAN                ·             ·
- │          locking strength     for update               ·             ·
- └── scan   ·                    ·                        (a, c)        ·
-·           estimated row count  1000 (missing stats)     ·             ·
-·           table                u@primary                ·             ·
-·           spans                FULL SCAN                ·             ·
-·           locking strength     for update               ·             ·
+·                   distribution         local                    ·             ·
+·                   vectorized           true                     ·             ·
+cross join (inner)  ·                    ·                        (a, b, a, c)  ·
+ │                  estimated row count  1000000 (missing stats)  ·             ·
+ ├── scan           ·                    ·                        (a, b)        ·
+ │                  estimated row count  1000 (missing stats)     ·             ·
+ │                  table                t@primary                ·             ·
+ │                  spans                FULL SCAN                ·             ·
+ │                  locking strength     for update               ·             ·
+ └── scan           ·                    ·                        (a, c)        ·
+·                   estimated row count  1000 (missing stats)     ·             ·
+·                   table                u@primary                ·             ·
+·                   spans                FULL SCAN                ·             ·
+·                   locking strength     for update               ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE OF t
 ----
-·           distribution         local                    ·             ·
-·           vectorized           true                     ·             ·
-cross join  ·                    ·                        (a, b, a, c)  ·
- │          estimated row count  1000000 (missing stats)  ·             ·
- │          type                 cross                    ·             ·
- ├── scan   ·                    ·                        (a, b)        ·
- │          estimated row count  1000 (missing stats)     ·             ·
- │          table                t@primary                ·             ·
- │          spans                FULL SCAN                ·             ·
- │          locking strength     for update               ·             ·
- └── scan   ·                    ·                        (a, c)        ·
-·           estimated row count  1000 (missing stats)     ·             ·
-·           table                u@primary                ·             ·
-·           spans                FULL SCAN                ·             ·
+·                   distribution         local                    ·             ·
+·                   vectorized           true                     ·             ·
+cross join (inner)  ·                    ·                        (a, b, a, c)  ·
+ │                  estimated row count  1000000 (missing stats)  ·             ·
+ ├── scan           ·                    ·                        (a, b)        ·
+ │                  estimated row count  1000 (missing stats)     ·             ·
+ │                  table                t@primary                ·             ·
+ │                  spans                FULL SCAN                ·             ·
+ │                  locking strength     for update               ·             ·
+ └── scan           ·                    ·                        (a, c)        ·
+·                   estimated row count  1000 (missing stats)     ·             ·
+·                   table                u@primary                ·             ·
+·                   spans                FULL SCAN                ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
-·           distribution         local                    ·             ·
-·           vectorized           true                     ·             ·
-cross join  ·                    ·                        (a, b, a, c)  ·
- │          estimated row count  1000000 (missing stats)  ·             ·
- │          type                 cross                    ·             ·
- ├── scan   ·                    ·                        (a, b)        ·
- │          estimated row count  1000 (missing stats)     ·             ·
- │          table                t@primary                ·             ·
- │          spans                FULL SCAN                ·             ·
- │          locking strength     for share                ·             ·
- └── scan   ·                    ·                        (a, c)        ·
-·           estimated row count  1000 (missing stats)     ·             ·
-·           table                u@primary                ·             ·
-·           spans                FULL SCAN                ·             ·
-·           locking strength     for update               ·             ·
+·                   distribution         local                    ·             ·
+·                   vectorized           true                     ·             ·
+cross join (inner)  ·                    ·                        (a, b, a, c)  ·
+ │                  estimated row count  1000000 (missing stats)  ·             ·
+ ├── scan           ·                    ·                        (a, b)        ·
+ │                  estimated row count  1000 (missing stats)     ·             ·
+ │                  table                t@primary                ·             ·
+ │                  spans                FULL SCAN                ·             ·
+ │                  locking strength     for share                ·             ·
+ └── scan           ·                    ·                        (a, c)        ·
+·                   estimated row count  1000 (missing stats)     ·             ·
+·                   table                u@primary                ·             ·
+·                   spans                FULL SCAN                ·             ·
+·                   locking strength     for update               ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
-·           distribution         local                    ·             ·
-·           vectorized           true                     ·             ·
-cross join  ·                    ·                        (a, b, a, c)  ·
- │          estimated row count  1000000 (missing stats)  ·             ·
- │          type                 cross                    ·             ·
- ├── scan   ·                    ·                        (a, b)        ·
- │          estimated row count  1000 (missing stats)     ·             ·
- │          table                t@primary                ·             ·
- │          spans                FULL SCAN                ·             ·
- │          locking strength     for update               ·             ·
- └── scan   ·                    ·                        (a, c)        ·
-·           estimated row count  1000 (missing stats)     ·             ·
-·           table                u@primary                ·             ·
-·           spans                FULL SCAN                ·             ·
-·           locking strength     for update               ·             ·
+·                   distribution         local                    ·             ·
+·                   vectorized           true                     ·             ·
+cross join (inner)  ·                    ·                        (a, b, a, c)  ·
+ │                  estimated row count  1000000 (missing stats)  ·             ·
+ ├── scan           ·                    ·                        (a, b)        ·
+ │                  estimated row count  1000 (missing stats)     ·             ·
+ │                  table                t@primary                ·             ·
+ │                  spans                FULL SCAN                ·             ·
+ │                  locking strength     for update               ·             ·
+ └── scan           ·                    ·                        (a, c)        ·
+·                   estimated row count  1000 (missing stats)     ·             ·
+·                   table                u@primary                ·             ·
+·                   spans                FULL SCAN                ·             ·
+·                   locking strength     for update               ·             ·
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
@@ -1257,20 +1234,19 @@ EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
-·           distribution         local                    ·             ·
-·           vectorized           true                     ·             ·
-cross join  ·                    ·                        (a, b, a, c)  ·
- │          estimated row count  1000000 (missing stats)  ·             ·
- │          type                 cross                    ·             ·
- ├── scan   ·                    ·                        (a, b)        ·
- │          estimated row count  1000 (missing stats)     ·             ·
- │          table                t@primary                ·             ·
- │          spans                FULL SCAN                ·             ·
- └── scan   ·                    ·                        (a, c)        ·
-·           estimated row count  1000 (missing stats)     ·             ·
-·           table                u@primary                ·             ·
-·           spans                FULL SCAN                ·             ·
-·           locking strength     for update               ·             ·
+·                   distribution         local                    ·             ·
+·                   vectorized           true                     ·             ·
+cross join (inner)  ·                    ·                        (a, b, a, c)  ·
+ │                  estimated row count  1000000 (missing stats)  ·             ·
+ ├── scan           ·                    ·                        (a, b)        ·
+ │                  estimated row count  1000 (missing stats)     ·             ·
+ │                  table                t@primary                ·             ·
+ │                  spans                FULL SCAN                ·             ·
+ └── scan           ·                    ·                        (a, c)        ·
+·                   estimated row count  1000 (missing stats)     ·             ·
+·                   table                u@primary                ·             ·
+·                   spans                FULL SCAN                ·             ·
+·                   locking strength     for update               ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -13,334 +13,338 @@ CREATE VIEW v AS SELECT a FROM t AS t2
 # Basic tests.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for no key update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for no key update     ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for share
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for share             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for key share
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for key share         ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for share
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for share             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for no key update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for no key update     ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t FOR UPDATE OF t2
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2
 
-query TTT
-EXPLAIN SELECT 1 FROM t FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t
 ----
-·          distribution      local
-·          vectorized        true
-render     ·                 ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             t@primary
-·          spans             FULL SCAN
-·          locking strength  for update
+·          distribution         local                 ·             ·
+·          vectorized           true                  ·             ·
+render     ·                    ·                     ("?column?")  ·
+ │         estimated row count  1000 (missing stats)  ·             ·
+ │         render 0             1                     ·             ·
+ └── scan  ·                    ·                     ()            ·
+·          estimated row count  1000 (missing stats)  ·             ·
+·          table                t@primary             ·             ·
+·          spans                FULL SCAN             ·             ·
+·          locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for update
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for no key update
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for no key update  ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for share
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for share          ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for key share
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for key share      ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for share
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for share          ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for no key update
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for no key update  ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for update
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             [/1 - /1]
-·     locking strength  for update
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
 
-query TTT
-EXPLAIN SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·          distribution      local
-·          vectorized        true
-render     ·                 ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             t@primary
-·          spans             [/1 - /1]
-·          locking strength  for update
+·          distribution         local              ·             ·
+·          vectorized           true               ·             ·
+render     ·                    ·                  ("?column?")  ·
+ │         estimated row count  1 (missing stats)  ·             ·
+ │         render 0             1                  ·             ·
+ └── scan  ·                    ·                  (a)           ·
+·          estimated row count  1 (missing stats)  ·             ·
+·          table                t@primary          ·             ·
+·          spans                /1-/1/#            ·             ·
+·          locking strength     for update         ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with table aliases.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t AS t2 FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 FOR UPDATE OF t2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t2
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
 # ------------------------------------------------------------------------------
 # Tests with numeric table references.
 # Cockroach numeric references start after 53 for user tables.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE OF t
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE OF t2
+EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE OF t2
 
 # ------------------------------------------------------------------------------
 # Tests with views.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM v FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM v FOR UPDATE OF v
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
 query error pgcode 42P01 relation "v2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM v FOR UPDATE OF v2
+EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v2
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM v FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF t
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM v FOR UPDATE OF t2
+EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF t2
 
 # ------------------------------------------------------------------------------
 # Tests with aliased views.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM v AS v2 FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
 query error pgcode 42P01 relation "v" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM v AS v2 FOR UPDATE OF v
+EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v
 
-query TTT
-EXPLAIN SELECT * FROM v AS v2 FOR UPDATE OF v2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v2
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -350,291 +354,315 @@ scan  ·                 ·
 # the filter.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t) FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for no key update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for no key update     ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for no key update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for no key update     ·    ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
 
-query TTT
-EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·     distribution      local
-·     vectorized        true
-scan  ·                 ·
-·     missing stats     ·
-·     table             t@primary
-·     spans             FULL SCAN
-·     locking strength  for update
+·     distribution         local                 ·    ·
+·     vectorized           true                  ·    ·
+scan  ·                    ·                     (a)  ·
+·     estimated row count  1000 (missing stats)  ·    ·
+·     table                t@primary             ·    ·
+·     spans                FULL SCAN             ·    ·
+·     locking strength     for update            ·    ·
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t) FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE
 ----
-·                    distribution   local
-·                    vectorized     false
-root                 ·              ·
- ├── values          ·              ·
- │                   size           1 column, 1 row
- └── subquery        ·              ·
-      │              id             @S1
-      │              original sql   (SELECT a FROM t)
-      │              exec mode      one row
-      └── max1row    ·              ·
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          t@primary
-·                    spans          FULL SCAN
+·                    distribution         local                 ·    ·
+·                    vectorized           false                 ·    ·
+root                 ·                    ·                     (a)  ·
+ ├── values          ·                    ·                     (a)  ·
+ │                   size                 1 column, 1 row       ·    ·
+ │                   row 0, expr 0        @S1                   ·    ·
+ └── subquery        ·                    ·                     ·    ·
+      │              id                   @S1                   ·    ·
+      │              original sql         (SELECT a FROM t)     ·    ·
+      │              exec mode            one row               ·    ·
+      └── max1row    ·                    ·                     (a)  ·
+           │         estimated row count  1                     ·    ·
+           └── scan  ·                    ·                     (a)  ·
+·                    estimated row count  1000 (missing stats)  ·    ·
+·                    table                t@primary             ·    ·
+·                    spans                FULL SCAN             ·    ·
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t FOR UPDATE)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE)
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── values          ·                 ·
- │                   size              1 column, 1 row
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      (SELECT a FROM t FOR UPDATE)
-      │              exec mode         one row
-      └── max1row    ·                 ·
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                         ·    ·
+·                    vectorized           false                         ·    ·
+root                 ·                    ·                             (a)  ·
+ ├── values          ·                    ·                             (a)  ·
+ │                   size                 1 column, 1 row               ·    ·
+ │                   row 0, expr 0        @S1                           ·    ·
+ └── subquery        ·                    ·                             ·    ·
+      │              id                   @S1                           ·    ·
+      │              original sql         (SELECT a FROM t FOR UPDATE)  ·    ·
+      │              exec mode            one row                       ·    ·
+      └── max1row    ·                    ·                             (a)  ·
+           │         estimated row count  1                             ·    ·
+           └── scan  ·                    ·                             (a)  ·
+·                    estimated row count  1000 (missing stats)          ·    ·
+·                    table                t@primary                     ·    ·
+·                    spans                FULL SCAN                     ·    ·
+·                    locking strength     for update                    ·    ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT (SELECT a FROM t) FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE OF t
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t FOR UPDATE OF t)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t)
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── values          ·                 ·
- │                   size              1 column, 1 row
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      (SELECT a FROM t FOR UPDATE OF t)
-      │              exec mode         one row
-      └── max1row    ·                 ·
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                              ·    ·
+·                    vectorized           false                              ·    ·
+root                 ·                    ·                                  (a)  ·
+ ├── values          ·                    ·                                  (a)  ·
+ │                   size                 1 column, 1 row                    ·    ·
+ │                   row 0, expr 0        @S1                                ·    ·
+ └── subquery        ·                    ·                                  ·    ·
+      │              id                   @S1                                ·    ·
+      │              original sql         (SELECT a FROM t FOR UPDATE OF t)  ·    ·
+      │              exec mode            one row                            ·    ·
+      └── max1row    ·                    ·                                  (a)  ·
+           │         estimated row count  1                                  ·    ·
+           └── scan  ·                    ·                                  (a)  ·
+·                    estimated row count  1000 (missing stats)               ·    ·
+·                    table                t@primary                          ·    ·
+·                    spans                FULL SCAN                          ·    ·
+·                    locking strength     for update                         ·    ·
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t) AS r FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE
 ----
-·                    distribution   local
-·                    vectorized     false
-root                 ·              ·
- ├── values          ·              ·
- │                   size           1 column, 1 row
- └── subquery        ·              ·
-      │              id             @S1
-      │              original sql   (SELECT a FROM t)
-      │              exec mode      one row
-      └── max1row    ·              ·
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          t@primary
-·                    spans          FULL SCAN
+·                    distribution         local                 ·    ·
+·                    vectorized           false                 ·    ·
+root                 ·                    ·                     (r)  ·
+ ├── values          ·                    ·                     (r)  ·
+ │                   size                 1 column, 1 row       ·    ·
+ │                   row 0, expr 0        @S1                   ·    ·
+ └── subquery        ·                    ·                     ·    ·
+      │              id                   @S1                   ·    ·
+      │              original sql         (SELECT a FROM t)     ·    ·
+      │              exec mode            one row               ·    ·
+      └── max1row    ·                    ·                     (a)  ·
+           │         estimated row count  1                     ·    ·
+           └── scan  ·                    ·                     (a)  ·
+·                    estimated row count  1000 (missing stats)  ·    ·
+·                    table                t@primary             ·    ·
+·                    spans                FULL SCAN             ·    ·
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t FOR UPDATE) AS r
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE) AS r
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── values          ·                 ·
- │                   size              1 column, 1 row
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      (SELECT a FROM t FOR UPDATE)
-      │              exec mode         one row
-      └── max1row    ·                 ·
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                         ·    ·
+·                    vectorized           false                         ·    ·
+root                 ·                    ·                             (r)  ·
+ ├── values          ·                    ·                             (r)  ·
+ │                   size                 1 column, 1 row               ·    ·
+ │                   row 0, expr 0        @S1                           ·    ·
+ └── subquery        ·                    ·                             ·    ·
+      │              id                   @S1                           ·    ·
+      │              original sql         (SELECT a FROM t FOR UPDATE)  ·    ·
+      │              exec mode            one row                       ·    ·
+      └── max1row    ·                    ·                             (a)  ·
+           │         estimated row count  1                             ·    ·
+           └── scan  ·                    ·                             (a)  ·
+·                    estimated row count  1000 (missing stats)          ·    ·
+·                    table                t@primary                     ·    ·
+·                    spans                FULL SCAN                     ·    ·
+·                    locking strength     for update                    ·    ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
 
-query TTT
-EXPLAIN SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
+query TTTTT
+EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── values          ·                 ·
- │                   size              1 column, 1 row
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      (SELECT a FROM t FOR UPDATE OF t)
-      │              exec mode         one row
-      └── max1row    ·                 ·
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                              ·    ·
+·                    vectorized           false                              ·    ·
+root                 ·                    ·                                  (r)  ·
+ ├── values          ·                    ·                                  (r)  ·
+ │                   size                 1 column, 1 row                    ·    ·
+ │                   row 0, expr 0        @S1                                ·    ·
+ └── subquery        ·                    ·                                  ·    ·
+      │              id                   @S1                                ·    ·
+      │              original sql         (SELECT a FROM t FOR UPDATE OF t)  ·    ·
+      │              exec mode            one row                            ·    ·
+      └── max1row    ·                    ·                                  (a)  ·
+           │         estimated row count  1                                  ·    ·
+           └── scan  ·                    ·                                  (a)  ·
+·                    estimated row count  1000 (missing stats)               ·    ·
+·                    table                t@primary                          ·    ·
+·                    spans                FULL SCAN                          ·    ·
+·                    locking strength     for update                         ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ----
-·               distribution           local
-·               vectorized             true
-lookup join     ·                      ·
- │              table                  t@primary
- │              type                   inner
- │              equality               (b) = (a)
- │              equality cols are key  ·
- │              parallel               ·
- └── distinct   ·                      ·
-      │         distinct on            b
-      └── scan  ·                      ·
-·               missing stats          ·
-·               table                  t@primary
-·               spans                  FULL SCAN
+·                    distribution           local                 ·          ·
+·                    vectorized             true                  ·          ·
+project              ·                      ·                     (a, b)     ·
+ │                   estimated row count    100 (missing stats)   ·          ·
+ └── lookup join     ·                      ·                     (b, a, b)  ·
+      │              estimated row count    99 (missing stats)    ·          ·
+      │              table                  t@primary             ·          ·
+      │              type                   inner                 ·          ·
+      │              equality               (b) = (a)             ·          ·
+      │              equality cols are key  ·                     ·          ·
+      └── distinct   ·                      ·                     (b)        ·
+           │         estimated row count    100 (missing stats)   ·          ·
+           │         distinct on            b                     ·          ·
+           └── scan  ·                      ·                     (b)        ·
+·                    estimated row count    1000 (missing stats)  ·          ·
+·                    table                  t@primary             ·          ·
+·                    spans                  FULL SCAN             ·          ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
 ----
-·               distribution           local
-·               vectorized             true
-lookup join     ·                      ·
- │              table                  t@primary
- │              type                   inner
- │              equality               (b) = (a)
- │              equality cols are key  ·
- │              parallel               ·
- └── distinct   ·                      ·
-      │         distinct on            b
-      └── scan  ·                      ·
-·               missing stats          ·
-·               table                  t@primary
-·               spans                  FULL SCAN
-·               locking strength       for update
+·                    distribution           local                 ·          ·
+·                    vectorized             true                  ·          ·
+project              ·                      ·                     (a, b)     ·
+ │                   estimated row count    100 (missing stats)   ·          ·
+ └── lookup join     ·                      ·                     (b, a, b)  ·
+      │              estimated row count    99 (missing stats)    ·          ·
+      │              table                  t@primary             ·          ·
+      │              type                   inner                 ·          ·
+      │              equality               (b) = (a)             ·          ·
+      │              equality cols are key  ·                     ·          ·
+      └── distinct   ·                      ·                     (b)        ·
+           │         estimated row count    100 (missing stats)   ·          ·
+           │         distinct on            b                     ·          ·
+           └── scan  ·                      ·                     (b)        ·
+·                    estimated row count    1000 (missing stats)  ·          ·
+·                    table                  t@primary             ·          ·
+·                    spans                  FULL SCAN             ·          ·
+·                    locking strength       for update            ·          ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
 ----
-·               distribution           local
-·               vectorized             true
-lookup join     ·                      ·
- │              table                  t@primary
- │              type                   inner
- │              equality               (b) = (a)
- │              equality cols are key  ·
- │              parallel               ·
- └── distinct   ·                      ·
-      │         distinct on            b
-      └── scan  ·                      ·
-·               missing stats          ·
-·               table                  t@primary
-·               spans                  FULL SCAN
+·                    distribution           local                 ·          ·
+·                    vectorized             true                  ·          ·
+project              ·                      ·                     (a, b)     ·
+ │                   estimated row count    100 (missing stats)   ·          ·
+ └── lookup join     ·                      ·                     (b, a, b)  ·
+      │              estimated row count    99 (missing stats)    ·          ·
+      │              table                  t@primary             ·          ·
+      │              type                   inner                 ·          ·
+      │              equality               (b) = (a)             ·          ·
+      │              equality cols are key  ·                     ·          ·
+      └── distinct   ·                      ·                     (b)        ·
+           │         estimated row count    100 (missing stats)   ·          ·
+           │         distinct on            b                     ·          ·
+           └── scan  ·                      ·                     (b)        ·
+·                    estimated row count    1000 (missing stats)  ·          ·
+·                    table                  t@primary             ·          ·
+·                    spans                  FULL SCAN             ·          ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
 ----
-·               distribution           local
-·               vectorized             true
-lookup join     ·                      ·
- │              table                  t@primary
- │              type                   inner
- │              equality               (b) = (a)
- │              equality cols are key  ·
- │              parallel               ·
- └── distinct   ·                      ·
-      │         distinct on            b
-      └── scan  ·                      ·
-·               missing stats          ·
-·               table                  t@primary
-·               spans                  FULL SCAN
-·               locking strength       for update
+·                    distribution           local                 ·          ·
+·                    vectorized             true                  ·          ·
+project              ·                      ·                     (a, b)     ·
+ │                   estimated row count    100 (missing stats)   ·          ·
+ └── lookup join     ·                      ·                     (b, a, b)  ·
+      │              estimated row count    99 (missing stats)    ·          ·
+      │              table                  t@primary             ·          ·
+      │              type                   inner                 ·          ·
+      │              equality               (b) = (a)             ·          ·
+      │              equality cols are key  ·                     ·          ·
+      └── distinct   ·                      ·                     (b)        ·
+           │         estimated row count    100 (missing stats)   ·          ·
+           │         distinct on            b                     ·          ·
+           └── scan  ·                      ·                     (b)        ·
+·                    estimated row count    1000 (missing stats)  ·          ·
+·                    table                  t@primary             ·          ·
+·                    spans                  FULL SCAN             ·          ·
+·                    locking strength       for update            ·          ·
 
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
@@ -647,771 +675,831 @@ lookup join     ·                      ·
 # contain locking clauses are not inlined.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM [SELECT a FROM t] FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [SELECT a FROM t] FOR UPDATE
 ----
-·          distribution   local
-·          vectorized     true
-render     ·              ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+·          distribution         local                 ·    ·
+·          vectorized           true                  ·    ·
+render     ·                    ·                     (a)  ·
+ │         estimated row count  1000 (missing stats)  ·    ·
+ │         render 0             a                     ·    ·
+ └── scan  ·                    ·                     (a)  ·
+·          estimated row count  1000 (missing stats)  ·    ·
+·          table                t@primary             ·    ·
+·          spans                FULL SCAN             ·    ·
 
-query TTT
-EXPLAIN WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
 ----
-·          distribution   local
-·          vectorized     true
-render     ·              ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+·          distribution         local                 ·    ·
+·          vectorized           true                  ·    ·
+render     ·                    ·                     (a)  ·
+ │         estimated row count  1000 (missing stats)  ·    ·
+ │         render 0             a                     ·    ·
+ └── scan  ·                    ·                     (a)  ·
+·          estimated row count  1000 (missing stats)  ·    ·
+·          table                t@primary             ·    ·
+·          spans                FULL SCAN             ·    ·
 
-query TTT
-EXPLAIN SELECT * FROM [SELECT a FROM t FOR UPDATE]
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── scan buffer     ·                 ·
- │                   label             buffer 1
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      SELECT a FROM t FOR UPDATE
-      │              exec mode         all rows
-      └── buffer     ·                 ·
-           │         label             buffer 1
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                       ·    ·
+·                    vectorized           false                       ·    ·
+root                 ·                    ·                           (a)  ·
+ ├── scan buffer     ·                    ·                           (a)  ·
+ │                   estimated row count  1000 (missing stats)        ·    ·
+ │                   label                buffer 1                    ·    ·
+ └── subquery        ·                    ·                           ·    ·
+      │              id                   @S1                         ·    ·
+      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
+      │              exec mode            all rows                    ·    ·
+      └── buffer     ·                    ·                           (a)  ·
+           │         label                buffer 1                    ·    ·
+           └── scan  ·                    ·                           (a)  ·
+·                    estimated row count  1000 (missing stats)        ·    ·
+·                    table                t@primary                   ·    ·
+·                    spans                FULL SCAN                   ·    ·
+·                    locking strength     for update                  ·    ·
 
-query TTT
-EXPLAIN WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
+query TTTTT
+EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
-·                    distribution      local
-·                    vectorized        false
-root                 ·                 ·
- ├── scan buffer     ·                 ·
- │                   label             buffer 1 (cte)
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      SELECT a FROM t FOR UPDATE
-      │              exec mode         all rows
-      └── buffer     ·                 ·
-           │         label             buffer 1 (cte)
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                       ·    ·
+·                    vectorized           false                       ·    ·
+root                 ·                    ·                           (a)  ·
+ ├── scan buffer     ·                    ·                           (a)  ·
+ │                   estimated row count  1000 (missing stats)        ·    ·
+ │                   label                buffer 1 (cte)              ·    ·
+ └── subquery        ·                    ·                           ·    ·
+      │              id                   @S1                         ·    ·
+      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
+      │              exec mode            all rows                    ·    ·
+      └── buffer     ·                    ·                           (a)  ·
+           │         label                buffer 1 (cte)              ·    ·
+           └── scan  ·                    ·                           (a)  ·
+·                    estimated row count  1000 (missing stats)        ·    ·
+·                    table                t@primary                   ·    ·
+·                    spans                FULL SCAN                   ·    ·
+·                    locking strength     for update                  ·    ·
 
 # Verify that the unused CTE doesn't get eliminated.
 # TODO(radu): we should at least not buffer the rows in this case.
-query TTT
-EXPLAIN WITH sfu AS (SELECT a FROM t FOR UPDATE)
+query TTTTT
+EXPLAIN (VERBOSE) WITH sfu AS (SELECT a FROM t FOR UPDATE)
 SELECT c FROM u
 ----
-·                    distribution      local
-·                    vectorized        true
-root                 ·                 ·
- ├── scan            ·                 ·
- │                   missing stats     ·
- │                   table             u@primary
- │                   spans             FULL SCAN
- └── subquery        ·                 ·
-      │              id                @S1
-      │              original sql      SELECT a FROM t FOR UPDATE
-      │              exec mode         all rows
-      └── buffer     ·                 ·
-           │         label             buffer 1 (sfu)
-           └── scan  ·                 ·
-·                    missing stats     ·
-·                    table             t@primary
-·                    spans             FULL SCAN
-·                    locking strength  for update
+·                    distribution         local                       ·    ·
+·                    vectorized           true                        ·    ·
+root                 ·                    ·                           (c)  ·
+ ├── scan            ·                    ·                           (c)  ·
+ │                   estimated row count  1000 (missing stats)        ·    ·
+ │                   table                u@primary                   ·    ·
+ │                   spans                FULL SCAN                   ·    ·
+ └── subquery        ·                    ·                           ·    ·
+      │              id                   @S1                         ·    ·
+      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
+      │              exec mode            all rows                    ·    ·
+      └── buffer     ·                    ·                           (a)  ·
+           │         label                buffer 1 (sfu)              ·    ·
+           └── scan  ·                    ·                           (a)  ·
+·                    estimated row count  1000 (missing stats)        ·    ·
+·                    table                t@primary                   ·    ·
+·                    spans                FULL SCAN                   ·    ·
+·                    locking strength     for update                  ·    ·
 
 # ------------------------------------------------------------------------------
 # Tests with joins.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for share
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for share             ·             ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for share
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for share             ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for no key update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for key share
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for no key update     ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for key share         ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for no key update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for no key update     ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
 # Postgres doesn't support applying locking clauses to joins. The following
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
 # We could do the same, but it's not hard to support these, so we do.
 
-query TTT
-EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
+EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u
+EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u
 
 query error pgcode 42P01 relation "u2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
+EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
 
-query TTT
-EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          type                inner
- │          equality            (a) = (a)
- │          left cols are key   ·
- │          right cols are key  ·
- │          mergeJoinOrder      +"(a=a)"
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               t@primary
- │          spans               FULL SCAN
- │          locking strength    for update
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               u@primary
-·           spans               FULL SCAN
-·           locking strength    for update
+·                distribution         local                 ·             ·
+·                vectorized           true                  ·             ·
+project          ·                    ·                     (a, b, c)     ·
+ │               estimated row count  1000 (missing stats)  ·             ·
+ └── merge join  ·                    ·                     (a, b, a, c)  ·
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          type                 inner                 ·             ·
+      │          equality             (a) = (a)             ·             ·
+      │          left cols are key    ·                     ·             ·
+      │          right cols are key   ·                     ·             ·
+      │          merge ordering       +"(a=a)"              ·             ·
+      ├── scan   ·                    ·                     (a, b)        +a
+      │          estimated row count  1000 (missing stats)  ·             ·
+      │          table                t@primary             ·             ·
+      │          spans                FULL SCAN             ·             ·
+      │          locking strength     for update            ·             ·
+      └── scan   ·                    ·                     (a, c)        +a
+·                estimated row count  1000 (missing stats)  ·             ·
+·                table                u@primary             ·             ·
+·                spans                FULL SCAN             ·             ·
+·                locking strength     for update            ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t, u FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE
 ----
-·           distribution      local
-·           vectorized        true
-cross join  ·                 ·
- │          type              cross
- ├── scan   ·                 ·
- │          missing stats     ·
- │          table             t@primary
- │          spans             FULL SCAN
- │          locking strength  for update
- └── scan   ·                 ·
-·           missing stats     ·
-·           table             u@primary
-·           spans             FULL SCAN
-·           locking strength  for update
+·           distribution         local                    ·             ·
+·           vectorized           true                     ·             ·
+cross join  ·                    ·                        (a, b, a, c)  ·
+ │          estimated row count  1000000 (missing stats)  ·             ·
+ │          type                 cross                    ·             ·
+ ├── scan   ·                    ·                        (a, b)        ·
+ │          estimated row count  1000 (missing stats)     ·             ·
+ │          table                t@primary                ·             ·
+ │          spans                FULL SCAN                ·             ·
+ │          locking strength     for update               ·             ·
+ └── scan   ·                    ·                        (a, c)        ·
+·           estimated row count  1000 (missing stats)     ·             ·
+·           table                u@primary                ·             ·
+·           spans                FULL SCAN                ·             ·
+·           locking strength     for update               ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t, u FOR UPDATE OF t
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE OF t
 ----
-·           distribution      local
-·           vectorized        true
-cross join  ·                 ·
- │          type              cross
- ├── scan   ·                 ·
- │          missing stats     ·
- │          table             t@primary
- │          spans             FULL SCAN
- │          locking strength  for update
- └── scan   ·                 ·
-·           missing stats     ·
-·           table             u@primary
-·           spans             FULL SCAN
+·           distribution         local                    ·             ·
+·           vectorized           true                     ·             ·
+cross join  ·                    ·                        (a, b, a, c)  ·
+ │          estimated row count  1000000 (missing stats)  ·             ·
+ │          type                 cross                    ·             ·
+ ├── scan   ·                    ·                        (a, b)        ·
+ │          estimated row count  1000 (missing stats)     ·             ·
+ │          table                t@primary                ·             ·
+ │          spans                FULL SCAN                ·             ·
+ │          locking strength     for update               ·             ·
+ └── scan   ·                    ·                        (a, c)        ·
+·           estimated row count  1000 (missing stats)     ·             ·
+·           table                u@primary                ·             ·
+·           spans                FULL SCAN                ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
-·           distribution      local
-·           vectorized        true
-cross join  ·                 ·
- │          type              cross
- ├── scan   ·                 ·
- │          missing stats     ·
- │          table             t@primary
- │          spans             FULL SCAN
- │          locking strength  for share
- └── scan   ·                 ·
-·           missing stats     ·
-·           table             u@primary
-·           spans             FULL SCAN
-·           locking strength  for update
+·           distribution         local                    ·             ·
+·           vectorized           true                     ·             ·
+cross join  ·                    ·                        (a, b, a, c)  ·
+ │          estimated row count  1000000 (missing stats)  ·             ·
+ │          type                 cross                    ·             ·
+ ├── scan   ·                    ·                        (a, b)        ·
+ │          estimated row count  1000 (missing stats)     ·             ·
+ │          table                t@primary                ·             ·
+ │          spans                FULL SCAN                ·             ·
+ │          locking strength     for share                ·             ·
+ └── scan   ·                    ·                        (a, c)        ·
+·           estimated row count  1000 (missing stats)     ·             ·
+·           table                u@primary                ·             ·
+·           spans                FULL SCAN                ·             ·
+·           locking strength     for update               ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
-·           distribution      local
-·           vectorized        true
-cross join  ·                 ·
- │          type              cross
- ├── scan   ·                 ·
- │          missing stats     ·
- │          table             t@primary
- │          spans             FULL SCAN
- │          locking strength  for update
- └── scan   ·                 ·
-·           missing stats     ·
-·           table             u@primary
-·           spans             FULL SCAN
-·           locking strength  for update
+·           distribution         local                    ·             ·
+·           vectorized           true                     ·             ·
+cross join  ·                    ·                        (a, b, a, c)  ·
+ │          estimated row count  1000000 (missing stats)  ·             ·
+ │          type                 cross                    ·             ·
+ ├── scan   ·                    ·                        (a, b)        ·
+ │          estimated row count  1000 (missing stats)     ·             ·
+ │          table                t@primary                ·             ·
+ │          spans                FULL SCAN                ·             ·
+ │          locking strength     for update               ·             ·
+ └── scan   ·                    ·                        (a, c)        ·
+·           estimated row count  1000 (missing stats)     ·             ·
+·           table                u@primary                ·             ·
+·           spans                FULL SCAN                ·             ·
+·           locking strength     for update               ·             ·
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
+EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
 
-query TTT
-EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
-·           distribution      local
-·           vectorized        true
-cross join  ·                 ·
- │          type              cross
- ├── scan   ·                 ·
- │          missing stats     ·
- │          table             t@primary
- │          spans             FULL SCAN
- └── scan   ·                 ·
-·           missing stats     ·
-·           table             u@primary
-·           spans             FULL SCAN
-·           locking strength  for update
+·           distribution         local                    ·             ·
+·           vectorized           true                     ·             ·
+cross join  ·                    ·                        (a, b, a, c)  ·
+ │          estimated row count  1000000 (missing stats)  ·             ·
+ │          type                 cross                    ·             ·
+ ├── scan   ·                    ·                        (a, b)        ·
+ │          estimated row count  1000 (missing stats)     ·             ·
+ │          table                t@primary                ·             ·
+ │          spans                FULL SCAN                ·             ·
+ └── scan   ·                    ·                        (a, c)        ·
+·           estimated row count  1000 (missing stats)     ·             ·
+·           table                u@primary                ·             ·
+·           spans                FULL SCAN                ·             ·
+·           locking strength     for update               ·             ·
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.
 # ------------------------------------------------------------------------------
 
-query TTT
-EXPLAIN SELECT * FROM t FOR UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR NO KEY UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for no key update
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for no key update     ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for share
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for share             ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for key share
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for key share         ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for share
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for share             ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for no key update
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for no key update     ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
+·     locking wait policy  nowait                ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t FOR UPDATE OF t NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                FULL SCAN
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local                 ·       ·
+·     vectorized           true                  ·       ·
+scan  ·                    ·                     (a, b)  ·
+·     estimated row count  1000 (missing stats)  ·       ·
+·     table                t@primary             ·       ·
+·     spans                FULL SCAN             ·       ·
+·     locking strength     for update            ·       ·
+·     locking wait policy  nowait                ·       ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t FOR UPDATE OF t2 NOWAIT
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 NOWAIT
 
-query TTT
-EXPLAIN SELECT 1 FROM t FOR UPDATE OF t NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t NOWAIT
 ----
-·          distribution         local
-·          vectorized           true
-render     ·                    ·
- └── scan  ·                    ·
-·          missing stats        ·
-·          table                t@primary
-·          spans                FULL SCAN
-·          locking strength     for update
-·          locking wait policy  nowait
+·          distribution         local                 ·             ·
+·          vectorized           true                  ·             ·
+render     ·                    ·                     ("?column?")  ·
+ │         estimated row count  1000 (missing stats)  ·             ·
+ │         render 0             1                     ·             ·
+ └── scan  ·                    ·                     ()            ·
+·          estimated row count  1000 (missing stats)  ·             ·
+·          table                t@primary             ·             ·
+·          spans                FULL SCAN             ·             ·
+·          locking strength     for update            ·             ·
+·          locking wait policy  nowait                ·             ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for no key update
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for no key update  ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for share
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for share          ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for key share
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for key share      ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for share
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for share          ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for no key update
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for no key update  ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
+·     locking wait policy  nowait             ·       ·
 
-query TTT
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
 ----
-·     distribution         local
-·     vectorized           true
-scan  ·                    ·
-·     missing stats        ·
-·     table                t@primary
-·     spans                [/1 - /1]
-·     locking strength     for update
-·     locking wait policy  nowait
+·     distribution         local              ·       ·
+·     vectorized           true               ·       ·
+scan  ·                    ·                  (a, b)  ·
+·     estimated row count  1 (missing stats)  ·       ·
+·     table                t@primary          ·       ·
+·     spans                /1-/1/#            ·       ·
+·     locking strength     for update         ·       ·
+·     locking wait policy  nowait             ·       ·
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
-EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
 
-query TTT
-EXPLAIN SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
 ----
-·          distribution         local
-·          vectorized           true
-render     ·                    ·
- └── scan  ·                    ·
-·          missing stats        ·
-·          table                t@primary
-·          spans                [/1 - /1]
-·          locking strength     for update
-·          locking wait policy  nowait
+·          distribution         local              ·             ·
+·          vectorized           true               ·             ·
+render     ·                    ·                  ("?column?")  ·
+ │         estimated row count  1 (missing stats)  ·             ·
+ │         render 0             1                  ·             ·
+ └── scan  ·                    ·                  (a)           ·
+·          estimated row count  1 (missing stats)  ·             ·
+·          table                t@primary          ·             ·
+·          spans                /1-/1/#            ·             ·
+·          locking strength     for update         ·             ·
+·          locking wait policy  nowait             ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -203,7 +203,7 @@ project               ·                    ·                    (b, a, c, d, a
       │               estimated row count  100 (missing stats)  ·                         ·
       │               type                 inner                ·                         ·
       │               equality             (b) = (b)            ·                         ·
-      │               mergeJoinOrder       +"(b=b)"             ·                         ·
+      │               merge ordering       +"(b=b)"             ·                         ·
       ├── index join  ·                    ·                    (a, b, c, d)              ·
       │    │          estimated row count  10 (missing stats)   ·                         ·
       │    │          table                t@primary            ·                         ·
@@ -818,7 +818,6 @@ ORDER BY total DESC
 sort            ·              ·
  │              order          -count_rows
  └── group      ·              ·
-      │         aggregate 0    count_rows()
       │         group by       resource_key
       └── scan  ·              ·
 ·               missing stats  ·
@@ -1122,7 +1121,6 @@ EXPLAIN SELECT * FROM noncover WHERE b = 2
 ·           vectorized     true
 index join  ·              ·
  │          table          noncover@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          noncover@b
@@ -1150,7 +1148,6 @@ EXPLAIN SELECT * FROM noncover WHERE c = 6
 ·           vectorized     true
 index join  ·              ·
  │          table          noncover@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          noncover@c
@@ -1238,7 +1235,6 @@ EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ·           vectorized     true
 index join  ·              ·
  │          table          noncover@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          noncover@c
@@ -1610,18 +1606,17 @@ scan  ·              ·
 query TTT
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             t4
- │              set               c
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             t4@primary
-·               spans             [/10/20 - /10/20]
-·               locking strength  for update
+·               distribution   local
+·               vectorized     false
+update          ·              ·
+ │              table          t4
+ │              set            c
+ │              auto commit    ·
+ └── render     ·              ·
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          t4@primary
+·               spans          [/10/20 - /10/20]
 
 # Optimization should not be applied for deletes.
 query TTT
@@ -1644,7 +1639,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t4@primary
 ·     spans          [/10/20 - /10/21]
-·     parallel       ·
 
 # Optimization should not be applied for partial primary key filter.
 query TTT
@@ -1668,4 +1662,3 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t4@primary
 ·     spans          [/1/1 - /1/1] [/1/5 - /1/5] [/5/1 - /5/1] [/5/5 - /5/5]
-·     parallel       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -195,31 +195,30 @@ output row: [2]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t x JOIN t y USING(b) WHERE x.b = '3'
 ----
-·                     distribution         local                ·                         ·
-·                     vectorized           true                 ·                         ·
-project               ·                    ·                    (b, a, c, d, a, c, d)     ·
- │                    estimated row count  100 (missing stats)  ·                         ·
- └── merge join       ·                    ·                    (a, b, c, d, a, b, c, d)  ·
-      │               estimated row count  100 (missing stats)  ·                         ·
-      │               type                 inner                ·                         ·
-      │               equality             (b) = (b)            ·                         ·
-      │               merge ordering       +"(b=b)"             ·                         ·
-      ├── index join  ·                    ·                    (a, b, c, d)              ·
-      │    │          estimated row count  10 (missing stats)   ·                         ·
-      │    │          table                t@primary            ·                         ·
-      │    │          key columns          a, b                 ·                         ·
-      │    └── scan   ·                    ·                    (a, b, c)                 ·
-      │               estimated row count  10 (missing stats)   ·                         ·
-      │               table                t@bc                 ·                         ·
-      │               spans                /"3"-/"3"/PrefixEnd  ·                         ·
-      └── index join  ·                    ·                    (a, b, c, d)              ·
-           │          estimated row count  10 (missing stats)   ·                         ·
-           │          table                t@primary            ·                         ·
-           │          key columns          a, b                 ·                         ·
-           └── scan   ·                    ·                    (a, b, c)                 ·
-·                     estimated row count  10 (missing stats)   ·                         ·
-·                     table                t@bc                 ·                         ·
-·                     spans                /"3"-/"3"/PrefixEnd  ·                         ·
+·                        distribution         local                ·                         ·
+·                        vectorized           true                 ·                         ·
+project                  ·                    ·                    (b, a, c, d, a, c, d)     ·
+ │                       estimated row count  100 (missing stats)  ·                         ·
+ └── merge join (inner)  ·                    ·                    (a, b, c, d, a, b, c, d)  ·
+      │                  estimated row count  100 (missing stats)  ·                         ·
+      │                  equality             (b) = (b)            ·                         ·
+      │                  merge ordering       +"(b=b)"             ·                         ·
+      ├── index join     ·                    ·                    (a, b, c, d)              ·
+      │    │             estimated row count  10 (missing stats)   ·                         ·
+      │    │             table                t@primary            ·                         ·
+      │    │             key columns          a, b                 ·                         ·
+      │    └── scan      ·                    ·                    (a, b, c)                 ·
+      │                  estimated row count  10 (missing stats)   ·                         ·
+      │                  table                t@bc                 ·                         ·
+      │                  spans                /"3"-/"3"/PrefixEnd  ·                         ·
+      └── index join     ·                    ·                    (a, b, c, d)              ·
+           │             estimated row count  10 (missing stats)   ·                         ·
+           │             table                t@primary            ·                         ·
+           │             key columns          a, b                 ·                         ·
+           └── scan      ·                    ·                    (a, b, c)                 ·
+·                        estimated row count  10 (missing stats)   ·                         ·
+·                        table                t@bc                 ·                         ·
+·                        spans                /"3"-/"3"/PrefixEnd  ·                         ·
 
 statement ok
 TRUNCATE TABLE t

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -21,7 +21,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          abcd@primary
 ·     spans          [/20 - /30]
-·     parallel       ·
 
 # No hint, reverse scan.
 query TTT
@@ -33,7 +32,6 @@ revscan  ·              ·
 ·        missing stats  ·
 ·        table          abcd@primary
 ·        spans          [/20 - /30]
-·        parallel       ·
 
 # Force primary
 query TTT
@@ -45,7 +43,6 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          abcd@primary
 ·     spans          [/20 - /30]
-·     parallel       ·
 
 # Force primary, reverse scan.
 query TTT
@@ -57,7 +54,6 @@ revscan  ·              ·
 ·        missing stats  ·
 ·        table          abcd@primary
 ·        spans          [/20 - /30]
-·        parallel       ·
 
 # Force primary, allow reverse scan.
 query TTT
@@ -69,7 +65,6 @@ revscan  ·              ·
 ·        missing stats  ·
 ·        table          abcd@primary
 ·        spans          [/20 - /30]
-·        parallel       ·
 
 # Force primary, forward scan.
 query TTT
@@ -83,7 +78,6 @@ sort       ·              ·
 ·          missing stats  ·
 ·          table          abcd@primary
 ·          spans          [/20 - /30]
-·          parallel       ·
 
 # Force index b
 query TTT
@@ -95,7 +89,6 @@ filter           ·              ·
  │               filter         (a >= 20) AND (a <= 30)
  └── index join  ·              ·
       │          table          abcd@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          abcd@b
@@ -111,7 +104,6 @@ filter             ·              ·
  │                 filter         (a >= 20) AND (a <= 30)
  └── index join    ·              ·
       │            table          abcd@primary
-      │            key columns    a
       └── revscan  ·              ·
 ·                  missing stats  ·
 ·                  table          abcd@b
@@ -125,7 +117,6 @@ EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ·             vectorized     true
 index join    ·              ·
  │            table          abcd@primary
- │            key columns    a
  └── revscan  ·              ·
 ·             missing stats  ·
 ·             table          abcd@b
@@ -140,7 +131,6 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ·             vectorized     true
 index join    ·              ·
  │            table          abcd@primary
- │            key columns    a
  └── revscan  ·              ·
 ·             missing stats  ·
 ·             table          abcd@b
@@ -156,7 +146,6 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ·                    vectorized     true
 index join           ·              ·
  │                   table          abcd@primary
- │                   key columns    a
  └── limit           ·              ·
       │              count          5
       └── sort       ·              ·
@@ -176,7 +165,6 @@ filter           ·              ·
  │               filter         (a >= 20) AND (a <= 30)
  └── index join  ·              ·
       │          table          abcd@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          abcd@cd
@@ -218,7 +206,6 @@ filter           ·              ·
  │               filter         (c >= 20) AND (c <= 30)
  └── index join  ·              ·
       │          table          abcd@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          abcd@b
@@ -258,7 +245,6 @@ filter           ·              ·
  │               filter         (c >= 20) AND (c < 40)
  └── index join  ·              ·
       │          table          abcd@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          abcd@b
@@ -273,7 +259,6 @@ filter           ·              ·
  │               filter         (a >= 20) AND (a <= 30)
  └── index join  ·              ·
       │          table          abcd@primary
-      │          key columns    a
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          abcd@b
@@ -286,7 +271,6 @@ EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ·           vectorized     true
 index join  ·              ·
  │          table          abcd@primary
- │          key columns    a
  └── scan   ·              ·
 ·           missing stats  ·
 ·           table          abcd@cd

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -60,28 +60,27 @@ query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                              distribution      local
-·                              vectorized        false
-root                           ·                 ·
- ├── limit                     ·                 ·
- │    │                        count             1
- │    └── scan buffer          ·                 ·
- │                             label             buffer 1 (a)
- └── subquery                  ·                 ·
-      │                        id                @S1
-      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode         all rows
-      └── buffer               ·                 ·
-           │                   label             buffer 1 (a)
-           └── update          ·                 ·
-                │              table             t
-                │              set               x
-                └── render     ·                 ·
-                     └── scan  ·                 ·
-·                              missing stats     ·
-·                              table             t@primary
-·                              spans             FULL SCAN
-·                              locking strength  for update
+·                              distribution   local
+·                              vectorized     false
+root                           ·              ·
+ ├── limit                     ·              ·
+ │    │                        count          1
+ │    └── scan buffer          ·              ·
+ │                             label          buffer 1 (a)
+ └── subquery                  ·              ·
+      │                        id             @S1
+      │                        original sql   UPDATE t SET x = x + 1 RETURNING x
+      │                        exec mode      all rows
+      └── buffer               ·              ·
+           │                   label          buffer 1 (a)
+           └── update          ·              ·
+                │              table          t
+                │              set            x
+                └── render     ·              ·
+                     └── scan  ·              ·
+·                              missing stats  ·
+·                              table          t@primary
+·                              spans          FULL SCAN
 
 query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
@@ -155,28 +154,27 @@ root                      ·              ·
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-·                              distribution      local
-·                              vectorized        false
-root                           ·                 ·
- ├── limit                     ·                 ·
- │    │                        count             1
- │    └── scan buffer          ·                 ·
- │                             label             buffer 1
- └── subquery                  ·                 ·
-      │                        id                @S1
-      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode         all rows
-      └── buffer               ·                 ·
-           │                   label             buffer 1
-           └── update          ·                 ·
-                │              table             t
-                │              set               x
-                └── render     ·                 ·
-                     └── scan  ·                 ·
-·                              missing stats     ·
-·                              table             t@primary
-·                              spans             FULL SCAN
-·                              locking strength  for update
+·                              distribution   local
+·                              vectorized     false
+root                           ·              ·
+ ├── limit                     ·              ·
+ │    │                        count          1
+ │    └── scan buffer          ·              ·
+ │                             label          buffer 1
+ └── subquery                  ·              ·
+      │                        id             @S1
+      │                        original sql   UPDATE t SET x = x + 1 RETURNING x
+      │                        exec mode      all rows
+      └── buffer               ·              ·
+           │                   label          buffer 1
+           └── update          ·              ·
+                │              table          t
+                │              set            x
+                └── render     ·              ·
+                     └── scan  ·              ·
+·                              missing stats  ·
+·                              table          t@primary
+·                              spans          FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
@@ -207,7 +205,6 @@ EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ·                         vectorized     false
 root                      ·              ·
  ├── group                ·              ·
- │    │                   aggregate 0    count_rows()
  │    │                   scalar         ·
  │    └── scan buffer     ·              ·
  │                        label          buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -204,8 +204,7 @@ EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ·                         distribution   local
 ·                         vectorized     false
 root                      ·              ·
- ├── group                ·              ·
- │    │                   scalar         ·
+ ├── group (scalar)       ·              ·
  │    └── scan buffer     ·              ·
  │                        label          buffer 1
  └── subquery             ·              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -228,7 +228,6 @@ EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ·                         vectorized     false
 root                      ·              ·
  ├── cross join           ·              ·
- │    │                   type           cross
  │    ├── scan buffer     ·              ·
  │    │                   label          buffer 1
  │    └── scan            ·              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -350,7 +350,7 @@ project                     ·                    ·                            
  └── project set            ·                    ·                              (a, a, generate_series)   ·
       │                     estimated row count  10                             ·                         ·
       │                     render 0             generate_series(a + 1, a + 1)  ·                         ·
-      └── union             ·                    ·                              (a, a)                    ·
+      └── except all        ·                    ·                              (a, a)                    ·
            │                estimated row count  1                              ·                         ·
            ├── project      ·                    ·                              (a, a)                    ·
            │    └── values  ·                    ·                              (a)                       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -16,7 +16,6 @@ EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ·                   distribution  local
 ·                   vectorized    true
 cross join          ·             ·
- │                  type          cross
  ├── project set    ·             ·
  │    └── emptyrow  ·             ·
  └── project set    ·             ·
@@ -58,27 +57,25 @@ CREATE TABLE u (b string)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-·                   distribution         local                     ·                                         ·
-·                   vectorized           true                      ·                                         ·
-cross join          ·                    ·                         (a, b, generate_series, generate_series)  ·
- │                  estimated row count  10000000 (missing stats)  ·                                         ·
- │                  type                 cross                     ·                                         ·
- ├── cross join     ·                    ·                         (a, b)                                    ·
- │    │             estimated row count  1000000 (missing stats)   ·                                         ·
- │    │             type                 cross                     ·                                         ·
- │    ├── scan      ·                    ·                         (a)                                       ·
- │    │             estimated row count  1000 (missing stats)      ·                                         ·
- │    │             table                t@primary                 ·                                         ·
- │    │             spans                FULL SCAN                 ·                                         ·
- │    └── scan      ·                    ·                         (b)                                       ·
- │                  estimated row count  1000 (missing stats)      ·                                         ·
- │                  table                u@primary                 ·                                         ·
- │                  spans                FULL SCAN                 ·                                         ·
- └── project set    ·                    ·                         (generate_series, generate_series)        ·
-      │             estimated row count  10                        ·                                         ·
-      │             render 0             generate_series(1, 2)     ·                                         ·
-      │             render 1             generate_series(3, 4)     ·                                         ·
-      └── emptyrow  ·                    ·                         ()                                        ·
+·                        distribution         local                     ·                                         ·
+·                        vectorized           true                      ·                                         ·
+cross join (inner)       ·                    ·                         (a, b, generate_series, generate_series)  ·
+ │                       estimated row count  10000000 (missing stats)  ·                                         ·
+ ├── cross join (inner)  ·                    ·                         (a, b)                                    ·
+ │    │                  estimated row count  1000000 (missing stats)   ·                                         ·
+ │    ├── scan           ·                    ·                         (a)                                       ·
+ │    │                  estimated row count  1000 (missing stats)      ·                                         ·
+ │    │                  table                t@primary                 ·                                         ·
+ │    │                  spans                FULL SCAN                 ·                                         ·
+ │    └── scan           ·                    ·                         (b)                                       ·
+ │                       estimated row count  1000 (missing stats)      ·                                         ·
+ │                       table                u@primary                 ·                                         ·
+ │                       spans                FULL SCAN                 ·                                         ·
+ └── project set         ·                    ·                         (generate_series, generate_series)        ·
+      │                  estimated row count  10                        ·                                         ·
+      │                  render 0             generate_series(1, 2)     ·                                         ·
+      │                  render 1             generate_series(3, 4)     ·                                         ·
+      └── emptyrow       ·                    ·                         ()                                        ·
 
 subtest correlated_SRFs
 
@@ -111,122 +108,118 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
   FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
 ----
-·                          distribution         local                                               ·                                                ·
-·                          vectorized           true                                                ·                                                ·
-sort                       ·                    ·                                                   (x, y, z, "information_schema._pg_expandarray")  +x
- │                         estimated row count  3267 (missing stats)                                ·                                                ·
- │                         order                +x                                                  ·                                                ·
- └── render                ·                    ·                                                   ("information_schema._pg_expandarray", x, y, z)  ·
-      │                    estimated row count  3267 (missing stats)                                ·                                                ·
-      │                    render 0             ((x, n) AS x, n)                                    ·                                                ·
-      │                    render 1             x                                                   ·                                                ·
-      │                    render 2             y                                                   ·                                                ·
-      │                    render 3             z                                                   ·                                                ·
-      └── project set      ·                    ·                                                   (x, y, x, z, x, n)                               ·
-           │               estimated row count  3267 (missing stats)                                ·                                                ·
-           │               render 0             information_schema._pg_expandarray(ARRAY[x, y, z])  ·                                                ·
-           └── merge join  ·                    ·                                                   (x, y, x, z)                                     ·
-                │          estimated row count  327 (missing stats)                                 ·                                                ·
-                │          type                 inner                                               ·                                                ·
-                │          equality             (x) = (x)                                           ·                                                ·
-                │          left cols are key    ·                                                   ·                                                ·
-                │          right cols are key   ·                                                   ·                                                ·
-                │          pred                 y < z                                               ·                                                ·
-                │          merge ordering       +"(x=x)"                                            ·                                                ·
-                ├── scan   ·                    ·                                                   (x, y)                                           +x
-                │          estimated row count  1000 (missing stats)                                ·                                                ·
-                │          table                xy@primary                                          ·                                                ·
-                │          spans                FULL SCAN                                           ·                                                ·
-                └── scan   ·                    ·                                                   (x, z)                                           +x
-·                          estimated row count  1000 (missing stats)                                ·                                                ·
-·                          table                xz@primary                                          ·                                                ·
-·                          spans                FULL SCAN                                           ·                                                ·
+·                                  distribution         local                                               ·                                                ·
+·                                  vectorized           true                                                ·                                                ·
+sort                               ·                    ·                                                   (x, y, z, "information_schema._pg_expandarray")  +x
+ │                                 estimated row count  3267 (missing stats)                                ·                                                ·
+ │                                 order                +x                                                  ·                                                ·
+ └── render                        ·                    ·                                                   ("information_schema._pg_expandarray", x, y, z)  ·
+      │                            estimated row count  3267 (missing stats)                                ·                                                ·
+      │                            render 0             ((x, n) AS x, n)                                    ·                                                ·
+      │                            render 1             x                                                   ·                                                ·
+      │                            render 2             y                                                   ·                                                ·
+      │                            render 3             z                                                   ·                                                ·
+      └── project set              ·                    ·                                                   (x, y, x, z, x, n)                               ·
+           │                       estimated row count  3267 (missing stats)                                ·                                                ·
+           │                       render 0             information_schema._pg_expandarray(ARRAY[x, y, z])  ·                                                ·
+           └── merge join (inner)  ·                    ·                                                   (x, y, x, z)                                     ·
+                │                  estimated row count  327 (missing stats)                                 ·                                                ·
+                │                  equality             (x) = (x)                                           ·                                                ·
+                │                  left cols are key    ·                                                   ·                                                ·
+                │                  right cols are key   ·                                                   ·                                                ·
+                │                  pred                 y < z                                               ·                                                ·
+                │                  merge ordering       +"(x=x)"                                            ·                                                ·
+                ├── scan           ·                    ·                                                   (x, y)                                           +x
+                │                  estimated row count  1000 (missing stats)                                ·                                                ·
+                │                  table                xy@primary                                          ·                                                ·
+                │                  spans                FULL SCAN                                           ·                                                ·
+                └── scan           ·                    ·                                                   (x, z)                                           +x
+·                                  estimated row count  1000 (missing stats)                                ·                                                ·
+·                                  table                xz@primary                                          ·                                                ·
+·                                  spans                FULL SCAN                                           ·                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
 ----
-·                           distribution         local                  ·                        ·
-·                           vectorized           true                   ·                        ·
-project                     ·                    ·                      (generate_series)        ·
- │                          estimated row count  3333 (missing stats)   ·                        ·
- └── project set            ·                    ·                      (x, z, generate_series)  ·
-      │                     estimated row count  3333 (missing stats)   ·                        ·
-      │                     render 0             generate_series(x, z)  ·                        ·
-      └── cross join        ·                    ·                      (x, z)                   ·
-           │                estimated row count  333 (missing stats)    ·                        ·
-           │                type                 semi                   ·                        ·
-           │                pred                 z < generate_series    ·                        ·
-           ├── scan         ·                    ·                      (x, z)                   ·
-           │                estimated row count  1000 (missing stats)   ·                        ·
-           │                table                xz@primary             ·                        ·
-           │                spans                FULL SCAN              ·                        ·
-           └── project set  ·                    ·                      (x, y, generate_series)  ·
-                │           estimated row count  10000 (missing stats)  ·                        ·
-                │           render 0             generate_series(x, y)  ·                        ·
-                └── scan    ·                    ·                      (x, y)                   ·
-·                           estimated row count  1000 (missing stats)   ·                        ·
-·                           table                xy@primary             ·                        ·
-·                           spans                FULL SCAN              ·                        ·
+·                            distribution         local                  ·                        ·
+·                            vectorized           true                   ·                        ·
+project                      ·                    ·                      (generate_series)        ·
+ │                           estimated row count  3333 (missing stats)   ·                        ·
+ └── project set             ·                    ·                      (x, z, generate_series)  ·
+      │                      estimated row count  3333 (missing stats)   ·                        ·
+      │                      render 0             generate_series(x, z)  ·                        ·
+      └── cross join (semi)  ·                    ·                      (x, z)                   ·
+           │                 estimated row count  333 (missing stats)    ·                        ·
+           │                 pred                 z < generate_series    ·                        ·
+           ├── scan          ·                    ·                      (x, z)                   ·
+           │                 estimated row count  1000 (missing stats)   ·                        ·
+           │                 table                xz@primary             ·                        ·
+           │                 spans                FULL SCAN              ·                        ·
+           └── project set   ·                    ·                      (x, y, generate_series)  ·
+                │            estimated row count  10000 (missing stats)  ·                        ·
+                │            render 0             generate_series(x, y)  ·                        ·
+                └── scan     ·                    ·                      (x, y)                   ·
+·                            estimated row count  1000 (missing stats)   ·                        ·
+·                            table                xy@primary             ·                        ·
+·                            spans                FULL SCAN              ·                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
   FROM xy NATURAL LEFT OUTER JOIN xz
 ----
-·                     distribution         local                                   ·                                                           ·
-·                     vectorized           true                                    ·                                                           ·
-project               ·                    ·                                       (generate_subscripts, generate_series, unnest, y, z)        ·
- │                    estimated row count  10000 (missing stats)                   ·                                                           ·
- └── project set      ·                    ·                                       (x, y, x, z, generate_subscripts, generate_series, unnest)  ·
-      │               estimated row count  10000 (missing stats)                   ·                                                           ·
-      │               render 0             generate_subscripts(ARRAY[0, x, 1, 2])  ·                                                           ·
-      │               render 1             generate_series(x, y)                   ·                                                           ·
-      │               render 2             unnest(ARRAY[0, x, y, z])               ·                                                           ·
-      └── merge join  ·                    ·                                       (x, y, x, z)                                                ·
-           │          estimated row count  1000 (missing stats)                    ·                                                           ·
-           │          type                 left outer                              ·                                                           ·
-           │          equality             (x) = (x)                               ·                                                           ·
-           │          left cols are key    ·                                       ·                                                           ·
-           │          right cols are key   ·                                       ·                                                           ·
-           │          merge ordering       +"(x=x)"                                ·                                                           ·
-           ├── scan   ·                    ·                                       (x, y)                                                      +x
-           │          estimated row count  1000 (missing stats)                    ·                                                           ·
-           │          table                xy@primary                              ·                                                           ·
-           │          spans                FULL SCAN                               ·                                                           ·
-           └── scan   ·                    ·                                       (x, z)                                                      +x
-·                     estimated row count  1000 (missing stats)                    ·                                                           ·
-·                     table                xz@primary                              ·                                                           ·
-·                     spans                FULL SCAN                               ·                                                           ·
+·                                  distribution         local                                   ·                                                           ·
+·                                  vectorized           true                                    ·                                                           ·
+project                            ·                    ·                                       (generate_subscripts, generate_series, unnest, y, z)        ·
+ │                                 estimated row count  10000 (missing stats)                   ·                                                           ·
+ └── project set                   ·                    ·                                       (x, y, x, z, generate_subscripts, generate_series, unnest)  ·
+      │                            estimated row count  10000 (missing stats)                   ·                                                           ·
+      │                            render 0             generate_subscripts(ARRAY[0, x, 1, 2])  ·                                                           ·
+      │                            render 1             generate_series(x, y)                   ·                                                           ·
+      │                            render 2             unnest(ARRAY[0, x, y, z])               ·                                                           ·
+      └── merge join (left outer)  ·                    ·                                       (x, y, x, z)                                                ·
+           │                       estimated row count  1000 (missing stats)                    ·                                                           ·
+           │                       equality             (x) = (x)                               ·                                                           ·
+           │                       left cols are key    ·                                       ·                                                           ·
+           │                       right cols are key   ·                                       ·                                                           ·
+           │                       merge ordering       +"(x=x)"                                ·                                                           ·
+           ├── scan                ·                    ·                                       (x, y)                                                      +x
+           │                       estimated row count  1000 (missing stats)                    ·                                                           ·
+           │                       table                xy@primary                              ·                                                           ·
+           │                       spans                FULL SCAN                               ·                                                           ·
+           └── scan                ·                    ·                                       (x, z)                                                      +x
+·                                  estimated row count  1000 (missing stats)                    ·                                                           ·
+·                                  table                xz@primary                              ·                                                           ·
+·                                  spans                FULL SCAN                               ·                                                           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-·                               distribution         local                                 ·                     ·
-·                               vectorized           true                                  ·                     ·
-root                            ·                    ·                                     (generate_series)     ·
- ├── project                    ·                    ·                                     (generate_series)     ·
- │    │                         estimated row count  10000 (missing stats)                 ·                     ·
- │    └── project set           ·                    ·                                     (z, generate_series)  ·
- │         │                    estimated row count  10000 (missing stats)                 ·                     ·
- │         │                    render 0             generate_series(@S1, z)               ·                     ·
- │         └── scan             ·                    ·                                     (z)                   ·
- │                              estimated row count  1000 (missing stats)                  ·                     ·
- │                              table                xz@primary                            ·                     ·
- │                              spans                FULL SCAN                             ·                     ·
- └── subquery                   ·                    ·                                     ·                     ·
-      │                         id                   @S1                                   ·                     ·
-      │                         original sql         (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
-      │                         exec mode            one row                               ·                     ·
-      └── max1row               ·                    ·                                     (unnest)              ·
-           │                    estimated row count  1                                     ·                     ·
-           └── project          ·                    ·                                     (unnest)              ·
-                │               estimated row count  2000 (missing stats)                  ·                     ·
-                └── apply join  ·                    ·                                     (x, y, unnest)        ·
-                     │          estimated row count  2000 (missing stats)                  ·                     ·
-                     │          type                 cross                                 ·                     ·
-                     └── scan   ·                    ·                                     (x, y)                ·
-·                               estimated row count  1000 (missing stats)                  ·                     ·
-·                               table                xy@primary                            ·                     ·
-·                               spans                FULL SCAN                             ·                     ·
+·                                       distribution         local                                 ·                     ·
+·                                       vectorized           true                                  ·                     ·
+root                                    ·                    ·                                     (generate_series)     ·
+ ├── project                            ·                    ·                                     (generate_series)     ·
+ │    │                                 estimated row count  10000 (missing stats)                 ·                     ·
+ │    └── project set                   ·                    ·                                     (z, generate_series)  ·
+ │         │                            estimated row count  10000 (missing stats)                 ·                     ·
+ │         │                            render 0             generate_series(@S1, z)               ·                     ·
+ │         └── scan                     ·                    ·                                     (z)                   ·
+ │                                      estimated row count  1000 (missing stats)                  ·                     ·
+ │                                      table                xz@primary                            ·                     ·
+ │                                      spans                FULL SCAN                             ·                     ·
+ └── subquery                           ·                    ·                                     ·                     ·
+      │                                 id                   @S1                                   ·                     ·
+      │                                 original sql         (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
+      │                                 exec mode            one row                               ·                     ·
+      └── max1row                       ·                    ·                                     (unnest)              ·
+           │                            estimated row count  1                                     ·                     ·
+           └── project                  ·                    ·                                     (unnest)              ·
+                │                       estimated row count  2000 (missing stats)                  ·                     ·
+                └── apply join (inner)  ·                    ·                                     (x, y, unnest)        ·
+                     │                  estimated row count  2000 (missing stats)                  ·                     ·
+                     └── scan           ·                    ·                                     (x, y)                ·
+·                                       estimated row count  1000 (missing stats)                  ·                     ·
+·                                       table                xy@primary                            ·                     ·
+·                                       spans                FULL SCAN                             ·                     ·
 
 # Regression test for #24676.
 statement ok
@@ -243,41 +236,40 @@ EXPLAIN (VERBOSE) SELECT
 FROM
   groups g
 ----
-·                                   distribution         local                             ·                                             ·
-·                                   vectorized           true                              ·                                             ·
-render                              ·                    ·                                 (group_name, jsonb_array_elements)            ·
- │                                  estimated row count  100000 (missing stats)            ·                                             ·
- │                                  render 0             data->>'name'                     ·                                             ·
- │                                  render 1             jsonb_array_elements              ·                                             ·
- └── project set                    ·                    ·                                 (id, data, "?column?", jsonb_array_elements)  ·
-      │                             estimated row count  100000 (missing stats)            ·                                             ·
-      │                             render 0             jsonb_array_elements("?column?")  ·                                             ·
-      └── distinct                  ·                    ·                                 (id, data, "?column?")                        ·
-           │                        estimated row count  10000 (missing stats)             ·                                             ·
-           │                        distinct on          id                                ·                                             ·
-           │                        error on duplicate   ·                                 ·                                             ·
-           └── project              ·                    ·                                 (id, data, "?column?")                        ·
-                └── hash join       ·                    ·                                 (column10, id, data, column11, "?column?")    ·
-                     │              estimated row count  10000 (missing stats)             ·                                             ·
-                     │              type                 left outer                        ·                                             ·
-                     │              equality             (column10) = (column11)           ·                                             ·
-                     ├── render     ·                    ·                                 (column10, id, data)                          ·
-                     │    │         estimated row count  1000 (missing stats)              ·                                             ·
-                     │    │         render 0             data->>'name'                     ·                                             ·
-                     │    │         render 1             id                                ·                                             ·
-                     │    │         render 2             data                              ·                                             ·
-                     │    └── scan  ·                    ·                                 (id, data)                                    ·
-                     │              estimated row count  1000 (missing stats)              ·                                             ·
-                     │              table                groups@primary                    ·                                             ·
-                     │              spans                FULL SCAN                         ·                                             ·
-                     └── render     ·                    ·                                 (column11, "?column?")                        ·
-                          │         estimated row count  1000 (missing stats)              ·                                             ·
-                          │         render 0             data->>'name'                     ·                                             ·
-                          │         render 1             data->'members'                   ·                                             ·
-                          └── scan  ·                    ·                                 (data)                                        ·
-·                                   estimated row count  1000 (missing stats)              ·                                             ·
-·                                   table                groups@primary                    ·                                             ·
-·                                   spans                FULL SCAN                         ·                                             ·
+·                                           distribution         local                             ·                                             ·
+·                                           vectorized           true                              ·                                             ·
+render                                      ·                    ·                                 (group_name, jsonb_array_elements)            ·
+ │                                          estimated row count  100000 (missing stats)            ·                                             ·
+ │                                          render 0             data->>'name'                     ·                                             ·
+ │                                          render 1             jsonb_array_elements              ·                                             ·
+ └── project set                            ·                    ·                                 (id, data, "?column?", jsonb_array_elements)  ·
+      │                                     estimated row count  100000 (missing stats)            ·                                             ·
+      │                                     render 0             jsonb_array_elements("?column?")  ·                                             ·
+      └── distinct                          ·                    ·                                 (id, data, "?column?")                        ·
+           │                                estimated row count  10000 (missing stats)             ·                                             ·
+           │                                distinct on          id                                ·                                             ·
+           │                                error on duplicate   ·                                 ·                                             ·
+           └── project                      ·                    ·                                 (id, data, "?column?")                        ·
+                └── hash join (left outer)  ·                    ·                                 (column10, id, data, column11, "?column?")    ·
+                     │                      estimated row count  10000 (missing stats)             ·                                             ·
+                     │                      equality             (column10) = (column11)           ·                                             ·
+                     ├── render             ·                    ·                                 (column10, id, data)                          ·
+                     │    │                 estimated row count  1000 (missing stats)              ·                                             ·
+                     │    │                 render 0             data->>'name'                     ·                                             ·
+                     │    │                 render 1             id                                ·                                             ·
+                     │    │                 render 2             data                              ·                                             ·
+                     │    └── scan          ·                    ·                                 (id, data)                                    ·
+                     │                      estimated row count  1000 (missing stats)              ·                                             ·
+                     │                      table                groups@primary                    ·                                             ·
+                     │                      spans                FULL SCAN                         ·                                             ·
+                     └── render             ·                    ·                                 (column11, "?column?")                        ·
+                          │                 estimated row count  1000 (missing stats)              ·                                             ·
+                          │                 render 0             data->>'name'                     ·                                             ·
+                          │                 render 1             data->'members'                   ·                                             ·
+                          └── scan          ·                    ·                                 (data)                                        ·
+·                                           estimated row count  1000 (missing stats)              ·                                             ·
+·                                           table                groups@primary                    ·                                             ·
+·                                           spans                FULL SCAN                         ·                                             ·
 
 # Regression test for #32162.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -132,7 +132,7 @@ sort                       ·                    ·                             
                 │          left cols are key    ·                                                   ·                                                ·
                 │          right cols are key   ·                                                   ·                                                ·
                 │          pred                 y < z                                               ·                                                ·
-                │          mergeJoinOrder       +"(x=x)"                                            ·                                                ·
+                │          merge ordering       +"(x=x)"                                            ·                                                ·
                 ├── scan   ·                    ·                                                   (x, y)                                           +x
                 │          estimated row count  1000 (missing stats)                                ·                                                ·
                 │          table                xy@primary                                          ·                                                ·
@@ -187,7 +187,7 @@ project               ·                    ·                                  
            │          equality             (x) = (x)                               ·                                                           ·
            │          left cols are key    ·                                       ·                                                           ·
            │          right cols are key   ·                                       ·                                                           ·
-           │          mergeJoinOrder       +"(x=x)"                                ·                                                           ·
+           │          merge ordering       +"(x=x)"                                ·                                                           ·
            ├── scan   ·                    ·                                       (x, y)                                                      +x
            │          estimated row count  1000 (missing stats)                    ·                                                           ·
            │          table                xy@primary                              ·                                                           ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -93,26 +93,25 @@ root                              ·                    ·                      
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc WHERE b < 0)
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-merge join      ·                    ·                     (a)     ·
- │              estimated row count  333 (missing stats)   ·       ·
- │              type                 semi                  ·       ·
- │              equality             (a) = (a)             ·       ·
- │              left cols are key    ·                     ·       ·
- │              right cols are key   ·                     ·       ·
- │              merge ordering       +"(a=a)"              ·       ·
- ├── scan       ·                    ·                     (a)     +a
- │              estimated row count  1000 (missing stats)  ·       ·
- │              table                abc@primary           ·       ·
- │              spans                FULL SCAN             ·       ·
- └── filter     ·                    ·                     (a, b)  +a
-      │         estimated row count  333 (missing stats)   ·       ·
-      │         filter               b < 0                 ·       ·
-      └── scan  ·                    ·                     (a, b)  +a
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                abc@primary           ·       ·
-·               spans                FULL SCAN             ·       ·
+·                  distribution         local                 ·       ·
+·                  vectorized           true                  ·       ·
+merge join (semi)  ·                    ·                     (a)     ·
+ │                 estimated row count  333 (missing stats)   ·       ·
+ │                 equality             (a) = (a)             ·       ·
+ │                 left cols are key    ·                     ·       ·
+ │                 right cols are key   ·                     ·       ·
+ │                 merge ordering       +"(a=a)"              ·       ·
+ ├── scan          ·                    ·                     (a)     +a
+ │                 estimated row count  1000 (missing stats)  ·       ·
+ │                 table                abc@primary           ·       ·
+ │                 spans                FULL SCAN             ·       ·
+ └── filter        ·                    ·                     (a, b)  +a
+      │            estimated row count  333 (missing stats)   ·       ·
+      │            filter               b < 0                 ·       ·
+      └── scan     ·                    ·                     (a, b)  +a
+·                  estimated row count  1000 (missing stats)  ·       ·
+·                  table                abc@primary           ·       ·
+·                  spans                FULL SCAN             ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
@@ -186,88 +185,84 @@ CREATE TABLE b (x INT PRIMARY KEY, z INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
-·           distribution         local                 ·       ·
-·           vectorized           true                  ·       ·
-merge join  ·                    ·                     (x, y)  ·
- │          estimated row count  1000 (missing stats)  ·       ·
- │          type                 semi                  ·       ·
- │          equality             (x) = (x)             ·       ·
- │          left cols are key    ·                     ·       ·
- │          right cols are key   ·                     ·       ·
- │          merge ordering       +"(x=x)"              ·       ·
- ├── scan   ·                    ·                     (x, y)  +x
- │          estimated row count  1000 (missing stats)  ·       ·
- │          table                a@primary             ·       ·
- │          spans                FULL SCAN             ·       ·
- └── scan   ·                    ·                     (x)     +x
-·           estimated row count  1000 (missing stats)  ·       ·
-·           table                b@primary             ·       ·
-·           spans                FULL SCAN             ·       ·
+·                  distribution         local                 ·       ·
+·                  vectorized           true                  ·       ·
+merge join (semi)  ·                    ·                     (x, y)  ·
+ │                 estimated row count  1000 (missing stats)  ·       ·
+ │                 equality             (x) = (x)             ·       ·
+ │                 left cols are key    ·                     ·       ·
+ │                 right cols are key   ·                     ·       ·
+ │                 merge ordering       +"(x=x)"              ·       ·
+ ├── scan          ·                    ·                     (x, y)  +x
+ │                 estimated row count  1000 (missing stats)  ·       ·
+ │                 table                a@primary             ·       ·
+ │                 spans                FULL SCAN             ·       ·
+ └── scan          ·                    ·                     (x)     +x
+·                  estimated row count  1000 (missing stats)  ·       ·
+·                  table                b@primary             ·       ·
+·                  spans                FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-hash join       ·                    ·                     (x, y)     ·
- │              estimated row count  1000 (missing stats)  ·          ·
- │              type                 semi                  ·          ·
- │              equality             (x) = (column7)       ·          ·
- │              left cols are key    ·                     ·          ·
- ├── scan       ·                    ·                     (x, y)     ·
- │              estimated row count  1000 (missing stats)  ·          ·
- │              table                a@primary             ·          ·
- │              spans                FULL SCAN             ·          ·
- └── render     ·                    ·                     (column7)  ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         render 0             x - 1                 ·          ·
-      └── scan  ·                    ·                     (x)        ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                b@primary             ·          ·
-·               spans                FULL SCAN             ·          ·
+·                 distribution         local                 ·          ·
+·                 vectorized           true                  ·          ·
+hash join (semi)  ·                    ·                     (x, y)     ·
+ │                estimated row count  1000 (missing stats)  ·          ·
+ │                equality             (x) = (column7)       ·          ·
+ │                left cols are key    ·                     ·          ·
+ ├── scan         ·                    ·                     (x, y)     ·
+ │                estimated row count  1000 (missing stats)  ·          ·
+ │                table                a@primary             ·          ·
+ │                spans                FULL SCAN             ·          ·
+ └── render       ·                    ·                     (column7)  ·
+      │           estimated row count  1000 (missing stats)  ·          ·
+      │           render 0             x - 1                 ·          ·
+      └── scan    ·                    ·                     (x)        ·
+·                 estimated row count  1000 (missing stats)  ·          ·
+·                 table                b@primary             ·          ·
+·                 spans                FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
 ----
-·           distribution         local                 ·       ·
-·           vectorized           true                  ·       ·
-merge join  ·                    ·                     (x, y)  ·
- │          estimated row count  0 (missing stats)     ·       ·
- │          type                 anti                  ·       ·
- │          equality             (x) = (x)             ·       ·
- │          left cols are key    ·                     ·       ·
- │          right cols are key   ·                     ·       ·
- │          merge ordering       +"(x=x)"              ·       ·
- ├── scan   ·                    ·                     (x, y)  +x
- │          estimated row count  1000 (missing stats)  ·       ·
- │          table                a@primary             ·       ·
- │          spans                FULL SCAN             ·       ·
- └── scan   ·                    ·                     (x)     +x
-·           estimated row count  1000 (missing stats)  ·       ·
-·           table                b@primary             ·       ·
-·           spans                FULL SCAN             ·       ·
+·                  distribution         local                 ·       ·
+·                  vectorized           true                  ·       ·
+merge join (anti)  ·                    ·                     (x, y)  ·
+ │                 estimated row count  0 (missing stats)     ·       ·
+ │                 equality             (x) = (x)             ·       ·
+ │                 left cols are key    ·                     ·       ·
+ │                 right cols are key   ·                     ·       ·
+ │                 merge ordering       +"(x=x)"              ·       ·
+ ├── scan          ·                    ·                     (x, y)  +x
+ │                 estimated row count  1000 (missing stats)  ·       ·
+ │                 table                a@primary             ·       ·
+ │                 spans                FULL SCAN             ·       ·
+ └── scan          ·                    ·                     (x)     +x
+·                  estimated row count  1000 (missing stats)  ·       ·
+·                  table                b@primary             ·       ·
+·                  spans                FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-hash join       ·                    ·                     (x, z)     ·
- │              estimated row count  0 (missing stats)     ·          ·
- │              type                 anti                  ·          ·
- │              equality             (x) = (column7)       ·          ·
- │              left cols are key    ·                     ·          ·
- ├── scan       ·                    ·                     (x, z)     ·
- │              estimated row count  1000 (missing stats)  ·          ·
- │              table                b@primary             ·          ·
- │              spans                FULL SCAN             ·          ·
- └── render     ·                    ·                     (column7)  ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         render 0             x - 1                 ·          ·
-      └── scan  ·                    ·                     (x)        ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                a@primary             ·          ·
-·               spans                FULL SCAN             ·          ·
+·                 distribution         local                 ·          ·
+·                 vectorized           true                  ·          ·
+hash join (anti)  ·                    ·                     (x, z)     ·
+ │                estimated row count  0 (missing stats)     ·          ·
+ │                equality             (x) = (column7)       ·          ·
+ │                left cols are key    ·                     ·          ·
+ ├── scan         ·                    ·                     (x, z)     ·
+ │                estimated row count  1000 (missing stats)  ·          ·
+ │                table                b@primary             ·          ·
+ │                spans                FULL SCAN             ·          ·
+ └── render       ·                    ·                     (column7)  ·
+      │           estimated row count  1000 (missing stats)  ·          ·
+      │           render 0             x - 1                 ·          ·
+      └── scan    ·                    ·                     (x)        ·
+·                 estimated row count  1000 (missing stats)  ·          ·
+·                 table                a@primary             ·          ·
+·                 spans                FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
@@ -291,13 +286,12 @@ root            ·                    ·                     ("array")  ·
 query TTTTT
 EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
 ----
-·           distribution         local                 ·          ·
-·           vectorized           false                 ·          ·
-apply join  ·                    ·                     (a, b, c)  ·
- │          estimated row count  2 (missing stats)     ·          ·
- │          type                 semi                  ·          ·
- │          pred                 column1 = a           ·          ·
- └── scan   ·                    ·                     (a, b, c)  ·
-·           estimated row count  1000 (missing stats)  ·          ·
-·           table                abc@primary           ·          ·
-·           spans                FULL SCAN             ·          ·
+·                  distribution         local                 ·          ·
+·                  vectorized           false                 ·          ·
+apply join (semi)  ·                    ·                     (a, b, c)  ·
+ │                 estimated row count  2 (missing stats)     ·          ·
+ │                 pred                 column1 = a           ·          ·
+ └── scan          ·                    ·                     (a, b, c)  ·
+·                  estimated row count  1000 (missing stats)  ·          ·
+·                  table                abc@primary           ·          ·
+·                  spans                FULL SCAN             ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -74,10 +74,9 @@ root                              ·                    ·                      
       │                           id                   @S2                                                                          ·               ·
       │                           original sql         (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
       │                           exec mode            one row                                                                      ·               ·
-      └── group                   ·                    ·                                                                            (any_not_null)  ·
+      └── group (scalar)          ·                    ·                                                                            (any_not_null)  ·
            │                      estimated row count  1 (missing stats)                                                            ·               ·
            │                      aggregate 0          any_not_null(a)                                                              ·               ·
-           │                      scalar               ·                                                                            ·               ·
            └── limit              ·                    ·                                                                            (a)             ·
                 │                 estimated row count  1 (missing stats)                                                            ·               ·
                 │                 count                1                                                                            ·               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -101,7 +101,7 @@ merge join      ·                    ·                     (a)     ·
  │              equality             (a) = (a)             ·       ·
  │              left cols are key    ·                     ·       ·
  │              right cols are key   ·                     ·       ·
- │              mergeJoinOrder       +"(a=a)"              ·       ·
+ │              merge ordering       +"(a=a)"              ·       ·
  ├── scan       ·                    ·                     (a)     +a
  │              estimated row count  1000 (missing stats)  ·       ·
  │              table                abc@primary           ·       ·
@@ -194,7 +194,7 @@ merge join  ·                    ·                     (x, y)  ·
  │          equality             (x) = (x)             ·       ·
  │          left cols are key    ·                     ·       ·
  │          right cols are key   ·                     ·       ·
- │          mergeJoinOrder       +"(x=x)"              ·       ·
+ │          merge ordering       +"(x=x)"              ·       ·
  ├── scan   ·                    ·                     (x, y)  +x
  │          estimated row count  1000 (missing stats)  ·       ·
  │          table                a@primary             ·       ·
@@ -237,7 +237,7 @@ merge join  ·                    ·                     (x, y)  ·
  │          equality             (x) = (x)             ·       ·
  │          left cols are key    ·                     ·       ·
  │          right cols are key   ·                     ·       ·
- │          mergeJoinOrder       +"(x=x)"              ·       ·
+ │          merge ordering       +"(x=x)"              ·       ·
  ├── scan   ·                    ·                     (x, y)  +x
  │          estimated row count  1000 (missing stats)  ·       ·
  │          table                a@primary             ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -26,7 +26,7 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 ·          distribution   local
 ·          vectorized     true
-append     ·              ·
+union all  ·              ·
  ├── scan  ·              ·
  │         missing stats  ·
  │         table          uniontest@primary
@@ -59,7 +59,7 @@ EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc OR
 sort                 ·                    ·                     (a)     +a
  │                   estimated row count  100 (missing stats)   ·       ·
  │                   order                +a                    ·       ·
- └── union           ·                    ·                     (a)     ·
+ └── intersect       ·                    ·                     (a)     ·
       │              estimated row count  100 (missing stats)   ·       ·
       ├── project    ·                    ·                     (a)     ·
       │    └── scan  ·                    ·                     (a, b)  ·
@@ -79,7 +79,7 @@ EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''
 ·                      distribution         local            ·                         ·
 ·                      vectorized           false            ·                         ·
 project                ·                    ·                (a)                       ·
- └── union             ·                    ·                (a, a)                    ·
+ └── except all        ·                    ·                (a, a)                    ·
       │                estimated row count  1                ·                         ·
       ├── project      ·                    ·                (a, a)                    ·
       │    └── values  ·                    ·                (a)                       ·
@@ -101,7 +101,7 @@ render                 ·                    ·                 ("?column?", "?c
  │                     render 0             "?column?"        ·                                     ·
  │                     render 1             "?column?"        ·                                     ·
  │                     render 2             "?column?"        ·                                     ·
- └── union             ·                    ·                 ("?column?", "?column?", "?column?")  ·
+ └── except            ·                    ·                 ("?column?", "?column?", "?column?")  ·
       │                estimated row count  1                 ·                                     ·
       ├── project      ·                    ·                 ("?column?", "?column?", "?column?")  ·
       │    └── values  ·                    ·                 ("?column?", "?column?")              ·
@@ -123,7 +123,7 @@ SELECT 1 FROM (SELECT k FROM uniontest WHERE k > 3 UNION ALL SELECT k FROM union
 render                    ·                    ·                     ("?column?")  ·
  │                        estimated row count  1333 (missing stats)  ·             ·
  │                        render 0             1                     ·             ·
- └── append               ·                    ·                     ()            ·
+ └── union all            ·                    ·                     ()            ·
       │                   estimated row count  1333 (missing stats)  ·             ·
       ├── project         ·                    ·                     ()            ·
       │    │              estimated row count  333 (missing stats)   ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -101,17 +101,16 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-·          distribution      local
-·          vectorized        false
-update     ·                 ·
- │         table             xyz
- │         set               y
- │         auto commit       ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             xyz@primary
-·          spans             FULL SCAN
-·          locking strength  for update
+·          distribution   local
+·          vectorized     false
+update     ·              ·
+ │         table          xyz
+ │         set            y
+ │         auto commit    ·
+ └── scan  ·              ·
+·          missing stats  ·
+·          table          xyz@primary
+·          spans          FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
@@ -242,19 +241,18 @@ update                    ·              ·
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             [ - /2]
-·               limit             1
-·               locking strength  for update
+·               distribution   local
+·               vectorized     false
+update          ·              ·
+ │              table          kv
+ │              set            v
+ │              auto commit    ·
+ └── render     ·              ·
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          kv@primary
+·               spans          [ - /2]
+·               limit          1
 
 # Check that updates on tables with multiple column families behave as
 # they should.
@@ -420,50 +418,46 @@ update                     ·                    ·                     ()      
 query TTT
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             [/3 - /3]
-·               locking strength  for update
+·               distribution   local
+·               vectorized     false
+update          ·              ·
+ │              table          kv
+ │              set            v
+ │              auto commit    ·
+ └── render     ·              ·
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          kv@primary
+·               spans          [/3 - /3]
 
 query TTT
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·          distribution      local
-·          vectorized        false
-update     ·                 ·
- │         table             kv
- │         set               v
- │         auto commit       ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             kv@primary
-·          spans             [/2 - /9]
-·          parallel          ·
-·          locking strength  for update
+·          distribution   local
+·          vectorized     false
+update     ·              ·
+ │         table          kv
+ │         set            v
+ │         auto commit    ·
+ └── scan  ·              ·
+·          missing stats  ·
+·          table          kv@primary
+·          spans          [/2 - /9]
 
 query TTT
 EXPLAIN UPDATE kv SET v = 10
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             FULL SCAN
-·               locking strength  for update
+·               distribution   local
+·               vectorized     false
+update          ·              ·
+ │              table          kv
+ │              set            v
+ │              auto commit    ·
+ └── render     ·              ·
+      └── scan  ·              ·
+·               missing stats  ·
+·               table          kv@primary
+·               spans          FULL SCAN
 
 statement ok
 CREATE TABLE kv3 (
@@ -477,39 +471,35 @@ CREATE TABLE kv3 (
 query TTT
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                     distribution      local
-·                     vectorized        false
-update                ·                 ·
- │                    table             kv3
- │                    set               k
- │                    auto commit       ·
- └── render           ·                 ·
-      └── index join  ·                 ·
-           │          table             kv3@primary
-           │          key columns       k
-           └── scan   ·                 ·
-·                     missing stats     ·
-·                     table             kv3@kv3_v_idx
-·                     spans             [/10 - /10]
-·                     locking strength  for update
+·                     distribution   local
+·                     vectorized     false
+update                ·              ·
+ │                    table          kv3
+ │                    set            k
+ │                    auto commit    ·
+ └── render           ·              ·
+      └── index join  ·              ·
+           │          table          kv3@primary
+           └── scan   ·              ·
+·                     missing stats  ·
+·                     table          kv3@kv3_v_idx
+·                     spans          [/10 - /10]
 
 query TTT
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                distribution      local
-·                vectorized        false
-update           ·                 ·
- │               table             kv3
- │               set               k
- │               auto commit       ·
- └── index join  ·                 ·
-      │          table             kv3@primary
-      │          key columns       k
-      └── scan   ·                 ·
-·                missing stats     ·
-·                table             kv3@kv3_v_idx
-·                spans             [/2 - /9]
-·                locking strength  for update
+·                distribution   local
+·                vectorized     false
+update           ·              ·
+ │               table          kv3
+ │               set            k
+ │               auto commit    ·
+ └── index join  ·              ·
+      │          table          kv3@primary
+      └── scan   ·              ·
+·                missing stats  ·
+·                table          kv3@kv3_v_idx
+·                spans          [/2 - /9]
 
 statement ok
 SET enable_implicit_select_for_update = false
@@ -542,7 +532,6 @@ update     ·              ·
 ·          missing stats  ·
 ·          table          kv@primary
 ·          spans          [/2 - /9]
-·          parallel       ·
 
 query TTT
 EXPLAIN UPDATE kv SET v = 10
@@ -609,7 +598,6 @@ update                ·              ·
  └── render           ·              ·
       └── index join  ·              ·
            │          table          kv3@primary
-           │          key columns    k
            └── scan   ·              ·
 ·                     missing stats  ·
 ·                     table          kv3@kv3_v_idx
@@ -626,7 +614,6 @@ update           ·              ·
  │               auto commit    ·
  └── index join  ·              ·
       │          table          kv3@primary
-      │          key columns    k
       └── scan   ·              ·
 ·                missing stats  ·
 ·                table          kv3@kv3_v_idx

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -15,7 +15,6 @@ update                ·                   ·
  │                    auto commit         ·
  └── render           ·                   ·
       └── merge join  ·                   ·
-           │          type                inner
            │          equality            (a) = (a)
            │          left cols are key   ·
            │          right cols are key  ·
@@ -44,7 +43,6 @@ update               ·                  ·
  └── distinct        ·                  ·
       │              distinct on        a
       └── hash join  ·                  ·
-           │         type               inner
            │         equality           (a) = (a)
            │         left cols are key  ·
            ├── scan  ·                  ·
@@ -76,7 +74,6 @@ update                ·                   ·
  │                    auto commit         ·
  └── render           ·                   ·
       └── merge join  ·                   ·
-           │          type                inner
            │          equality            (a) = (a)
            │          left cols are key   ·
            │          right cols are key  ·
@@ -93,38 +90,37 @@ update                ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
-·                     distribution         local                 ·                                 ·
-·                     vectorized           false                 ·                                 ·
-update                ·                    ·                     (a, b, c, a, b, c)                ·
- │                    estimated row count  1000 (missing stats)  ·                                 ·
- │                    table                abc                   ·                                 ·
- │                    set                  b, c                  ·                                 ·
- │                    auto commit          ·                     ·                                 ·
- └── render           ·                    ·                     (a, b, c, b_new, c_new, a, b, c)  ·
-      │               estimated row count  1000 (missing stats)  ·                                 ·
-      │               render 0             b + 1                 ·                                 ·
-      │               render 1             c + 2                 ·                                 ·
-      │               render 2             a                     ·                                 ·
-      │               render 3             b                     ·                                 ·
-      │               render 4             c                     ·                                 ·
-      │               render 5             a                     ·                                 ·
-      │               render 6             b                     ·                                 ·
-      │               render 7             c                     ·                                 ·
-      └── merge join  ·                    ·                     (a, b, c, a, b, c)                ·
-           │          estimated row count  1000 (missing stats)  ·                                 ·
-           │          type                 inner                 ·                                 ·
-           │          equality             (a) = (a)             ·                                 ·
-           │          left cols are key    ·                     ·                                 ·
-           │          right cols are key   ·                     ·                                 ·
-           │          merge ordering       +"(a=a)"              ·                                 ·
-           ├── scan   ·                    ·                     (a, b, c)                         +a
-           │          estimated row count  1000 (missing stats)  ·                                 ·
-           │          table                abc@primary           ·                                 ·
-           │          spans                FULL SCAN             ·                                 ·
-           └── scan   ·                    ·                     (a, b, c)                         +a
-·                     estimated row count  1000 (missing stats)  ·                                 ·
-·                     table                abc@primary           ·                                 ·
-·                     spans                FULL SCAN             ·                                 ·
+·                             distribution         local                 ·                                 ·
+·                             vectorized           false                 ·                                 ·
+update                        ·                    ·                     (a, b, c, a, b, c)                ·
+ │                            estimated row count  1000 (missing stats)  ·                                 ·
+ │                            table                abc                   ·                                 ·
+ │                            set                  b, c                  ·                                 ·
+ │                            auto commit          ·                     ·                                 ·
+ └── render                   ·                    ·                     (a, b, c, b_new, c_new, a, b, c)  ·
+      │                       estimated row count  1000 (missing stats)  ·                                 ·
+      │                       render 0             b + 1                 ·                                 ·
+      │                       render 1             c + 2                 ·                                 ·
+      │                       render 2             a                     ·                                 ·
+      │                       render 3             b                     ·                                 ·
+      │                       render 4             c                     ·                                 ·
+      │                       render 5             a                     ·                                 ·
+      │                       render 6             b                     ·                                 ·
+      │                       render 7             c                     ·                                 ·
+      └── merge join (inner)  ·                    ·                     (a, b, c, a, b, c)                ·
+           │                  estimated row count  1000 (missing stats)  ·                                 ·
+           │                  equality             (a) = (a)             ·                                 ·
+           │                  left cols are key    ·                     ·                                 ·
+           │                  right cols are key   ·                     ·                                 ·
+           │                  merge ordering       +"(a=a)"              ·                                 ·
+           ├── scan           ·                    ·                     (a, b, c)                         +a
+           │                  estimated row count  1000 (missing stats)  ·                                 ·
+           │                  table                abc@primary           ·                                 ·
+           │                  spans                FULL SCAN             ·                                 ·
+           └── scan           ·                    ·                     (a, b, c)                         +a
+·                             estimated row count  1000 (missing stats)  ·                                 ·
+·                             table                abc@primary           ·                                 ·
+·                             spans                FULL SCAN             ·                                 ·
 
 # Update values of table from values expression
 query TTT
@@ -140,7 +136,6 @@ update                 ·                      ·
       │                distinct on            a
       └── lookup join  ·                      ·
            │           table                  abc@primary
-           │           type                   inner
            │           equality               (column1) = (a)
            │           equality cols are key  ·
            └── values  ·                      ·
@@ -165,14 +160,12 @@ update                    ·                  ·
  └── distinct             ·                  ·
       │                   distinct on        a
       └── hash join       ·                  ·
-           │              type               inner
            │              equality           (a) = (a)
            ├── scan       ·                  ·
            │              missing stats      ·
            │              table              ab@primary
            │              spans              FULL SCAN
            └── hash join  ·                  ·
-                │         type               inner
                 │         equality           (a) = (a)
                 │         left cols are key  ·
                 ├── scan  ·                  ·
@@ -206,14 +199,12 @@ update                    ·                  ·
  └── distinct             ·                  ·
       │                   distinct on        a
       └── hash join       ·                  ·
-           │              type               inner
            │              equality           (a) = (a)
            ├── scan       ·                  ·
            │              missing stats      ·
            │              table              ab@primary
            │              spans              FULL SCAN
            └── hash join  ·                  ·
-                │         type               inner
                 │         equality           (a) = (a)
                 │         left cols are key  ·
                 ├── scan  ·                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -19,7 +19,6 @@ update                ·                   ·
            │          equality            (a) = (a)
            │          left cols are key   ·
            │          right cols are key  ·
-           │          mergeJoinOrder      +"(a=a)"
            ├── scan   ·                   ·
            │          missing stats       ·
            │          table               abc@primary
@@ -81,7 +80,6 @@ update                ·                   ·
            │          equality            (a) = (a)
            │          left cols are key   ·
            │          right cols are key  ·
-           │          mergeJoinOrder      +"(a=a)"
            ├── scan   ·                   ·
            │          missing stats       ·
            │          table               abc@primary
@@ -118,7 +116,7 @@ update                ·                    ·                     (a, b, c, a, 
            │          equality             (a) = (a)             ·                                 ·
            │          left cols are key    ·                     ·                                 ·
            │          right cols are key   ·                     ·                                 ·
-           │          mergeJoinOrder       +"(a=a)"              ·                                 ·
+           │          merge ordering       +"(a=a)"              ·                                 ·
            ├── scan   ·                    ·                     (a, b, c)                         +a
            │          estimated row count  1000 (missing stats)  ·                                 ·
            │          table                abc@primary           ·                                 ·
@@ -145,7 +143,6 @@ update                 ·                      ·
            │           type                   inner
            │           equality               (column1) = (a)
            │           equality cols are key  ·
-           │           parallel               ·
            └── values  ·                      ·
 ·                      size                   3 columns, 2 rows
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -90,10 +90,9 @@ upsert                              ·                      ·
  │                                  estimated row count    0 (missing stats)
  │                                  into                   kv(k, v)
  │                                  auto commit            ·
- └── lookup join                    ·                      ·
+ └── lookup join (inner)            ·                      ·
       │                             estimated row count    2 (missing stats)
       │                             table                  kv@primary
-      │                             type                   inner
       │                             equality               (k) = (k)
       │                             equality cols are key  ·
       └── distinct                  ·                      ·
@@ -135,37 +134,36 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
 ]
 ----
-·                           distribution         local
-·                           vectorized           false
-upsert                      ·                    ·
- │                          estimated row count  0 (missing stats)
- │                          into                 indexed(a, b, c, d)
- │                          auto commit          ·
- └── project                ·                    ·
-      └── render            ·                    ·
-           │                estimated row count  1 (missing stats)
-           │                render 0             column8 > 0
-           │                render 1             column1
-           │                render 2             column7
-           │                render 3             column8
-           │                render 4             column9
-           │                render 5             a
-           │                render 6             b
-           │                render 7             c
-           │                render 8             d
-           └── cross join   ·                    ·
-                │           estimated row count  1 (missing stats)
-                │           type                 left outer
-                ├── values  ·                    ·
-                │           size                 4 columns, 1 row
-                │           row 0, expr 0        1
-                │           row 0, expr 1        CAST(NULL AS INT8)
-                │           row 0, expr 2        10
-                │           row 0, expr 3        11
-                └── scan    ·                    ·
-·                           estimated row count  1 (missing stats)
-·                           table                indexed@primary
-·                           spans                /1-/1/#
+·                                       distribution         local
+·                                       vectorized           false
+upsert                                  ·                    ·
+ │                                      estimated row count  0 (missing stats)
+ │                                      into                 indexed(a, b, c, d)
+ │                                      auto commit          ·
+ └── project                            ·                    ·
+      └── render                        ·                    ·
+           │                            estimated row count  1 (missing stats)
+           │                            render 0             column8 > 0
+           │                            render 1             column1
+           │                            render 2             column7
+           │                            render 3             column8
+           │                            render 4             column9
+           │                            render 5             a
+           │                            render 6             b
+           │                            render 7             c
+           │                            render 8             d
+           └── cross join (left outer)  ·                    ·
+                │                       estimated row count  1 (missing stats)
+                ├── values              ·                    ·
+                │                       size                 4 columns, 1 row
+                │                       row 0, expr 0        1
+                │                       row 0, expr 1        CAST(NULL AS INT8)
+                │                       row 0, expr 2        10
+                │                       row 0, expr 3        11
+                └── scan                ·                    ·
+·                                       estimated row count  1 (missing stats)
+·                                       table                indexed@primary
+·                                       spans                /1-/1/#
 
 # Drop index and verify that existing values no longer need to be fetched.
 statement ok
@@ -404,22 +402,21 @@ BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
 query TTTTT
 EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 ----
-·                      distribution           local               ·                      ·
-·                      vectorized             false               ·                      ·
-upsert                 ·                      ·                   ()                     ·
- │                     estimated row count    0 (missing stats)   ·                      ·
- │                     into                   table38627(a, b)    ·                      ·
- └── project           ·                      ·                   (a, b, a, b, c, b, a)  ·
-      └── lookup join  ·                      ·                   (a, b, a, b, c)        ·
-           │           estimated row count    1 (missing stats)   ·                      ·
-           │           table                  table38627@primary  ·                      ·
-           │           type                   inner               ·                      ·
-           │           equality               (a) = (a)           ·                      ·
-           │           equality cols are key  ·                   ·                      ·
-           └── scan    ·                      ·                   (a, b)                 ·
-·                      estimated row count    1 (missing stats)   ·                      ·
-·                      table                  table38627@primary  ·                      ·
-·                      spans                  /1-/1/#             ·                      ·
+·                              distribution           local               ·                      ·
+·                              vectorized             false               ·                      ·
+upsert                         ·                      ·                   ()                     ·
+ │                             estimated row count    0 (missing stats)   ·                      ·
+ │                             into                   table38627(a, b)    ·                      ·
+ └── project                   ·                      ·                   (a, b, a, b, c, b, a)  ·
+      └── lookup join (inner)  ·                      ·                   (a, b, a, b, c)        ·
+           │                   estimated row count    1 (missing stats)   ·                      ·
+           │                   table                  table38627@primary  ·                      ·
+           │                   equality               (a) = (a)           ·                      ·
+           │                   equality cols are key  ·                   ·                      ·
+           └── scan            ·                      ·                   (a, b)                 ·
+·                              estimated row count    1 (missing stats)   ·                      ·
+·                              table                  table38627@primary  ·                      ·
+·                              spans                  /1-/1/#             ·                      ·
 
 statement ok
 COMMIT
@@ -437,41 +434,40 @@ query TTTTT
 EXPLAIN (VERBOSE)
 INSERT INTO tdup VALUES (2, 2, 2), (3, 2, 2) ON CONFLICT (z, y) DO UPDATE SET z=1
 ----
-·                                distribution           local                                        ·                                                  ·
-·                                vectorized             false                                        ·                                                  ·
-upsert                           ·                      ·                                            ()                                                 ·
- │                               estimated row count    0 (missing stats)                            ·                                                  ·
- │                               into                   tdup(x, y, z)                                ·                                                  ·
- │                               auto commit            ·                                            ·                                                  ·
- └── project                     ·                      ·                                            (column1, column2, column3, x, y, z, upsert_z, x)  ·
-      └── render                 ·                      ·                                            (upsert_z, column1, column2, column3, x, y, z)     ·
-           │                     estimated row count    2 (missing stats)                            ·                                                  ·
-           │                     render 0               CASE WHEN x IS NULL THEN column3 ELSE 1 END  ·                                                  ·
-           │                     render 1               column1                                      ·                                                  ·
-           │                     render 2               column2                                      ·                                                  ·
-           │                     render 3               column3                                      ·                                                  ·
-           │                     render 4               x                                            ·                                                  ·
-           │                     render 5               y                                            ·                                                  ·
-           │                     render 6               z                                            ·                                                  ·
-           └── lookup join       ·                      ·                                            (column1, column2, column3, x, y, z)               ·
-                │                estimated row count    2 (missing stats)                            ·                                                  ·
-                │                table                  tdup@tdup_y_z_key                            ·                                                  ·
-                │                type                   left outer                                   ·                                                  ·
-                │                equality               (column2, column3) = (y,z)                   ·                                                  ·
-                │                equality cols are key  ·                                            ·                                                  ·
-                └── distinct     ·                      ·                                            (column1, column2, column3)                        ·
-                     │           estimated row count    2                                            ·                                                  ·
-                     │           distinct on            column2, column3                             ·                                                  ·
-                     │           nulls are distinct     ·                                            ·                                                  ·
-                     │           error on duplicate     ·                                            ·                                                  ·
-                     └── values  ·                      ·                                            (column1, column2, column3)                        ·
-·                                size                   3 columns, 2 rows                            ·                                                  ·
-·                                row 0, expr 0          2                                            ·                                                  ·
-·                                row 0, expr 1          2                                            ·                                                  ·
-·                                row 0, expr 2          2                                            ·                                                  ·
-·                                row 1, expr 0          3                                            ·                                                  ·
-·                                row 1, expr 1          2                                            ·                                                  ·
-·                                row 1, expr 2          2                                            ·                                                  ·
+·                                        distribution           local                                        ·                                                  ·
+·                                        vectorized             false                                        ·                                                  ·
+upsert                                   ·                      ·                                            ()                                                 ·
+ │                                       estimated row count    0 (missing stats)                            ·                                                  ·
+ │                                       into                   tdup(x, y, z)                                ·                                                  ·
+ │                                       auto commit            ·                                            ·                                                  ·
+ └── project                             ·                      ·                                            (column1, column2, column3, x, y, z, upsert_z, x)  ·
+      └── render                         ·                      ·                                            (upsert_z, column1, column2, column3, x, y, z)     ·
+           │                             estimated row count    2 (missing stats)                            ·                                                  ·
+           │                             render 0               CASE WHEN x IS NULL THEN column3 ELSE 1 END  ·                                                  ·
+           │                             render 1               column1                                      ·                                                  ·
+           │                             render 2               column2                                      ·                                                  ·
+           │                             render 3               column3                                      ·                                                  ·
+           │                             render 4               x                                            ·                                                  ·
+           │                             render 5               y                                            ·                                                  ·
+           │                             render 6               z                                            ·                                                  ·
+           └── lookup join (left outer)  ·                      ·                                            (column1, column2, column3, x, y, z)               ·
+                │                        estimated row count    2 (missing stats)                            ·                                                  ·
+                │                        table                  tdup@tdup_y_z_key                            ·                                                  ·
+                │                        equality               (column2, column3) = (y,z)                   ·                                                  ·
+                │                        equality cols are key  ·                                            ·                                                  ·
+                └── distinct             ·                      ·                                            (column1, column2, column3)                        ·
+                     │                   estimated row count    2                                            ·                                                  ·
+                     │                   distinct on            column2, column3                             ·                                                  ·
+                     │                   nulls are distinct     ·                                            ·                                                  ·
+                     │                   error on duplicate     ·                                            ·                                                  ·
+                     └── values          ·                      ·                                            (column1, column2, column3)                        ·
+·                                        size                   3 columns, 2 rows                            ·                                                  ·
+·                                        row 0, expr 0          2                                            ·                                                  ·
+·                                        row 0, expr 1          2                                            ·                                                  ·
+·                                        row 0, expr 2          2                                            ·                                                  ·
+·                                        row 1, expr 0          3                                            ·                                                  ·
+·                                        row 1, expr 1          2                                            ·                                                  ·
+·                                        row 1, expr 2          2                                            ·                                                  ·
 
 statement ok
 CREATE TABLE target (a INT PRIMARY KEY, b INT, c INT, UNIQUE (b, c))
@@ -486,41 +482,40 @@ EXPLAIN (VERBOSE)
 INSERT INTO target SELECT x, y, z FROM source WHERE (y IS NULL OR y > 0) AND x <> 1
 ON CONFLICT (b, c) DO UPDATE SET b=5
 ----
-·                                   distribution         local                                  ·                                ·
-·                                   vectorized           false                                  ·                                ·
-upsert                              ·                    ·                                      ()                               ·
- │                                  estimated row count  0 (missing stats)                      ·                                ·
- │                                  into                 target(a, b, c)                        ·                                ·
- │                                  auto commit          ·                                      ·                                ·
- └── project                        ·                    ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
-      └── render                    ·                    ·                                      (upsert_b, x, y, z, a, b, c)     ·
-           │                        estimated row count  311 (missing stats)                    ·                                ·
-           │                        render 0             CASE WHEN a IS NULL THEN y ELSE 5 END  ·                                ·
-           │                        render 1             x                                      ·                                ·
-           │                        render 2             y                                      ·                                ·
-           │                        render 3             z                                      ·                                ·
-           │                        render 4             a                                      ·                                ·
-           │                        render 5             b                                      ·                                ·
-           │                        render 6             c                                      ·                                ·
-           └── merge join           ·                    ·                                      (a, b, c, x, y, z)               ·
-                │                   estimated row count  311 (missing stats)                    ·                                ·
-                │                   type                 right outer                            ·                                ·
-                │                   equality             (b, c) = (y, z)                        ·                                ·
-                │                   merge ordering       +"(b=y)",+"(c=z)"                      ·                                ·
-                ├── scan            ·                    ·                                      (a, b, c)                        +b,+c
-                │                   estimated row count  1000 (missing stats)                   ·                                ·
-                │                   table                target@target_b_c_key                  ·                                ·
-                │                   spans                FULL SCAN                              ·                                ·
-                └── distinct        ·                    ·                                      (x, y, z)                        +y,+z
-                     │              estimated row count  311 (missing stats)                    ·                                ·
-                     │              distinct on          y, z                                   ·                                ·
-                     │              nulls are distinct   ·                                      ·                                ·
-                     │              error on duplicate   ·                                      ·                                ·
-                     │              order key            y, z                                   ·                                ·
-                     └── filter     ·                    ·                                      (x, y, z)                        +y,+z
-                          │         estimated row count  311 (missing stats)                    ·                                ·
-                          │         filter               x != 1                                 ·                                ·
-                          └── scan  ·                    ·                                      (x, y, z)                        +y,+z
-·                                   estimated row count  333 (missing stats)                    ·                                ·
-·                                   table                source@source_y_z_idx                  ·                                ·
-·                                   spans                /NULL-/!NULL /1-                       ·                                ·
+·                                        distribution         local                                  ·                                ·
+·                                        vectorized           false                                  ·                                ·
+upsert                                   ·                    ·                                      ()                               ·
+ │                                       estimated row count  0 (missing stats)                      ·                                ·
+ │                                       into                 target(a, b, c)                        ·                                ·
+ │                                       auto commit          ·                                      ·                                ·
+ └── project                             ·                    ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
+      └── render                         ·                    ·                                      (upsert_b, x, y, z, a, b, c)     ·
+           │                             estimated row count  311 (missing stats)                    ·                                ·
+           │                             render 0             CASE WHEN a IS NULL THEN y ELSE 5 END  ·                                ·
+           │                             render 1             x                                      ·                                ·
+           │                             render 2             y                                      ·                                ·
+           │                             render 3             z                                      ·                                ·
+           │                             render 4             a                                      ·                                ·
+           │                             render 5             b                                      ·                                ·
+           │                             render 6             c                                      ·                                ·
+           └── merge join (right outer)  ·                    ·                                      (a, b, c, x, y, z)               ·
+                │                        estimated row count  311 (missing stats)                    ·                                ·
+                │                        equality             (b, c) = (y, z)                        ·                                ·
+                │                        merge ordering       +"(b=y)",+"(c=z)"                      ·                                ·
+                ├── scan                 ·                    ·                                      (a, b, c)                        +b,+c
+                │                        estimated row count  1000 (missing stats)                   ·                                ·
+                │                        table                target@target_b_c_key                  ·                                ·
+                │                        spans                FULL SCAN                              ·                                ·
+                └── distinct             ·                    ·                                      (x, y, z)                        +y,+z
+                     │                   estimated row count  311 (missing stats)                    ·                                ·
+                     │                   distinct on          y, z                                   ·                                ·
+                     │                   nulls are distinct   ·                                      ·                                ·
+                     │                   error on duplicate   ·                                      ·                                ·
+                     │                   order key            y, z                                   ·                                ·
+                     └── filter          ·                    ·                                      (x, y, z)                        +y,+z
+                          │              estimated row count  311 (missing stats)                    ·                                ·
+                          │              filter               x != 1                                 ·                                ·
+                          └── scan       ·                    ·                                      (x, y, z)                        +y,+z
+·                                        estimated row count  333 (missing stats)                    ·                                ·
+·                                        table                source@source_y_z_idx                  ·                                ·
+·                                        spans                /NULL-/!NULL /1-                       ·                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -96,7 +96,6 @@ upsert                              ·                      ·
       │                             type                   inner
       │                             equality               (k) = (k)
       │                             equality cols are key  ·
-      │                             parallel               ·
       └── distinct                  ·                      ·
            │                        estimated row count    2 (missing stats)
            │                        distinct on            k
@@ -417,7 +416,6 @@ upsert                 ·                      ·                   ()          
            │           type                   inner               ·                      ·
            │           equality               (a) = (a)           ·                      ·
            │           equality cols are key  ·                   ·                      ·
-           │           parallel               ·                   ·                      ·
            └── scan    ·                      ·                   (a, b)                 ·
 ·                      estimated row count    1 (missing stats)   ·                      ·
 ·                      table                  table38627@primary  ·                      ·
@@ -461,7 +459,6 @@ upsert                           ·                      ·                     
                 │                type                   left outer                                   ·                                                  ·
                 │                equality               (column2, column3) = (y,z)                   ·                                                  ·
                 │                equality cols are key  ·                                            ·                                                  ·
-                │                parallel               ·                                            ·                                                  ·
                 └── distinct     ·                      ·                                            (column1, column2, column3)                        ·
                      │           estimated row count    2                                            ·                                                  ·
                      │           distinct on            column2, column3                             ·                                                  ·
@@ -509,7 +506,7 @@ upsert                              ·                    ·                    
                 │                   estimated row count  311 (missing stats)                    ·                                ·
                 │                   type                 right outer                            ·                                ·
                 │                   equality             (b, c) = (y, z)                        ·                                ·
-                │                   mergeJoinOrder       +"(b=y)",+"(c=z)"                      ·                                ·
+                │                   merge ordering       +"(b=y)",+"(c=z)"                      ·                                ·
                 ├── scan            ·                    ·                                      (a, b, c)                        +b,+c
                 │                   estimated row count  1000 (missing stats)                   ·                                ·
                 │                   table                target@target_b_c_key                  ·                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -67,7 +67,6 @@ EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_cl
 ·                          vectorized             false
 virtual table lookup join  ·                      ·
  │                         table                  pg_class@pg_class_oid_idx
- │                         type                   inner
  │                         equality               (conrelid) = (oid)
  │                         equality cols are key  ·
  └── virtual table         ·                      ·
@@ -76,15 +75,14 @@ virtual table lookup join  ·                      ·
 query TTT
 EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
-·                          distribution           local
-·                          vectorized             false
-virtual table lookup join  ·                      ·
- │                         table                  pg_class@pg_class_oid_idx
- │                         type                   left outer
- │                         equality               (conrelid) = (oid)
- │                         equality cols are key  ·
- └── virtual table         ·                      ·
-·                          table                  pg_constraint@primary
+·                                       distribution           local
+·                                       vectorized             false
+virtual table lookup join (left outer)  ·                      ·
+ │                                      table                  pg_class@pg_class_oid_idx
+ │                                      equality               (conrelid) = (oid)
+ │                                      equality cols are key  ·
+ └── virtual table                      ·                      ·
+·                                       table                  pg_constraint@primary
 
 # Can't lookup into a vtable with no index.
 query error could not produce
@@ -122,7 +120,6 @@ sort                                                               ·           
  │                                                                 order                  +conname
  └── render                                                        ·                      ·
       └── hash join                                                ·                      ·
-           │                                                       type                   inner
            │                                                       equality               (oid) = (connamespace)
            ├── filter                                              ·                      ·
            │    │                                                  filter                 nspname IN ('public',)
@@ -130,27 +127,23 @@ sort                                                               ·           
            │                                                       table                  pg_namespace@primary
            └── virtual table lookup join                           ·                      ·
                 │                                                  table                  pg_attribute@pg_attribute_attrelid_idx
-                │                                                  type                   inner
                 │                                                  equality               (oid) = (attrelid)
                 │                                                  equality cols are key  ·
                 │                                                  pred                   column135 = attnum
                 └── render                                         ·                      ·
                      └── virtual table lookup join                 ·                      ·
                           │                                        table                  pg_attribute@pg_attribute_attrelid_idx
-                          │                                        type                   inner
                           │                                        equality               (oid) = (attrelid)
                           │                                        equality cols are key  ·
                           │                                        pred                   (column110 = attnum) AND (attrelid = 'b'::REGCLASS)
                           └── render                               ·                      ·
                                └── virtual table lookup join       ·                      ·
                                     │                              table                  pg_class@pg_class_oid_idx
-                                    │                              type                   inner
                                     │                              equality               (conrelid) = (oid)
                                     │                              equality cols are key  ·
                                     │                              pred                   oid = 'b'::REGCLASS
                                     └── virtual table lookup join  ·                      ·
                                          │                         table                  pg_class@pg_class_oid_idx
-                                         │                         type                   inner
                                          │                         equality               (confrelid) = (oid)
                                          │                         equality cols are key  ·
                                          └── filter                ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -70,7 +70,6 @@ virtual table lookup join  ·                      ·
  │                         type                   inner
  │                         equality               (conrelid) = (oid)
  │                         equality cols are key  ·
- │                         parallel               ·
  └── virtual table         ·                      ·
 ·                          table                  pg_constraint@primary
 
@@ -84,7 +83,6 @@ virtual table lookup join  ·                      ·
  │                         type                   left outer
  │                         equality               (conrelid) = (oid)
  │                         equality cols are key  ·
- │                         parallel               ·
  └── virtual table         ·                      ·
 ·                          table                  pg_constraint@primary
 
@@ -135,7 +133,6 @@ sort                                                               ·           
                 │                                                  type                   inner
                 │                                                  equality               (oid) = (attrelid)
                 │                                                  equality cols are key  ·
-                │                                                  parallel               ·
                 │                                                  pred                   column135 = attnum
                 └── render                                         ·                      ·
                      └── virtual table lookup join                 ·                      ·
@@ -143,7 +140,6 @@ sort                                                               ·           
                           │                                        type                   inner
                           │                                        equality               (oid) = (attrelid)
                           │                                        equality cols are key  ·
-                          │                                        parallel               ·
                           │                                        pred                   (column110 = attnum) AND (attrelid = 'b'::REGCLASS)
                           └── render                               ·                      ·
                                └── virtual table lookup join       ·                      ·
@@ -151,14 +147,12 @@ sort                                                               ·           
                                     │                              type                   inner
                                     │                              equality               (conrelid) = (oid)
                                     │                              equality cols are key  ·
-                                    │                              parallel               ·
                                     │                              pred                   oid = 'b'::REGCLASS
                                     └── virtual table lookup join  ·                      ·
                                          │                         table                  pg_class@pg_class_oid_idx
                                          │                         type                   inner
                                          │                         equality               (confrelid) = (oid)
                                          │                         equality cols are key  ·
-                                         │                         parallel               ·
                                          └── filter                ·                      ·
                                               │                    filter                 (conrelid = 'b'::REGCLASS) AND (contype = 'f')
                                               └── virtual table    ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -390,30 +390,29 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·                    distribution         local                                                                    ·             ·
-·                    vectorized           false                                                                    ·             ·
-root                 ·                    ·                                                                        (avg)         ·
- ├── project         ·                    ·                                                                        (avg)         ·
- │    │              estimated row count  1000 (missing stats)                                                     ·             ·
- │    └── window     ·                    ·                                                                        (v, w, avg)   ·
- │         │         estimated row count  1000 (missing stats)                                                     ·             ·
- │         │         window 0             avg(v) OVER (PARTITION BY w ROWS BETWEEN @S1 PRECEDING AND 1 FOLLOWING)  ·             ·
- │         └── scan  ·                    ·                                                                        (v, w)        ·
- │                   estimated row count  1000 (missing stats)                                                     ·             ·
- │                   table                kv@primary                                                               ·             ·
- │                   spans                FULL SCAN                                                                ·             ·
- └── subquery        ·                    ·                                                                        ·             ·
-      │              id                   @S1                                                                      ·             ·
-      │              original sql         (SELECT count(*) FROM kv)                                                ·             ·
-      │              exec mode            one row                                                                  ·             ·
-      └── group      ·                    ·                                                                        (count_rows)  ·
-           │         estimated row count  1 (missing stats)                                                        ·             ·
-           │         aggregate 0          count_rows()                                                             ·             ·
-           │         scalar               ·                                                                        ·             ·
-           └── scan  ·                    ·                                                                        ()            ·
-·                    estimated row count  1000 (missing stats)                                                     ·             ·
-·                    table                kv@primary                                                               ·             ·
-·                    spans                FULL SCAN                                                                ·             ·
+·                         distribution         local                                                                    ·             ·
+·                         vectorized           false                                                                    ·             ·
+root                      ·                    ·                                                                        (avg)         ·
+ ├── project              ·                    ·                                                                        (avg)         ·
+ │    │                   estimated row count  1000 (missing stats)                                                     ·             ·
+ │    └── window          ·                    ·                                                                        (v, w, avg)   ·
+ │         │              estimated row count  1000 (missing stats)                                                     ·             ·
+ │         │              window 0             avg(v) OVER (PARTITION BY w ROWS BETWEEN @S1 PRECEDING AND 1 FOLLOWING)  ·             ·
+ │         └── scan       ·                    ·                                                                        (v, w)        ·
+ │                        estimated row count  1000 (missing stats)                                                     ·             ·
+ │                        table                kv@primary                                                               ·             ·
+ │                        spans                FULL SCAN                                                                ·             ·
+ └── subquery             ·                    ·                                                                        ·             ·
+      │                   id                   @S1                                                                      ·             ·
+      │                   original sql         (SELECT count(*) FROM kv)                                                ·             ·
+      │                   exec mode            one row                                                                  ·             ·
+      └── group (scalar)  ·                    ·                                                                        (count_rows)  ·
+           │              estimated row count  1 (missing stats)                                                        ·             ·
+           │              aggregate 0          count_rows()                                                             ·             ·
+           └── scan       ·                    ·                                                                        ()            ·
+·                         estimated row count  1000 (missing stats)                                                     ·             ·
+·                         table                kv@primary                                                               ·             ·
+·                         spans                FULL SCAN                                                                ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -10,28 +10,27 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
-·                      distribution         local                    ·       ·
-·                      vectorized           false                    ·       ·
-root                   ·                    ·                        (a, a)  ·
- ├── cross join        ·                    ·                        (a, a)  ·
- │    │                estimated row count  1000000 (missing stats)  ·       ·
- │    │                type                 cross                    ·       ·
- │    ├── scan buffer  ·                    ·                        (a)     ·
- │    │                estimated row count  1000 (missing stats)     ·       ·
- │    │                label                buffer 1 (t)             ·       ·
- │    └── scan buffer  ·                    ·                        (a)     ·
- │                     estimated row count  1000 (missing stats)     ·       ·
- │                     label                buffer 1 (t)             ·       ·
- └── subquery          ·                    ·                        ·       ·
-      │                id                   @S1                      ·       ·
-      │                original sql         SELECT a FROM y          ·       ·
-      │                exec mode            all rows                 ·       ·
-      └── buffer       ·                    ·                        (a)     ·
-           │           label                buffer 1 (t)             ·       ·
-           └── scan    ·                    ·                        (a)     ·
-·                      estimated row count  1000 (missing stats)     ·       ·
-·                      table                y@primary                ·       ·
-·                      spans                FULL SCAN                ·       ·
+·                        distribution         local                    ·       ·
+·                        vectorized           false                    ·       ·
+root                     ·                    ·                        (a, a)  ·
+ ├── cross join (inner)  ·                    ·                        (a, a)  ·
+ │    │                  estimated row count  1000000 (missing stats)  ·       ·
+ │    ├── scan buffer    ·                    ·                        (a)     ·
+ │    │                  estimated row count  1000 (missing stats)     ·       ·
+ │    │                  label                buffer 1 (t)             ·       ·
+ │    └── scan buffer    ·                    ·                        (a)     ·
+ │                       estimated row count  1000 (missing stats)     ·       ·
+ │                       label                buffer 1 (t)             ·       ·
+ └── subquery            ·                    ·                        ·       ·
+      │                  id                   @S1                      ·       ·
+      │                  original sql         SELECT a FROM y          ·       ·
+      │                  exec mode            all rows                 ·       ·
+      └── buffer         ·                    ·                        (a)     ·
+           │             label                buffer 1 (t)             ·       ·
+           └── scan      ·                    ·                        (a)     ·
+·                        estimated row count  1000 (missing stats)     ·       ·
+·                        table                y@primary                ·       ·
+·                        spans                FULL SCAN                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -87,19 +86,18 @@ EXPLAIN (VERBOSE)
   FROM
     w, table39010
 ----
-·           distribution         local                    ·      ·
-·           vectorized           true                     ·      ·
-cross join  ·                    ·                        (col)  ·
- │          estimated row count  1000000 (missing stats)  ·      ·
- │          type                 cross                    ·      ·
- ├── scan   ·                    ·                        ()     ·
- │          estimated row count  1000 (missing stats)     ·      ·
- │          table                table39010@primary       ·      ·
- │          spans                FULL SCAN                ·      ·
- └── scan   ·                    ·                        (col)  ·
-·           estimated row count  1000 (missing stats)     ·      ·
-·           table                table39010@primary       ·      ·
-·           spans                FULL SCAN                ·      ·
+·                   distribution         local                    ·      ·
+·                   vectorized           true                     ·      ·
+cross join (inner)  ·                    ·                        (col)  ·
+ │                  estimated row count  1000000 (missing stats)  ·      ·
+ ├── scan           ·                    ·                        ()     ·
+ │                  estimated row count  1000 (missing stats)     ·      ·
+ │                  table                table39010@primary       ·      ·
+ │                  spans                FULL SCAN                ·      ·
+ └── scan           ·                    ·                        (col)  ·
+·                   estimated row count  1000 (missing stats)     ·      ·
+·                   table                table39010@primary       ·      ·
+·                   spans                FULL SCAN                ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -110,10 +110,9 @@ EXPLAIN (VERBOSE)
 ----
 ·                        distribution         local               ·          ·
 ·                        vectorized           false               ·          ·
-group                    ·                    ·                   (sum)      ·
+group (scalar)           ·                    ·                   (sum)      ·
  │                       estimated row count  1 (missing stats)   ·          ·
  │                       aggregate 0          sum(n)              ·          ·
- │                       scalar               ·                   ·          ·
  └── render              ·                    ·                   (n)        ·
       │                  estimated row count  10 (missing stats)  ·          ·
       │                  render 0             column1             ·          ·

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -276,7 +276,7 @@ var nodeNames = [...]string{
 	recursiveCTEOp:         "recursive cte",
 	renderOp:               "render",
 	saveTableOp:            "save table",
-	scalarGroupByOp:        "group",
+	scalarGroupByOp:        "group (scalar)",
 	scanBufferOp:           "scan buffer",
 	scanOp:                 "", // This node does not have a fixed name.
 	sequenceSelectOp:       "sequence select",
@@ -785,9 +785,6 @@ func (e *emitter) emitGroupByAttributes(
 	}
 	if len(groupColOrdering) > 0 {
 		e.ob.Attr("ordered", groupColOrdering.String(inputCols))
-	}
-	if isScalar {
-		e.ob.Attr("scalar", "")
 	}
 }
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -218,11 +218,11 @@ func (e *emitter) nodeName(n *Node) (string, error) {
 
 	case setOpOp:
 		a := n.args.(*setOpArgs)
-		// TODO(radu): fix these terrible names.
-		if a.Typ == tree.UnionOp && a.All {
-			return "append", nil
+		name := strings.ToLower(a.Typ.String())
+		if a.All {
+			name += " all"
 		}
-		return "union", nil
+		return name, nil
 
 	case opaqueOp:
 		a := n.args.(*opaqueArgs)

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -100,6 +100,14 @@ func (ob *OutputBuilder) Attr(key string, value interface{}) {
 	ob.AddField(key, fmt.Sprint(value))
 }
 
+// VAttr adds an information field under the current node, if the Verbose flag
+// is set.
+func (ob *OutputBuilder) VAttr(key string, value interface{}) {
+	if ob.flags.Verbose {
+		ob.AddField(key, fmt.Sprint(value))
+	}
+}
+
 // Attrf is a formatter version of Attr.
 func (ob *OutputBuilder) Attrf(key, format string, args ...interface{}) {
 	ob.AddField(key, fmt.Sprintf(format, args...))
@@ -127,6 +135,13 @@ func (ob *OutputBuilder) Expr(key string, expr tree.TypedExpr, varColumns sqlbas
 	})
 	f.FormatNode(expr)
 	ob.AddField(key, f.CloseAndGetString())
+}
+
+// VExpr is a verbose-only variant of Expr.
+func (ob *OutputBuilder) VExpr(key string, expr tree.TypedExpr, varColumns sqlbase.ResultColumns) {
+	if ob.flags.Verbose {
+		ob.Expr(key, expr, varColumns)
+	}
 }
 
 // buildTreeRows creates the treeprinter structure; returns one string for each

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -89,8 +89,6 @@ children:
   children:
   - name: group
     attrs:
-    - key: aggregate 0
-      value: sum(value)
     - key: group by
       value: cid
     children:

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -133,34 +133,31 @@ children: []
 plan-string
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
 ----
-                     distribution         local
-                     vectorized           false
-project                                                         (cid int, date date, value decimal)
- │                   estimated row count  1000 (missing stats)
- └── hash join                                                  (cid int, value decimal, date date, date date)
-      │              estimated row count  980 (missing stats)
-      │              type                 inner
-      │              equality             (date) = (date)
-      │              right cols are key
-      ├── scan                                                  (cid int, value decimal, date date)
-      │              estimated row count  1000 (missing stats)
-      │              table                orders@primary
-      │              spans                FULL SCAN
-      └── distinct                                              (date date)
-           │         estimated row count  100 (missing stats)
-           │         distinct on          date
-           └── scan                                             (date date)
-                     estimated row count  1000 (missing stats)
-                     table                orders@primary
-                     spans                FULL SCAN
+                        distribution         local
+                        vectorized           false
+project                                                            (cid int, date date, value decimal)
+ │                      estimated row count  1000 (missing stats)
+ └── hash join (inner)                                             (cid int, value decimal, date date, date date)
+      │                 estimated row count  980 (missing stats)
+      │                 equality             (date) = (date)
+      │                 right cols are key
+      ├── scan                                                     (cid int, value decimal, date date)
+      │                 estimated row count  1000 (missing stats)
+      │                 table                orders@primary
+      │                 spans                FULL SCAN
+      └── distinct                                                 (date date)
+           │            estimated row count  100 (missing stats)
+           │            distinct on          date
+           └── scan                                                (date date)
+                        estimated row count  1000 (missing stats)
+                        table                orders@primary
+                        spans                FULL SCAN
 
 plan-tree
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
 ----
 name: hash join
 attrs:
-- key: type
-  value: inner
 - key: equality
   value: (date) = (date)
 - key: right cols are key


### PR DESCRIPTION
#### sql: omit various EXPLAIN fields in non-verbose mode

This change removes some unnecessary fields, and relegates others to the VERBOSE
variant.

Release note (sql change): various improvements to EXPLAIN plans.

#### sql: improve EXPLAIN output for join nodes

This change folds the type of join (inner/outer/etc) into the node name itself
(e.g. `hash join (left outer)`). The "inner" type is omitted in non-verbose
mode.

Release note (sql change): various improvements to EXPLAIN plans.

#### sql: improve EXPLAIN output for scalar group by

Move "scalar" to the node name instead of a separate field.

Release note (sql change): various improvements to EXPLAIN plans.

#### sql: improve EXPLAIN output for set operations

Improve the node names for set operation: `union/intersect/except [all]`.

Release note (sql change): various improvements in EXPLAIN plans.
