### PR TITLE
bulkio: Fix transaction semantics in job scheduler.

### DIFF
--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -20,6 +20,14 @@ import (
 )
 
 func (d *delegator) delegateShowJobs(n *tree.ShowJobs) (tree.Statement, error) {
+	if n.Schedules != nil {
+		// Limit the jobs displayed to the ones started by specified schedules.
+		return parse(fmt.Sprintf(`
+SHOW JOBS SELECT id FROM system.jobs WHERE created_by_type='%s' and created_by_id IN (%s)
+`, jobs.CreatedByScheduledJobs, n.Schedules.String()),
+		)
+	}
+
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Jobs)
 
 	if n.Schedules != nil {


### PR DESCRIPTION
Fixes #53033
Fixes #52959 

Use transaction when querying for the schedules to run.
In addition, ensure that a single bad schedule does not cause
all of the previous work to be wasted by using transaction savepoints.


Release Notes: None