### PR TITLE
jobs: rename scheduled job name to label

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -235,7 +235,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
-					nameRe:     "BACKUP .*: INCREMENTAL",
+					nameRe:     "BACKUP .*",
 					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 					paused:     true,
@@ -254,7 +254,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
-					nameRe:     "my-backup: INCREMENTAL",
+					nameRe:     "my-backup",
 					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
 					period:     time.Hour,
 					paused:     true,
@@ -304,7 +304,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			user:      enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
-					nameRe:     "my_backup_name: INCREMENTAL",
+					nameRe:     "my_backup_name",
 					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH revision_history, detached",
 					period:     time.Hour,
 					paused:     true,
@@ -336,7 +336,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "partitioned-backup",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP DATABASE system 
+		CREATE SCHEDULE FOR BACKUP DATABASE system
     INTO ('nodelocal://0/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://0/backup2?COCKROACH_LOCALITY=default')
 		WITH revision_history
     RECURRING '1 2 * * *'
@@ -406,7 +406,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				stmt := getScheduledBackupStatement(t, s.ExecutionArgs())
 				expectedSchedule, ok := expectedByName[stmt]
 				require.True(t, ok, "could not find matching name for %q", stmt)
-				require.Regexp(t, regexp.MustCompile(expectedSchedule.nameRe), s.ScheduleName())
+				require.Regexp(t, regexp.MustCompile(expectedSchedule.nameRe), s.ScheduleLabel())
 
 				expectedShown := fmt.Sprintf("%q", expectedSchedule.backupStmt)
 				if expectedSchedule.shownStmt != "" {

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -172,7 +172,7 @@ func (s *jobScheduler) processSchedule(
 	// Grab job executor and execute the job.
 	log.Infof(ctx,
 		"Starting job for schedule %d (%s); next run scheduled for %s",
-		schedule.ScheduleID(), schedule.ScheduleName(), schedule.NextRun())
+		schedule.ScheduleID(), schedule.ScheduleLabel(), schedule.NextRun())
 
 	if err := executor.ExecuteJob(ctx, s.JobExecutionConfig, s.env, schedule, txn); err != nil {
 		return errors.Wrapf(err, "executing schedule %d", schedule.ScheduleID())

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -524,7 +524,7 @@ func TestJobSchedulerDaemonUsesSystemTables(t *testing.T) {
 
 	// Create a one off job which writes some values into 'foo' table.
 	schedule := NewScheduledJob(scheduledjobs.ProdJobSchedulerEnv)
-	schedule.SetScheduleName("test schedule")
+	schedule.SetScheduleLabel("test schedule")
 	schedule.SetNextRun(timeutil.Now())
 	any, err := types.MarshalAny(
 		&jobspb.SqlStatementExecutionArg{Statement: "INSERT INTO defaultdb.foo VALUES (1), (2), (3)"})

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -36,7 +36,7 @@ import (
 // Do not manipulate these fields directly, use methods in the ScheduledJob.
 type scheduledJobRecord struct {
 	ScheduleID      int64                     `col:"schedule_id"`
-	ScheduleName    string                    `col:"schedule_name"`
+	ScheduleLabel   string                    `col:"schedule_name"`
 	Owner           string                    `col:"owner"`
 	NextRun         time.Time                 `col:"next_run"`
 	ScheduleExpr    string                    `col:"schedule_expr"`
@@ -110,14 +110,14 @@ func (j *ScheduledJob) ScheduleID() int64 {
 	return j.rec.ScheduleID
 }
 
-// ScheduleName returns schedule name.
-func (j *ScheduledJob) ScheduleName() string {
-	return j.rec.ScheduleName
+// ScheduleLabel returns schedule label.
+func (j *ScheduledJob) ScheduleLabel() string {
+	return j.rec.ScheduleLabel
 }
 
-// SetScheduleName updates schedule name.
-func (j *ScheduledJob) SetScheduleName(name string) {
-	j.rec.ScheduleName = name
+// SetScheduleLabel updates schedule label.
+func (j *ScheduledJob) SetScheduleLabel(label string) {
+	j.rec.ScheduleLabel = label
 	j.markDirty("schedule_name")
 }
 
@@ -424,7 +424,7 @@ func (j *ScheduledJob) marshalChanges() ([]string, []interface{}, error) {
 
 		switch col {
 		case `schedule_name`:
-			arg = tree.NewDString(j.rec.ScheduleName)
+			arg = tree.NewDString(j.rec.ScheduleLabel)
 		case `owner`:
 			arg = tree.NewDString(j.rec.Owner)
 		case `next_run`:

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -93,9 +93,9 @@ func newTestHelperForTables(
 }
 
 // newScheduledJob is a helper to create scheduled job with helper environment.
-func (h *testHelper) newScheduledJob(t *testing.T, scheduleName, sql string) *ScheduledJob {
+func (h *testHelper) newScheduledJob(t *testing.T, scheduleLabel, sql string) *ScheduledJob {
 	j := NewScheduledJob(h.env)
-	j.SetScheduleName(scheduleName)
+	j.SetScheduleLabel(scheduleLabel)
 	any, err := types.MarshalAny(&jobspb.SqlStatementExecutionArg{Statement: sql})
 	require.NoError(t, err)
 	j.SetExecutionDetails(InlineExecutorName, jobspb.ExecutionArguments{Args: any})
@@ -105,10 +105,10 @@ func (h *testHelper) newScheduledJob(t *testing.T, scheduleName, sql string) *Sc
 // newScheduledJobForExecutor is a helper to create scheduled job for the specified
 // executor and its args.
 func (h *testHelper) newScheduledJobForExecutor(
-	scheduleName, executorName string, executorArgs *types.Any,
+	scheduleLabel, executorName string, executorArgs *types.Any,
 ) *ScheduledJob {
 	j := NewScheduledJob(h.env)
-	j.SetScheduleName(scheduleName)
+	j.SetScheduleLabel(scheduleLabel)
 	j.SetExecutionDetails(executorName, jobspb.ExecutionArguments{Args: executorArgs})
 	return j
 }
@@ -150,8 +150,8 @@ func addFakeJob(t *testing.T, h *testHelper, scheduleID int64, status Status, tx
 	datums, err := h.cfg.InternalExecutor.QueryRowEx(context.Background(), "fake-job", txn,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		fmt.Sprintf(`
-INSERT INTO %s (created_by_type, created_by_id, status, payload) 
-VALUES ($1, $2, $3, $4) 
+INSERT INTO %s (created_by_type, created_by_id, status, payload)
+VALUES ($1, $2, $3, $4)
 RETURNING id`,
 			h.env.SystemJobsTableName(),
 		),

--- a/pkg/sql/delegate/show_schedules.go
+++ b/pkg/sql/delegate/show_schedules.go
@@ -27,7 +27,7 @@ func (d *delegator) delegateShowSchedules(n *tree.ShowSchedules) (tree.Statement
 
 	columnExprs := []string{
 		"schedule_id as id",
-		"schedule_name as name",
+		"schedule_name as label",
 		"(CASE WHEN next_run IS NULL THEN 'PAUSED' ELSE 'ACTIVE' END) AS status",
 		"next_run",
 		"(CASE WHEN schedule_expr IS NULL THEN 'NEVER' ELSE schedule_expr END) as recurrence",

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2268,7 +2268,7 @@ create_schedule_for_backup_stmt:
   /*$10=*/cron_expr /*$11=*/opt_full_backup_clause /*$12=*/opt_with_schedule_options
   {
     $$.val = &tree.ScheduledBackup{
-      ScheduleName:     $3.expr(),
+      ScheduleLabel:    $3.expr(),
       Recurrence:       $10.expr(),
       FullBackup:       $11.fullBackupClause(),
       To:               $8.stringOrPlaceholderOptList(),

--- a/pkg/sql/sem/tree/schedule.go
+++ b/pkg/sql/sem/tree/schedule.go
@@ -18,7 +18,7 @@ type FullBackupClause struct {
 
 // ScheduledBackup represents scheduled backup job.
 type ScheduledBackup struct {
-	ScheduleName    Expr
+	ScheduleLabel   Expr
 	Recurrence      Expr
 	FullBackup      *FullBackupClause /* nil implies choose default */
 	Targets         *TargetList       /* nil implies tree.AllDescriptors coverage */
@@ -33,9 +33,9 @@ var _ Statement = &ScheduledBackup{}
 func (node *ScheduledBackup) Format(ctx *FmtCtx) {
 	ctx.WriteString("CREATE SCHEDULE")
 
-	if node.ScheduleName != nil {
+	if node.ScheduleLabel != nil {
 		ctx.WriteString(" ")
-		node.ScheduleName.Format(ctx)
+		node.ScheduleLabel.Format(ctx)
 	}
 
 	ctx.WriteString(" FOR BACKUP")


### PR DESCRIPTION
Name implies unique identification and has already led to confusion
in our initial testing and QA. Calling it label feels like it establishes
more accurate user expectations.

Release note: none.