### PR TITLE
Makefile: misc spacing adjustment for cleaner build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1565,10 +1565,10 @@ bin/.docgen_functions: bin/docgen
 
 bin/.docgen_http: bin/docgen $(PROTOC)
 	docgen http \
-		--protoc $(PROTOC) \
-		--gendoc ./bin/protoc-gen-doc \
-		--out docs/generated/http \
-		--protobuf pkg:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
+	--protoc $(PROTOC) \
+	--gendoc ./bin/protoc-gen-doc \
+	--out docs/generated/http \
+	--protobuf pkg:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
 	touch $@
 
 .PHONY: docs/generated/redact_safe.md


### PR DESCRIPTION
Scratching a tiny itch. Before:

```
  docgen http \
                  --protoc ...
                  --gendoc ...
                  --out ...
                  --protobuf ...
```

After:

```
  docgen http \
          --protoc ...
          --gendoc ...
          --out ...
          --protobuf ...
```

Release note: None