### PR TITLE
colexec: create new message to send metadata in unordered synchronizer

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -852,7 +852,6 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "vectorize", func(t *testing.T, vectorize bool) {
 		vectorizeOpt := "off"
 		if vectorize {
-			skip.WithIssue(t, 52948)
 			vectorizeOpt = "on"
 		}
 		for _, testCase := range testCases {


### PR DESCRIPTION
This commit fixes a race condition where a metadata message would be
double-freed and therefore the same object returned to two different goroutines
from a sync.Pool.

The root cause of this issue was that input goroutines in the parallel
unordered synchronizer use a single message that is sent repeatedly over a
channel instead of multiple messages to avoid allocations. A scenario could
occur where an input would drain metadata and set its message's metadata field
while its message was still unread in the channel. The message would then be
sent on the channel again, and the synchronizer's DrainMeta method would read
the first message with the metadata field set, followed by the same message a
second time. This results in returning the same metadata message twice to the
distsql receiver, which would release the same metadata twice.

The solution is to instead allocate a new message when draining, which will
leave message already present in the channel untouched.

Release note: None (no release with bug)

Fixes #52890 
Fixes #52948 