### PR TITLE
opt: add rule to replace ST_Distance with ST_DWithin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -731,33 +731,33 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, inclusive.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, exclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, exclusive.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
-</span></td></tr>
-<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geometry_a_str: <a href="string.html">string</a>, geometry_b_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
-<p>This variant will cast all geometry_str arguments into Geometry types.</p>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, exclusive.</p>
+<p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="_st_equals"></a><code>_st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
 <p>This function utilizes the GEOS module.</p>
@@ -1157,21 +1157,39 @@ from the given Geometry.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 </span></td></tr>
-<tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, inclusive.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a_str: <a href="string.html">string</a>, geometry_b_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a_str: <a href="string.html">string</a>, geometry_b_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, inclusive.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
+<p>This variant will cast all geometry_str arguments into Geometry types.</p>
+</span></td></tr>
+<tr><td><a name="st_dwithinexclusive"></a><code>st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, exclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="st_dwithinexclusive"></a><code>st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, exclusive.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="st_dwithinexclusive"></a><code>st_dwithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, exclusive.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="st_dwithinexclusive"></a><code>st_dwithinexclusive(geometry_a_str: <a href="string.html">string</a>, geometry_b_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, exclusive.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -745,6 +745,20 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithinexclusive"></a><code>_st_dwithinexclusive(geometry_a_str: <a href="string.html">string</a>, geometry_b_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<p>This variant will cast all geometry_str arguments into Geometry types.</p>
+</span></td></tr>
 <tr><td><a name="_st_equals"></a><code>_st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant does not utilize any geospatial index.</p>

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -42,6 +42,20 @@ const (
 	EmptyBehaviorOmit EmptyBehavior = 1
 )
 
+// FnExclusivity is used to indicate whether a geo function should have
+// inclusive or exclusive semantics. For example, DWithin == (Distance <= x),
+// while DWithinExclusive == (Distance < x).
+type FnExclusivity bool
+
+const (
+	// FnExclusive indicates that the corresponding geo function should have
+	// exclusive semantics.
+	FnExclusive FnExclusivity = true
+	// FnInclusive indicates that the corresponding geo function should have
+	// inclusive semantics.
+	FnInclusive FnExclusivity = false
+)
+
 //
 // Geospatial Type
 //

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -54,7 +54,8 @@ func Distance(
 		aRegions,
 		bRegions,
 		a.BoundingRect().Intersects(b.BoundingRect()),
-		0,
+		0,     /* stopAfter */
+		false, /* exclusive */
 	)
 }
 
@@ -176,8 +177,10 @@ func (c *s2GeodistEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.Poi
 }
 
 // distanceGeographyRegions calculates the distance between two sets of regions.
-// It will quit if it finds a distance that is less than stopAfterLE.
-// It is not guaranteed to find the absolute minimum distance if stopAfterLE > 0.
+// If exclusive is false, it will quit if it finds a distance that is less than
+// or equal to stopAfter. Otherwise, it will quit if a distance less than
+// stopAfter is found. It is not guaranteed to find the absolute minimum
+// distance if stopAfter > 0.
 //
 // !!! SURPRISING BEHAVIOR WARNING FOR SPHEROIDS !!!
 // PostGIS evaluates the distance between spheroid regions by computing the min of
@@ -197,7 +200,8 @@ func distanceGeographyRegions(
 	aRegions []s2.Region,
 	bRegions []s2.Region,
 	boundingBoxIntersects bool,
-	stopAfterLE float64,
+	stopAfter float64,
+	exclusive bool,
 ) (float64, error) {
 	minDistance := math.MaxFloat64
 	for _, aRegion := range aRegions {
@@ -206,7 +210,12 @@ func distanceGeographyRegions(
 			return 0, err
 		}
 		for _, bRegion := range bRegions {
-			minDistanceUpdater := newGeographyMinDistanceUpdater(spheroid, useSphereOrSpheroid, stopAfterLE)
+			minDistanceUpdater := newGeographyMinDistanceUpdater(
+				spheroid,
+				useSphereOrSpheroid,
+				stopAfter,
+				exclusive,
+			)
 			bGeodist, err := regionToGeodistShape(bRegion)
 			if err != nil {
 				return 0, err
@@ -238,7 +247,8 @@ type geographyMinDistanceUpdater struct {
 	useSphereOrSpheroid UseSphereOrSpheroid
 	minEdge             s2.Edge
 	minD                s1.ChordAngle
-	stopAfterLE         s1.ChordAngle
+	stopAfter           s1.ChordAngle
+	exclusive           bool
 }
 
 var _ geodist.DistanceUpdater = (*geographyMinDistanceUpdater)(nil)
@@ -246,7 +256,10 @@ var _ geodist.DistanceUpdater = (*geographyMinDistanceUpdater)(nil)
 // newGeographyMinDistanceUpdater returns a new geographyMinDistanceUpdater with the
 // correct arguments set up.
 func newGeographyMinDistanceUpdater(
-	spheroid *geographiclib.Spheroid, useSphereOrSpheroid UseSphereOrSpheroid, stopAfterLE float64,
+	spheroid *geographiclib.Spheroid,
+	useSphereOrSpheroid UseSphereOrSpheroid,
+	stopAfter float64,
+	exclusive bool,
 ) *geographyMinDistanceUpdater {
 	multiplier := 1.0
 	if useSphereOrSpheroid == UseSpheroid {
@@ -255,12 +268,13 @@ func newGeographyMinDistanceUpdater(
 		// buffer for spheroid distances being slightly off.
 		multiplier -= SpheroidErrorFraction
 	}
-	stopAfterLEChordAngle := s1.ChordAngleFromAngle(s1.Angle(stopAfterLE * multiplier / spheroid.SphereRadius))
+	stopAfterChordAngle := s1.ChordAngleFromAngle(s1.Angle(stopAfter * multiplier / spheroid.SphereRadius))
 	return &geographyMinDistanceUpdater{
 		spheroid:            spheroid,
 		minD:                math.MaxFloat64,
 		useSphereOrSpheroid: useSphereOrSpheroid,
-		stopAfterLE:         stopAfterLEChordAngle,
+		stopAfter:           stopAfterChordAngle,
+		exclusive:           exclusive,
 	}
 }
 
@@ -288,7 +302,9 @@ func (u *geographyMinDistanceUpdater) Update(aPoint geodist.Point, bPoint geodis
 		// If we have a threshold, determine if we can stop early.
 		// If the sphere distance is within range of the stopAfter, we can
 		// definitively say we've reach the close enough point.
-		if u.minD <= u.stopAfterLE {
+		if !u.exclusive && u.minD <= u.stopAfter {
+			return true
+		} else if u.exclusive && u.minD < u.stopAfter {
 			return true
 		}
 	}

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DWithin returns whether a is within distance d of b. If A or B contains empty
-// Geography objects, this will return false. If exclusive is false, DWithin is
+// Geography objects, this will return false. If inclusive, DWithin is
 // equivalent to Distance(a, b) <= d. Otherwise, DWithin is instead equivalent
 // to Distance(a, b) < d.
 func DWithin(
@@ -25,7 +25,7 @@ func DWithin(
 	b *geo.Geography,
 	distance float64,
 	useSphereOrSpheroid UseSphereOrSpheroid,
-	exclusive bool,
+	exclusive geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -16,10 +16,16 @@ import (
 	"github.com/golang/geo/s1"
 )
 
-// DWithin returns whether a is within distance d of b, i.e. Distance(a, b) <= d.
-// If A or B contains empty Geography objects, this will return false.
+// DWithin returns whether a is within distance d of b. If A or B contains empty
+// Geography objects, this will return false. If exclusive is false, DWithin is
+// equivalent to Distance(a, b) <= d. Otherwise, DWithin is instead equivalent
+// to Distance(a, b) < d.
 func DWithin(
-	a *geo.Geography, b *geo.Geography, distance float64, useSphereOrSpheroid UseSphereOrSpheroid,
+	a *geo.Geography,
+	b *geo.Geography,
+	distance float64,
+	useSphereOrSpheroid UseSphereOrSpheroid,
+	exclusive bool,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
@@ -61,9 +67,13 @@ func DWithin(
 		bRegions,
 		a.BoundingRect().Intersects(b.BoundingRect()),
 		distance,
+		exclusive,
 	)
 	if err != nil {
 		return false, err
+	}
+	if exclusive {
+		return maybeClosestDistance < distance, nil
 	}
 	return maybeClosestDistance <= distance, nil
 }

--- a/pkg/geo/geogfn/dwithin_test.go
+++ b/pkg/geo/geogfn/dwithin_test.go
@@ -48,13 +48,26 @@ func TestDWithin(t *testing.T) {
 						}
 						for _, val := range []float64{zeroValue, 1, 10, 10000} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
 								require.NoError(t, err)
 								require.True(t, dwithin)
+							})
+							t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
+								exclusiveExpected := true
+								if val == subTC.expected {
+									exclusiveExpected = false
+								}
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								require.NoError(t, err)
+								require.Equal(t, dwithin, exclusiveExpected)
+
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								require.NoError(t, err)
+								require.Equal(t, dwithin, exclusiveExpected)
 							})
 						}
 					} else {
@@ -65,11 +78,20 @@ func TestDWithin(t *testing.T) {
 							subTC.expected * 2,
 						} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								require.NoError(t, err)
+								require.True(t, dwithin)
+							})
+							t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								require.NoError(t, err)
+								require.True(t, dwithin)
+
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 							})
@@ -82,11 +104,20 @@ func TestDWithin(t *testing.T) {
 							subTC.expected / 2,
 						} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								require.NoError(t, err)
+								require.False(t, dwithin)
+							})
+							t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								require.NoError(t, err)
+								require.False(t, dwithin)
+
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 							})
@@ -98,12 +129,12 @@ func TestDWithin(t *testing.T) {
 	}
 
 	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
-		_, err := DWithin(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, 0, UseSpheroid)
+		_, err := DWithin(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, 0, UseSpheroid, false /* exclusive */)
 		requireMismatchingSRIDError(t, err)
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeography("POINT(1.0 2.0)"), geo.MustParseGeography("POINT(3.0 4.0)"), -0.01, UseSpheroid)
+		_, err := DWithin(geo.MustParseGeography("POINT(1.0 2.0)"), geo.MustParseGeography("POINT(3.0 4.0)"), -0.01, UseSpheroid, false /* exclusive */)
 		require.Error(t, err)
 	})
 
@@ -125,7 +156,7 @@ func TestDWithin(t *testing.T) {
 					require.NoError(t, err)
 					b, err := geo.ParseGeography(tc.b)
 					require.NoError(t, err)
-					dwithin, err := DWithin(a, b, 0, useSphereOrSpheroid)
+					dwithin, err := DWithin(a, b, 0, useSphereOrSpheroid, false /* exclusive */)
 					require.NoError(t, err)
 					require.False(t, dwithin)
 				})

--- a/pkg/geo/geogfn/dwithin_test.go
+++ b/pkg/geo/geogfn/dwithin_test.go
@@ -48,11 +48,11 @@ func TestDWithin(t *testing.T) {
 						}
 						for _, val := range []float64{zeroValue, 1, 10, 10000} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 							})
@@ -61,13 +61,13 @@ func TestDWithin(t *testing.T) {
 								if val == subTC.expected {
 									exclusiveExpected = false
 								}
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
-								require.Equal(t, dwithin, exclusiveExpected)
+								require.Equal(t, exclusiveExpected, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
-								require.Equal(t, dwithin, exclusiveExpected)
+								require.Equal(t, exclusiveExpected, dwithin)
 							})
 						}
 					} else {
@@ -78,20 +78,20 @@ func TestDWithin(t *testing.T) {
 							subTC.expected * 2,
 						} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 							})
 							t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
 								require.True(t, dwithin)
 							})
@@ -104,20 +104,20 @@ func TestDWithin(t *testing.T) {
 							subTC.expected / 2,
 						} {
 							t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, false /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnInclusive)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 							})
 							t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
-								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err := DWithin(a, b, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 
-								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, true /* exclusive */)
+								dwithin, err = DWithin(b, a, val, subTC.useSphereOrSpheroid, geo.FnExclusive)
 								require.NoError(t, err)
 								require.False(t, dwithin)
 							})
@@ -129,12 +129,12 @@ func TestDWithin(t *testing.T) {
 	}
 
 	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
-		_, err := DWithin(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, 0, UseSpheroid, false /* exclusive */)
+		_, err := DWithin(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, 0, UseSpheroid, geo.FnInclusive)
 		requireMismatchingSRIDError(t, err)
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeography("POINT(1.0 2.0)"), geo.MustParseGeography("POINT(3.0 4.0)"), -0.01, UseSpheroid, false /* exclusive */)
+		_, err := DWithin(geo.MustParseGeography("POINT(1.0 2.0)"), geo.MustParseGeography("POINT(3.0 4.0)"), -0.01, UseSpheroid, geo.FnInclusive)
 		require.Error(t, err)
 	})
 
@@ -156,7 +156,7 @@ func TestDWithin(t *testing.T) {
 					require.NoError(t, err)
 					b, err := geo.ParseGeography(tc.b)
 					require.NoError(t, err)
-					dwithin, err := DWithin(a, b, 0, useSphereOrSpheroid, false /* exclusive */)
+					dwithin, err := DWithin(a, b, 0, useSphereOrSpheroid, geo.FnInclusive)
 					require.NoError(t, err)
 					require.False(t, dwithin)
 				})

--- a/pkg/geo/geoindex/geoindex.go
+++ b/pkg/geo/geoindex/geoindex.go
@@ -44,6 +44,7 @@ var RelationshipMap = map[string]RelationshipType{
 	"st_overlaps":         Intersects,
 	"st_touches":          Intersects,
 	"st_within":           CoveredBy,
+	"st_dwithinexclusive": DWithin,
 }
 
 // RelationshipReverseMap contains a default function for each of the

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -54,7 +54,9 @@ func MaxDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 // DWithin determines if any part of geometry A is within D units of geometry B.
 // If exclusive is false, DWithin is equivalent to Distance(a, b) <= d.
 // Otherwise, DWithin is equivalent to Distance(a, b) < d.
-func DWithin(a *geo.Geometry, b *geo.Geometry, d float64, exclusive bool) (bool, error) {
+func DWithin(
+	a *geo.Geometry, b *geo.Geometry, d float64, exclusive geo.FnExclusivity,
+) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
@@ -167,7 +169,7 @@ func minDistanceInternal(
 	b *geo.Geometry,
 	stopAfter float64,
 	emptyBehavior geo.EmptyBehavior,
-	exclusive bool,
+	exclusive geo.FnExclusivity,
 ) (float64, error) {
 	u := newGeomMinDistanceUpdater(stopAfter, exclusive)
 	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox())}
@@ -391,7 +393,7 @@ func (c *geomGeodistEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.P
 type geomMinDistanceUpdater struct {
 	currentValue float64
 	stopAfter    float64
-	exclusive    bool
+	exclusive    geo.FnExclusivity
 	// coordA represents the first vertex of the edge that holds the maximum distance.
 	coordA geom.Coord
 	// coordB represents the second vertex of the edge that holds the maximum distance.
@@ -404,7 +406,9 @@ var _ geodist.DistanceUpdater = (*geomMinDistanceUpdater)(nil)
 
 // newGeomMinDistanceUpdater returns a new geomMinDistanceUpdater with the
 // correct arguments set up.
-func newGeomMinDistanceUpdater(stopAfter float64, exclusive bool) *geomMinDistanceUpdater {
+func newGeomMinDistanceUpdater(
+	stopAfter float64, exclusive geo.FnExclusivity,
+) *geomMinDistanceUpdater {
 	return &geomMinDistanceUpdater{
 		currentValue:        math.MaxFloat64,
 		stopAfter:           stopAfter,

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -39,7 +39,7 @@ func MinDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 	if a.SRID() != b.SRID() {
 		return 0, geo.NewMismatchingSRIDsError(a, b)
 	}
-	return minDistanceInternal(a, b, 0, geo.EmptyBehaviorOmit)
+	return minDistanceInternal(a, b, 0, geo.EmptyBehaviorOmit, false /* exclusive */)
 }
 
 // MaxDistance returns the maximum distance across every pair of points comprising
@@ -52,7 +52,9 @@ func MaxDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 }
 
 // DWithin determines if any part of geometry A is within D units of geometry B.
-func DWithin(a *geo.Geometry, b *geo.Geometry, d float64) (bool, error) {
+// If exclusive is false, DWithin is equivalent to Distance(a, b) <= d.
+// Otherwise, DWithin is equivalent to Distance(a, b) < d.
+func DWithin(a *geo.Geometry, b *geo.Geometry, d float64, exclusive bool) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
@@ -62,13 +64,16 @@ func DWithin(a *geo.Geometry, b *geo.Geometry, d float64) (bool, error) {
 	if !a.CartesianBoundingBox().Buffer(d, d).Intersects(b.CartesianBoundingBox()) {
 		return false, nil
 	}
-	dist, err := minDistanceInternal(a, b, d, geo.EmptyBehaviorError)
+	dist, err := minDistanceInternal(a, b, d, geo.EmptyBehaviorError, exclusive)
 	if err != nil {
 		// In case of any empty geometries return false.
 		if geo.IsEmptyGeometryError(err) {
 			return false, nil
 		}
 		return false, err
+	}
+	if exclusive {
+		return dist < d, nil
 	}
 	return dist <= d, nil
 }
@@ -112,7 +117,7 @@ func ShortestLineString(a *geo.Geometry, b *geo.Geometry) (*geo.Geometry, error)
 	if a.SRID() != b.SRID() {
 		return nil, geo.NewMismatchingSRIDsError(a, b)
 	}
-	u := newGeomMinDistanceUpdater(0)
+	u := newGeomMinDistanceUpdater(0 /*stopAfter */, false /* exclusive */)
 	return distanceLineStringInternal(a, b, u, geo.EmptyBehaviorOmit)
 }
 
@@ -158,9 +163,13 @@ func maxDistanceInternal(
 // minDistanceInternal finds the minimum distance between two geometries.
 // This implementation is done in-house, as compared to using GEOS.
 func minDistanceInternal(
-	a *geo.Geometry, b *geo.Geometry, stopAfterLE float64, emptyBehavior geo.EmptyBehavior,
+	a *geo.Geometry,
+	b *geo.Geometry,
+	stopAfter float64,
+	emptyBehavior geo.EmptyBehavior,
+	exclusive bool,
 ) (float64, error) {
-	u := newGeomMinDistanceUpdater(stopAfterLE)
+	u := newGeomMinDistanceUpdater(stopAfter, exclusive)
 	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox())}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
@@ -376,10 +385,13 @@ func (c *geomGeodistEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.P
 
 // geomMinDistanceUpdater finds the minimum distance using geom calculations.
 // And preserve the line's endpoints as geom.Coord which corresponds to minimum
-// distance. Methods will return early if it finds a minimum distance <= stopAfterLE.
+// distance. If exclusive is false, methods will return early if it finds a
+// minimum distance <= stopAfter. Otherwise, methods will return early if it
+// finds a minimum distance < stopAfter.
 type geomMinDistanceUpdater struct {
 	currentValue float64
-	stopAfterLE  float64
+	stopAfter    float64
+	exclusive    bool
 	// coordA represents the first vertex of the edge that holds the maximum distance.
 	coordA geom.Coord
 	// coordB represents the second vertex of the edge that holds the maximum distance.
@@ -392,10 +404,11 @@ var _ geodist.DistanceUpdater = (*geomMinDistanceUpdater)(nil)
 
 // newGeomMinDistanceUpdater returns a new geomMinDistanceUpdater with the
 // correct arguments set up.
-func newGeomMinDistanceUpdater(stopAfterLE float64) *geomMinDistanceUpdater {
+func newGeomMinDistanceUpdater(stopAfter float64, exclusive bool) *geomMinDistanceUpdater {
 	return &geomMinDistanceUpdater{
 		currentValue:        math.MaxFloat64,
-		stopAfterLE:         stopAfterLE,
+		stopAfter:           stopAfter,
+		exclusive:           exclusive,
 		coordA:              nil,
 		coordB:              nil,
 		geometricalObjOrder: geometricalObjectsNotFlipped,
@@ -422,7 +435,10 @@ func (u *geomMinDistanceUpdater) Update(aPoint geodist.Point, bPoint geodist.Poi
 			u.coordA = a
 			u.coordB = b
 		}
-		return dist <= u.stopAfterLE
+		if u.exclusive {
+			return dist < u.stopAfter
+		}
+		return dist <= u.stopAfter
 	}
 	return false
 }

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -457,11 +457,11 @@ func TestDWithin(t *testing.T) {
 				tc.expectedMinDistance * 2,
 			} {
 				t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-					dwithin, err := DWithin(a, b, val, false /* exclusive */)
+					dwithin, err := DWithin(a, b, val, geo.FnInclusive)
 					require.NoError(t, err)
 					require.Equal(t, expected, dwithin)
 
-					dwithin, err = DWithin(b, a, val, false /* exclusive */)
+					dwithin, err = DWithin(b, a, val, geo.FnInclusive)
 					require.NoError(t, err)
 					require.Equal(t, expected, dwithin)
 				})
@@ -470,11 +470,11 @@ func TestDWithin(t *testing.T) {
 					if val == tc.expectedMinDistance {
 						exclusiveExpected = false
 					}
-					dwithin, err := DWithin(a, b, val, true /* exclusive */)
+					dwithin, err := DWithin(a, b, val, geo.FnExclusive)
 					require.NoError(t, err)
 					require.Equal(t, exclusiveExpected, dwithin)
 
-					dwithin, err = DWithin(b, a, val, true /* exclusive */)
+					dwithin, err = DWithin(b, a, val, geo.FnExclusive)
 					require.NoError(t, err)
 					require.Equal(t, exclusiveExpected, dwithin)
 				})
@@ -487,20 +487,20 @@ func TestDWithin(t *testing.T) {
 			} {
 				if val > 0 {
 					t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-						dwithin, err := DWithin(a, b, val, false /* exclusive */)
+						dwithin, err := DWithin(a, b, val, geo.FnInclusive)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 
-						dwithin, err = DWithin(b, a, val, false /* exclusive */)
+						dwithin, err = DWithin(b, a, val, geo.FnInclusive)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 					})
 					t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
-						dwithin, err := DWithin(a, b, val, true /* exclusive */)
+						dwithin, err := DWithin(a, b, val, geo.FnExclusive)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 
-						dwithin, err = DWithin(b, a, val, true /* exclusive */)
+						dwithin, err = DWithin(b, a, val, geo.FnExclusive)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 					})
@@ -516,7 +516,7 @@ func TestDWithin(t *testing.T) {
 				require.NoError(t, err)
 				b, err := geo.ParseGeometry(tc.b)
 				require.NoError(t, err)
-				dwithin, err := DWithin(a, b, 0, false /* exclusive */)
+				dwithin, err := DWithin(a, b, 0, geo.FnInclusive)
 				require.NoError(t, err)
 				require.False(t, dwithin)
 			})
@@ -529,7 +529,7 @@ func TestDWithin(t *testing.T) {
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, false /* exclusive */)
+		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, geo.FnInclusive)
 		require.Error(t, err)
 	})
 }
@@ -591,7 +591,7 @@ func TestDFullyWithin(t *testing.T) {
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, false /* exclusive */)
+		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, geo.FnInclusive)
 		require.Error(t, err)
 	})
 }

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -457,13 +457,26 @@ func TestDWithin(t *testing.T) {
 				tc.expectedMinDistance * 2,
 			} {
 				t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-					dwithin, err := DWithin(a, b, val)
+					dwithin, err := DWithin(a, b, val, false /* exclusive */)
 					require.NoError(t, err)
 					require.Equal(t, expected, dwithin)
 
-					dwithin, err = DWithin(a, b, val)
+					dwithin, err = DWithin(b, a, val, false /* exclusive */)
 					require.NoError(t, err)
 					require.Equal(t, expected, dwithin)
+				})
+				t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
+					exclusiveExpected := expected
+					if val == tc.expectedMinDistance {
+						exclusiveExpected = false
+					}
+					dwithin, err := DWithin(a, b, val, true /* exclusive */)
+					require.NoError(t, err)
+					require.Equal(t, exclusiveExpected, dwithin)
+
+					dwithin, err = DWithin(b, a, val, true /* exclusive */)
+					require.NoError(t, err)
+					require.Equal(t, exclusiveExpected, dwithin)
 				})
 			}
 
@@ -474,11 +487,20 @@ func TestDWithin(t *testing.T) {
 			} {
 				if val > 0 {
 					t.Run(fmt.Sprintf("dwithin:%f", val), func(t *testing.T) {
-						dwithin, err := DWithin(a, b, val)
+						dwithin, err := DWithin(a, b, val, false /* exclusive */)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 
-						dwithin, err = DWithin(a, b, val)
+						dwithin, err = DWithin(b, a, val, false /* exclusive */)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+					})
+					t.Run(fmt.Sprintf("dwithinexclusive:%f", val), func(t *testing.T) {
+						dwithin, err := DWithin(a, b, val, true /* exclusive */)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+
+						dwithin, err = DWithin(b, a, val, true /* exclusive */)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 					})
@@ -494,7 +516,7 @@ func TestDWithin(t *testing.T) {
 				require.NoError(t, err)
 				b, err := geo.ParseGeometry(tc.b)
 				require.NoError(t, err)
-				dwithin, err := DWithin(a, b, 0)
+				dwithin, err := DWithin(a, b, 0, false /* exclusive */)
 				require.NoError(t, err)
 				require.False(t, dwithin)
 			})
@@ -507,7 +529,7 @@ func TestDWithin(t *testing.T) {
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01)
+		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, false /* exclusive */)
 		require.Error(t, err)
 	})
 }
@@ -569,7 +591,7 @@ func TestDFullyWithin(t *testing.T) {
 	})
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
-		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01)
+		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01, false /* exclusive */)
 		require.Error(t, err)
 	})
 }

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -247,3 +247,32 @@
 )
 =>
 (MakeIntersectionFunction $args)
+
+# FoldCmpSTDistanceLeft replaces an expression of the form:
+# 'ST_Distance(...) <= x' with a call to ST_DWithin or ST_DWithinExclusive. This
+# replacement allows early-exit behavior, and may enable use of an inverted
+# index scan. See the MakeSTDWithin method for the specific variation on
+# ST_DWithin that is used to replace expressions with different comparison
+# operators (e.g. '<' vs '<=').
+[FoldCmpSTDistanceLeft, Normalize]
+(Ge | Gt | Le | Lt
+    $left:(Function
+        $args:*
+        $private:(FunctionPrivate "st_distance")
+    )
+    $right:*
+)
+=>
+(MakeSTDWithinLeft (OpName) $args $right)
+
+# FoldCmpSTDistanceRight mirrors FoldCmpSTDistanceLeft.
+[FoldCmpSTDistanceRight, Normalize]
+(Ge | Gt | Le | Lt
+    $left:*
+    $right:(Function
+        $args:*
+        $private:(FunctionPrivate "st_distance")
+    )
+)
+=>
+(MakeSTDWithinRight (OpName) $args $left)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -732,7 +732,7 @@ project
 # FoldEqZeroSTDistance
 # --------------------------------------------------
 
-# Geography case.
+# Geometry case.
 norm expect=FoldEqZeroSTDistance
 SELECT * FROM geom_geog WHERE st_distance(geom, 'POINT(0.0 0.0)') = 0
 ----
@@ -744,7 +744,7 @@ select
  └── filters
       └── st_intersects(geom:1, '010100000000000000000000000000000000000000') [outer=(1), immutable]
 
-# Geometry case.
+# Geography case.
 norm expect=FoldEqZeroSTDistance
 SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)') = 0
 ----
@@ -767,3 +767,131 @@ select
  │    └── columns: geom:1 geog:2 val:3
  └── filters
       └── st_distance(geom:1, '010100000000000000000000000000000000000000') = 1.0 [outer=(1), immutable]
+
+# --------------------------------------------------
+# FoldCmpSTDistanceLeft
+# --------------------------------------------------
+
+# Geometry case with '<=' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geom, 'point(0.0 0.0)') <= 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithin(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# Geometry case with '<' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance('point(0.0 0.0)', geom) < 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithinexclusive('010100000000000000000000000000000000000000', geom:1, 5.0) [outer=(1), immutable]
+
+# Geometry case with '>=' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geom, 'point(0.0 0.0)') >= 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dwithinexclusive(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# Geometry case with '>' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geom, 'point(0.0 0.0)') > 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dwithin(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# Geography case with '<=' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geog, 'point(0.0 0.0)') <= 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithin(geog:2, '0101000020E610000000000000000000000000000000000000', 5.0) [outer=(2), immutable]
+
+# Geography case with '<' operator.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geog, 'point(0.0 0.0)') < 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithinexclusive(geog:2, '0101000020E610000000000000000000000000000000000000', 5.0) [outer=(2), immutable]
+
+# --------------------------------------------------
+# FoldCmpSTDistanceRight
+# --------------------------------------------------
+
+# Case with '<=' operator.
+norm expect=FoldCmpSTDistanceRight
+SELECT * FROM geom_geog WHERE val <= st_distance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dwithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '<' operator.
+norm expect=FoldCmpSTDistanceRight
+SELECT * FROM geom_geog WHERE val < st_distance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dwithin(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '>=' operator.
+norm expect=FoldCmpSTDistanceRight
+SELECT * FROM geom_geog WHERE val >= st_distance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithin(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '>' operator.
+norm expect=FoldCmpSTDistanceRight
+SELECT * FROM geom_geog WHERE val > st_distance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3280,6 +3280,58 @@ project
       └── filters
            └── st_covers(n.geom:16, c.geom:10) [outer=(10,16), immutable]
 
+# Case for ST_DWithinExclusive.
+opt expect=GenerateInvertedJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_DWithinExclusive(c.geom, n.geom, 50)
+----
+project
+ ├── columns: name:15 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:15 n.geom:16
+      ├── key columns: [13] = [13]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
+      │    ├── inverted-expr
+      │    │    └── st_dwithinexclusive(c.geom:10, n.geom:16, 50.0)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_dwithinexclusive(c.geom:10, n.geom:16, 50.0) [outer=(10,16), immutable]
+
+# Commuted version of previous test.
+opt expect=GenerateInvertedJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_DWithinExclusive(n.geom, c.geom, 50)
+----
+project
+ ├── columns: name:15 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:15 n.geom:16
+      ├── key columns: [13] = [13]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
+      │    ├── inverted-expr
+      │    │    └── st_dwithin(c.geom:10, n.geom:16, 50.0)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_dwithinexclusive(n.geom:16, c.geom:10, 50.0) [outer=(10,16), immutable]
+
 # Complex join filter.
 opt expect=GenerateInvertedJoins
 SELECT

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1850,6 +1850,69 @@ project
       └── filters
            └── st_dwithin('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4, 2000.0, false) [outer=(4), immutable]
 
+# Test for ST_DWithinExclusive
+opt
+SELECT k FROM g WHERE ST_DWithinExclusive('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null geom:3
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      ├── index-join g
+      │    ├── columns: k:1!null geom:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /6
+      │         │    ├── tight: false
+      │         │    └── union spans: ["\x89", "\xfd ")
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom_inverted_key:6!null
+      │              ├── inverted constraint: /6/1
+      │              │    └── spans: ["\x89", "\xfd ")
+      │              ├── key: (1)
+      │              └── fd: (1)-->(6)
+      └── filters
+           └── st_dwithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable]
+
+# Commuted version of previous test.
+opt
+SELECT k FROM g WHERE ST_DWithinExclusive(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, 2)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null geom:3
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      ├── index-join g
+      │    ├── columns: k:1!null geom:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /6
+      │         │    ├── tight: false
+      │         │    └── union spans: ["\x89", "\xfd ")
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom_inverted_key:6!null
+      │              ├── inverted constraint: /6/1
+      │              │    └── spans: ["\x89", "\xfd ")
+      │              ├── key: (1)
+      │              └── fd: (1)-->(6)
+      └── filters
+           └── st_dwithinexclusive(geom:3, '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', 2.0) [outer=(3), immutable]
 
 # Multiple geospatial functions.
 opt

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2530,7 +2530,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
-	"st_dwithin": makeSTDWithinBuiltin(false /* exclusive */),
+	"st_dwithin": makeSTDWithinBuiltin(geo.FnInclusive),
 	"st_equals": makeBuiltin(
 		defProps(),
 		geometryOverload2BinaryPredicate(
@@ -3941,7 +3941,7 @@ Bottom Left.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
-	"_st_dwithinexclusive": makeSTDWithinBuiltin(true /* exclusive */),
+	"st_dwithinexclusive": makeSTDWithinBuiltin(geo.FnExclusive),
 }
 
 // returnCompatibilityFixedStringBuiltin is an overload that takes in 0 arguments
@@ -4213,7 +4213,7 @@ func initGeoBuiltins() {
 		"st_intersects",
 		"st_intersection",
 		"st_length",
-		"_st_dwithinexclusive",
+		"st_dwithinexclusive",
 	} {
 		builtin, exists := geoBuiltins[builtinName]
 		if !exists {
@@ -4492,7 +4492,11 @@ func stAsGeoJSONFromTuple(
 	return tree.NewDString(string(marshalledIndent)), nil
 }
 
-func makeSTDWithinBuiltin(exclusive bool) builtinDefinition {
+func makeSTDWithinBuiltin(exclusive geo.FnExclusivity) builtinDefinition {
+	exclusivityStr := ", inclusive."
+	if exclusive {
+		exclusivityStr = ", exclusive."
+	}
 	return makeBuiltin(
 		defProps(),
 		tree.Overload{
@@ -4513,7 +4517,8 @@ func makeSTDWithinBuiltin(exclusive bool) builtinDefinition {
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info: "Returns true if any of geometry_a is within distance units of geometry_b.",
+				info: "Returns true if any of geometry_a is within distance units of geometry_b" +
+					exclusivityStr,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
@@ -4535,7 +4540,8 @@ func makeSTDWithinBuiltin(exclusive bool) builtinDefinition {
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info:         "Returns true if any of geography_a is within distance meters of geography_b." + usesSpheroidMessage + spheroidDistanceMessage,
+				info: "Returns true if any of geography_a is within distance meters of geography_b" +
+					exclusivityStr + usesSpheroidMessage + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib,
 				precision:    "1cm",
 			}.String(),
@@ -4562,7 +4568,8 @@ func makeSTDWithinBuiltin(exclusive bool) builtinDefinition {
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info:         "Returns true if any of geography_a is within distance meters of geography_b." + spheroidDistanceMessage,
+				info: "Returns true if any of geography_a is within distance meters of geography_b" +
+					exclusivityStr + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib | usesS2,
 				precision:    "1cm",
 			}.String(),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2530,82 +2530,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
-	"st_dwithin": makeBuiltin(
-		defProps(),
-		tree.Overload{
-			Types: tree.ArgTypes{
-				{"geometry_a", types.Geometry},
-				{"geometry_b", types.Geometry},
-				{"distance", types.Float},
-			},
-			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				a := args[0].(*tree.DGeometry)
-				b := args[1].(*tree.DGeometry)
-				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DWithin(a.Geometry, b.Geometry, float64(*dist))
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDBool(tree.DBool(ret)), nil
-			},
-			Info: infoBuilder{
-				info: "Returns true if any of geometry_a is within distance units of geometry_b.",
-			}.String(),
-			Volatility: tree.VolatilityImmutable,
-		},
-		tree.Overload{
-			Types: tree.ArgTypes{
-				{"geography_a", types.Geography},
-				{"geography_b", types.Geography},
-				{"distance", types.Float},
-			},
-			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				a := args[0].(*tree.DGeography)
-				b := args[1].(*tree.DGeography)
-				dist := args[2].(*tree.DFloat)
-				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), geogfn.UseSpheroid)
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDBool(tree.DBool(ret)), nil
-			},
-			Info: infoBuilder{
-				info:         "Returns true if any of geography_a is within distance meters of geography_b." + usesSpheroidMessage + spheroidDistanceMessage,
-				libraryUsage: usesGeographicLib,
-				precision:    "1cm",
-			}.String(),
-			Volatility: tree.VolatilityImmutable,
-		},
-		tree.Overload{
-			Types: tree.ArgTypes{
-				{"geography_a", types.Geography},
-				{"geography_b", types.Geography},
-				{"distance", types.Float},
-				{"use_spheroid", types.Bool},
-			},
-			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				a := args[0].(*tree.DGeography)
-				b := args[1].(*tree.DGeography)
-				dist := args[2].(*tree.DFloat)
-				useSpheroid := args[3].(*tree.DBool)
-
-				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), toUseSphereOrSpheroid(useSpheroid))
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDBool(tree.DBool(ret)), nil
-			},
-			Info: infoBuilder{
-				info:         "Returns true if any of geography_a is within distance meters of geography_b." + spheroidDistanceMessage,
-				libraryUsage: usesGeographicLib | usesS2,
-				precision:    "1cm",
-			}.String(),
-			Volatility: tree.VolatilityImmutable,
-		},
-	),
+	"st_dwithin": makeSTDWithinBuiltin(false /* exclusive */),
 	"st_equals": makeBuiltin(
 		defProps(),
 		geometryOverload2BinaryPredicate(
@@ -4016,6 +3941,7 @@ Bottom Left.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+	"_st_dwithinexclusive": makeSTDWithinBuiltin(true /* exclusive */),
 }
 
 // returnCompatibilityFixedStringBuiltin is an overload that takes in 0 arguments
@@ -4287,6 +4213,7 @@ func initGeoBuiltins() {
 		"st_intersects",
 		"st_intersection",
 		"st_length",
+		"_st_dwithinexclusive",
 	} {
 		builtin, exists := geoBuiltins[builtinName]
 		if !exists {
@@ -4563,4 +4490,83 @@ func stAsGeoJSONFromTuple(
 		return nil, err
 	}
 	return tree.NewDString(string(marshalledIndent)), nil
+}
+
+func makeSTDWithinBuiltin(exclusive bool) builtinDefinition {
+	return makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_a", types.Geometry},
+				{"geometry_b", types.Geometry},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := args[0].(*tree.DGeometry)
+				b := args[1].(*tree.DGeometry)
+				dist := args[2].(*tree.DFloat)
+				ret, err := geomfn.DWithin(a.Geometry, b.Geometry, float64(*dist), exclusive)
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if any of geometry_a is within distance units of geometry_b.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geography_a", types.Geography},
+				{"geography_b", types.Geography},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := args[0].(*tree.DGeography)
+				b := args[1].(*tree.DGeography)
+				dist := args[2].(*tree.DFloat)
+				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), geogfn.UseSpheroid, exclusive)
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info:         "Returns true if any of geography_a is within distance meters of geography_b." + usesSpheroidMessage + spheroidDistanceMessage,
+				libraryUsage: usesGeographicLib,
+				precision:    "1cm",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geography_a", types.Geography},
+				{"geography_b", types.Geography},
+				{"distance", types.Float},
+				{"use_spheroid", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := args[0].(*tree.DGeography)
+				b := args[1].(*tree.DGeography)
+				dist := args[2].(*tree.DFloat)
+				useSpheroid := args[3].(*tree.DBool)
+
+				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), toUseSphereOrSpheroid(useSpheroid), exclusive)
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info:         "Returns true if any of geography_a is within distance meters of geography_b." + spheroidDistanceMessage,
+				libraryUsage: usesGeographicLib | usesS2,
+				precision:    "1cm",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	)
 }


### PR DESCRIPTION
`ST_DWithin` is equivalent to the expression `ST_Distance <= x`.
Similar reformulations can be made for different comparison operators
(<, >, >=). 

This PR consists of two commits. The first commit adds an internal builtin
function `ST_DWithinExclusive`, which is equivalent to `ST_Distance < x`
but is able to exit early.

The second commit adds two rules that replace expressions of the form 
`ST_Distance <= x` with either `ST_DWithin` or `ST_DWithinExclusive` 
depending on the comparison operator used. This replacement is desirable 
because the `ST_DWithin` function can exit early, while `ST_Distance` cannot
do the same. `ST_DWithin` can also be used to generate an inverted index scan.

Fixes #52028

Release note: None