### PR TITLE
logictest: skip cascade if run with 3node-tenant

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant(53040)
+
 # Tests for the experimental opt-driven cascades.
 subtest OptDriven
 


### PR DESCRIPTION
This test currently takes an unexpectedly long time to run.

Release note: None