### PR TITLE
opt: add rule to convert ST_Distance = 0 to ST_Intersects

### DIFF
--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -113,3 +113,23 @@ func findTimeZoneFunction(typ *types.T) (*tree.FunctionProperties, *tree.Overloa
 	}
 	panic(errors.AssertionFailedf("could not find overload for timezone"))
 }
+
+// MakeIntersectionFunction returns an ST_Intersects function for the given
+// arguments.
+func (c *CustomFuncs) MakeIntersectionFunction(args memo.ScalarListExpr) opt.ScalarExpr {
+	const name = "st_intersects"
+	resultType := types.Bool
+	props, overload, ok := memo.FindFunction(&args, name)
+	if !ok {
+		panic(errors.AssertionFailedf("could not find overload for %s", name))
+	}
+	return c.f.ConstructFunction(
+		args,
+		&memo.FunctionPrivate{
+			Name:       name,
+			Typ:        resultType,
+			Properties: props,
+			Overload:   overload,
+		},
+	)
+}

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -137,6 +137,12 @@ func (c *CustomFuncs) IsConstJSON(expr opt.ScalarExpr) bool {
 	return false
 }
 
+// IsFloatDatum returns true if the given tree.Datum is a DFloat.
+func (c *CustomFuncs) IsFloatDatum(datum tree.Datum) bool {
+	_, ok := datum.(*tree.DFloat)
+	return ok
+}
+
 // ----------------------------------------------------------------------
 //
 // Column functions
@@ -1014,6 +1020,11 @@ func (c *CustomFuncs) IntConst(d *tree.DInt) opt.ScalarExpr {
 // second.
 func (c *CustomFuncs) IsGreaterThan(first, second tree.Datum) bool {
 	return first.Compare(c.f.evalCtx, second) == 1
+}
+
+// DatumsEqual returns true if the first datum compares as equal to the second.
+func (c *CustomFuncs) DatumsEqual(first, second tree.Datum) bool {
+	return first.Compare(c.f.evalCtx, second) == 0
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -234,3 +234,16 @@
     $tz
     (MakeTimeZoneFunction (FirstScalarListExpr $args) $right)
 )
+
+# FoldEqZeroSTDistance matches an expression of the form: 'ST_Distance(a,b) = 0'
+# and replaces it with 'ST_Intersects(a,b)'. This replacement allows for
+# early-exit behavior, and may allow an inverted index scan to be generated.
+[FoldEqZeroSTDistance, Normalize]
+(Eq
+    (Function $args:* $private:(FunctionPrivate "st_distance"))
+    $right:(Const
+        $value:* & (IsFloatDatum $value) & (DatumsEqual $value 0)
+    )
+)
+=>
+(MakeIntersectionFunction $args)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -2,6 +2,14 @@ exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, d DATE)
 ----
 
+exec-ddl
+CREATE TABLE geom_geog (
+  geom GEOMETRY,
+  geog GEOGRAPHY,
+  val FLOAT
+)
+----
+
 # --------------------------------------------------
 # CommuteVarInequality
 # --------------------------------------------------
@@ -719,3 +727,43 @@ project
  │    └── columns: ts:1
  └── projections
       └── ts:1 <= '2020-06-01 13:35:55' [as="?column?":5, outer=(1)]
+
+# --------------------------------------------------
+# FoldEqZeroSTDistance
+# --------------------------------------------------
+
+# Geography case.
+norm expect=FoldEqZeroSTDistance
+SELECT * FROM geom_geog WHERE st_distance(geom, 'POINT(0.0 0.0)') = 0
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_intersects(geom:1, '010100000000000000000000000000000000000000') [outer=(1), immutable]
+
+# Geometry case.
+norm expect=FoldEqZeroSTDistance
+SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)') = 0
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_intersects(geog:2, '0101000020E610000000000000000000000000000000000000') [outer=(2), immutable]
+
+# No-op case because the constant is nonzero.
+norm expect-not=FoldEqZeroSTDistance
+SELECT * FROM geom_geog WHERE st_distance(geom, 'POINT(0.0 0.0)') = 1
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_distance(geom:1, '010100000000000000000000000000000000000000') = 1.0 [outer=(1), immutable]


### PR DESCRIPTION
This PR adds a normalization rule that matches an expression of the
form `ST_Distance(a, b) = 0` and replaces it with `ST_Intersects(a, b)`.
Using `ST_Intersects` allows cheap bounding box calculations to be used
in many cases. In addition, `ST_Intersects` can be used to generate an
inverted index scan, while `ST_Distance` cannot.

Release note: None