### PR TITLE
build: add backup/KMS/n3cpu4 to nightly AWS roachtest run

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -85,7 +85,7 @@ case "${CLOUD}" in
     CPUQUOTA=384
     if [ -z "${TESTS}" ]; then
       TESTS="kv(0|95)|ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/
-      (nodes=3/ops=2000/conc=1)|backup/KMS"
+      (nodes=3/ops=2000/conc=1)|backup/(KMS/n3cpu4)"
     fi
     ;;
   *)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -81,7 +81,7 @@ func registerBackup(r *testRegistry) {
 
 	KMSSpec := makeClusterSpec(3)
 	r.Add(testSpec{
-		Name:       fmt.Sprintf("backup/KMS/%s", KMSSpec),
+		Name:       fmt.Sprintf("backup/KMS/%s", KMSSpec.String()),
 		Owner:      OwnerBulkIO,
 		Cluster:    KMSSpec,
 		MinVersion: "v20.2.0",


### PR DESCRIPTION
The newly added backup/KMS/n3cpu4 test was not picked up by TC. I
suspect it was because the regex provided in the nightly script was
missing the cluster spec suffix. This change adds that.

It was picked up by gcs but skipped as expected.

Release note: None