### PR TITLE
logictest: increase rate limits for tenants

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(53040)
-
 # Tests for the experimental opt-driven cascades.
 subtest OptDriven
 


### PR DESCRIPTION
The default rate limits were causing extreme test slowness in some logic tests
(e.g. cascade).

Release note: None

Fixes #53040 