### PR TITLE
backupccl: fix test name

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4871,7 +4871,7 @@ func TestBackupRestoreShowJob(t *testing.T) {
 	)
 }
 
-func TestBackupCreatedStatsWithUniqueName(t *testing.T) {
+func TestBackupCreatedStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
This test name was accidentally changed in a recent PR. This changes it
back.

Release note: None