### PR TITLE
sql: fix panic when resolving a target on non-existent db

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1135,3 +1135,6 @@ public greeting2  hello
 public int        Z|S of int
 public notbad     dup|DUP
 uds    typ        schema
+
+statement error pq: cannot create "fakedb.typ" because the target database or schema does not exist
+CREATE TYPE fakedb.typ AS ENUM ('schema')

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -120,6 +120,9 @@ func (p *planner) ResolveTargetObject(
 	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		prefix, namePrefix, err = resolver.ResolveTargetObject(ctx, p, un)
 	})
+	if err != nil {
+		return nil, namePrefix, err
+	}
 	return prefix.Database, namePrefix, err
 }
 


### PR DESCRIPTION
When trying to resolve a target on non-existent DB, we would have a nil
deference panic due to a missing error check.

Some ways that could have triggered this panic:
- Resolving {types,sequences}
- Renaming a table

Release note (bug fix): Fix a crash that may occur when referencing a
database that does not exist when trying to create a type, sequence or
when renaming a table.