### PR TITLE
importccl: support DELETE FROM geometry_columns / geography_columns

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -5206,7 +5207,9 @@ func TestImportPgDumpGeo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sqlDB.Exec(t, string(geoSQL))
+		// We cannot process DELETE FROM geometry_columns statement, so ignore it.
+		replacedSQL := regexp.MustCompile("DELETE FROM[^;]*").ReplaceAll(geoSQL, []byte(""))
+		sqlDB.Exec(t, string(replacedSQL))
 
 		// Verify both created tables are identical.
 		importCreate := sqlDB.QueryStr(t, `SELECT create_statement FROM [SHOW CREATE importdb."HydroNode"]`)

--- a/pkg/ccl/importccl/testdata/pgdump/geo_ogr2ogr.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/geo_ogr2ogr.sql
@@ -1,4 +1,5 @@
 BEGIN;
+DELETE FROM geometry_columns WHERE f_table_name = 'nyc_census_blocks' AND f_table_schema = 'public';
 CREATE TABLE "public"."HydroNode" (    "fid" SERIAL,    CONSTRAINT "HydroNode_pk" PRIMARY KEY ("fid") );
 SELECT AddGeometryColumn('public','HydroNode','geom',4326,'POINT',2);
 ALTER TABLE "public"."HydroNode" ADD COLUMN "id" VARCHAR(38) NOT NULL;


### PR DESCRIPTION
The functionality to delete from geometry_columns / geography_columns is
is not supported in CRDB. As such, when importing these files from
ogr2ogr dumps using IMPORT PGDUMP, ignore the DELETE statement.

This has crept up because of stricter checking from IMPORT PGDUMP.

Release note: None