### PR TITLE
sql/opt: add implicit SELECT FOR UPDATE support for UPSERT statements

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -644,6 +644,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	lookupCols exec.TableColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
+	locking *tree.LockingItem,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: lookup join")

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1560,6 +1560,11 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
 
+	var locking *tree.LockingItem
+	if b.forceForUpdateLocking {
+		locking = forUpdateLocking
+	}
+
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinOpToJoinType(join.JoinType),
 		input.root,
@@ -1570,6 +1575,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		lookupOrdinals,
 		onExpr,
 		res.reqOrdering(join),
+		locking,
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -309,6 +309,7 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
+ │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join (anti)  ·                   ·
@@ -337,6 +338,7 @@ root                               ·                      ·
  │                                 missing stats          ·
  │                                 table                  child@primary
  │                                 spans                  [/10 - /10]
+ │                                 locking strength       for update
  └── fk-check                      ·                      ·
       └── error if rows            ·                      ·
            └── lookup join (anti)  ·                      ·
@@ -362,6 +364,7 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               parent@primary
  │                                    spans               FULL SCAN
+ │                                    locking strength    for update
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
  │         └── hash join              ·                   ·
@@ -402,39 +405,40 @@ root                                  ·                   ·
 query TTT
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
-·                                     distribution   local
-·                                     vectorized     false
-root                                  ·              ·
- ├── update                           ·              ·
- │    │                               table          parent
- │    │                               set            p
- │    └── buffer                      ·              ·
- │         │                          label          buffer 1
- │         └── render                 ·              ·
- │              └── scan              ·              ·
- │                                    missing stats  ·
- │                                    table          parent@parent_other_key
- │                                    spans          [/10 - /10]
- ├── fk-check                         ·              ·
- │    └── error if rows               ·              ·
- │         └── lookup join (semi)     ·              ·
- │              │                     table          child@child_p_idx
- │              │                     equality       (p) = (p)
- │              └── except            ·              ·
- │                   ├── scan buffer  ·              ·
- │                   │                label          buffer 1
- │                   └── scan buffer  ·              ·
- │                                    label          buffer 1
- └── fk-check                         ·              ·
-      └── error if rows               ·              ·
-           └── lookup join (semi)     ·              ·
-                │                     table          child_nullable@child_nullable_p_idx
-                │                     equality       (p) = (p)
-                └── except            ·              ·
-                     ├── scan buffer  ·              ·
-                     │                label          buffer 1
-                     └── scan buffer  ·              ·
-·                                     label          buffer 1
+·                                     distribution      local
+·                                     vectorized        false
+root                                  ·                 ·
+ ├── update                           ·                 ·
+ │    │                               table             parent
+ │    │                               set               p
+ │    └── buffer                      ·                 ·
+ │         │                          label             buffer 1
+ │         └── render                 ·                 ·
+ │              └── scan              ·                 ·
+ │                                    missing stats     ·
+ │                                    table             parent@parent_other_key
+ │                                    spans             [/10 - /10]
+ │                                    locking strength  for update
+ ├── fk-check                         ·                 ·
+ │    └── error if rows               ·                 ·
+ │         └── lookup join (semi)     ·                 ·
+ │              │                     table             child@child_p_idx
+ │              │                     equality          (p) = (p)
+ │              └── except            ·                 ·
+ │                   ├── scan buffer  ·                 ·
+ │                   │                label             buffer 1
+ │                   └── scan buffer  ·                 ·
+ │                                    label             buffer 1
+ └── fk-check                         ·                 ·
+      └── error if rows               ·                 ·
+           └── lookup join (semi)     ·                 ·
+                │                     table             child_nullable@child_nullable_p_idx
+                │                     equality          (p) = (p)
+                └── except            ·                 ·
+                     ├── scan buffer  ·                 ·
+                     │                label             buffer 1
+                     └── scan buffer  ·                 ·
+·                                     label             buffer 1
 
 statement ok
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
@@ -455,6 +459,7 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               child@primary
  │                                    spans               FULL SCAN
+ │                                    locking strength    for update
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·
@@ -490,6 +495,7 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
+ │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join (anti)  ·                   ·
@@ -517,6 +523,7 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
+ │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join (anti)  ·                   ·
@@ -545,6 +552,7 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               child@primary
  │                                    spans               FULL SCAN
+ │                                    locking strength    for update
  ├── fk-check                         ·                   ·
  │    └── error if rows               ·                   ·
  │         └── hash join (anti)       ·                   ·
@@ -594,6 +602,7 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               child@primary
  │                               spans               FULL SCAN
+ │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join (anti)  ·                   ·
@@ -625,6 +634,7 @@ root                             ·                   ·
  │                               missing stats       ·
  │                               table               self@primary
  │                               spans               FULL SCAN
+ │                               locking strength    for update
  └── fk-check                    ·                   ·
       └── error if rows          ·                   ·
            └── hash join (anti)  ·                   ·
@@ -653,6 +663,7 @@ root                                  ·                   ·
  │                                    missing stats       ·
  │                                    table               self@primary
  │                                    spans               FULL SCAN
+ │                                    locking strength    for update
  └── fk-check                         ·                   ·
       └── error if rows               ·                   ·
            └── hash join              ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1613,17 +1613,18 @@ scan  ·              ·
 query TTT
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          t4
- │              set            c
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          t4@primary
-·               spans          [/10/20 - /10/20]
+·               distribution      local
+·               vectorized        false
+update          ·                 ·
+ │              table             t4
+ │              set               c
+ │              auto commit       ·
+ └── render     ·                 ·
+      └── scan  ·                 ·
+·               missing stats     ·
+·               table             t4@primary
+·               spans             [/10/20 - /10/20]
+·               locking strength  for update
 
 # Optimization should not be applied for deletes.
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -60,27 +60,28 @@ query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                              distribution   local
-·                              vectorized     false
-root                           ·              ·
- ├── limit                     ·              ·
- │    │                        count          1
- │    └── scan buffer          ·              ·
- │                             label          buffer 1 (a)
- └── subquery                  ·              ·
-      │                        id             @S1
-      │                        original sql   UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode      all rows
-      └── buffer               ·              ·
-           │                   label          buffer 1 (a)
-           └── update          ·              ·
-                │              table          t
-                │              set            x
-                └── render     ·              ·
-                     └── scan  ·              ·
-·                              missing stats  ·
-·                              table          t@primary
-·                              spans          FULL SCAN
+·                              distribution      local
+·                              vectorized        false
+root                           ·                 ·
+ ├── limit                     ·                 ·
+ │    │                        count             1
+ │    └── scan buffer          ·                 ·
+ │                             label             buffer 1 (a)
+ └── subquery                  ·                 ·
+      │                        id                @S1
+      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
+      │                        exec mode         all rows
+      └── buffer               ·                 ·
+           │                   label             buffer 1 (a)
+           └── update          ·                 ·
+                │              table             t
+                │              set               x
+                └── render     ·                 ·
+                     └── scan  ·                 ·
+·                              missing stats     ·
+·                              table             t@primary
+·                              spans             FULL SCAN
+·                              locking strength  for update
 
 query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
@@ -154,27 +155,28 @@ root                      ·              ·
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-·                              distribution   local
-·                              vectorized     false
-root                           ·              ·
- ├── limit                     ·              ·
- │    │                        count          1
- │    └── scan buffer          ·              ·
- │                             label          buffer 1
- └── subquery                  ·              ·
-      │                        id             @S1
-      │                        original sql   UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode      all rows
-      └── buffer               ·              ·
-           │                   label          buffer 1
-           └── update          ·              ·
-                │              table          t
-                │              set            x
-                └── render     ·              ·
-                     └── scan  ·              ·
-·                              missing stats  ·
-·                              table          t@primary
-·                              spans          FULL SCAN
+·                              distribution      local
+·                              vectorized        false
+root                           ·                 ·
+ ├── limit                     ·                 ·
+ │    │                        count             1
+ │    └── scan buffer          ·                 ·
+ │                             label             buffer 1
+ └── subquery                  ·                 ·
+      │                        id                @S1
+      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
+      │                        exec mode         all rows
+      └── buffer               ·                 ·
+           │                   label             buffer 1
+           └── update          ·                 ·
+                │              table             t
+                │              set               x
+                └── render     ·                 ·
+                     └── scan  ·                 ·
+·                              missing stats     ·
+·                              table             t@primary
+·                              spans             FULL SCAN
+·                              locking strength  for update
 
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -101,16 +101,17 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-·          distribution   local
-·          vectorized     false
-update     ·              ·
- │         table          xyz
- │         set            y
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          xyz@primary
-·          spans          FULL SCAN
+·          distribution      local
+·          vectorized        false
+update     ·                 ·
+ │         table             xyz
+ │         set               y
+ │         auto commit       ·
+ └── scan  ·                 ·
+·          missing stats     ·
+·          table             xyz@primary
+·          spans             FULL SCAN
+·          locking strength  for update
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
@@ -241,18 +242,19 @@ update                    ·              ·
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          [ - /2]
-·               limit          1
+·               distribution      local
+·               vectorized        false
+update          ·                 ·
+ │              table             kv
+ │              set               v
+ │              auto commit       ·
+ └── render     ·                 ·
+      └── scan  ·                 ·
+·               missing stats     ·
+·               table             kv@primary
+·               spans             [ - /2]
+·               limit             1
+·               locking strength  for update
 
 # Check that updates on tables with multiple column families behave as
 # they should.
@@ -418,46 +420,49 @@ update                     ·                    ·                     ()      
 query TTT
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          [/3 - /3]
+·               distribution      local
+·               vectorized        false
+update          ·                 ·
+ │              table             kv
+ │              set               v
+ │              auto commit       ·
+ └── render     ·                 ·
+      └── scan  ·                 ·
+·               missing stats     ·
+·               table             kv@primary
+·               spans             [/3 - /3]
+·               locking strength  for update
 
 query TTT
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·          distribution   local
-·          vectorized     false
-update     ·              ·
- │         table          kv
- │         set            v
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          kv@primary
-·          spans          [/2 - /9]
+·          distribution      local
+·          vectorized        false
+update     ·                 ·
+ │         table             kv
+ │         set               v
+ │         auto commit       ·
+ └── scan  ·                 ·
+·          missing stats     ·
+·          table             kv@primary
+·          spans             [/2 - /9]
+·          locking strength  for update
 
 query TTT
 EXPLAIN UPDATE kv SET v = 10
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          FULL SCAN
+·               distribution      local
+·               vectorized        false
+update          ·                 ·
+ │              table             kv
+ │              set               v
+ │              auto commit       ·
+ └── render     ·                 ·
+      └── scan  ·                 ·
+·               missing stats     ·
+·               table             kv@primary
+·               spans             FULL SCAN
+·               locking strength  for update
 
 statement ok
 CREATE TABLE kv3 (
@@ -471,35 +476,37 @@ CREATE TABLE kv3 (
 query TTT
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                     distribution   local
-·                     vectorized     false
-update                ·              ·
- │                    table          kv3
- │                    set            k
- │                    auto commit    ·
- └── render           ·              ·
-      └── index join  ·              ·
-           │          table          kv3@primary
-           └── scan   ·              ·
-·                     missing stats  ·
-·                     table          kv3@kv3_v_idx
-·                     spans          [/10 - /10]
+·                     distribution      local
+·                     vectorized        false
+update                ·                 ·
+ │                    table             kv3
+ │                    set               k
+ │                    auto commit       ·
+ └── render           ·                 ·
+      └── index join  ·                 ·
+           │          table             kv3@primary
+           └── scan   ·                 ·
+·                     missing stats     ·
+·                     table             kv3@kv3_v_idx
+·                     spans             [/10 - /10]
+·                     locking strength  for update
 
 query TTT
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                distribution   local
-·                vectorized     false
-update           ·              ·
- │               table          kv3
- │               set            k
- │               auto commit    ·
- └── index join  ·              ·
-      │          table          kv3@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          kv3@kv3_v_idx
-·                spans          [/2 - /9]
+·                distribution      local
+·                vectorized        false
+update           ·                 ·
+ │               table             kv3
+ │               set               k
+ │               auto commit       ·
+ └── index join  ·                 ·
+      │          table             kv3@primary
+      └── scan   ·                 ·
+·                missing stats     ·
+·                table             kv3@kv3_v_idx
+·                spans             [/2 - /9]
+·                locking strength  for update
 
 statement ok
 SET enable_implicit_select_for_update = false

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -164,6 +164,49 @@ upsert                                  ·                    ·
 ·                                       estimated row count  1 (missing stats)
 ·                                       table                indexed@primary
 ·                                       spans                /1-/1/#
+·                                       locking strength     for update
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1), (2), (3), (4)
+]
+----
+·                                        distribution           local
+·                                        vectorized             false
+upsert                                   ·                      ·
+ │                                       estimated row count    0 (missing stats)
+ │                                       into                   indexed(a, b, c, d)
+ │                                       auto commit            ·
+ └── project                             ·                      ·
+      └── render                         ·                      ·
+           │                             estimated row count    4 (missing stats)
+           │                             render 0               column8 > 0
+           │                             render 1               column1
+           │                             render 2               column7
+           │                             render 3               column8
+           │                             render 4               column9
+           │                             render 5               a
+           │                             render 6               b
+           │                             render 7               c
+           │                             render 8               d
+           └── lookup join (left outer)  ·                      ·
+                │                        estimated row count    4 (missing stats)
+                │                        table                  indexed@primary
+                │                        equality               (column1) = (a)
+                │                        equality cols are key  ·
+                │                        locking strength       for update
+                └── render               ·                      ·
+                     │                   estimated row count    4
+                     │                   render 0               column1 + 10
+                     │                   render 1               CAST(NULL AS INT8)
+                     │                   render 2               10
+                     │                   render 3               column1
+                     └── values          ·                      ·
+·                                        size                   1 column, 4 rows
+·                                        row 0, expr 0          1
+·                                        row 1, expr 0          2
+·                                        row 2, expr 0          3
+·                                        row 3, expr 0          4
 
 # Drop index and verify that existing values no longer need to be fetched.
 statement ok

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -497,6 +497,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			ob.Attr("equality cols are key", "")
 		}
 		ob.Expr("pred", a.OnCond, appendColumns(inputCols, tableColumns(a.Table, a.LookupCols)...))
+		e.emitLockingPolicy(a.Locking)
 
 	case interleavedJoinOp:
 		a := n.args.(*interleavedJoinArgs)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -737,10 +737,10 @@ func (e *emitter) emitLockingPolicy(locking *tree.LockingItem) {
 	strength := descpb.ToScanLockingStrength(locking.Strength)
 	waitPolicy := descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 	if strength != descpb.ScanLockingStrength_FOR_NONE {
-		e.ob.VAttr("locking strength", strength.PrettyString())
+		e.ob.Attr("locking strength", strength.PrettyString())
 	}
 	if waitPolicy != descpb.ScanLockingWaitPolicy_BLOCK {
-		e.ob.VAttr("locking wait policy", waitPolicy.PrettyString())
+		e.ob.Attr("locking wait policy", waitPolicy.PrettyString())
 	}
 }
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -244,6 +244,7 @@ define LookupJoin {
     LookupCols exec.TableColumnOrdinalSet
     OnCond tree.TypedExpr
     ReqOrdering exec.OutputOrdering
+    Locking *tree.LockingItem
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -624,6 +624,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	lookupCols exec.TableColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
+	locking *tree.LockingItem,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)
@@ -638,6 +639,10 @@ func (ef *execFactory) ConstructLookupJoin(
 	}
 
 	tableScan.index = indexDesc
+	if locking != nil {
+		tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
+		tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
+	}
 
 	n := &lookupJoinNode{
 		input:        input.(planNode),


### PR DESCRIPTION
Fixes #50180.

This commit adds support for implicit SELECT FOR UPDATE support for UPSERT statements with a VALUES clause. This should improve throughput and latency for contended UPSERT statements in much the same way that 435fa43 did for UPDATE statements. However, this only has an effect on UPSERT statements into tables with multiple indexes because UPSERT statements into single-index tables hit a fast-path where they perform a blind-write without doing an initial row scan.

Conceptually, if we picture an UPSERT statement as the composition of a SELECT statement and an INSERT statement (with loosened semantics around existing rows) then this change performs the following transformation:
```
UPSERT t = SELECT FROM t + INSERT INTO t
=>
UPSERT t = SELECT FROM t FOR UPDATE + INSERT INTO t
```

I plan to test this out on a contended `indexes` workload at some point in the future.

Release note (sql change): UPSERT statements now acquire locks using the FOR UPDATE locking mode during their initial row scan, which improves performance for contended workloads when UPSERTing into tables with multiple indexes. This behavior is configurable using the enable_implicit_select_for_update session variable and the sql.defaults.implicit_select_for_update.enabled cluster setting.