### PR TITLE
sql: fix race in app stats

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -495,18 +495,21 @@ func (s *sqlStats) getStmtStats(
 				}
 			}
 			if ok {
+				stats.Lock()
+				data := stats.data
+				distSQLUsed := stats.distSQLUsed
+				vectorized := stats.vectorized
+				stats.Unlock()
+
 				k := roachpb.StatementStatisticsKey{
 					Query:       maybeScrubbed,
-					DistSQL:     stats.distSQLUsed,
+					DistSQL:     distSQLUsed,
 					Opt:         true,
-					Vec:         stats.vectorized,
+					Vec:         vectorized,
 					ImplicitTxn: q.implicitTxn,
 					Failed:      q.failed,
 					App:         maybeHashedAppName,
 				}
-				stats.Lock()
-				data := stats.data
-				stats.Unlock()
 
 				if scrub {
 					// Quantize the counts to avoid leaking information that way.


### PR DESCRIPTION
I introduced a race by retrieving the distsql/vectorized flags from the
statement entry without locking it. This change fixes it by moving the access to
the existing locked section.

Fixes #53000.

Release note: None