### PR TITLE
colexec: fix dynamic batch behavior in hash joiner with low mem limit

### DIFF
--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -371,8 +371,12 @@ func NewExternalHashJoiner(
 		partitionsToJoinUsingSortMerge: make([]int, 0),
 		leftJoinerInput:                leftJoinerInput,
 		rightJoinerInput:               rightJoinerInput,
+		// Note that the external hash joiner is responsible for making sure
+		// that partitions to join using in-memory hash joiner fit under the
+		// limit, so we use the same unlimited allocator for both
+		// buildSideAllocator and outputUnlimitedAllocator arguments.
 		inMemHashJoiner: NewHashJoiner(
-			unlimitedAllocator, spec, leftJoinerInput, rightJoinerInput,
+			unlimitedAllocator, unlimitedAllocator, spec, leftJoinerInput, rightJoinerInput,
 		).(*hashJoiner),
 		diskBackedSortMerge: diskBackedSortMerge,
 	}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1075,7 +1075,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										)
 										require.NoError(b, err)
 										hj := NewHashJoiner(
-											testAllocator, hjSpec,
+											testAllocator, testAllocator, hjSpec,
 											leftSource, rightSource,
 										)
 										hj.Init()

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1743,7 +1743,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	}
 	mj.Init()
 	hj := NewHashJoiner(
-		testAllocator, HashJoinerSpec{
+		testAllocator, testAllocator, HashJoinerSpec{
 			joinType: descpb.InnerJoin,
 			left: hashJoinerSourceSpec{
 				eqCols: []uint32{0}, sourceTypes: typs,


### PR DESCRIPTION
The disk-spilling logic in the hash joiner relies on the assumption that
a memory limit error can only occur during the building of the hash
table. However, this assumption was recently broken in the case of the
low `workmem` limit setting by the dynamic batch size work - it now
became possible for an error to occur during output population. As
a result, we might have already consumed some batches from the left
input and have emitted partial results before we fall back to the
external hash joiner, and this would result in some tuples not being
emitted at all (if we have a pending batch from the left).

This problem is now fixed by restoring the invariant with the
introduction of an unlimited allocator into the in-memory hash joiner.
The unlimited allocator is used only to populate the output (meaning
that we have already successfully built the hash table from the right
side) at the phase of the hash join algorithm when we consume the left
side one batch at a time and populate the output also one batch at
a time, so such choice is acceptable. This additionally allows to
properly account for the memory used by the output batch.

Note that the only other disk-spilling operator (different sorters that
fallback to the external sort) weren't impacted by this because they are
able to correctly export the buffered tuples regardless of when the
memory limit error occurs.

Fixes: #52859.

Release note: None