### PR TITLE
sql: add privilege validation for different object types

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -163,7 +163,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 
 		// Validate privilege descriptors directly as the db/table level Validate
 		// may fix up the descriptor.
-		if err := privileges.Validate(descriptor.GetID()); err != nil {
+		if err := privileges.Validate(descriptor.GetID(), n.grantOn); err != nil {
 			return err
 		}
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1303,7 +1303,7 @@ CREATE TABLE information_schema.user_privileges (
 				dbNameStr := tree.NewDString(dbDesc.GetName())
 				for _, u := range []string{security.RootUser, security.AdminRole} {
 					grantee := tree.NewDString(u)
-					for _, p := range privilege.DBSchemaTablePrivileges.SortedNames() {
+					for _, p := range privilege.DBTablePrivileges.SortedNames() {
 						if err := addRow(
 							grantee,            // grantee
 							dbNameStr,          // table_catalog

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -16,10 +16,10 @@ a              pg_extension        root     ALL
 a              public              admin    ALL
 a              public              root     ALL
 
-statement error user root must have exactly ALL privileges on system object with ID=.*
+statement error user root must have exactly ALL privileges on system database with ID=.*
 REVOKE SELECT ON DATABASE a FROM root
 
-statement error user admin must have exactly ALL privileges on system object with ID=.*
+statement error user admin must have exactly ALL privileges on system database with ID=.*
 REVOKE SELECT ON DATABASE a FROM admin
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -495,16 +495,16 @@ GRANT DELETE, INSERT ON system.descriptor TO root
 statement error user root does not have ALL privilege on relation descriptor
 GRANT ALL ON system.descriptor TO root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root must have exactly GRANT, SELECT privileges on system database with ID=.*
 REVOKE GRANT ON DATABASE system FROM root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root must have exactly GRANT, SELECT privileges on system table with ID=.*
 REVOKE GRANT ON system.namespace FROM root
 
 statement error user root does not have ALL privilege on relation namespace
 REVOKE ALL ON system.namespace FROM root
 
-statement error user root does not have privileges over system object with ID=.*
+statement error user root does not have privileges over system table with ID=.*
 REVOKE GRANT,SELECT ON system.namespace FROM root
 
 statement error user root does not have ALL privilege on database system
@@ -513,7 +513,7 @@ GRANT ALL ON DATABASE system TO admin
 statement error user root does not have DELETE privilege on database system
 GRANT DELETE, INSERT ON DATABASE system TO admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user admin must have exactly GRANT, SELECT privileges on system database with ID=.*
 REVOKE GRANT ON DATABASE system FROM admin
 
 statement error user root does not have ALL privilege on relation namespace
@@ -525,19 +525,19 @@ GRANT DELETE, INSERT ON system.descriptor TO admin
 statement error user root does not have ALL privilege on relation descriptor
 GRANT ALL ON system.descriptor TO admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user admin must have exactly GRANT, SELECT privileges on system table with ID=.*
 REVOKE GRANT ON system.descriptor FROM admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user admin must have exactly GRANT, SELECT privileges on system database with ID=.*
 REVOKE GRANT ON DATABASE system FROM admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user admin must have exactly GRANT, SELECT privileges on system table with ID=.*
 REVOKE GRANT ON system.namespace FROM admin
 
 statement error user root does not have ALL privilege on relation namespace
 REVOKE ALL ON system.namespace FROM admin
 
-statement error user admin does not have privileges over system object with ID=.*
+statement error user admin does not have privileges over system table with ID=.*
 REVOKE GRANT,SELECT ON system.namespace FROM admin
 
 # Some tables (we test system.lease here) used to allow multiple privilege sets for

--- a/pkg/sql/logictest/testdata/logic_test/type_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/type_privileges
@@ -8,8 +8,14 @@ user root
 
 statement ok
 GRANT CREATE, DROP ON DATABASE test TO testuser;
+
+statement ok
 CREATE TYPE test AS ENUM ('hello');
+
+statement ok
 CREATE TABLE for_view(x test);
+
+statement ok
 GRANT SELECT on for_view TO testuser;
 
 # Ensure a user without explicit privileges can use the type if it is
@@ -116,4 +122,3 @@ ALTER TYPE test RENAME to test1
 # testuser should be able to drop the type now.
 statement ok
 DROP TYPE test1
-

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -60,11 +60,12 @@ const (
 
 // Predefined sets of privileges.
 var (
-	AllPrivileges           = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG}
-	ReadData                = List{GRANT, SELECT}
-	ReadWriteData           = List{GRANT, SELECT, INSERT, DELETE, UPDATE}
-	DBSchemaTablePrivileges = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG}
-	TypePrivileges          = List{ALL, GRANT, USAGE}
+	AllPrivileges     = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG}
+	ReadData          = List{GRANT, SELECT}
+	ReadWriteData     = List{GRANT, SELECT, INSERT, DELETE, UPDATE}
+	DBTablePrivileges = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG}
+	SchemaPrivileges  = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG}
+	TypePrivileges    = List{ALL, GRANT, USAGE}
 )
 
 // Mask returns the bitmask for a given privilege.
@@ -195,7 +196,7 @@ func ListFromStrings(strs []string) (List, error) {
 func ValidatePrivileges(privileges List, objectType ObjectType) error {
 	validPrivs := GetValidPrivilegesForObject(objectType)
 	for _, priv := range privileges {
-		// Check if priv is in DBSchemaTablePrivileges.
+		// Check if priv is in DBTablePrivileges.
 		if validPrivs.ToBitField()&priv.Mask() == 0 {
 			return pgerror.Newf(pgcode.InvalidGrantOperation,
 				"invalid privilege type %s for %s", priv.String(), objectType)
@@ -209,8 +210,10 @@ func ValidatePrivileges(privileges List, objectType ObjectType) error {
 // specified object type.
 func GetValidPrivilegesForObject(objectType ObjectType) List {
 	switch objectType {
-	case Table, Database, Schema:
-		return DBSchemaTablePrivileges
+	case Table, Database:
+		return DBTablePrivileges
+	case Schema:
+		return SchemaPrivileges
 	case Type:
 		return TypePrivileges
 	case Any:

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -179,7 +180,7 @@ func (desc *ImmutableDatabaseDescriptor) Validate() error {
 	descpb.MaybeFixPrivileges(desc.GetID(), desc.Privileges)
 
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate(desc.GetID())
+	return desc.Privileges.Validate(desc.GetID(), privilege.Database)
 }
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1897,7 +1898,7 @@ func (desc *ImmutableTableDescriptor) ValidateTable() error {
 	}
 
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate(desc.GetID())
+	return desc.Privileges.Validate(desc.GetID(), privilege.Table)
 }
 
 func (desc *ImmutableTableDescriptor) validateColumnFamilies(

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -413,6 +414,11 @@ func (desc *ImmutableTypeDescriptor) Validate(
 				return errors.AssertionFailedf("duplicate enum member %q", desc.EnumMembers[i].LogicalRepresentation)
 			}
 			members[desc.EnumMembers[i].LogicalRepresentation] = struct{}{}
+		}
+
+		// Validate the Privileges of the descriptor.
+		if err := desc.Privileges.Validate(desc.ID, privilege.Type); err != nil {
+			return err
 		}
 	case descpb.TypeDescriptor_ALIAS:
 		if desc.Alias == nil {

--- a/pkg/sql/sqlbase/type_desc_test.go
+++ b/pkg/sql/sqlbase/type_desc_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -225,27 +227,40 @@ func TestValidateTypeDesc(t *testing.T) {
 	writeDesc(&descpb.Descriptor{Union: &descpb.Descriptor_Schema{}}, 101)
 	writeDesc(&descpb.Descriptor{Union: &descpb.Descriptor_Type{}}, 102)
 
+	defaultPrivileges := descpb.NewDefaultPrivilegeDescriptor(security.RootUser)
+	invalidPrivileges := descpb.NewDefaultPrivilegeDescriptor(security.RootUser)
+	// Make the PrivilegeDescriptor invalid by granting SELECT to a type.
+	invalidPrivileges.Grant("foo", privilege.List{privilege.SELECT})
+	typeDescID := descpb.ID(keys.MaxReservedDescID + 1)
 	testData := []struct {
 		err  string
 		desc descpb.TypeDescriptor
 	}{
 		{
 			`empty type name`,
-			descpb.TypeDescriptor{},
+			descpb.TypeDescriptor{
+				Privileges: defaultPrivileges,
+			},
 		},
 		{
 			`invalid ID 0`,
-			descpb.TypeDescriptor{Name: "t"},
+			descpb.TypeDescriptor{
+				Name:       "t",
+				Privileges: defaultPrivileges,
+			},
 		},
 		{
 			`invalid parentID 0`,
-			descpb.TypeDescriptor{Name: "t", ID: 1},
+			descpb.TypeDescriptor{
+				Name: "t", ID: typeDescID,
+				Privileges: defaultPrivileges,
+			},
 		},
 		{
 			`enum members are not sorted [{[2] a ALL} {[1] b ALL}]`,
 			descpb.TypeDescriptor{
 				Name:     "t",
-				ID:       1,
+				ID:       typeDescID,
 				ParentID: 1,
 				Kind:     descpb.TypeDescriptor_ENUM,
 				EnumMembers: []descpb.TypeDescriptor_EnumMember{
@@ -258,13 +273,14 @@ func TestValidateTypeDesc(t *testing.T) {
 						PhysicalRepresentation: []byte{1},
 					},
 				},
+				Privileges: defaultPrivileges,
 			},
 		},
 		{
 			`duplicate enum physical rep [1]`,
 			descpb.TypeDescriptor{
 				Name:     "t",
-				ID:       1,
+				ID:       typeDescID,
 				ParentID: 1,
 				Kind:     descpb.TypeDescriptor_ENUM,
 				EnumMembers: []descpb.TypeDescriptor_EnumMember{
@@ -277,13 +293,14 @@ func TestValidateTypeDesc(t *testing.T) {
 						PhysicalRepresentation: []byte{1},
 					},
 				},
+				Privileges: defaultPrivileges,
 			},
 		},
 		{
 			`duplicate enum member "a"`,
 			descpb.TypeDescriptor{
 				Name:     "t",
-				ID:       1,
+				ID:       typeDescID,
 				ParentID: 1,
 				Kind:     descpb.TypeDescriptor_ENUM,
 				EnumMembers: []descpb.TypeDescriptor_EnumMember{
@@ -296,59 +313,77 @@ func TestValidateTypeDesc(t *testing.T) {
 						PhysicalRepresentation: []byte{2},
 					},
 				},
+				Privileges: defaultPrivileges,
 			},
 		},
 		{
 			`ALIAS type desc has nil alias type`,
 			descpb.TypeDescriptor{
-				Name:     "t",
-				ID:       1,
-				ParentID: 1,
-				Kind:     descpb.TypeDescriptor_ALIAS,
+				Name:       "t",
+				ID:         typeDescID,
+				ParentID:   1,
+				Kind:       descpb.TypeDescriptor_ALIAS,
+				Privileges: defaultPrivileges,
 			},
 		},
 		{
 			`parentID 500 does not exist`,
 			descpb.TypeDescriptor{
-				Name:     "t",
-				ID:       1,
-				ParentID: 500,
-				Kind:     descpb.TypeDescriptor_ALIAS,
-				Alias:    types.Int,
+				Name:       "t",
+				ID:         typeDescID,
+				ParentID:   500,
+				Kind:       descpb.TypeDescriptor_ALIAS,
+				Alias:      types.Int,
+				Privileges: defaultPrivileges,
 			},
 		},
 		{
 			`parentSchemaID 500 does not exist`,
 			descpb.TypeDescriptor{
 				Name:           "t",
-				ID:             1,
+				ID:             typeDescID,
 				ParentID:       100,
 				ParentSchemaID: 500,
 				Kind:           descpb.TypeDescriptor_ALIAS,
 				Alias:          types.Int,
+				Privileges:     defaultPrivileges,
 			},
 		},
 		{
 			"arrayTypeID 500 does not exist",
 			descpb.TypeDescriptor{
 				Name:           "t",
-				ID:             1,
+				ID:             typeDescID,
 				ParentID:       100,
 				ParentSchemaID: 101,
 				Kind:           descpb.TypeDescriptor_ENUM,
 				ArrayTypeID:    500,
+				Privileges:     defaultPrivileges,
 			},
 		},
 		{
 			"referencing descriptor 500 does not exist",
 			descpb.TypeDescriptor{
 				Name:                     "t",
-				ID:                       1,
+				ID:                       typeDescID,
 				ParentID:                 100,
 				ParentSchemaID:           101,
 				Kind:                     descpb.TypeDescriptor_ENUM,
 				ArrayTypeID:              102,
 				ReferencingDescriptorIDs: []descpb.ID{500},
+				Privileges:               defaultPrivileges,
+			},
+		},
+		{
+			"user foo must not have SELECT privileges on system type with ID=50",
+			descpb.TypeDescriptor{
+				Name:           "t",
+				ID:             typeDescID,
+				ParentID:       100,
+				ParentSchemaID: 101,
+				Kind:           descpb.TypeDescriptor_ENUM,
+				ArrayTypeID:    102,
+				Privileges:     invalidPrivileges,
 			},
 		},
 	}

--- a/pkg/sql/sqlbase/validate_test.go
+++ b/pkg/sql/sqlbase/validate_test.go
@@ -214,9 +214,7 @@ var validationMap = []struct {
 			"Alias":                    {status: iSolemnlySwearThisFieldIsValidated},
 			"State":                    {status: thisFieldReferencesNoObjects},
 			"ReferencingDescriptorIDs": {status: iSolemnlySwearThisFieldIsValidated},
-			"Privileges": {status: todoIAmKnowinglyAddingTechDebt,
-				reason: "TODO(richardjcai): Will add privilege validation in a separate " +
-					"PR to avoid making this PR too big #52716."},
+			"Privileges":               {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 }


### PR DESCRIPTION
Add logic in Validate to ensure only certain privileges can be
granted on certain descriptors.

Example: USAGE is invalid on tables, SELECT is invalid on types.

Release note: None