### PR TITLE
bors: revert to original behavior

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,21 +2,13 @@
 
 # List of commit statuses that must pass on the merge commit before it is
 # pushed to master.
-#
-# This is left at being compile only as a rough heuristic to detect merge-skew.
-# We don't bother running/waiting on the full CI for merge commits.
-#
-# TODO(irfansharif): It'd be nice if we could use the build/builder.sh checkout
-# as pulled out in the github CI target, with pre-compiled C++ deps, etc. in
-# order to run the final `mkrelease` step. That would bring `bors r+` to merge
-# down to about a minute or so on our CI machines.
-status = ["Compile Build (Cockroach)"]
+status = ["GitHub CI (Cockroach)"]
 
 # List of commit statuses that must not be failing on the PR commit when it is
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will
 # construct the merge commit in parallel and simply wait for success right
 # before merging.
-pr_status = ["license/cla", "GitHub CI (Cockroach)"]
+pr_status = ["license/cla"]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.
 block_labels = ["do-not-merge"]


### PR DESCRIPTION
We've had 5 merge skews over the past week. This is a drag on developer
time (especially near the stability period) where a red master affects
our ability to merge. As such, revert back to the old bors behavior.

Hopefully bors will now no longer silently crash as fixes that caused
crashes in the past no longer occur.

Release note: None