### PR TITLE
jobs: unskip TestRegistryLifecycle/rollback

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -545,8 +544,6 @@ func TestRegistryLifecycle(t *testing.T) {
 
 	// Verify that pause and cancel in a rollback do nothing.
 	t.Run("rollback", func(t *testing.T) {
-		skip.WithIssue(t, 52767, "flaky")
-
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()


### PR DESCRIPTION
The test flakiness was introduced by #52697 and fixed by #52710.

Fixes #52767.

Release note: none.