### PR TITLE
batcheval: deflake version-upgrade (again)

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -64,7 +64,6 @@ func registerAcceptance(r *testRegistry) {
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
 			timeout:    30 * time.Minute,
-			skip:       "https://github.com/cockroachdb/cockroach/issues/52907",
 		},
 	}
 	tags := []string{"default", "quick"}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -904,6 +904,15 @@ func splitTriggerHelper(
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}
 
+	if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionAbortSpanBytes) {
+		// Since the stats here is used to seed the initial state for the RHS
+		// replicas, we need to be careful about zero-ing out the abort span
+		// bytes if the cluster version introducing it is not yet active. Not
+		// doing so can result in inconsistencies in MVCCStats across replicas
+		// in a mixed-version cluster.
+		h.AbsPostSplitRight().AbortSpanBytes = 0
+	}
+
 	// Note: we don't copy the queue last processed times. This means
 	// we'll process the RHS range in consistency and time series
 	// maintenance queues again possibly sooner than if we copied. The
@@ -1032,14 +1041,6 @@ func splitTriggerHelper(
 	deltaPostSplitLeft := h.DeltaPostSplitLeft()
 	if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionContainsEstimatesCounter) {
 		deltaPostSplitLeft.ContainsEstimates = 0
-	}
-	if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionAbortSpanBytes) {
-		// Since the stats here is used to seed the initial state for the RHS
-		// replicas, we need to be careful about zero-ing out the abort span
-		// bytes if the cluster version introducing it is not yet active. Not
-		// doing so can result in inconsistencies in MVCCStats across replicas
-		// in a mixed-version cluster.
-		pd.Replicated.Split.RHSDelta.AbortSpanBytes = 0
 	}
 	return deltaPostSplitLeft, pd, nil
 }


### PR DESCRIPTION
Fixes #52907. Unskips it as well.

The patch in #52750 was not quite complete. We had zeroed out the
replicated RHS delta appropriately, but forgot to consider the RHS stats
added to the batch then later used to seed RHS state. I re-verified this
patch using the same `splits/mixed-version` test but running for more
iterations.

Release note: None