### PR TITLE
opt: add INSERT ON CONFLICT WHERE syntax for selecting arbiter indexes

### DIFF
--- a/docs/generated/sql/bnf/on_conflict.bnf
+++ b/docs/generated/sql/bnf/on_conflict.bnf
@@ -1,3 +1,4 @@
 on_conflict ::=
-	'ON' 'CONFLICT' ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) 'DO' 'UPDATE' 'SET' ( ( ( ( column_name '=' a_expr ) | ( '(' ( ( ( column_name ) ) ( ( ',' ( column_name ) ) )* ) ')' '=' ( '(' select_stmt ')' | ( '(' ')' | '(' ( a_expr | a_expr ',' | a_expr ',' ( ( a_expr ) ( ( ',' a_expr ) )* ) ) ')' ) ) ) ) ) ( ( ',' ( ( column_name '=' a_expr ) | ( '(' ( ( ( column_name ) ) ( ( ',' ( column_name ) ) )* ) ')' '=' ( '(' select_stmt ')' | ( '(' ')' | '(' ( a_expr | a_expr ',' | a_expr ',' ( ( a_expr ) ( ( ',' a_expr ) )* ) ) ')' ) ) ) ) ) )* ) 
-	| 'ON' 'CONFLICT' ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) 'DO' 'NOTHING'
+	'ON' 'CONFLICT' 'DO' 'NOTHING'
+	| 'ON' 'CONFLICT' '(' ( ( name ) ( ( ',' name ) )* ) ')'  'DO' 'NOTHING'
+	| 'ON' 'CONFLICT' '(' ( ( name ) ( ( ',' name ) )* ) ')'  'DO' 'UPDATE' 'SET' ( ( ( ( column_name '=' a_expr ) | ( '(' ( ( ( column_name ) ) ( ( ',' ( column_name ) ) )* ) ')' '=' ( '(' select_stmt ')' | ( '(' ')' | '(' ( a_expr | a_expr ',' | a_expr ',' ( ( a_expr ) ( ( ',' a_expr ) )* ) ) ')' ) ) ) ) ) ( ( ',' ( ( column_name '=' a_expr ) | ( '(' ( ( ( column_name ) ) ( ( ',' ( column_name ) ) )* ) ')' '=' ( '(' select_stmt ')' | ( '(' ')' | '(' ( a_expr | a_expr ',' | a_expr ',' ( ( a_expr ) ( ( ',' a_expr ) )* ) ) ')' ) ) ) ) ) )* ) 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -471,8 +471,9 @@ insert_rest ::=
 	| 'DEFAULT' 'VALUES'
 
 on_conflict ::=
-	'ON' 'CONFLICT' opt_conf_expr 'DO' 'UPDATE' 'SET' set_clause_list opt_where_clause
-	| 'ON' 'CONFLICT' opt_conf_expr 'DO' 'NOTHING'
+	'ON' 'CONFLICT' 'DO' 'NOTHING'
+	| 'ON' 'CONFLICT' '(' name_list ')' opt_where_clause 'DO' 'NOTHING'
+	| 'ON' 'CONFLICT' '(' name_list ')' opt_where_clause 'DO' 'UPDATE' 'SET' set_clause_list opt_where_clause
 
 pause_jobs_stmt ::=
 	'PAUSE' 'JOB' a_expr
@@ -1295,10 +1296,6 @@ table_elem ::=
 
 insert_column_item ::=
 	column_name
-
-opt_conf_expr ::=
-	'(' name_list ')'
-	| 
 
 session_var ::=
 	'identifier'

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -857,7 +857,7 @@ var specs = []stmtSpec{
 	},
 	{
 		name: "on_conflict",
-		inline: []string{"opt_conf_expr", "name_list", "set_clause_list", "insert_column_list",
+		inline: []string{"name_list", "set_clause_list", "insert_column_list",
 			"insert_column_item", "set_clause", "single_set_clause", "multiple_set_clause", "in_expr", "expr_list",
 			"expr_tuple1_ambiguous", "tuple1_ambiguous_values"},
 		replace: map[string]string{

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -831,6 +831,63 @@ DROP INDEX i2
 statement ok
 DELETE from u
 
+# Tests for ON CONFLICT (a) [WHERE ...] DO NOTHING.
+
+# An ON CONFLICT without a WHERE clause cannot use a unique partial index as an
+# arbiter.
+statement error pgcode 42P10 there is no unique or exclusion constraint matching the ON CONFLICT specification
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) DO NOTHING
+
+# An ON CONFLICT with a WHERE clause cannot use a unique partial index if the
+# WHERE clause does not imply the partial index predicate.
+statement error pgcode 42P10 there is no unique or exclusion constraint matching the ON CONFLICT specification
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b < -1 DO NOTHING
+
+# An ON CONFLICT without a WHERE clause can use a unique pseudo-partial index as
+# an arbiter.
+statement ok
+CREATE UNIQUE INDEX i2 ON u (b) WHERE 1 = 1;
+INSERT INTO u VALUES (1, 1) ON CONFLICT (b) DO NOTHING;
+DELETE FROM u;
+DROP INDEX i2;
+
+# An ON CONFLICT with any WHERE clause can use a unique non-partial index as an
+# arbiter.
+statement ok
+CREATE UNIQUE INDEX i2 ON u (b);
+INSERT INTO u VALUES (1, 1) ON CONFLICT (b) WHERE b > 0 DO NOTHING;
+DROP INDEX i2;
+
+# An ON CONFLICT with a WHERE clause can be use a unique partial index if the
+# WHERE clause implies the partial index predicate.
+statement ok
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b > 1 DO NOTHING;
+INSERT INTO u VALUES (1, 2) ON CONFLICT (a) WHERE b > 1 DO NOTHING;
+
+query II rowsort
+SELECT * FROM u
+----
+1   1
+
+# There can be duplicate key errors from unique partial indexes that are not
+# arbiters.
+statement ok
+CREATE UNIQUE INDEX i2 ON u (a) WHERE b < 0;
+INSERT INTO u VALUES (-1, -1);
+
+statement error pgcode 23505 duplicate key value \(a\)=\(-1\) violates unique constraint \"i2\"
+INSERT INTO u VALUES (-1, -1) ON CONFLICT (a) WHERE b > 0 DO NOTHING
+
+# Two arbiters can be used to detect conflicts and avoid duplicate key errors.
+statement ok
+INSERT INTO u VALUES (1, 2), (-1, -2) ON CONFLICT (a) WHERE b > 0 AND b < 0 DO NOTHING
+
+statement ok
+DROP INDEX i2
+
+statement ok
+DELETE FROM u
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -120,9 +120,6 @@ INSERT INTO kv VALUES (4, 10) ON CONFLICT (k) DO UPDATE SET v = v + 1
 statement count 1
 INSERT INTO kv VALUES (4, 10) ON CONFLICT (k) DO UPDATE SET v = kv.v + 20
 
-statement error there is no unique or exclusion constraint matching the ON CONFLICT specification
-INSERT INTO kv VALUES (4, 10) ON CONFLICT DO UPDATE SET v = kv.v + 20
-
 statement error duplicate key value \(k\)=\(3\) violates unique constraint "primary"
 INSERT INTO kv VALUES (2, 10) ON CONFLICT (k) DO UPDATE SET k = 3, v = 10
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/partialidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -290,7 +290,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		// rows that have conflicts. See the buildInputForDoNothing comment for
 		// more details.
 		conflictOrds := mb.mapPublicColumnNamesToOrdinals(ins.OnConflict.Columns)
-		mb.buildInputForDoNothing(inScope, conflictOrds)
+		mb.buildInputForDoNothing(inScope, conflictOrds, ins.OnConflict.ArbiterPredicate)
 
 		// Since buildInputForDoNothing filters out rows with conflicts, always
 		// insert rows that are not filtered.
@@ -664,16 +664,11 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 // filter that discards rows that have a conflict (by checking a not-null table
 // column to see if it was null-extended by the left join). See the comment
 // header for Builder.buildInsert for an example.
-func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds util.FastIntSet) {
-	// DO NOTHING clause does not require ON CONFLICT columns.
-	var conflictIndex cat.Index
-	if !conflictOrds.Empty() {
-		// Check that the ON CONFLICT columns reference at most one target row by
-		// ensuring they match columns of a UNIQUE index. Using LEFT OUTER JOIN
-		// to detect conflicts relies upon this being true (otherwise result
-		// cardinality could increase). This is also a Postgres requirement.
-		conflictIndex = mb.ensureUniqueConflictCols(conflictOrds)
-	}
+func (mb *mutationBuilder) buildInputForDoNothing(
+	inScope *scope, conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
+) {
+	// Determine the set of arbiter indexes to use to check for conflicts.
+	arbiterIndexes := mb.arbiterIndexes(conflictOrds, arbiterPredicate)
 
 	insertColSet := mb.outScope.expr.Relational().OutputCols
 	insertColScope := mb.outScope.replace()
@@ -686,25 +681,16 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 	// Loop again over each UNIQUE index, potentially creating a left join +
 	// filter for each one.
 	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
+		// Skip non-arbiter indexes.
+		if !arbiterIndexes.Contains(idx) {
+			continue
+		}
+
 		index := mb.tab.Index(idx)
-		if !index.IsUnique() {
-			continue
-		}
-
-		// If conflict columns were explicitly specified, then only check for a
-		// conflict on a single index. Otherwise, check on all indexes.
-		if conflictIndex != nil && conflictIndex != index {
-			continue
-		}
-
-		pred, isPartial := index.Predicate()
+		_, isPartial := index.Predicate()
 		var predExpr tree.Expr
 		if isPartial {
-			var err error
-			predExpr, err = parser.ParseExpr(pred)
-			if err != nil {
-				panic(err)
-			}
+			predExpr = mb.parsePartialIndexPredicateExpr(idx)
 		}
 
 		// Build the right side of the left outer join. Use a new metadata instance
@@ -1163,6 +1149,111 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 	mb.outScope = projectionsScope
+}
+
+// arbiterIndexes returns the set of index ordinals to be used as arbiter
+// indexes for an INSERT ON CONFLICT statement. This function panics if no
+// arbiter indexes are found.
+//
+// Arbiter indexes ensure that the columns designated by conflictOrds reference
+// at most one target row of a UNIQUE index. Using LEFT OUTER JOINs to detect
+// conflicts relies upon this being true (otherwise result cardinality could
+// increase). This is also a Postgres requirement.
+//
+// An arbiter index:
+//
+//   1. Must have lax key columns that match the columns in conflictOrds.
+//   2. If it is a partial index, its predicate must be implied by the
+//      arbiterPredicate supplied by the user.
+//
+// If conflictOrds is empty then all unique indexes are returned as arbiters.
+// This is required to support a DO NOTHING with no ON CONFLICT columns. In this
+// case, all unique indexes are used to check for conflicts.
+//
+// If a non-partial or pseudo-partial arbiter index is found, the return set
+// contains only that index. No other arbiter is necessary because a non-partial
+// or pseudo-partial index guarantee uniqueness of their columns across all
+// rows.
+func (mb *mutationBuilder) arbiterIndexes(
+	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
+) (arbiters util.FastIntSet) {
+	// If conflictOrds is empty, then all unique indexes are arbiters.
+	if conflictOrds.Empty() {
+		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
+			if mb.tab.Index(idx).IsUnique() {
+				arbiters.Add(idx)
+			}
+		}
+		return arbiters
+	}
+
+	tabMeta := mb.md.TableMeta(mb.tabID)
+	var tableScope *scope
+	var im *partialidx.Implicator
+	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
+		index := mb.tab.Index(idx)
+
+		// Skip non-unique indexes. Use lax key columns, which always contain
+		// the minimum columns that ensure uniqueness. Null values are
+		// considered to be *not* equal, but that's OK because the join
+		// condition rejects nulls anyway.
+		if !index.IsUnique() || index.LaxKeyColumnCount() != conflictOrds.Len() {
+			continue
+		}
+
+		// Determine whether the conflict columns match the columns in the lax
+		// key. If not, the index cannot be an arbiter index.
+		indexOrds := getIndexLaxKeyOrdinals(index)
+		if !indexOrds.Equals(conflictOrds) {
+			continue
+		}
+
+		_, isPartial := index.Predicate()
+
+		// If the index is not a partial index, it can always be an arbiter.
+		// Furthermore, it is the only arbiter needed because it guarantees
+		// uniqueness of its columns across all rows.
+		if !isPartial {
+			return util.MakeFastIntSet(idx)
+		}
+
+		// Initialize tableScope once and only if needed.
+		if tableScope == nil {
+			tableScope = mb.b.allocScope()
+			tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
+		}
+
+		// If the index is a pseudo-partial index, it can always be an arbiter.
+		// Furthermore, it is the only arbiter needed because it guarantees
+		// uniqueness of its columns across all rows.
+		predFilter := mb.b.buildPartialIndexPredicate(tableScope, mb.parsePartialIndexPredicateExpr(idx))
+		if predFilter.IsTrue() {
+			return util.MakeFastIntSet(idx)
+		}
+
+		// If the index is a partial index, then it can only be an arbiter if
+		// the arbiterPredicate implies it.
+		if arbiterPredicate != nil {
+
+			// Initialize the Implicator once.
+			if im == nil {
+				im = &partialidx.Implicator{}
+				im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
+			}
+
+			arbiterFilter := mb.b.buildPartialIndexPredicate(tableScope, arbiterPredicate)
+			if _, ok := im.FiltersImplyPredicate(arbiterFilter, predFilter); ok {
+				arbiters.Add(idx)
+			}
+		}
+	}
+
+	if arbiters.Empty() {
+		panic(pgerror.Newf(pgcode.InvalidColumnReference,
+			"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
+	}
+
+	return arbiters
 }
 
 // ensureUniqueConflictCols tries to prove that the given set of column ordinals

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -136,9 +136,14 @@ type mutationBuilder struct {
 	// are joined into larger LEFT OUTER JOIN expressions.
 	subqueries []*scope
 
-	// parsedExprs is a cached set of parsed default and computed expressions
+	// parsedColExprs is a cached set of parsed default and computed expressions
 	// from the table schema. These are parsed once and cached for reuse.
-	parsedExprs []tree.Expr
+	parsedColExprs []tree.Expr
+
+	// parsedIndexExprs is a cached set of parsed partial index predicate
+	// expressions from the table schema. These are parsed once and cached for
+	// reuse.
+	parsedIndexExprs []tree.Expr
 
 	// checks contains foreign key check queries; see buildFK* methods.
 	checks memo.FKChecksExpr
@@ -787,16 +792,11 @@ func (mb *mutationBuilder) projectPartialIndexCols(colIDs opt.ColList, predScope
 		ord := 0
 		for i, n := 0, mb.tab.DeletableIndexCount(); i < n; i++ {
 			index := mb.tab.Index(i)
-			predicate, ok := index.Predicate()
-			if !ok {
+			if _, isPartial := index.Predicate(); !isPartial {
 				continue
 			}
 
-			expr, err := parser.ParseExpr(predicate)
-			if err != nil {
-				panic(err)
-			}
-
+			expr := mb.parsePartialIndexPredicateExpr(i)
 			texpr := predScope.resolveAndRequireType(expr, types.Bool)
 			scopeCol := mb.b.addColumn(projectionScope, "", texpr)
 
@@ -974,14 +974,14 @@ func (mb *mutationBuilder) checkNumCols(expected, actual int) {
 // computed value expression for the given table column, and caches it for
 // reuse.
 func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.Expr {
-	if mb.parsedExprs == nil {
-		mb.parsedExprs = make([]tree.Expr, mb.tab.ColumnCount())
+	if mb.parsedColExprs == nil {
+		mb.parsedColExprs = make([]tree.Expr, mb.tab.ColumnCount())
 	}
 
 	// Return expression from cache, if it was already parsed previously.
 	ord := mb.tabID.ColumnOrdinal(colID)
-	if mb.parsedExprs[ord] != nil {
-		return mb.parsedExprs[ord]
+	if mb.parsedColExprs[ord] != nil {
+		return mb.parsedColExprs[ord]
 	}
 
 	var exprStr string
@@ -1009,7 +1009,36 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 		panic(err)
 	}
 
-	mb.parsedExprs[ord] = expr
+	mb.parsedColExprs[ord] = expr
+	return expr
+}
+
+// parsePartialIndexPredicateExpr parses the partial index predicate for the
+// given index and caches it for reuse. This function panics if the index at the
+// given ordinal is not a partial index.
+func (mb *mutationBuilder) parsePartialIndexPredicateExpr(idx cat.IndexOrdinal) tree.Expr {
+	index := mb.tab.Index(idx)
+
+	predStr, isPartial := index.Predicate()
+	if !isPartial {
+		panic(errors.AssertionFailedf("index at ordinal %d is not a partial index", idx))
+	}
+
+	if mb.parsedIndexExprs == nil {
+		mb.parsedIndexExprs = make([]tree.Expr, mb.tab.DeletableIndexCount())
+	}
+
+	// Return expression from the cache, if it was already parsed previously.
+	if mb.parsedIndexExprs[idx] != nil {
+		return mb.parsedIndexExprs[idx]
+	}
+
+	expr, err := parser.ParseExpr(predStr)
+	if err != nil {
+		panic(err)
+	}
+
+	mb.parsedIndexExprs[idx] = expr
 	return expr
 }
 

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// buildPartialIndexPredicate builds a memo.FiltersExpr from the given
+// tree.Expr. The expression must be of type Bool and it must be immutable.
+// Simple normalization is applied to the expression in order to facilitate
+// implication logic. See Factory.NormalizePartialIndexPredicate for more
+// details.
+func (b *Builder) buildPartialIndexPredicate(tableScope *scope, expr tree.Expr) memo.FiltersExpr {
+	texpr := tableScope.resolveAndRequireType(expr, types.Bool)
+
+	var scalar opt.ScalarExpr
+	b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
+		scalar = b.buildScalar(texpr, tableScope, nil, nil, nil)
+	})
+
+	// Wrap the scalar in a FiltersItem.
+	filter := b.factory.ConstructFiltersItem(scalar)
+
+	// Expressions with non-immutable operators are not supported as partial
+	// index predicates.
+	if filter.ScalarProps().VolatilitySet.HasStable() || filter.ScalarProps().VolatilitySet.HasVolatile() {
+		panic(errors.AssertionFailedf("partial index predicate is not immutable"))
+	}
+
+	// Wrap the predicate filter expression in a FiltersExpr and normalize it.
+	filters := memo.FiltersExpr{filter}
+	return b.factory.NormalizePartialIndexPredicate(filters)
+}

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2177,3 +2177,198 @@ insert unique_partial_indexes
       │                   └── column3:7
       └── projections
            └── column3:7 = 'foo' [as=column17:17]
+
+exec-ddl
+CREATE UNIQUE INDEX u2 ON unique_partial_indexes (b) WHERE c = 'bar'
+----
+
+# Build scans for both partial indexes when the arbiter predicate implies them.
+build
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
+----
+insert unique_partial_indexes
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column18:18 column19:19
+ └── project
+      ├── columns: column18:18!null column19:19!null column1:5!null column2:6!null column3:7!null
+      ├── project
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    └── upsert-distinct-on
+      │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct2:17
+      │         ├── grouping columns: column2:6!null upsert_partial_index_distinct2:17
+      │         ├── project
+      │         │    ├── columns: upsert_partial_index_distinct2:17 column1:5!null column2:6!null column3:7!null
+      │         │    ├── project
+      │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    └── select
+      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:13 b:14 c:15
+      │         │    │         ├── left-join (hash)
+      │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:13 b:14 c:15
+      │         │    │         │    ├── project
+      │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    └── upsert-distinct-on
+      │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:12
+      │         │    │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:12
+      │         │    │         │    │         ├── project
+      │         │    │         │    │         │    ├── columns: upsert_partial_index_distinct1:12 column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │         │    ├── project
+      │         │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │         │    │    └── select
+      │         │    │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │         │    │         │    │         ├── left-join (hash)
+      │         │    │         │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │         │    │         │    │         │    ├── values
+      │         │    │         │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │         │    │         │    │    └── (1, 1, 'bar')
+      │         │    │         │    │         │    │         │    ├── select
+      │         │    │         │    │         │    │         │    │    ├── columns: a:8!null b:9 c:10!null
+      │         │    │         │    │         │    │         │    │    ├── scan unique_partial_indexes
+      │         │    │         │    │         │    │         │    │    │    ├── columns: a:8!null b:9 c:10
+      │         │    │         │    │         │    │         │    │    │    └── partial index predicates
+      │         │    │         │    │         │    │         │    │    │         ├── secondary: filters
+      │         │    │         │    │         │    │         │    │    │         │    └── c:10 = 'foo'
+      │         │    │         │    │         │    │         │    │    │         └── u2: filters
+      │         │    │         │    │         │    │         │    │    │              └── c:10 = 'bar'
+      │         │    │         │    │         │    │         │    │    └── filters
+      │         │    │         │    │         │    │         │    │         └── c:10 = 'foo'
+      │         │    │         │    │         │    │         │    └── filters
+      │         │    │         │    │         │    │         │         ├── column2:6 = b:9
+      │         │    │         │    │         │    │         │         └── column3:7 = 'foo'
+      │         │    │         │    │         │    │         └── filters
+      │         │    │         │    │         │    │              └── a:8 IS NULL
+      │         │    │         │    │         │    └── projections
+      │         │    │         │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:12]
+      │         │    │         │    │         └── aggregations
+      │         │    │         │    │              ├── first-agg [as=column1:5]
+      │         │    │         │    │              │    └── column1:5
+      │         │    │         │    │              └── first-agg [as=column3:7]
+      │         │    │         │    │                   └── column3:7
+      │         │    │         │    ├── select
+      │         │    │         │    │    ├── columns: a:13!null b:14 c:15!null
+      │         │    │         │    │    ├── scan unique_partial_indexes
+      │         │    │         │    │    │    ├── columns: a:13!null b:14 c:15
+      │         │    │         │    │    │    └── partial index predicates
+      │         │    │         │    │    │         ├── secondary: filters
+      │         │    │         │    │    │         │    └── c:15 = 'foo'
+      │         │    │         │    │    │         └── u2: filters
+      │         │    │         │    │    │              └── c:15 = 'bar'
+      │         │    │         │    │    └── filters
+      │         │    │         │    │         └── c:15 = 'bar'
+      │         │    │         │    └── filters
+      │         │    │         │         ├── column2:6 = b:14
+      │         │    │         │         └── column3:7 = 'bar'
+      │         │    │         └── filters
+      │         │    │              └── a:13 IS NULL
+      │         │    └── projections
+      │         │         └── (column3:7 = 'bar') OR NULL::BOOL [as=upsert_partial_index_distinct2:17]
+      │         └── aggregations
+      │              ├── first-agg [as=column1:5]
+      │              │    └── column1:5
+      │              └── first-agg [as=column3:7]
+      │                   └── column3:7
+      └── projections
+           ├── column3:7 = 'foo' [as=column18:18]
+           └── column3:7 = 'bar' [as=column19:19]
+
+exec-ddl
+CREATE UNIQUE INDEX u3 ON unique_partial_indexes (b)
+----
+
+# If there is a non-partial unique index, then it is the only arbiter.
+build
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
+----
+insert unique_partial_indexes
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column12:12 column13:13
+ └── project
+      ├── columns: column12:12!null column13:13!null column1:5!null column2:6!null column3:7!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    ├── grouping columns: column2:6!null
+      │    ├── project
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    └── select
+      │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │    │         ├── left-join (hash)
+      │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │    │         │    ├── values
+      │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │         │    │    └── (1, 1, 'bar')
+      │    │         │    ├── scan unique_partial_indexes
+      │    │         │    │    ├── columns: a:8!null b:9 c:10
+      │    │         │    │    └── partial index predicates
+      │    │         │    │         ├── secondary: filters
+      │    │         │    │         │    └── c:10 = 'foo'
+      │    │         │    │         └── u2: filters
+      │    │         │    │              └── c:10 = 'bar'
+      │    │         │    └── filters
+      │    │         │         └── column2:6 = b:9
+      │    │         └── filters
+      │    │              └── a:8 IS NULL
+      │    └── aggregations
+      │         ├── first-agg [as=column1:5]
+      │         │    └── column1:5
+      │         └── first-agg [as=column3:7]
+      │              └── column3:7
+      └── projections
+           ├── column3:7 = 'foo' [as=column12:12]
+           └── column3:7 = 'bar' [as=column13:13]
+
+exec-ddl
+DROP INDEX u3
+----
+
+exec-ddl
+CREATE UNIQUE INDEX u4 ON unique_partial_indexes (b) WHERE 1 = 1
+----
+
+# If there is a pseudo-partial unique index, then it is the only arbiter. Note
+# that the "opt" test directive is used here rather than "build". This is
+# because "build" disables optimization like constant-folding. This causes the
+# predicate of the pseudo-partial index, (1 = 1), to not fold to an empty
+# FiltersExpr (which is equivalent to true). The mutationBuilder.arbiterIndexes
+# function therefore cannot detect that the index is pseudo-partial. The "opt"
+# directive does not disable optimizations, resulting in more accurate
+# representation of real-world behavior and allowing the output of this test to
+# reflect that the pseudo-partial index is the only arbiter.
+opt
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
+----
+insert unique_partial_indexes
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column13:13 column14:14 column15:15
+ └── project
+      ├── columns: column13:13!null column14:14!null column15:15!null column1:5!null column2:6!null column3:7!null
+      ├── select
+      │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9
+      │    ├── left-join (cross)
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9
+      │    │    ├── values
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    └── (1, 1, 'bar')
+      │    │    ├── select
+      │    │    │    ├── columns: a:8!null b:9!null
+      │    │    │    ├── scan unique_partial_indexes@u4,partial
+      │    │    │    │    └── columns: a:8!null b:9
+      │    │    │    └── filters
+      │    │    │         └── b:9 = 1
+      │    │    └── filters (true)
+      │    └── filters
+      │         └── a:8 IS NULL
+      └── projections
+           ├── column3:7 = 'foo' [as=column13:13]
+           ├── column3:7 = 'bar' [as=column14:14]
+           └── true [as=column15:15]

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -737,8 +737,9 @@ func TestParse(t *testing.T) {
 
 		{`INSERT INTO a VALUES (1) ON CONFLICT DO NOTHING`},
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a) DO NOTHING`},
-		{`INSERT INTO a VALUES (1) ON CONFLICT DO UPDATE SET a = 1`},
+		{`INSERT INTO a VALUES (1) ON CONFLICT (a) WHERE b > 0 DO NOTHING`},
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a) DO UPDATE SET a = 1`},
+		{`INSERT INTO a VALUES (1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = 1`},
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a, b) DO UPDATE SET a = 1`},
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a) DO UPDATE SET a = 1, b = excluded.a`},
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a) DO UPDATE SET a = 1 WHERE b > 2`},
@@ -3022,8 +3023,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE TABLE a(b TSVECTOR)`, 7821, `tsvector`, ``},
 		{`CREATE TABLE a(b TXID_SNAPSHOT)`, 0, `txid_snapshot`, ``},
 		{`CREATE TABLE a(b XML)`, 0, `xml`, ``},
-
-		{`INSERT INTO a VALUES (1) ON CONFLICT (x) WHERE x > 3 DO NOTHING`, 32557, ``, ``},
 
 		{`UPDATE foo SET (a, a.b) = (1, 2)`, 27792, ``, ``},
 		{`UPDATE foo SET a.b = 1`, 27792, ``, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -999,7 +999,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %type <empty> first_or_next
 
 %type <tree.Statement> insert_rest
-%type <tree.NameList> opt_conf_expr opt_col_def_list
+%type <tree.NameList> opt_col_def_list
 %type <*tree.OnConflict> on_conflict
 
 %type <tree.Statement> begin_transaction
@@ -7088,7 +7088,10 @@ opt_equal:
 // %Text:
 // INSERT INTO <tablename> [[AS] <name>] [( <colnames...> )]
 //        <selectclause>
-//        [ON CONFLICT [( <colnames...> )] {DO UPDATE SET ... [WHERE <expr>] | DO NOTHING}]
+//        [ON CONFLICT {
+//          [( <colnames...> )] [WHERE <arbiter_predicate>] DO NOTHING |
+//          ( <colnames...> ) [WHERE <index_predicate>] DO UPDATE SET ... [WHERE <expr>]
+//        }
 //        [RETURNING <exprs...>]
 // %SeeAlso: UPSERT, UPDATE, DELETE, WEBDOCS/insert.html
 insert_stmt:
@@ -7190,26 +7193,31 @@ insert_column_item:
 | column_name '.' error { return unimplementedWithIssue(sqllex, 27792) }
 
 on_conflict:
-  ON CONFLICT opt_conf_expr DO UPDATE SET set_clause_list opt_where_clause
+  ON CONFLICT DO NOTHING
   {
-    $$.val = &tree.OnConflict{Columns: $3.nameList(), Exprs: $7.updateExprs(), Where: tree.NewWhere(tree.AstWhere, $8.expr())}
+    $$.val = &tree.OnConflict{
+      Columns: tree.NameList(nil),
+      DoNothing: true,
+    }
   }
-| ON CONFLICT opt_conf_expr DO NOTHING
+| ON CONFLICT '(' name_list ')' opt_where_clause DO NOTHING
   {
-    $$.val = &tree.OnConflict{Columns: $3.nameList(), DoNothing: true}
+    $$.val = &tree.OnConflict{
+      Columns: $4.nameList(),
+      ArbiterPredicate: $6.expr(),
+      DoNothing: true,
+    }
   }
-
-opt_conf_expr:
-  '(' name_list ')'
+| ON CONFLICT '(' name_list ')' opt_where_clause DO UPDATE SET set_clause_list opt_where_clause
   {
-    $$.val = $2.nameList()
+    $$.val = &tree.OnConflict{
+      Columns: $4.nameList(),
+      ArbiterPredicate: $6.expr(),
+      Exprs: $10.updateExprs(),
+      Where: tree.NewWhere(tree.AstWhere, $11.expr()),
+    }
   }
-| '(' name_list ')' where_clause { return unimplementedWithIssue(sqllex, 32557) }
-| ON CONSTRAINT constraint_name { return unimplementedWithIssue(sqllex, 28161) }
-| /* EMPTY */
-  {
-    $$.val = tree.NameList(nil)
-  }
+| ON CONFLICT ON CONSTRAINT constraint_name { return unimplementedWithIssue(sqllex, 28161) }
 
 returning_clause:
   RETURNING target_list

--- a/pkg/sql/sem/tree/insert.go
+++ b/pkg/sql/sem/tree/insert.go
@@ -57,6 +57,10 @@ func (node *Insert) Format(ctx *FmtCtx) {
 			ctx.FormatNode(&node.OnConflict.Columns)
 			ctx.WriteString(")")
 		}
+		if node.OnConflict.ArbiterPredicate != nil {
+			ctx.WriteString(" WHERE ")
+			ctx.FormatNode(node.OnConflict.ArbiterPredicate)
+		}
 		if node.OnConflict.DoNothing {
 			ctx.WriteString(" DO NOTHING")
 		} else {
@@ -79,20 +83,21 @@ func (node *Insert) DefaultValues() bool {
 	return node.Rows.Select == nil
 }
 
-// OnConflict represents an `ON CONFLICT (columns) DO UPDATE SET exprs WHERE
-// where` clause.
+// OnConflict represents an `ON CONFLICT (columns) WHERE arbiter DO UPDATE SET
+// exprs WHERE where` clause.
 //
 // The zero value for OnConflict is used to signal the UPSERT short form, which
 // uses the primary key for as the conflict index and the values being inserted
 // for Exprs.
 type OnConflict struct {
-	Columns   NameList
-	Exprs     UpdateExprs
-	Where     *Where
-	DoNothing bool
+	Columns          NameList
+	ArbiterPredicate Expr
+	Exprs            UpdateExprs
+	Where            *Where
+	DoNothing        bool
 }
 
 // IsUpsertAlias returns true if the UPSERT syntactic sugar was used.
 func (oc *OnConflict) IsUpsertAlias() bool {
-	return oc != nil && oc.Columns == nil && oc.Exprs == nil && oc.Where == nil && !oc.DoNothing
+	return oc != nil && oc.Columns == nil && oc.ArbiterPredicate == nil && oc.Exprs == nil && oc.Where == nil && !oc.DoNothing
 }

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -954,6 +954,9 @@ func (node *Insert) doc(p *PrettyCfg) pretty.Doc {
 			cond = p.bracket("(", p.Doc(&node.OnConflict.Columns), ")")
 		}
 		items = append(items, p.row("ON CONFLICT", cond))
+		if node.OnConflict.ArbiterPredicate != nil {
+			items = append(items, p.row("WHERE", p.Doc(node.OnConflict.ArbiterPredicate)))
+		}
 
 		if node.OnConflict.DoNothing {
 			items = append(items, p.row("DO", pretty.Keyword("NOTHING")))


### PR DESCRIPTION
This commit adds support for selecting unique partial indexes as
"arbiters" for `INSERT ON CONFLICT` statements. An arbiter index is a
unique index that is used to detect conflicts in which to perform the
`ON CONFLICT` action on.

Unique partial indexes can only be used as arbiters if the arbiter
predicate in the `ON CONFLICT` statement implies the partial index's
predicate.

To avoid parsing the same partial index predicates multiple times, this
commit also adds a `parsedIndexExprs` cache to `mutationBuilder`,
similar to the cache it has for default and computed column expressions.

Finally, this commit also makes the parsing of `ON CONFLICT DO UPDATE`
more strict. It now requires a list of conflict columns. This matches
Postgres behavior.

From https://www.postgresql.org/docs/12/sql-insert.html:

> For ON CONFLICT DO UPDATE, a conflict_target must be provided.

In Postgres, the `conflict_target` can be a list of columns or a
constraint name. Cockroach currently only supports a list of column
names as a conflict target, so the list of column names preceeding
`DO UPDATE` is now required by the parser.

Release note (sql change): An `INSERT ... ON CONFLICT DO UPDATE`
statement without a list of column names after `ON CONFLICT` now results
in a SQL syntax error with the error code 42601. Previously it errored
with the message "there is no unqiue or exlcusion constraint matching
the ON CONFLICT specification" and the error code 42P10.
