### PR TITLE
sql/rowcontainer: avoid over-allocating when rowCapacity provided

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -110,7 +110,7 @@ func (a *applyJoinNode) startExec(params runParams) error {
 	a.run.out = make(tree.Datums, len(a.columns))
 	ci := sqlbase.ColTypeInfoFromResCols(a.rightCols)
 	acc := params.EvalContext().Mon.MakeBoundAccount()
-	a.run.rightRows = rowcontainer.NewRowContainer(acc, ci, 0 /* rowCapacity */)
+	a.run.rightRows = rowcontainer.NewRowContainer(acc, ci)
 	return nil
 }
 

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -38,7 +38,6 @@ func (n *bufferNode) startExec(params runParams) error {
 	n.bufferedRows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(getPlanColumns(n.plan, false /* mut */)),
-		0, /* rowCapacity */
 	)
 	return nil
 }

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -494,7 +494,7 @@ func (r *createStatsResumer) Resume(
 	evalCtx := p.ExtendedEvalContext()
 
 	ci := sqlbase.ColTypeInfoFromColTypes([]*types.T{})
-	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci, 0)
+	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci)
 	defer func() {
 		if rows != nil {
 			rows.Close(ctx)

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -76,7 +76,8 @@ func (d *deleteNode) startExec(params runParams) error {
 	if d.run.rowsNeeded {
 		d.run.td.rows = rowcontainer.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(d.columns), 0)
+			sqlbase.ColTypeInfoFromResCols(d.columns),
+		)
 	}
 	return d.run.td.init(params.ctx, params.p.txn, params.EvalContext())
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -892,7 +892,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	} else {
 		typ = sqlbase.ColTypeInfoFromColTypes(subqueryPhysPlan.ResultTypes)
 	}
-	rows = rowcontainer.NewRowContainer(subqueryMemAccount, typ, 0)
+	rows = rowcontainer.NewRowContainer(subqueryMemAccount, typ)
 	defer rows.Close(ctx)
 
 	subqueryRowReceiver := NewRowResultWriter(rows)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -83,16 +83,13 @@ type insertRun struct {
 	traceKV bool
 }
 
-func (r *insertRun) initRowContainer(
-	params runParams, columns sqlbase.ResultColumns, rowCapacity int,
-) {
+func (r *insertRun) initRowContainer(params runParams, columns sqlbase.ResultColumns) {
 	if !r.rowsNeeded {
 		return
 	}
 	r.ti.rows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(columns),
-		rowCapacity,
 	)
 
 	// In some cases (e.g. `INSERT INTO t (a) ...`) the data source
@@ -199,7 +196,7 @@ func (n *insertNode) startExec(params runParams) error {
 	// Cache traceKV during execution, to avoid re-evaluating it for every row.
 	n.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
-	n.run.initRowContainer(params, n.columns, 0 /* rowCapacity */)
+	n.run.initRowContainer(params, n.columns)
 
 	return n.run.ti.init(params.ctx, params.p.txn, params.EvalContext())
 }

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -232,7 +232,7 @@ func (n *insertFastPathNode) startExec(params runParams) error {
 	// Cache traceKV during execution, to avoid re-evaluating it for every row.
 	n.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
-	n.run.initRowContainer(params, n.columns, 0 /* rowCapacity */)
+	n.run.initRowContainer(params, n.columns)
 
 	n.run.numInputCols = len(n.input[0])
 	n.run.inputBuf = make(tree.Datums, len(n.input)*n.run.numInputCols)

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -55,7 +55,6 @@ func (n *recursiveCTENode) startExec(params runParams) error {
 	n.workingRows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
-		0, /* rowCapacity */
 	)
 	n.nextRowIdx = 0
 	return nil
@@ -105,7 +104,6 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 	n.workingRows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
-		0, /* rowCapacity */
 	)
 
 	// Set up a bufferNode that can be used as a reference for a scanBufferNode.

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -12,6 +12,7 @@ package rowcontainer
 
 import (
 	"context"
+	"math/bits"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -40,11 +41,9 @@ type RowContainer struct {
 	// index is performed using shifting.
 	rowsPerChunk      int
 	rowsPerChunkShift uint
-	// preallocChunks is the number of chunks we allocate upfront (on the first
-	// AddRow call).
-	preallocChunks int
-	chunks         [][]tree.Datum
-	numRows        int
+	chunks            [][]tree.Datum
+	firstChunk        [1][]tree.Datum // avoids allocation
+	numRows           int
 
 	// chunkMemSize is the memory used by a chunk.
 	chunkMemSize int64
@@ -71,11 +70,6 @@ type RowContainer struct {
 // this row container. Should probably be created by
 // Session.makeBoundAccount() or Session.TxnState.makeBoundAccount().
 //
-// The rowCapacity argument indicates how many rows are to be
-// expected; it is used to pre-allocate the outer array of row
-// references, in the fashion of Go's capacity argument to the make()
-// function.
-//
 // Note that we could, but do not (yet), report the size of the row
 // container itself to the monitor in this constructor. This is
 // because the various planNodes are not (yet) equipped to call
@@ -86,7 +80,21 @@ type RowContainer struct {
 // test properly.  The trade-off is that very large table schemas or
 // column selections could cause unchecked and potentially dangerous
 // memory growth.
-func NewRowContainer(acc mon.BoundAccount, ti sqlbase.ColTypeInfo, rowCapacity int) *RowContainer {
+func NewRowContainer(acc mon.BoundAccount, ti sqlbase.ColTypeInfo) *RowContainer {
+	return NewRowContainerWithCapacity(acc, ti, 0)
+}
+
+// NewRowContainerWithCapacity is like NewRowContainer, but it accepts a
+// rowCapacity argument.
+//
+// If provided, rowCapacity indicates how many rows are to be expected.
+// The value is used to configure the size of chunks that are allocated
+// within the container such that if no more than the specific number of
+// rows is added to the container, only a single chunk will be allocated
+// and wasted space will be kept to a minimum.
+func NewRowContainerWithCapacity(
+	acc mon.BoundAccount, ti sqlbase.ColTypeInfo, rowCapacity int,
+) *RowContainer {
 	c := &RowContainer{}
 	c.Init(acc, ti, rowCapacity)
 	return c
@@ -99,20 +107,24 @@ func (c *RowContainer) Init(acc mon.BoundAccount, ti sqlbase.ColTypeInfo, rowCap
 
 	c.numCols = nCols
 	c.memAcc = acc
-	c.preallocChunks = 1
 
-	if nCols != 0 {
+	if rowCapacity != 0 {
+		// If there is a row capacity provided, we use a single chunk with
+		// sufficient capacity. The following is equivalent to:
+		//
+		//  c.rowsPerChunkShift = ceil(log2(rowCapacity))
+		//
+		c.rowsPerChunkShift = 64 - uint(bits.LeadingZeros64(uint64(rowCapacity-1)))
+	} else if nCols != 0 {
 		// If the rows have columns, we use 64 rows per chunk.
 		c.rowsPerChunkShift = 6
-		c.rowsPerChunk = 1 << c.rowsPerChunkShift
-		if rowCapacity > 0 {
-			c.preallocChunks = (rowCapacity + c.rowsPerChunk - 1) / c.rowsPerChunk
-		}
 	} else {
-		// If there are no columns, every row gets mapped to the first chunk.
+		// If there are no columns, every row gets mapped to the first chunk,
+		// which ends up being a zero-length slice because each row contains no
+		// columns.
 		c.rowsPerChunkShift = 32
-		c.rowsPerChunk = 1 << c.rowsPerChunkShift
 	}
+	c.rowsPerChunk = 1 << c.rowsPerChunkShift
 
 	for i := 0; i < nCols; i++ {
 		sz, variable := tree.DatumTypeSize(ti.Type(i))
@@ -175,7 +187,11 @@ func (c *RowContainer) allocChunks(ctx context.Context, numChunks int) error {
 	}
 
 	if c.chunks == nil {
-		c.chunks = make([][]tree.Datum, 0, numChunks)
+		if numChunks == 1 {
+			c.chunks = c.firstChunk[:0:1]
+		} else {
+			c.chunks = make([][]tree.Datum, 0, numChunks)
+		}
 	}
 
 	datums := make([]tree.Datum, numChunks*datumsPerChunk)
@@ -223,11 +239,8 @@ func (c *RowContainer) AddRow(ctx context.Context, row tree.Datums) (tree.Datums
 	}
 	chunk, pos := c.getChunkAndPos(c.numRows)
 	if chunk == len(c.chunks) {
-		numChunks := c.preallocChunks
-		if len(c.chunks) > 0 {
-			// Grow the number of chunks by a fraction.
-			numChunks = 1 + len(c.chunks)/8
-		}
+		// Grow the number of chunks by a fraction.
+		numChunks := 1 + len(c.chunks)/8
 		if err := c.allocChunks(ctx, numChunks); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -112,7 +112,6 @@ func (c *RowContainer) Init(acc mon.BoundAccount, ti sqlbase.ColTypeInfo, rowCap
 		// If there are no columns, every row gets mapped to the first chunk.
 		c.rowsPerChunkShift = 32
 		c.rowsPerChunk = 1 << c.rowsPerChunkShift
-		c.chunks = [][]tree.Datum{{}}
 	}
 
 	for i := 0; i < nCols; i++ {
@@ -213,6 +212,9 @@ func (c *RowContainer) AddRow(ctx context.Context, row tree.Datums) (tree.Datums
 		panic(errors.AssertionFailedf("invalid row length %d, expected %d", len(row), c.numCols))
 	}
 	if c.numCols == 0 {
+		if c.chunks == nil {
+			c.chunks = [][]tree.Datum{{}}
+		}
 		c.numRows++
 		return nil, nil
 	}

--- a/pkg/sql/rowcontainer/datum_row_container_test.go
+++ b/pkg/sql/rowcontainer/datum_row_container_test.go
@@ -37,7 +37,7 @@ func TestRowContainer(t *testing.T) {
 				m := mon.NewUnlimitedMonitor(
 					context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 				)
-				rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCol), 0)
+				rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCol))
 				row := make(tree.Datums, numCols)
 				for i := 0; i < numRows; i++ {
 					for j := range row {
@@ -84,7 +84,7 @@ func TestRowContainerAtOutOfRange(t *testing.T) {
 	defer m.Stop(ctx)
 
 	resCols := sqlbase.ResultColumns{sqlbase.ResultColumn{Typ: types.Int}}
-	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCols), 0)
+	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCols))
 	defer rc.Close(ctx)
 
 	// Verify that a panic is thrown for out-of-range conditions.
@@ -110,7 +110,7 @@ func TestRowContainerZeroCols(t *testing.T) {
 	m := mon.NewUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
 	defer m.Stop(ctx)
 
-	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(nil), 0)
+	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(nil))
 	defer rc.Close(ctx)
 
 	const numRows = 10
@@ -166,7 +166,7 @@ func BenchmarkRowContainerAt(b *testing.B) {
 		resCol[i] = sqlbase.ResultColumn{Typ: types.Int}
 	}
 
-	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCol), 0)
+	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCol))
 	defer rc.Close(context.Background())
 
 	row := make(tree.Datums, numCols)

--- a/pkg/sql/rowcontainer/datum_row_container_test.go
+++ b/pkg/sql/rowcontainer/datum_row_container_test.go
@@ -129,6 +129,26 @@ func TestRowContainerZeroCols(t *testing.T) {
 	if len(row) != 0 {
 		t.Fatalf("expected empty row")
 	}
+
+	// Clear and try again.
+	rc.Clear(context.Background())
+
+	const numRowsAfterClear = 5
+	for i := 0; i < numRowsAfterClear; i++ {
+		if _, err := rc.AddRow(context.Background(), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rc.Len() != numRowsAfterClear {
+		t.Fatalf("expected %d rows, but found %d", numRowsAfterClear, rc.Len())
+	}
+	row = rc.At(0)
+	if row == nil {
+		t.Fatalf("expected non-nil row")
+	}
+	if len(row) != 0 {
+		t.Fatalf("expected empty row")
+	}
 }
 
 func BenchmarkRowContainerAt(b *testing.B) {

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -816,7 +816,7 @@ func (h *HashDiskBackedRowContainer) Init(
 	}
 	if h.mrc == nil {
 		h.mrc = &MemRowContainer{}
-		h.mrc.InitWithMon(ordering, types, h.evalCtx, h.memoryMonitor, 0 /* rowCapacity */)
+		h.mrc.InitWithMon(ordering, types, h.evalCtx, h.memoryMonitor)
 	}
 	hmrc := MakeHashMemRowContainer(h.mrc)
 	h.hmrc = &hmrc

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -56,8 +56,6 @@ type DiskBackedNumberedRowContainer struct {
 //    spills to disk.
 //  - memoryMonitor is used to monitor this container's memory usage.
 //  - diskMonitor is used to monitor this container's disk usage.
-//  - rowCapacity (if not 0) specifies the number of rows in-memory container
-//    should be preallocated for.
 func NewDiskBackedNumberedRowContainer(
 	deDup bool,
 	types []*types.T,
@@ -65,7 +63,6 @@ func NewDiskBackedNumberedRowContainer(
 	engine diskmap.Factory,
 	memoryMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
-	rowCapacity int,
 ) *DiskBackedNumberedRowContainer {
 	d := &DiskBackedNumberedRowContainer{
 		deDup:         deDup,
@@ -73,7 +70,7 @@ func NewDiskBackedNumberedRowContainer(
 		rowIterMemAcc: memoryMonitor.MakeBoundAccount(),
 	}
 	d.rc = &DiskBackedRowContainer{}
-	d.rc.Init(nil /*ordering*/, types, evalCtx, engine, memoryMonitor, diskMonitor, rowCapacity)
+	d.rc.Init(nil /*ordering*/, types, evalCtx, engine, memoryMonitor, diskMonitor)
 	if deDup {
 		ordering := make(sqlbase.ColumnOrdering, len(types))
 		for i := range types {
@@ -81,7 +78,7 @@ func NewDiskBackedNumberedRowContainer(
 			ordering[i].Direction = encoding.Ascending
 		}
 		deduper := &DiskBackedRowContainer{}
-		deduper.Init(ordering, types, evalCtx, engine, memoryMonitor, diskMonitor, rowCapacity)
+		deduper.Init(ordering, types, evalCtx, engine, memoryMonitor, diskMonitor)
 		deduper.DoDeDuplicate()
 		d.deduper = deduper
 	}

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -86,7 +86,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
 	rc := NewDiskBackedNumberedRowContainer(
 		true /*deDup*/, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor,
-		0 /*rowCapacity*/)
+	)
 	defer rc.Close(ctx)
 
 	// Each pass does an UnsafeReset at the end.
@@ -174,7 +174,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
 	rc := NewDiskBackedNumberedRowContainer(
 		false /*deDup*/, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor,
-		0 /*rowCapacity*/)
+	)
 	defer rc.Close(ctx)
 
 	// Each pass does an UnsafeReset at the end.
@@ -375,7 +375,7 @@ func makeNumberedContainerUsingNRC(
 ) numberedContainerUsingNRC {
 	memoryMonitor := makeMemMonitorAndStart(ctx, st, memoryBudget)
 	rc := NewDiskBackedNumberedRowContainer(
-		false /* deDup */, types, evalCtx, engine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+		false /* deDup */, types, evalCtx, engine, memoryMonitor, diskMonitor)
 	require.NoError(t, rc.testingSpillToDisk(ctx))
 	return numberedContainerUsingNRC{rc: rc, memoryMonitor: memoryMonitor}
 }
@@ -426,7 +426,7 @@ func makeNumberedContainerUsingIRC(
 ) numberedContainerUsingIRC {
 	memoryMonitor := makeMemMonitorAndStart(ctx, st, memoryBudget)
 	rc := NewDiskBackedIndexedRowContainer(
-		nil /* ordering */, types, evalCtx, engine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+		nil /* ordering */, types, evalCtx, engine, memoryMonitor, diskMonitor)
 	require.NoError(t, rc.SpillToDisk(ctx))
 	return numberedContainerUsingIRC{rc: rc, memoryMonitor: memoryMonitor}
 }

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -101,7 +101,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	var mc MemRowContainer
 	mc.InitWithMon(
 		sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}},
-		[]*types.T{types.Int, types.String}, evalCtx, m, 0, /* rowCapacity */
+		[]*types.T{types.Int, types.String}, evalCtx, m,
 	)
 	defer mc.Close(ctx)
 
@@ -228,7 +228,6 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		tempEngine,
 		memoryMonitor,
 		diskMonitor,
-		0, /* rowCapacity */
 	)
 	defer rc.Close(ctx)
 
@@ -393,7 +392,6 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 		tempEngine,
 		memoryMonitor,
 		diskMonitor,
-		0, /* rowCapacity */
 	)
 	defer rc.Close(ctx)
 	rc.DoDeDuplicate()
@@ -516,7 +514,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				mid := numRows / 2
 				for i := 0; i < mid; i++ {
@@ -580,7 +578,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				for _, row := range rows {
 					if err := rc.AddRow(ctx, row); err != nil {
@@ -675,7 +673,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				if err := rc.SpillToDisk(ctx); err != nil {
 					t.Fatal(err)
@@ -741,7 +739,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			storedTypes[len(typs)] = sqlbase.OneIntCol[0]
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+				rc := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				for i := 0; i < numRows; i++ {
 					if err := rc.AddRow(ctx, rows[i]); err != nil {
@@ -782,7 +780,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			storedTypes[len(typs)] = sqlbase.OneIntCol[0]
 
 			func() {
-				d := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+				d := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 				defer d.Close(ctx)
 				if err := d.SpillToDisk(ctx); err != nil {
 					t.Fatal(err)
@@ -942,7 +940,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	accessPattern := generateAccessPattern(numRows)
 
 	b.Run("InMemory", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		for i := 0; i < len(rows); i++ {
 			if err := rc.AddRow(ctx, rows[i]); err != nil {
@@ -964,7 +962,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	})
 
 	b.Run("OnDiskWithCache", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		if err := rc.SpillToDisk(ctx); err != nil {
 			b.Fatal(err)
@@ -989,7 +987,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	})
 
 	b.Run("OnDiskWithoutCache", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
+		rc := NewDiskBackedIndexedRowContainer(nil, sqlbase.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		if err := rc.SpillToDisk(ctx); err != nil {
 			b.Fatal(err)

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -202,10 +202,10 @@ func newHashJoiner(
 	}
 
 	h.rows[leftSide].InitWithMon(
-		nil /* ordering */, h.leftSource.OutputTypes(), h.EvalCtx, h.MemMonitor, 0, /* rowCapacity */
+		nil /* ordering */, h.leftSource.OutputTypes(), h.EvalCtx, h.MemMonitor,
 	)
 	h.rows[rightSide].InitWithMon(
-		nil /* ordering */, h.rightSource.OutputTypes(), h.EvalCtx, h.MemMonitor, 0, /* rowCapacity */
+		nil /* ordering */, h.rightSource.OutputTypes(), h.EvalCtx, h.MemMonitor,
 	)
 
 	if h.joinType == descpb.IntersectAllJoin || h.joinType == descpb.ExceptAllJoin {

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -128,7 +128,6 @@ func newInvertedFilterer(
 		ifr.FlowCtx.Cfg.TempStorage,
 		ifr.MemMonitor,
 		ifr.diskMonitor,
-		0, /* rowCapacity */
 	)
 
 	if sp := opentracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && tracing.IsRecording(sp) {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -290,7 +290,6 @@ func newInvertedJoiner(
 		ij.FlowCtx.Cfg.TempStorage,
 		ij.MemMonitor,
 		ij.diskMonitor,
-		0, /* rowCapacity */
 	)
 
 	return ij, nil

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -304,7 +304,6 @@ func (jr *joinReader) initJoinReaderStrategy(
 		jr.FlowCtx.Cfg.TempStorage,
 		jr.MemMonitor,
 		jr.diskMonitor,
-		0, /* rowCapacity */
 	)
 	if limit < mon.DefaultPoolAllocationSize {
 		// The memory limit is too low for caching, most likely to force disk

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -78,7 +78,6 @@ func (s *sorterBase) init(
 		flowCtx.Cfg.TempStorage,
 		memMonitor,
 		s.diskMonitor,
-		0, /* rowCapacity */
 	)
 	s.rows = &rc
 

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -642,7 +642,6 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *tree.Eva
 		w.FlowCtx.Cfg.TempStorage,
 		w.MemMonitor,
 		w.diskMonitor,
-		0, /* rowCapacity */
 	)
 	i, err := w.allRowsPartitioned.NewAllRowsIterator(ctx)
 	if err != nil {

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -263,7 +263,6 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 			flowCtx.Cfg.TempStorage,
 			rb.outputs[i].memoryMonitor,
 			rb.outputs[i].diskMonitor,
-			0, /* rowCapacity */
 		)
 
 		// Initialize any outboxes.

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -471,7 +471,7 @@ func scrubRunDistSQL(
 ) (*rowcontainer.RowContainer, error) {
 	ci := sqlbase.ColTypeInfoFromColTypes(columnTypes)
 	acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
-	rows := rowcontainer.NewRowContainer(acc, ci, 0 /* rowCapacity */)
+	rows := rowcontainer.NewRowContainer(acc, ci)
 	rowResultWriter := NewRowResultWriter(rows)
 	recv := MakeDistSQLReceiver(
 		ctx,

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -44,7 +44,6 @@ func (s *spoolNode) startExec(params runParams) error {
 	s.rows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(planColumns(s.source)),
-		0, /* rowCapacity */
 	)
 
 	// Accumulate all the rows up to the hardLimit, if any.

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -110,7 +110,6 @@ func (tu *optTableUpserter) init(
 		tu.rowsUpserted = rowcontainer.NewRowContainer(
 			evalCtx.Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromColDescs(tu.returnCols),
-			0, /* rowCapacity */
 		)
 
 		// Create the map from colIds to the expected columns.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -130,7 +130,8 @@ func (u *updateNode) startExec(params runParams) error {
 	if u.run.rowsNeeded {
 		u.run.tu.rows = rowcontainer.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(u.columns), 0)
+			sqlbase.ColTypeInfoFromResCols(u.columns),
+		)
 	}
 	return u.run.tu.init(params.ctx, params.p.txn, params.EvalContext())
 }

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -116,8 +116,10 @@ func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity
 	return &valuesNode{
 		columns: columns,
 		valuesRun: valuesRun{
-			rows: rowcontainer.NewRowContainer(
-				p.EvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
+			rows: rowcontainer.NewRowContainerWithCapacity(
+				p.EvalContext().Mon.MakeBoundAccount(),
+				sqlbase.ColTypeInfoFromResCols(columns),
+				capacity,
 			),
 		},
 	}
@@ -140,7 +142,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	// others that create a valuesNode internally for storing results
 	// from other planNodes), so its expressions need evaluating.
 	// This may run subqueries.
-	n.rows = rowcontainer.NewRowContainer(
+	n.rows = rowcontainer.NewRowContainerWithCapacity(
 		params.extendedEvalCtx.Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(n.columns),
 		len(n.tuples),

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -238,8 +238,10 @@ var _ rowPusher = &vTableLookupJoinNode{}
 // startExec implements the planNode interface.
 func (v *vTableLookupJoinNode) startExec(params runParams) error {
 	v.run.keyCtx = constraint.KeyContext{EvalCtx: params.EvalContext()}
-	v.run.rows = rowcontainer.NewRowContainer(params.EvalContext().Mon.MakeBoundAccount(),
-		sqlbase.ColTypeInfoFromResCols(v.columns), 0)
+	v.run.rows = rowcontainer.NewRowContainer(
+		params.EvalContext().Mon.MakeBoundAccount(),
+		sqlbase.ColTypeInfoFromResCols(v.columns),
+	)
 	v.run.indexKeyDatums = make(tree.Datums, len(v.columns))
 	var err error
 	db, err := params.p.LogicalSchemaAccessor().GetDatabaseDesc(


### PR DESCRIPTION
This commit adjusts RowContainer's handling of the optional `rowCapacity`
parameter to be more efficient and more closely aligned with what a user
of it wants. Before this change, the only effect that `rowCapacity` had
was pre-allocate a sufficient number of chunks during the first call to
`AddRow` to accommodate the specified capacity. This was lacking in two
ways:
1. the RowContainer still allocated 64 row chunks, so a rowCapacity above
   64 rows would still perform multiple heap allocations. The only benefit
   `rowCapacity` has was avoid resizing the chunk slice itself, which
   provided minimal actual benefit.
2. the RowContainer still allocated 64 row chunks, so a rowCapacity below
   64 rows would still allocate a chunk large enough to accommodate 64 rows.

This commit addresses these deficiencies by adjusting the meaning of the
`rowCapacity` parameter. Now when provided, the value is used to
configure the size of chunks that are allocated within the container
such that if no more than the specific number of rows is added to the
container, only a single chunk will be allocated and wasted space will
be kept to a minimum. This is a measurable win for the parameter's only
user, `valuesNode`.

This improvement shows up prominently in single-node kv0 benchmarks like
`kv0/enc=false/nodes=1` and `kv0/enc=false/nodes=1/cpu=32`. Before this
change, the 64-row chunk allocation in `valuesNode`'s RowContainer was
the second most expensive (by total bytes allocated, `alloc_space`)
allocation in the system. Each 64-row chunk resulted in a 2 KiB heap
allocation. Added together, this was responsible for **5.64%** of all
memory allocated by Cockroach while running the workload. With this
change, the chunk size for the RowContainer used by `valuesNode` can be
as small as 1-row, which translates to 32B heap allocations. This drops
the aggregate cost of this allocation down to just **0.19%** of all
memory allocated by Cockroach.

#### Before:

<img width="543" alt="Screen Shot 2020-08-19 at 3 17 51 PM" src="https://user-images.githubusercontent.com/5438456/90682029-5a554000-e232-11ea-9f83-78c25913a45e.png">

#### After:

<img width="423" alt="Screen Shot 2020-08-19 at 3 17 59 PM" src="https://user-images.githubusercontent.com/5438456/90682037-5cb79a00-e232-11ea-97bb-f310bc859ed5.png">

The impact on top-line throughput for the workloads is measurable:
```
name                   old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=1   12.2k ± 4%   12.6k ± 4%  +3.79%  (p=0.002 n=10+10)

name                   old p50(ms)  new p50(ms)  delta
kv0/enc=false/nodes=1    4.91 ± 4%    4.70 ± 0%  -4.28%  (p=0.001 n=10+8)

name                   old p99(ms)  new p99(ms)  delta
kv0/enc=false/nodes=1    19.3 ± 3%    18.9 ± 6%    ~     (p=0.337 n=10+10)
```

Release note (performance improvement): a large heap allocation performed
during INSERT statements was removed, resulting in an increase to throughput
for single-row INSERT statements.