### PR TITLE
colexec: add support for DISTINCT ordered aggregation

### DIFF
--- a/pkg/sql/colexec/aggregate_funcs.go
+++ b/pkg/sql/colexec/aggregate_funcs.go
@@ -361,3 +361,42 @@ func ProcessAggregations(
 	}
 	return
 }
+
+// aggBucket stores the aggregation functions for the corresponding aggregation
+// group as well as other utility information.
+type aggBucket struct {
+	fns []aggregateFunc
+	// seen is a slice of maps used to handle distinct aggregation. A
+	// corresponding entry in the slice is nil if the function doesn't have a
+	// DISTINCT clause. The slice itself will be nil whenever no aggregate
+	// function has a DISTINCT clause.
+	seen []map[string]struct{}
+}
+
+func (b *aggBucket) init(
+	batch coldata.Batch, fns []aggregateFunc, seen []map[string]struct{}, groups []bool,
+) {
+	b.fns = fns
+	for fnIdx, fn := range b.fns {
+		fn.Init(groups, batch.ColVec(fnIdx))
+	}
+	b.seen = seen
+}
+
+const sizeOfAggBucket = unsafe.Sizeof(aggBucket{})
+
+// aggBucketAlloc is a utility struct that batches allocations of aggBuckets.
+type aggBucketAlloc struct {
+	allocator *colmem.Allocator
+	buf       []aggBucket
+}
+
+func (a *aggBucketAlloc) newAggBucket() *aggBucket {
+	if len(a.buf) == 0 {
+		a.allocator.AdjustMemoryUsage(int64(hashAggregatorAllocSize * sizeOfAggBucket))
+		a.buf = make([]aggBucket, hashAggregatorAllocSize)
+	}
+	ret := &a.buf[0]
+	a.buf = a.buf[1:]
+	return ret
+}

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -23,11 +23,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stringarena"
+	"github.com/cockroachdb/errors"
 )
 
-// hashAggregatorHelper is a helper for the hash aggregator that facilitates
-// the selection of tuples on which to perform the aggregation.
-type hashAggregatorHelper interface {
+// aggregatorHelper is a helper for the aggregators that facilitates the
+// selection of tuples on which to perform the aggregation.
+type aggregatorHelper interface {
 	// makeSeenMaps returns a slice of maps used to handle distinct aggregation
 	// of a single aggregation bucket. A corresponding entry in the slice is
 	// nil if the function doesn't have a DISTINCT clause. The slice itself
@@ -36,21 +37,24 @@ type hashAggregatorHelper interface {
 	// performAggregation performs aggregation of all functions in bucket on
 	// tuples in vecs that are relevant for each function (meaning that only
 	// tuples that pass the criteria - like DISTINCT and/or FILTER will be
-	// aggregated).
-	performAggregation(ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *hashAggBucket)
+	// aggregated). groups is a boolean slice in which 'true' represents a
+	// start of the new aggregation group (when groups is nil, then all tuples
+	// belong to the same group).
+	performAggregation(ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, groups []bool)
 }
 
-// newHashAggregatorHelper creates a new hashAggregatorHelper based on the
-// provided aggregator specification. If there are no functions that perform
-// either DISTINCT or FILTER aggregation, then the defaultHashAggregatorHelper
+// newAggregatorHelper creates a new aggregatorHelper based on the provided
+// aggregator specification. If there are no functions that perform either
+// DISTINCT or FILTER aggregation, then the defaultAggregatorHelper
 // is returned which has negligible performance overhead.
-func newHashAggregatorHelper(
+func newAggregatorHelper(
 	allocator *colmem.Allocator,
 	memAccount *mon.BoundAccount,
 	inputTypes []*types.T,
 	spec *execinfrapb.AggregatorSpec,
 	datumAlloc *sqlbase.DatumAlloc,
-) hashAggregatorHelper {
+	isHashAgg bool,
+) aggregatorHelper {
 	hasDistinct, hasFilterAgg := false, false
 	aggFilter := make([]int, len(spec.Aggregations))
 	for i, aggFn := range spec.Aggregations {
@@ -64,11 +68,18 @@ func newHashAggregatorHelper(
 			aggFilter[i] = tree.NoColumnIdx
 		}
 	}
-
 	if !hasDistinct && !hasFilterAgg {
-		return newDefaultHashAggregatorHelper(spec)
+		return newDefaultAggregatorHelper(spec)
 	}
-	filters := make([]*filteringSingleFunctionHelper, len(spec.Aggregations))
+	if !isHashAgg {
+		if hasFilterAgg {
+			colexecerror.InternalError(errors.AssertionFailedf(
+				"filtering ordered aggregation is not supported",
+			))
+		}
+		return newDistinctOrderedAggregatorHelper(memAccount, inputTypes, spec, datumAlloc)
+	}
+	filters := make([]*filteringSingleFunctionHashHelper, len(spec.Aggregations))
 	for i, filterIdx := range aggFilter {
 		filters[i] = newFilteringHashAggHelper(allocator, inputTypes, filterIdx)
 	}
@@ -78,34 +89,34 @@ func newHashAggregatorHelper(
 	return newFilteringDistinctHashAggregatorHelper(memAccount, inputTypes, spec, filters, datumAlloc)
 }
 
-// defaultHashAggregatorHelper is the default hashAggregatorHelper for the case
+// defaultAggregatorHelper is the default aggregatorHelper for the case
 // when no aggregate function is performing DISTINCT or FILTERing aggregation.
-type defaultHashAggregatorHelper struct {
+type defaultAggregatorHelper struct {
 	spec *execinfrapb.AggregatorSpec
 }
 
-var _ hashAggregatorHelper = &defaultHashAggregatorHelper{}
+var _ aggregatorHelper = &defaultAggregatorHelper{}
 
-func newDefaultHashAggregatorHelper(spec *execinfrapb.AggregatorSpec) hashAggregatorHelper {
-	return &defaultHashAggregatorHelper{spec: spec}
+func newDefaultAggregatorHelper(spec *execinfrapb.AggregatorSpec) aggregatorHelper {
+	return &defaultAggregatorHelper{spec: spec}
 }
 
-func (h *defaultHashAggregatorHelper) makeSeenMaps() []map[string]struct{} {
+func (h *defaultAggregatorHelper) makeSeenMaps() []map[string]struct{} {
 	return nil
 }
 
-func (h *defaultHashAggregatorHelper) performAggregation(
-	_ context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *hashAggBucket,
+func (h *defaultAggregatorHelper) performAggregation(
+	_ context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	for fnIdx, fn := range bucket.fns {
 		fn.Compute(vecs, h.spec.Aggregations[fnIdx].ColIdx, inputLen, sel)
 	}
 }
 
-// hashAggregatorHelperBase is a utility struct that provides non-default
-// hashAggregatorHelpers with the logic necessary for saving/restoring the
+// aggregatorHelperBase is a utility struct that provides non-default
+// aggregatorHelpers with the logic necessary for saving/restoring the
 // input state.
-type hashAggregatorHelperBase struct {
+type aggregatorHelperBase struct {
 	spec *execinfrapb.AggregatorSpec
 
 	vecs    []coldata.Vec
@@ -114,49 +125,50 @@ type hashAggregatorHelperBase struct {
 	origLen int
 }
 
-func newAggregatorHelperBase(spec *execinfrapb.AggregatorSpec) *hashAggregatorHelperBase {
-	b := &hashAggregatorHelperBase{spec: spec}
+func newAggregatorHelperBase(spec *execinfrapb.AggregatorSpec) *aggregatorHelperBase {
+	b := &aggregatorHelperBase{spec: spec}
 	b.origSel = make([]int, coldata.BatchSize())
 	return b
 }
 
-func (h *hashAggregatorHelperBase) saveState(vecs []coldata.Vec, origLen int, origSel []int) {
-	h.vecs = vecs
-	h.origLen = origLen
-	h.usesSel = origSel != nil
-	if h.usesSel {
-		copy(h.origSel[:h.origLen], origSel[:h.origLen])
+func (b *aggregatorHelperBase) saveState(vecs []coldata.Vec, origLen int, origSel []int) {
+	b.vecs = vecs
+	b.origLen = origLen
+	b.usesSel = origSel != nil
+	if b.usesSel {
+		copy(b.origSel[:b.origLen], origSel[:b.origLen])
 	}
 }
 
-func (h *hashAggregatorHelperBase) restoreState() ([]coldata.Vec, int, []int) {
-	sel := h.origSel
-	if !h.usesSel {
+func (b *aggregatorHelperBase) restoreState() ([]coldata.Vec, int, []int) {
+	sel := b.origSel
+	if !b.usesSel {
 		sel = nil
 	}
-	return h.vecs, h.origLen, sel
+	return b.vecs, b.origLen, sel
 }
 
-// filteringSingleFunctionHelper is a utility struct that helps with handling
-// of a FILTER clause of a single aggregate function.
-type filteringSingleFunctionHelper struct {
+// filteringSingleFunctionHashHelper is a utility struct that helps with
+// handling of a FILTER clause of a single aggregate function for the hash
+// aggregation.
+type filteringSingleFunctionHashHelper struct {
 	filter      colexecbase.Operator
 	filterInput *singleBatchOperator
 }
 
-var noFilterHashAggHelper = &filteringSingleFunctionHelper{}
+var noFilterHashAggHelper = &filteringSingleFunctionHashHelper{}
 
-// newFilteringHashAggHelper returns a new filteringSingleFunctionHelper.
+// newFilteringHashAggHelper returns a new filteringSingleFunctionHashHelper.
 // tree.NoColumnIdx index can be used to indicate that there is no FILTER
 // clause for the aggregate function.
 func newFilteringHashAggHelper(
 	allocator *colmem.Allocator, typs []*types.T, filterIdx int,
-) *filteringSingleFunctionHelper {
+) *filteringSingleFunctionHashHelper {
 	if filterIdx == tree.NoColumnIdx {
 		return noFilterHashAggHelper
 	}
 	filterInput := newSingleBatchOperator(allocator, typs)
-	h := &filteringSingleFunctionHelper{
+	h := &filteringSingleFunctionHashHelper{
 		filter:      newBoolVecToSelOp(filterInput, filterIdx),
 		filterInput: filterInput,
 	}
@@ -166,7 +178,7 @@ func newFilteringHashAggHelper(
 // applyFilter returns the updated selection vector that includes only tuples
 // for which filtering column has 'true' value set. It also returns whether
 // state might have been modified.
-func (h *filteringSingleFunctionHelper) applyFilter(
+func (h *filteringSingleFunctionHashHelper) applyFilter(
 	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int,
 ) (_ []coldata.Vec, _ int, _ []int, maybeModified bool) {
 	if h.filter == nil {
@@ -177,23 +189,23 @@ func (h *filteringSingleFunctionHelper) applyFilter(
 	return newBatch.ColVecs(), newBatch.Length(), newBatch.Selection(), true
 }
 
-// filteringHashAggregatorHelper is a hashAggregatorHelper that handles the
+// filteringHashAggregatorHelper is an aggregatorHelper that handles the
 // aggregate functions which have at least one FILTER clause but no DISTINCT
-// clauses.
+// clauses for the hash aggregation.
 type filteringHashAggregatorHelper struct {
-	*hashAggregatorHelperBase
+	*aggregatorHelperBase
 
-	filters []*filteringSingleFunctionHelper
+	filters []*filteringSingleFunctionHashHelper
 }
 
-var _ hashAggregatorHelper = &filteringHashAggregatorHelper{}
+var _ aggregatorHelper = &filteringHashAggregatorHelper{}
 
 func newFilteringHashAggregatorHelper(
-	spec *execinfrapb.AggregatorSpec, filters []*filteringSingleFunctionHelper,
-) hashAggregatorHelper {
+	spec *execinfrapb.AggregatorSpec, filters []*filteringSingleFunctionHashHelper,
+) aggregatorHelper {
 	h := &filteringHashAggregatorHelper{
-		hashAggregatorHelperBase: newAggregatorHelperBase(spec),
-		filters:                  filters,
+		aggregatorHelperBase: newAggregatorHelperBase(spec),
+		filters:              filters,
 	}
 	return h
 }
@@ -203,7 +215,7 @@ func (h *filteringHashAggregatorHelper) makeSeenMaps() []map[string]struct{} {
 }
 
 func (h *filteringHashAggregatorHelper) performAggregation(
-	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *hashAggBucket,
+	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	h.saveState(vecs, inputLen, sel)
 	for fnIdx, fn := range bucket.fns {
@@ -222,31 +234,24 @@ func (h *filteringHashAggregatorHelper) performAggregation(
 	}
 }
 
-// filteringDistinctHashAggregatorHelper is a hashAggregatorHelper that handles
-// the aggregate functions with any number of DISTINCT and/or FILTER clauses.
-// The helper should be shared among all groups for aggregation. The filtering
-// is delegated to filteringHashAggHelpers, and this struct handles the
-// "distinctness" of aggregation.
-// Note that the "distinctness" of tuples is handled by encoding aggregation
-// columns of a tuple (one tuple at a time) and storing it in a seen map that
-// is separate for each aggregation group and for each aggregate function with
-// DISTINCT clause.
+// distinctAggregatorHelperBase is a utility struct that facilitates handling
+// of DISTINCT clause for aggregatorHelpers. Note that the "distinctness" of
+// tuples is handled by encoding aggregation columns of a tuple (one tuple at a
+// time) and storing it in a seen map that is separate for each aggregation
+// group and for each aggregate function with DISTINCT clause.
 // Other approaches have been prototyped but showed worse performance:
 // - using the vectorized hash table - the benefit of such approach is that we
 // don't reduce ourselves to one tuple at a time (because we would be hashing
 // the full columns at once), but the big disadvantage is that the full tuples
 // are stored in the hash table (instead of an encoded representation).
-// TODO(yuzefovich): reevaluate the vectorized hash table once it is
-// dynamically resizable and can store only a subset of columns from the input.
 // - using a single global map for a particular aggregate function that is
 // shared among all aggregation groups - the benefit of such approach is that
 // we only have a handful of map, but it turned out that such global map grows
 // a lot bigger and has worse performance.
-type filteringDistinctHashAggregatorHelper struct {
-	*hashAggregatorHelperBase
+type distinctAggregatorHelperBase struct {
+	*aggregatorHelperBase
 
 	inputTypes       []*types.T
-	filters          []*filteringSingleFunctionHelper
 	aggColsConverter *vecToDatumConverter
 	arena            stringarena.Arena
 	datumAlloc       *sqlbase.DatumAlloc
@@ -259,21 +264,17 @@ type filteringDistinctHashAggregatorHelper struct {
 	}
 }
 
-var _ hashAggregatorHelper = &filteringDistinctHashAggregatorHelper{}
-
-func newFilteringDistinctHashAggregatorHelper(
+func newDistinctAggregatorHelperBase(
 	memAccount *mon.BoundAccount,
 	inputTypes []*types.T,
 	spec *execinfrapb.AggregatorSpec,
-	filters []*filteringSingleFunctionHelper,
 	datumAlloc *sqlbase.DatumAlloc,
-) hashAggregatorHelper {
-	h := &filteringDistinctHashAggregatorHelper{
-		hashAggregatorHelperBase: newAggregatorHelperBase(spec),
-		inputTypes:               inputTypes,
-		arena:                    stringarena.Make(memAccount),
-		datumAlloc:               datumAlloc,
-		filters:                  filters,
+) *distinctAggregatorHelperBase {
+	b := &distinctAggregatorHelperBase{
+		aggregatorHelperBase: newAggregatorHelperBase(spec),
+		inputTypes:           inputTypes,
+		arena:                stringarena.Make(memAccount),
+		datumAlloc:           datumAlloc,
 	}
 	var vecIdxsToConvert []int
 	for _, aggFn := range spec.Aggregations {
@@ -292,19 +293,19 @@ func newFilteringDistinctHashAggregatorHelper(
 			}
 		}
 	}
-	h.aggColsConverter = newVecToDatumConverter(len(inputTypes), vecIdxsToConvert)
-	h.scratch.converted = []tree.Datum{nil}
-	h.scratch.sel = make([]int, coldata.BatchSize())
-	return h
+	b.aggColsConverter = newVecToDatumConverter(len(inputTypes), vecIdxsToConvert)
+	b.scratch.converted = []tree.Datum{nil}
+	b.scratch.sel = make([]int, coldata.BatchSize())
+	return b
 }
 
-func (h *filteringDistinctHashAggregatorHelper) makeSeenMaps() []map[string]struct{} {
+func (b *distinctAggregatorHelperBase) makeSeenMaps() []map[string]struct{} {
 	// Note that we consciously don't account for the memory used under seen
 	// maps because that memory is likely noticeably smaller than the memory
 	// used (and accounted for) in other parts of the hash aggregation (the
 	// vectorized hash table and the aggregate functions).
-	seen := make([]map[string]struct{}, len(h.spec.Aggregations))
-	for i, aggFn := range h.spec.Aggregations {
+	seen := make([]map[string]struct{}, len(b.spec.Aggregations))
+	for i, aggFn := range b.spec.Aggregations {
 		if aggFn.Distinct {
 			seen[i] = make(map[string]struct{})
 		}
@@ -318,32 +319,45 @@ func (h *filteringDistinctHashAggregatorHelper) makeSeenMaps() []map[string]stru
 // conversion of the relevant aggregate columns *without* deselection. This
 // function assumes that seen map is non-nil and is the same that is used for
 // all batches from the same aggregation group.
-func (h *filteringDistinctHashAggregatorHelper) selectDistinctTuples(
-	ctx context.Context, inputLen int, sel []int, inputIdxs []uint32, seen map[string]struct{},
+func (b *distinctAggregatorHelperBase) selectDistinctTuples(
+	ctx context.Context,
+	inputLen int,
+	sel []int,
+	inputIdxs []uint32,
+	seen map[string]struct{},
+	groups []bool,
 ) (newLen int, newSel []int) {
-	newSel = h.scratch.sel
+	newSel = b.scratch.sel
 	var (
 		tupleIdx int
 		err      error
 		s        string
 	)
 	for idx := 0; idx < inputLen; idx++ {
-		h.scratch.encoded = h.scratch.encoded[:0]
+		b.scratch.encoded = b.scratch.encoded[:0]
 		tupleIdx = idx
 		if sel != nil {
 			tupleIdx = sel[idx]
 		}
+		if groups != nil && groups[tupleIdx] {
+			// We have encountered a new group, so we need to clear the seen
+			// map. It turns out that it is faster to delete entries from the
+			// old map rather than allocating a new one.
+			for s := range seen {
+				delete(seen, s)
+			}
+		}
 		for _, colIdx := range inputIdxs {
-			h.scratch.ed.Datum = h.aggColsConverter.getDatumColumn(int(colIdx))[tupleIdx]
-			h.scratch.encoded, err = h.scratch.ed.Fingerprint(
-				h.inputTypes[colIdx], h.datumAlloc, h.scratch.encoded,
+			b.scratch.ed.Datum = b.aggColsConverter.getDatumColumn(int(colIdx))[tupleIdx]
+			b.scratch.encoded, err = b.scratch.ed.Fingerprint(
+				b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded,
 			)
 			if err != nil {
 				colexecerror.InternalError(err)
 			}
 		}
-		if _, seenPreviously := seen[string(h.scratch.encoded)]; !seenPreviously {
-			s, err = h.arena.AllocBytes(ctx, h.scratch.encoded)
+		if _, seenPreviously := seen[string(b.scratch.encoded)]; !seenPreviously {
+			s, err = b.arena.AllocBytes(ctx, b.scratch.encoded)
 			if err != nil {
 				colexecerror.InternalError(err)
 			}
@@ -355,10 +369,41 @@ func (h *filteringDistinctHashAggregatorHelper) selectDistinctTuples(
 	return
 }
 
-// performAggregation executes Compute on all fns paying attention to distinct
-// tuples if the corresponding function performs DISTINCT aggregation (as well
-// as to any present FILTER clauses). For such functions the approach is as
-// follows:
+// filteringDistinctHashAggregatorHelper is an aggregatorHelper that handles
+// the aggregate functions with any number of DISTINCT and/or FILTER clauses
+// for the hash aggregation. The helper should be shared among all groups for
+// aggregation. The filtering is delegated to filteringSingleFunctionHashHelper
+// whereas the "distinctness" is delegated to distinctAggregatorHelperBase.
+type filteringDistinctHashAggregatorHelper struct {
+	*distinctAggregatorHelperBase
+
+	filters []*filteringSingleFunctionHashHelper
+}
+
+var _ aggregatorHelper = &filteringDistinctHashAggregatorHelper{}
+
+func newFilteringDistinctHashAggregatorHelper(
+	memAccount *mon.BoundAccount,
+	inputTypes []*types.T,
+	spec *execinfrapb.AggregatorSpec,
+	filters []*filteringSingleFunctionHashHelper,
+	datumAlloc *sqlbase.DatumAlloc,
+) aggregatorHelper {
+	return &filteringDistinctHashAggregatorHelper{
+		distinctAggregatorHelperBase: newDistinctAggregatorHelperBase(
+			memAccount,
+			inputTypes,
+			spec,
+			datumAlloc,
+		),
+		filters: filters,
+	}
+}
+
+// performAggregation executes Compute on all aggregate functions in bucket
+// paying attention to distinct tuples if the corresponding function performs
+// DISTINCT aggregation (as well as to any present FILTER clauses).
+// For such functions the approach is as follows:
 // 1. Store the input state because we will be modifying some of it.
 // 2. Convert all aggregate columns of functions that perform DISTINCT
 //    aggregation.
@@ -371,15 +416,69 @@ func (h *filteringDistinctHashAggregatorHelper) selectDistinctTuples(
 //    4) Restore the state to the original state (if it might have been
 //       modified).
 func (h *filteringDistinctHashAggregatorHelper) performAggregation(
-	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *hashAggBucket,
+	ctx context.Context, vecs []coldata.Vec, inputLen int, sel []int, bucket *aggBucket, _ []bool,
 ) {
 	h.saveState(vecs, inputLen, sel)
 	h.aggColsConverter.convertVecs(vecs, inputLen, sel)
-	var maybeModified bool
 	for aggFnIdx, aggFn := range h.spec.Aggregations {
+		var maybeModified bool
 		vecs, inputLen, sel, maybeModified = h.filters[aggFnIdx].applyFilter(ctx, vecs, inputLen, sel)
 		if inputLen > 0 && aggFn.Distinct {
-			inputLen, sel = h.selectDistinctTuples(ctx, inputLen, sel, aggFn.ColIdx, bucket.seen[aggFnIdx])
+			inputLen, sel = h.selectDistinctTuples(
+				ctx, inputLen, sel, aggFn.ColIdx, bucket.seen[aggFnIdx], nil, /* groups */
+			)
+			maybeModified = true
+		}
+		if inputLen > 0 {
+			bucket.fns[aggFnIdx].Compute(vecs, aggFn.ColIdx, inputLen, sel)
+		}
+		if maybeModified {
+			vecs, inputLen, sel = h.restoreState()
+		}
+	}
+}
+
+type distinctOrderedAggregatorHelper struct {
+	*distinctAggregatorHelperBase
+}
+
+var _ aggregatorHelper = &distinctOrderedAggregatorHelper{}
+
+func newDistinctOrderedAggregatorHelper(
+	memAccount *mon.BoundAccount,
+	inputTypes []*types.T,
+	spec *execinfrapb.AggregatorSpec,
+	datumAlloc *sqlbase.DatumAlloc,
+) aggregatorHelper {
+	return &distinctOrderedAggregatorHelper{
+		distinctAggregatorHelperBase: newDistinctAggregatorHelperBase(
+			memAccount,
+			inputTypes,
+			spec,
+			datumAlloc,
+		),
+	}
+}
+
+// performAggregation executes Compute on all aggregate function in bucket
+// paying attention to distinct tuples if the corresponding function performs
+// DISTINCT aggregation
+func (h *distinctOrderedAggregatorHelper) performAggregation(
+	ctx context.Context,
+	vecs []coldata.Vec,
+	inputLen int,
+	sel []int,
+	bucket *aggBucket,
+	groups []bool,
+) {
+	h.saveState(vecs, inputLen, sel)
+	h.aggColsConverter.convertVecs(vecs, inputLen, sel)
+	for aggFnIdx, aggFn := range h.spec.Aggregations {
+		var maybeModified bool
+		if aggFn.Distinct {
+			inputLen, sel = h.selectDistinctTuples(
+				ctx, inputLen, sel, aggFn.ColIdx, bucket.seen[aggFnIdx], groups,
+			)
 			maybeModified = true
 		}
 		if inputLen > 0 {

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -175,9 +175,6 @@ func isSupported(mode sessiondata.VectorizeExecMode, spec *execinfrapb.Processor
 			return err
 		}
 		for _, agg := range aggSpec.Aggregations {
-			if agg.Distinct && !needHash {
-				return errors.Newf("distinct ordered aggregation not supported")
-			}
 			if agg.FilterColIdx != nil && !needHash {
 				return errors.Newf("filtering ordered aggregation not supported")
 			}
@@ -708,8 +705,8 @@ func NewColOperator(
 			} else {
 				evalCtx.SingleDatumAggMemAccount = streamingMemAccount
 				result.Op, err = colexec.NewOrderedAggregator(
-					streamingAllocator, inputs[0], inputTypes, aggSpec, evalCtx,
-					constructors, constArguments, result.ColumnTypes, aggSpec.IsScalar(),
+					streamingAllocator, streamingMemAccount, inputs[0], inputTypes, aggSpec,
+					evalCtx, constructors, constArguments, result.ColumnTypes, aggSpec.IsScalar(),
 				)
 				result.IsStreaming = true
 			}

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -147,7 +147,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 				runTestsWithTyps(t, []tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, unorderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 						return agg.new(
-							testAllocator, input[0], tc.typs, tc.spec, &evalCtx,
+							testAllocator, testMemAcc, input[0], tc.typs, tc.spec, &evalCtx,
 							constructors, constArguments, outputTypes, false, /* isScalar */
 						)
 					})

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -59,7 +58,7 @@ type hashAggregator struct {
 	allocator *colmem.Allocator
 	spec      *execinfrapb.AggregatorSpec
 
-	aggHelper          hashAggregatorHelper
+	aggHelper          aggregatorHelper
 	inputTypes         []*types.T
 	outputTypes        []*types.T
 	inputArgsConverter *vecToDatumConverter
@@ -67,7 +66,7 @@ type hashAggregator struct {
 	// buckets contains all aggregation groups that we have so far. There is
 	// 1-to-1 mapping between buckets[i] and ht.vals[i]. Once the output from
 	// the buckets has been flushed, buckets will be sliced up accordingly.
-	buckets []*hashAggBucket
+	buckets []*aggBucket
 	// ht stores tuples that are "heads" of the corresponding aggregation
 	// groups ("head" here means the tuple that was first seen from the group).
 	ht *hashTable
@@ -92,7 +91,7 @@ type hashAggregator struct {
 	output coldata.Batch
 
 	aggFnsAlloc *aggregateFuncsAlloc
-	hashAlloc   hashAggBucketAlloc
+	hashAlloc   aggBucketAlloc
 	datumAlloc  sqlbase.DatumAlloc
 	toClose     Closers
 }
@@ -109,7 +108,7 @@ const hashAggregatorAllocSize = 128
 // The input specifications to this function are the same as that of the
 // NewOrderedAggregator function.
 // memAccount should be the same as the one used by allocator and will be used
-// by hashAggregatorHelper to handle DISTINCT clause.
+// by aggregatorHelper to handle DISTINCT clause.
 func NewHashAggregator(
 	allocator *colmem.Allocator,
 	memAccount *mon.BoundAccount,
@@ -135,10 +134,10 @@ func NewHashAggregator(
 		inputArgsConverter: inputArgsConverter,
 		toClose:            toClose,
 		aggFnsAlloc:        aggFnsAlloc,
-		hashAlloc:          hashAggBucketAlloc{allocator: allocator},
+		hashAlloc:          aggBucketAlloc{allocator: allocator},
 	}
 	hashAgg.datumAlloc.AllocSize = hashAggregatorAllocSize
-	hashAgg.aggHelper = newHashAggregatorHelper(allocator, memAccount, inputTypes, spec, &hashAgg.datumAlloc)
+	hashAgg.aggHelper = newAggregatorHelper(allocator, memAccount, inputTypes, spec, &hashAgg.datumAlloc, true /* isHashAgg */)
 	return hashAgg, err
 }
 
@@ -315,7 +314,9 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 				// group.
 				eqChain := op.scratch.eqChains[eqChainsSlot]
 				bucket := op.buckets[headID-1]
-				op.aggHelper.performAggregation(ctx, inputVecs, len(eqChain), eqChain, bucket)
+				op.aggHelper.performAggregation(
+					ctx, inputVecs, len(eqChain), eqChain, bucket, nil, /* groups */
+				)
 				// We have fully processed this equality chain, so we need to
 				// reset its length.
 				op.scratch.eqChains[eqChainsSlot] = op.scratch.eqChains[eqChainsSlot][:0]
@@ -336,10 +337,17 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 			// so we'll create a new bucket and make sure that the head of this
 			// equality chain is appended to the hash table in the
 			// corresponding position.
-			bucket := op.hashAlloc.newHashAggBucket()
+			bucket := op.hashAlloc.newAggBucket()
 			op.buckets = append(op.buckets, bucket)
-			bucket.init(op.output, op.aggFnsAlloc.makeAggregateFuncs(), op.aggHelper.makeSeenMaps())
-			op.aggHelper.performAggregation(ctx, inputVecs, len(eqChain), eqChain, bucket)
+			// We know that all selected tuples belong to the same single
+			// group, so we can pass 'nil' for the 'groups' argument.
+			bucket.init(
+				op.output, op.aggFnsAlloc.makeAggregateFuncs(),
+				op.aggHelper.makeSeenMaps(), nil, /* groups */
+			)
+			op.aggHelper.performAggregation(
+				ctx, inputVecs, len(eqChain), eqChain, bucket, nil, /* groups */
+			)
 			newGroupsHeadsSel = append(newGroupsHeadsSel, eqChainsHeads[eqChainSlot])
 			// We need to compact the hash buffer according to the new groups
 			// head tuples selection vector we're building.
@@ -373,44 +381,4 @@ func (op *hashAggregator) reset(ctx context.Context) {
 
 func (op *hashAggregator) Close(ctx context.Context) error {
 	return op.toClose.Close(ctx)
-}
-
-// hashAggBucket stores the aggregation functions for the corresponding
-// aggregation group as well as other utility information.
-type hashAggBucket struct {
-	fns []aggregateFunc
-	// seen is a slice of maps used to handle distinct aggregation. A
-	// corresponding entry in the slice is nil if the function doesn't have a
-	// DISTINCT clause. The slice itself will be nil whenever no aggregate
-	// function has a DISTINCT clause.
-	seen []map[string]struct{}
-}
-
-const sizeOfHashAggBucket = unsafe.Sizeof(hashAggBucket{})
-
-func (v *hashAggBucket) init(b coldata.Batch, fns []aggregateFunc, seen []map[string]struct{}) {
-	v.fns = fns
-	for fnIdx, fn := range v.fns {
-		// We know that all selected tuples in b belong to the same single
-		// group, so we can pass 'nil' for the first argument.
-		fn.Init(nil /* groups */, b.ColVec(fnIdx))
-	}
-	v.seen = seen
-}
-
-// hashAggBucketAlloc is a utility struct that batches allocations of
-// hashAggBuckets.
-type hashAggBucketAlloc struct {
-	allocator *colmem.Allocator
-	buf       []hashAggBucket
-}
-
-func (a *hashAggBucketAlloc) newHashAggBucket() *hashAggBucket {
-	if len(a.buf) == 0 {
-		a.allocator.AdjustMemoryUsage(int64(hashAggregatorAllocSize * sizeOfHashAggBucket))
-		a.buf = make([]hashAggBucket, hashAggregatorAllocSize)
-	}
-	ret := &a.buf[0]
-	a.buf = a.buf[1:]
-	return ret
 }

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -235,11 +235,6 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 					// possibly include DISTINCT and/or FILTER clauses.
 					for _, aggFn := range aggregations {
 						distinctProb := 0.5
-						if !hashAgg {
-							// We currently support distinct aggregation only
-							// for hash aggregator.
-							distinctProb = 0
-						}
 						if hasJSONColumn {
 							// We currently cannot encode json columns, so we
 							// don't support distinct aggregation in both

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -621,7 +621,11 @@ func (ag *hashAggregator) emitRow() (
 		ag.alreadyAccountedFor = 0
 		for _, f := range ag.funcs {
 			if f.seen != nil {
-				f.seen = make(map[string]struct{})
+				// It turns out that it is faster to delete entries from the
+				// old map rather than allocating a new one.
+				for s := range f.seen {
+					delete(f.seen, s)
+				}
 			}
 		}
 
@@ -683,7 +687,11 @@ func (ag *orderedAggregator) emitRow() (
 		}
 		for _, f := range ag.funcs {
 			if f.seen != nil {
-				f.seen = make(map[string]struct{})
+				// It turns out that it is faster to delete entries from the
+				// old map rather than allocating a new one.
+				for s := range f.seen {
+					delete(f.seen, s)
+				}
 			}
 		}
 


### PR DESCRIPTION
**rowexec: speed up DISTINCT aggregation a bit**

Previously, whenever we needed to clear `seen` map (which tracks the
tuples we have already seen for the aggregation group), we would create
a new map. However, it turns out that it is actually faster (according
to micro-benchmarks) to delete all entries from the old map instead
which is what this commit does.

Release note: None

**colexec: add support for DISTINCT ordered aggregation**

This commit adds the support for DISTINCT ordered aggregation by
reusing the same code (with minor modification to reset `seen` maps when
the new group is encountered) as we have for hash aggregation. Quick
benchmarks show about 6-7x improvement when comparing against a wrapped
row-by-row processor.

Closes: #39242.

Release note (sql change): Vectorized execution now natively supports
ordered aggregation with DISTINCT clause.