### PR TITLE
geo/geomfn: implement ST_Dimension({geometry})

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1119,6 +1119,8 @@ from the given Geometry.</p>
 <tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
+<tr><td><a name="st_dimension"></a><code>st_dimension(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of topological dimensions of a given Geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_disjoint"></a><code>st_disjoint(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a does not overlap, touch or is within geometry_b.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
@@ -1415,7 +1417,7 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_multipolygonfromwkb"></a><code>st_multipolygonfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation with an SRID. If the shape underneath is not MultiPolygon, NULL is returned.</p>
 </span></td></tr>
-<tr><td><a name="st_ndims"></a><code>st_ndims(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of dimensions of a given Geometry.</p>
+<tr><td><a name="st_ndims"></a><code>st_ndims(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of coordinate dimensions of a given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_npoints"></a><code>st_npoints(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of points in a given Geometry. Works for any shape type.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/unary_operators_test.go
+++ b/pkg/geo/geomfn/unary_operators_test.go
@@ -96,3 +96,30 @@ func TestArea(t *testing.T) {
 		})
 	}
 }
+
+func TestDimension(t *testing.T) {
+	testCases := []struct {
+		wkt      string
+		expected int
+	}{
+		{"POINT(1.0 1.0)", 0},
+		{"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)", 1},
+		{"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0))", 2},
+		{"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1))", 2},
+		{"MULTIPOINT((1.0 1.0), (2.0 2.0))", 0},
+		{"MULTILINESTRING((1.0 1.0, 2.0 2.0, 3.0 3.0), (6.0 6.0, 7.0 6.0))", 1},
+		{"MULTIPOLYGON(((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 3.0)), ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1)))", 2},
+		{"GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40),POLYGON ((40 40, 20 45, 45 30, 40 40)))", 2},
+		{"GEOMETRYCOLLECTION (GEOMETRYCOLLECTION(POINT (40 10),LINESTRING (10 10, 20 20, 10 40),POLYGON ((40 40, 20 45, 45 30, 40 40))))", 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeometry(tc.wkt)
+			require.NoError(t, err)
+			ret, err := Dimension(g)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -2640,29 +2640,30 @@ Square (right)                            POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
 Square overlapping left and right square  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 
 # basic metadata
-query TTTIII
+query TTTIIII
 SELECT
   a.dsc,
   GeometryType(a.geom),
   ST_GeometryType(a.geom),
   ST_NDims(a.geom),
+  ST_Dimension(a.geom),
   ST_NPoints(a.geom),
   ST_NumGeometries(a.geom)
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  GeometryCollection  ST_GeometryCollection  0     0     0
-Empty LineString                          LineString          ST_LineString          2     0     0
-Empty Point                               Point               ST_Point               2     0     0
-Faraway point                             Point               ST_Point               2     1     1
-Line going through left and right square  LineString          ST_LineString          2     2     1
-NULL                                      NULL                NULL                   NULL  NULL  NULL
-Nested Geometry Collection                GeometryCollection  ST_GeometryCollection  2     1     1
-Point middle of Left Square               Point               ST_Point               2     1     1
-Point middle of Right Square              Point               ST_Point               2     1     1
-Square (left)                             Polygon             ST_Polygon             2     5     1
-Square (right)                            Polygon             ST_Polygon             2     5     1
-Square overlapping left and right square  Polygon             ST_Polygon             2     5     1
+Empty GeometryCollection                  GeometryCollection  ST_GeometryCollection  0     0     0     0
+Empty LineString                          LineString          ST_LineString          2     1     0     0
+Empty Point                               Point               ST_Point               2     0     0     0
+Faraway point                             Point               ST_Point               2     0     1     1
+Line going through left and right square  LineString          ST_LineString          2     1     2     1
+NULL                                      NULL                NULL                   NULL  NULL  NULL  NULL
+Nested Geometry Collection                GeometryCollection  ST_GeometryCollection  2     0     1     1
+Point middle of Left Square               Point               ST_Point               2     0     1     1
+Point middle of Right Square              Point               ST_Point               2     0     1     1
+Square (left)                             Polygon             ST_Polygon             2     2     5     1
+Square (right)                            Polygon             ST_Polygon             2     2     5     1
+Square overlapping left and right square  Polygon             ST_Polygon             2     2     5     1
 
 query TTTT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1438,7 +1438,24 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 			},
 			types.Int,
 			infoBuilder{
-				info: "Returns the number of dimensions of a given Geometry.",
+				info: "Returns the number of coordinate dimensions of a given Geometry.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_dimension": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				dim, err := geomfn.Dimension(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(dim)), nil
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of topological dimensions of a given Geometry.",
 			},
 			tree.VolatilityImmutable,
 		),


### PR DESCRIPTION
Also update documentation for `ST_NDims` to specify that it returns the coordinate dimensions, while `ST_Dimension` returns the topology dimensions.

Release note (sql change): Implement the geometry builtin `ST_Dimension`.

Closes #48918.