### PR TITLE
tree: remove pointer definition for DBox2D

### DIFF
--- a/pkg/geo/bbox.go
+++ b/pkg/geo/bbox.go
@@ -48,15 +48,15 @@ func (b *CartesianBoundingBox) Repr() string {
 }
 
 // ParseCartesianBoundingBox parses a box2d string into a bounding box.
-func ParseCartesianBoundingBox(s string) (*CartesianBoundingBox, error) {
-	b := &CartesianBoundingBox{}
+func ParseCartesianBoundingBox(s string) (CartesianBoundingBox, error) {
+	b := CartesianBoundingBox{}
 	var prefix string
 	numScanned, err := fmt.Sscanf(s, "%3s(%f %f,%f %f)", &prefix, &b.LoX, &b.LoY, &b.HiX, &b.HiY)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing box2d")
+		return b, errors.Wrapf(err, "error parsing box2d")
 	}
 	if numScanned != 5 || strings.ToLower(prefix) != "box" {
-		return nil, errors.Newf("expected format 'box(min_x min_y,max_x max_y)'")
+		return b, errors.Newf("expected format 'box(min_x min_y,max_x max_y)'")
 	}
 	return b, nil
 }

--- a/pkg/geo/bbox_test.go
+++ b/pkg/geo/bbox_test.go
@@ -23,12 +23,12 @@ import (
 func TestParseCartesianBoundingBox(t *testing.T) {
 	testCases := []struct {
 		s             string
-		expected      *CartesianBoundingBox
+		expected      CartesianBoundingBox
 		expectedError bool
 	}{
 		{
 			s: "box(1 2,3 4)",
-			expected: &CartesianBoundingBox{
+			expected: CartesianBoundingBox{
 				BoundingBox: geopb.BoundingBox{
 					LoX: 1,
 					LoY: 2,
@@ -39,7 +39,7 @@ func TestParseCartesianBoundingBox(t *testing.T) {
 		},
 		{
 			s: "BOX(1 2,3 4)",
-			expected: &CartesianBoundingBox{
+			expected: CartesianBoundingBox{
 				BoundingBox: geopb.BoundingBox{
 					LoX: 1,
 					LoY: 2,

--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -13,7 +13,6 @@ package geomfn
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
-	"github.com/cockroachdb/errors"
 )
 
 // Centroid returns the Centroid of a given Geometry.
@@ -26,12 +25,9 @@ func Centroid(g *geo.Geometry) (*geo.Geometry, error) {
 }
 
 // ClipByRect clips a given Geometry by the given BoundingBox.
-func ClipByRect(g *geo.Geometry, b *geo.CartesianBoundingBox) (*geo.Geometry, error) {
+func ClipByRect(g *geo.Geometry, b geo.CartesianBoundingBox) (*geo.Geometry, error) {
 	if g.Empty() {
 		return g, nil
-	}
-	if b == nil {
-		return nil, errors.Newf("expected not null bounding box")
 	}
 	clipByRectEWKB, err := geos.ClipByRect(g.EWKB(), b.LoX, b.LoY, b.HiX, b.HiY)
 	if err != nil {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -434,7 +434,7 @@ func (v *Value) SetGeo(so geopb.SpatialObject) error {
 
 // SetBox2D encodes the specified Box2D value into the bytes field of the
 // receiver, sets the tag and clears the checksum.
-func (v *Value) SetBox2D(b *geo.CartesianBoundingBox) {
+func (v *Value) SetBox2D(b geo.CartesianBoundingBox) {
 	v.ensureRawBytes(headerSize + 32)
 	encoding.EncodeUint64Ascending(v.RawBytes[headerSize:headerSize], math.Float64bits(b.LoX))
 	encoding.EncodeUint64Ascending(v.RawBytes[headerSize+8:headerSize+8], math.Float64bits(b.HiX))
@@ -582,35 +582,35 @@ func (v Value) GetGeo() (geopb.SpatialObject, error) {
 
 // GetBox2D decodes a geo value from the bytes field of the receiver. If the
 // tag is not BOX2D an error will be returned.
-func (v Value) GetBox2D() (*geo.CartesianBoundingBox, error) {
+func (v Value) GetBox2D() (geo.CartesianBoundingBox, error) {
+	box := geo.CartesianBoundingBox{}
 	if tag := v.GetTag(); tag != ValueType_BOX2D {
-		return nil, fmt.Errorf("value type is not %s: %s", ValueType_BOX2D, tag)
+		return box, fmt.Errorf("value type is not %s: %s", ValueType_BOX2D, tag)
 	}
-	box := &geo.CartesianBoundingBox{}
 	dataBytes := v.dataBytes()
 	if len(dataBytes) != 32 {
-		return nil, fmt.Errorf("float64 value should be exactly 32 bytes: %d", len(dataBytes))
+		return box, fmt.Errorf("float64 value should be exactly 32 bytes: %d", len(dataBytes))
 	}
 	var err error
 	var val uint64
 	dataBytes, val, err = encoding.DecodeUint64Ascending(dataBytes)
 	if err != nil {
-		return nil, err
+		return box, err
 	}
 	box.LoX = math.Float64frombits(val)
 	dataBytes, val, err = encoding.DecodeUint64Ascending(dataBytes)
 	if err != nil {
-		return nil, err
+		return box, err
 	}
 	box.HiX = math.Float64frombits(val)
 	dataBytes, val, err = encoding.DecodeUint64Ascending(dataBytes)
 	if err != nil {
-		return nil, err
+		return box, err
 	}
 	box.LoY = math.Float64frombits(val)
 	_, val, err = encoding.DecodeUint64Ascending(dataBytes)
 	if err != nil {
-		return nil, err
+		return box, err
 	}
 	box.HiY = math.Float64frombits(val)
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
@@ -172,6 +172,11 @@ BOX(-1 -1,1 1)
 BOX(4 -5,4 -5)
 BOX(-1 -5,4 1)
 
+query T
+select st_combinebbox(st_expand(NULL::BOX2D, 0.7845514859561931:::FLOAT8::FLOAT8)::BOX2D::BOX2D, '010200000000000000':::GEOMETRY::GEOMETRY)::BOX2D;
+----
+NULL
+
 subtest st_expand
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1045,7 +1045,7 @@ oid     typname        typnamespace  typowner  typlen  typbyval  typtype
 90001   _geometry      1307062959    NULL      -1      false     b
 90002   geography      1307062959    NULL      -1      false     b
 90003   _geography     1307062959    NULL      -1      false     b
-90004   box2d          1307062959    NULL      8       true      b
+90004   box2d          1307062959    NULL      32      true      b
 90005   _box2d         1307062959    NULL      -1      false     b
 100064  newtype1       2332901747    NULL      -1      false     e
 100065  _newtype1      2332901747    NULL      -1      false     b

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -672,7 +672,7 @@ func (agg *stExtentAgg) Result() (tree.Datum, error) {
 	if agg.bbox == nil {
 		return tree.DNull, nil
 	}
-	return tree.NewDBox2D(agg.bbox), nil
+	return tree.NewDBox2D(*agg.bbox), nil
 }
 
 // Reset implements the AggregateFunc interface.

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -715,10 +715,11 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DBox2D:
 			return d, nil
 		case *DGeometry:
-			if d.Geometry.Empty() {
+			bbox := d.CartesianBoundingBox()
+			if bbox == nil {
 				return DNull, nil
 			}
-			return NewDBox2D(d.CartesianBoundingBox()), nil
+			return NewDBox2D(*bbox), nil
 		}
 
 	case types.GeographyFamily:

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2937,11 +2937,11 @@ func (d *DGeometry) Size() uintptr {
 
 // DBox2D is the Datum representation of the Box2D type.
 type DBox2D struct {
-	*geo.CartesianBoundingBox
+	geo.CartesianBoundingBox
 }
 
 // NewDBox2D returns a new Box2D Datum.
-func NewDBox2D(b *geo.CartesianBoundingBox) *DBox2D {
+func NewDBox2D(b geo.CartesianBoundingBox) *DBox2D {
 	return &DBox2D{CartesianBoundingBox: b}
 }
 
@@ -2990,7 +2990,7 @@ func (d *DBox2D) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	o := other.(*DBox2D)
-	return d.CartesianBoundingBox.Compare(o.CartesianBoundingBox)
+	return d.CartesianBoundingBox.Compare(&o.CartesianBoundingBox)
 }
 
 // Prev implements the Datum interface.
@@ -3041,7 +3041,7 @@ func (d *DBox2D) Format(ctx *FmtCtx) {
 
 // Size implements the Datum interface.
 func (d *DBox2D) Size() uintptr {
-	return unsafe.Sizeof(*d) + unsafe.Sizeof(*d.CartesianBoundingBox)
+	return unsafe.Sizeof(*d) + unsafe.Sizeof(d.CartesianBoundingBox)
 }
 
 // DJSON is the JSON Datum.
@@ -4651,7 +4651,7 @@ var baseDatumTypeSizes = map[types.Family]struct {
 }{
 	types.UnknownFamily:        {unsafe.Sizeof(dNull{}), fixedSize},
 	types.BoolFamily:           {unsafe.Sizeof(DBool(false)), fixedSize},
-	types.Box2DFamily:          {unsafe.Sizeof(DBox2D{CartesianBoundingBox: &geo.CartesianBoundingBox{}}), fixedSize},
+	types.Box2DFamily:          {unsafe.Sizeof(DBox2D{CartesianBoundingBox: geo.CartesianBoundingBox{}}), fixedSize},
 	types.BitFamily:            {unsafe.Sizeof(DBitArray{}), variableSize},
 	types.IntFamily:            {unsafe.Sizeof(DInt(0)), fixedSize},
 	types.FloatFamily:          {unsafe.Sizeof(DFloat(0.0)), fixedSize},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2559,8 +2559,8 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 					return nil, err
 				}
 				ret := op(
-					MustBeDBox2D(left).CartesianBoundingBox,
-					MustBeDBox2D(right).CartesianBoundingBox,
+					&MustBeDBox2D(left).CartesianBoundingBox,
+					&MustBeDBox2D(right).CartesianBoundingBox,
 				)
 				return MakeDBool(DBool(ret)), nil
 			},
@@ -2574,7 +2574,7 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 					return nil, err
 				}
 				ret := op(
-					MustBeDBox2D(left).CartesianBoundingBox,
+					&MustBeDBox2D(left).CartesianBoundingBox,
 					MustBeDGeometry(right).CartesianBoundingBox(),
 				)
 				return MakeDBool(DBool(ret)), nil
@@ -2590,7 +2590,7 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 				}
 				ret := op(
 					MustBeDGeometry(left).CartesianBoundingBox(),
-					MustBeDBox2D(right).CartesianBoundingBox,
+					&MustBeDBox2D(right).CartesianBoundingBox,
 				)
 				return MakeDBool(DBool(ret)), nil
 			},

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -82,7 +82,7 @@ func SampleDatum(t *types.T) Datum {
 		return NewDOid(DInt(1009))
 	case types.Box2DFamily:
 		b := geo.NewCartesianBoundingBox().AddPoint(1, 2).AddPoint(3, 4)
-		return NewDBox2D(b)
+		return NewDBox2D(*b)
 	case types.GeographyFamily:
 		return NewDGeography(geo.MustParseGeographyFromEWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")))
 	case types.GeometryFamily:

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -292,7 +292,7 @@ func DecodeTableKey(
 		}
 		return a.NewDBytes(tree.DBytes(r)), rkey, err
 	case types.Box2DFamily:
-		var r *geo.CartesianBoundingBox
+		var r geo.CartesianBoundingBox
 		if dir == encoding.Ascending {
 			rkey, r, err = encoding.DecodeBox2DAscending(key)
 		} else {

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -108,7 +108,7 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 		}
 	case types.Box2DFamily:
 		b := geo.NewCartesianBoundingBox().AddPoint(rng.NormFloat64(), rng.NormFloat64()).AddPoint(rng.NormFloat64(), rng.NormFloat64())
-		return tree.NewDBox2D(b)
+		return tree.NewDBox2D(*b)
 	case types.GeographyFamily:
 		gm, err := typ.GeoMetadata()
 		if err != nil {
@@ -513,7 +513,7 @@ var (
 			&tree.DInterval{Duration: duration.MakeDuration(0, 0, 290*12)},
 		},
 		types.Box2DFamily: {
-			&tree.DBox2D{CartesianBoundingBox: &geo.CartesianBoundingBox{BoundingBox: geopb.BoundingBox{LoX: -10, HiX: 10, LoY: -10, HiY: 10}}},
+			&tree.DBox2D{CartesianBoundingBox: geo.CartesianBoundingBox{BoundingBox: geopb.BoundingBox{LoX: -10, HiX: 10, LoY: -10, HiY: 10}}},
 		},
 		types.GeographyFamily: {
 			// NOTE(otan): we cannot use WKT here because roachtests do not have geos uploaded.

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -981,7 +981,7 @@ func decodeTime(b []byte) (r []byte, sec int64, nsec int64, err error) {
 }
 
 // EncodeBox2DAscending encodes a bounding box in ascending order.
-func EncodeBox2DAscending(b []byte, box *geo.CartesianBoundingBox) ([]byte, error) {
+func EncodeBox2DAscending(b []byte, box geo.CartesianBoundingBox) ([]byte, error) {
 	b = append(b, box2DMarker)
 	b = EncodeFloatAscending(b, box.LoX)
 	b = EncodeFloatAscending(b, box.HiX)
@@ -991,7 +991,7 @@ func EncodeBox2DAscending(b []byte, box *geo.CartesianBoundingBox) ([]byte, erro
 }
 
 // EncodeBox2DDescending encodes a bounding box in descending order.
-func EncodeBox2DDescending(b []byte, box *geo.CartesianBoundingBox) ([]byte, error) {
+func EncodeBox2DDescending(b []byte, box geo.CartesianBoundingBox) ([]byte, error) {
 	b = append(b, box2DMarker)
 	b = EncodeFloatDescending(b, box.LoX)
 	b = EncodeFloatDescending(b, box.HiX)
@@ -1001,57 +1001,57 @@ func EncodeBox2DDescending(b []byte, box *geo.CartesianBoundingBox) ([]byte, err
 }
 
 // DecodeBox2DAscending decodes a box2D object in ascending order.
-func DecodeBox2DAscending(b []byte) ([]byte, *geo.CartesianBoundingBox, error) {
+func DecodeBox2DAscending(b []byte) ([]byte, geo.CartesianBoundingBox, error) {
+	box := geo.CartesianBoundingBox{}
 	if PeekType(b) != Box2D {
-		return nil, nil, errors.Errorf("did not find Box2D marker")
+		return nil, box, errors.Errorf("did not find Box2D marker")
 	}
 
 	b = b[1:]
-	box := &geo.CartesianBoundingBox{}
 	var err error
 	b, box.LoX, err = DecodeFloatAscending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.HiX, err = DecodeFloatAscending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.LoY, err = DecodeFloatAscending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.HiY, err = DecodeFloatAscending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	return b, box, nil
 }
 
 // DecodeBox2DDescending decodes a box2D object in descending order.
-func DecodeBox2DDescending(b []byte) ([]byte, *geo.CartesianBoundingBox, error) {
+func DecodeBox2DDescending(b []byte) ([]byte, geo.CartesianBoundingBox, error) {
+	box := geo.CartesianBoundingBox{}
 	if PeekType(b) != Box2D {
-		return nil, nil, errors.Errorf("did not find Box2D marker")
+		return nil, box, errors.Errorf("did not find Box2D marker")
 	}
 
 	b = b[1:]
-	box := &geo.CartesianBoundingBox{}
 	var err error
 	b, box.LoX, err = DecodeFloatDescending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.HiX, err = DecodeFloatDescending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.LoY, err = DecodeFloatDescending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	b, box.HiY, err = DecodeFloatDescending(b)
 	if err != nil {
-		return nil, nil, err
+		return nil, box, err
 	}
 	return b, box, nil
 }
@@ -2252,14 +2252,14 @@ func EncodeUntaggedTimeTZValue(appendTo []byte, t timetz.TimeTZ) []byte {
 
 // EncodeBox2DValue encodes a geo.CartesianBoundingBox with its value tag, appends it to
 // the supplied buffer and returns the final buffer.
-func EncodeBox2DValue(appendTo []byte, colID uint32, b *geo.CartesianBoundingBox) ([]byte, error) {
+func EncodeBox2DValue(appendTo []byte, colID uint32, b geo.CartesianBoundingBox) ([]byte, error) {
 	appendTo = EncodeValueTag(appendTo, colID, Box2D)
 	return EncodeUntaggedBox2DValue(appendTo, b)
 }
 
 // EncodeUntaggedBox2DValue encodes a geo.CartesianBoundingBox value, appends it to the supplied buffer,
 // and returns the final buffer.
-func EncodeUntaggedBox2DValue(appendTo []byte, b *geo.CartesianBoundingBox) ([]byte, error) {
+func EncodeUntaggedBox2DValue(appendTo []byte, b geo.CartesianBoundingBox) ([]byte, error) {
 	appendTo = EncodeFloatAscending(appendTo, b.LoX)
 	appendTo = EncodeFloatAscending(appendTo, b.HiX)
 	appendTo = EncodeFloatAscending(appendTo, b.LoY)
@@ -2554,25 +2554,25 @@ func DecodeDecimalValue(b []byte) (remaining []byte, d apd.Decimal, err error) {
 // DecodeUntaggedBox2DValue decodes a value encoded by EncodeUntaggedBox2DValue.
 func DecodeUntaggedBox2DValue(
 	b []byte,
-) (remaining []byte, box *geo.CartesianBoundingBox, err error) {
-	box = &geo.CartesianBoundingBox{}
+) (remaining []byte, box geo.CartesianBoundingBox, err error) {
+	box = geo.CartesianBoundingBox{}
 	remaining = b
 
 	remaining, box.LoX, err = DecodeFloatAscending(remaining)
 	if err != nil {
-		return b, nil, err
+		return b, box, err
 	}
 	remaining, box.HiX, err = DecodeFloatAscending(remaining)
 	if err != nil {
-		return b, nil, err
+		return b, box, err
 	}
 	remaining, box.LoY, err = DecodeFloatAscending(remaining)
 	if err != nil {
-		return b, nil, err
+		return b, box, err
 	}
 	remaining, box.HiY, err = DecodeFloatAscending(remaining)
 	if err != nil {
-		return b, nil, err
+		return b, box, err
 	}
 	return remaining, box, err
 }

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1150,10 +1150,10 @@ func TestEncodeDecodeTimeTZ(t *testing.T) {
 
 func TestEncodeDecodeBox2D(t *testing.T) {
 	testCases := []struct {
-		ordered []*geo.CartesianBoundingBox
+		ordered []geo.CartesianBoundingBox
 	}{
 		{
-			ordered: []*geo.CartesianBoundingBox{
+			ordered: []geo.CartesianBoundingBox{
 				{BoundingBox: geopb.BoundingBox{LoX: -100, HiX: 99, LoY: -100, HiY: 100}},
 				{BoundingBox: geopb.BoundingBox{LoX: -100, HiX: 100, LoY: -100, HiY: 100}},
 				{BoundingBox: geopb.BoundingBox{LoX: -50, HiX: 100, LoY: -100, HiY: 100}},
@@ -1173,7 +1173,7 @@ func TestEncodeDecodeBox2D(t *testing.T) {
 					for j := range tc.ordered {
 						var b []byte
 						var err error
-						var decoded *geo.CartesianBoundingBox
+						var decoded geo.CartesianBoundingBox
 
 						if dir == Ascending {
 							b, err = EncodeBox2DAscending(b, tc.ordered[j])


### PR DESCRIPTION
Box2D should never actually be nil inside, so remove that requirement.

Resolves #53013.

Release note: None