### PR TITLE
sql: drop schemas when dropping parent database

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -241,3 +241,24 @@ DROP SCHEMA scdrop1, scdrop2, scdrop3 CASCADE
 
 query T
 SELECT table_name FROM [SHOW TABLES] WHERE table_name LIKE 'scdrop%'
+
+subtest drop_database
+
+# Ensure that user defined schemas are dropped when dropping the parent database.
+statement ok
+CREATE DATABASE with_schemas;
+USE with_schemas;
+CREATE SCHEMA dropschema1;
+CREATE SCHEMA dropschema2;
+CREATE TABLE dropschema1.dropschema1_tb (x INT);
+CREATE TYPE dropschema1.dropschema1_typ AS ENUM ('schema');
+CREATE TABLE dropschema2.dropschema2_tb (y INT);
+USE test
+
+statement ok
+DROP DATABASE with_schemas CASCADE
+
+# There shouldn't be any left over namespace entries from the schemas
+# or elements within the schemas.
+query I
+SELECT id FROM system.namespace WHERE name LIKE 'dropschema%'

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -269,6 +269,7 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 	return p.createDropDatabaseJob(
 		ctx,
 		n.db.ID,
+		nil, /* schemasToDrop */
 		nil, /* tableDropDetails */
 		nil, /* typesToDrop */
 		tree.AsStringWithFQNames(n.n, params.Ann()),

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -36,6 +36,7 @@ func (p *planner) getVirtualTabler() VirtualTabler {
 func (p *planner) createDropDatabaseJob(
 	ctx context.Context,
 	databaseID descpb.ID,
+	schemasToDrop []descpb.ID,
 	tableDropDetails []jobspb.DroppedTableDetails,
 	typesToDrop []*typedesc.Mutable,
 	jobDesc string,
@@ -59,6 +60,7 @@ func (p *planner) createDropDatabaseJob(
 		Username:      p.User(),
 		DescriptorIDs: tableIDs,
 		Details: jobspb.SchemaChangeDetails{
+			DroppedSchemas:    schemasToDrop,
 			DroppedTables:     tableDropDetails,
 			DroppedTypes:      typeIDs,
 			DroppedDatabaseID: databaseID,


### PR DESCRIPTION
Fixes #52362.

This commit updates `DROP DATABASE CASCADE` to also clean up any child
user defined schemas.

Release note: None