### PR TITLE
cli/debug: add SQL-decoding to printed keys

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -926,6 +926,12 @@ If specified, print the system config contents. Beware that the output will be
 long and not particularly human-readable.`,
 	}
 
+	DecodeAsTable = FlagInfo{
+		Name: "decode-as-table",
+		Description: `
+Base64-encoded Descriptor to use as the table when decoding KVs.`,
+	}
+
 	DrainWait = FlagInfo{
 		Name: "drain-wait",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -302,6 +302,7 @@ var debugCtx struct {
 	ballastSize       base.SizeSpec
 	printSystemConfig bool
 	maxResults        int
+	decodeAsTableDesc string
 }
 
 // setDebugContextDefaults set the default values in debugCtx.  This
@@ -317,6 +318,7 @@ func setDebugContextDefaults() {
 	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
 	debugCtx.maxResults = 0
 	debugCtx.printSystemConfig = false
+	debugCtx.decodeAsTableDesc = ""
 }
 
 // startCtx captures the command-line arguments for the `start` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -778,6 +778,7 @@ func init() {
 		intFlag(f, &debugCtx.maxResults, cliflags.Limit)
 		boolFlag(f, &debugCtx.values, cliflags.Values)
 		boolFlag(f, &debugCtx.sizes, cliflags.Sizes)
+		stringFlag(f, &debugCtx.decodeAsTableDesc, cliflags.DecodeAsTable)
 	}
 	{
 		f := debugRangeDataCmd.Flags()


### PR DESCRIPTION
This adds a `--decode-as-table` flag to `debug keys --values`.

When passed a base64 encoded Descriptor, which can be obtained via
`select encode(descriptor, 'base64') from system.descriptor where id = x`,
it will attempt to decode KVs using a SQL row-fetcher backed by that
descriptor and print them as col1=val1, col2=val2,...

Release note: none.