### PR TITLE
stats: use leased types in the stats cache

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -458,6 +458,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 			cfg.db,
 			cfg.circularInternalExecutor,
 			codec,
+			leaseMgr,
+			cfg.Settings,
 		),
 
 		// Note: don't forget to add the secondary loggers as closers

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -65,6 +66,8 @@ func TestMaybeRefreshStats(t *testing.T) {
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
@@ -142,6 +145,8 @@ func TestAverageRefreshTime(t *testing.T) {
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
@@ -378,6 +383,8 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
@@ -416,6 +423,8 @@ func TestNoRetryOnFailure(t *testing.T) {
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	r := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -44,6 +45,8 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		db,
 		ex,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 
 	// The test data must be ordered by CreatedAt DESC so the calculated set of

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -18,8 +18,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -61,6 +63,9 @@ type TableStatisticsCache struct {
 	ClientDB    *kv.DB
 	SQLExecutor sqlutil.InternalExecutor
 	Codec       keys.SQLCodec
+
+	LeaseMgr *lease.Manager
+	Settings *cluster.Settings
 }
 
 // The cache stores *cacheEntry objects. The fields are protected by the
@@ -99,11 +104,15 @@ func NewTableStatisticsCache(
 	db *kv.DB,
 	sqlExecutor sqlutil.InternalExecutor,
 	codec keys.SQLCodec,
+	leaseManager *lease.Manager,
+	settings *cluster.Settings,
 ) *TableStatisticsCache {
 	tableStatsCache := &TableStatisticsCache{
 		ClientDB:    db,
 		SQLExecutor: sqlExecutor,
 		Codec:       codec,
+		LeaseMgr:    leaseManager,
+		Settings:    settings,
 	}
 	tableStatsCache.mu.cache = cache.NewUnorderedCache(cache.Config{
 		Policy:      cache.CacheLRU,
@@ -334,8 +343,8 @@ const (
 
 // parseStats converts the given datums to a TableStatistic object. It might
 // need to run a query to get user defined type metadata.
-func parseStats(
-	ctx context.Context, db *kv.DB, codec keys.SQLCodec, datums tree.Datums,
+func (sc *TableStatisticsCache) parseStats(
+	ctx context.Context, datums tree.Datums,
 ) (*TableStatistic, error) {
 	if datums == nil || datums.Len() == 0 {
 		return nil, nil
@@ -401,28 +410,25 @@ func parseStats(
 
 		// Decode the histogram data so that it's usable by the opt catalog.
 		res.Histogram = make([]cat.HistogramBucket, len(res.HistogramData.Buckets))
-		typ := res.HistogramData.ColumnType
 		// Hydrate the type in case any user defined types are present.
 		// There are cases where typ is nil, so don't do anything if so.
-		if typ != nil && typ.UserDefined() {
-			// TODO (rohany): This should instead query a leased copy of the type.
-			// TODO (rohany): If we are caching data about types here, then this
-			//  cache needs to be invalidated as well when type metadata changes.
-			// TODO (rohany): It might be better to store the type metadata used when
-			//  collecting the stats in the HistogramData object itself, and avoid
-			//  this query and caching/leasing problem.
+		if typ := res.HistogramData.ColumnType; typ != nil && typ.UserDefined() {
 			// The metadata accessed here is never older than the metadata used when
 			// collecting the stats. Changes to types are backwards compatible across
 			// versions, so using a newer version of the type metadata here is safe.
-			err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				typeLookup := func(ctx context.Context, id descpb.ID) (tree.TypeName, sqlbase.TypeDescriptor, error) {
-					return resolver.ResolveTypeDescByID(ctx, txn, codec, id, tree.ObjectLookupFlags{})
-				}
-				name, typeDesc, err := typeLookup(ctx, sqlbase.GetTypeDescID(typ))
-				if err != nil {
-					return err
-				}
-				return typeDesc.HydrateTypeInfoWithName(ctx, typ, &name, sqlbase.TypeLookupFunc(typeLookup))
+			// Given that we never delete members from enum types, a descriptor we
+			// get from the lease manager will be able to be used to decode these stats,
+			// even if it wasn't the descriptor that was used to collect the stats.
+			// If have types that are not backwards compatible in this way, then we
+			// will need to start writing a timestamp on the stats objects and request
+			// TypeDescriptor's with the timestamp that the stats were recorded with.
+			err := sc.ClientDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				collection := descs.NewCollection(ctx, sc.Settings, sc.LeaseMgr)
+				defer collection.ReleaseAll(ctx)
+				resolver := descs.NewDistSQLTypeResolver(collection, txn)
+				var err error
+				res.HistogramData.ColumnType, err = resolver.ResolveTypeByOID(ctx, typ.Oid())
+				return err
 			})
 			if err != nil {
 				return nil, err
@@ -431,7 +437,7 @@ func parseStats(
 		var a sqlbase.DatumAlloc
 		for i := range res.Histogram {
 			bucket := &res.HistogramData.Buckets[i]
-			datum, _, err := sqlbase.DecodeTableKey(&a, typ, bucket.UpperBound, encoding.Ascending)
+			datum, _, err := sqlbase.DecodeTableKey(&a, res.HistogramData.ColumnType, bucket.UpperBound, encoding.Ascending)
 			if err != nil {
 				return nil, err
 			}
@@ -476,7 +482,7 @@ ORDER BY "createdAt" DESC
 
 	var statsList []*TableStatistic
 	for _, row := range rows {
-		stats, err := parseStats(ctx, sc.ClientDB, sc.Codec, row)
+		stats, err := sc.parseStats(ctx, row)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -233,6 +234,8 @@ func TestCacheBasic(t *testing.T) {
 		db,
 		ex,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	for _, tableID := range tableIDs {
 		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {
@@ -325,6 +328,8 @@ CREATE STATISTICS s FROM tt;
 		kvDB,
 		s.InternalExecutor().(sqlutil.InternalExecutor),
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	tbl := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "tt")
 	// Get stats for our table. We are ensuring here that the access to the stats
@@ -364,6 +369,8 @@ func TestCacheWait(t *testing.T) {
 		db,
 		ex,
 		keys.SystemSQLCodec,
+		s.LeaseManager().(*lease.Manager),
+		s.ClusterSettings(),
 	)
 	for _, tableID := range tableIDs {
 		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {


### PR DESCRIPTION
This commit switches the stats cache to use leased types rather than
accessing types directly. This was the final user of the direct type
access methods, so that code is removed as well.

Release note: None