### PR TITLE
opt: teach buildScan how to use inverted histograms

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1255,6 +1255,10 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		tab := f.Memo.metadata.Table(t.Table)
 		fmt.Fprintf(f.Buffer, " %s", tab.Name())
 
+	case *InvertedFilterPrivate:
+		col := f.Memo.metadata.ColumnMeta(t.InvertedColumn)
+		fmt.Fprintf(f.Buffer, " %s", col.Alias)
+
 	case *LookupJoinPrivate:
 		tab := f.Memo.metadata.Table(t.Table)
 		if t.Index == cat.PrimaryIndex {

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -1,0 +1,531 @@
+exec-ddl
+CREATE TABLE t (i int, g GEOMETRY, INVERTED INDEX (g))
+----
+
+# Histogram boundaries are from a `POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0,
+# 0.0 1.0, 0.0 0.0))` row. The row_count is lower than the sum of the
+# histogram's num_eq and num_range because there are more entries in
+# the inverted index than rows in the table.
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 1000,
+    "null_count": 0
+  },
+  {
+    "columns": ["g"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 7,
+    "null_count": 0,
+    "histo_col_type":"BYTES",
+    "histo_buckets":[{
+      "num_eq":1000,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd0555555555555555"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd0fffffff00000000"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd1000000100000000"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd1aaaaaab00000000"
+    }]
+  }
+]'
+----
+
+# Selecting from within the polygon means the histogram will estimate
+# many rows returned, thus making a search on the PK favorable.
+opt
+SELECT i FROM t WHERE st_intersects('LINESTRING(0.5 0.5, 0.7 0.7)', g) ORDER BY i LIMIT 1
+----
+project
+ ├── columns: i:1(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── limit
+      ├── columns: i:1(int) g:2(geometry)
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── stats: [rows=1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── sort
+      │    ├── columns: i:1(int) g:2(geometry)
+      │    ├── immutable
+      │    ├── stats: [rows=666.666667]
+      │    ├── ordering: +1
+      │    ├── limit hint: 1.00
+      │    └── select
+      │         ├── columns: i:1(int) g:2(geometry)
+      │         ├── immutable
+      │         ├── stats: [rows=666.666667]
+      │         ├── scan t
+      │         │    ├── columns: i:1(int) g:2(geometry)
+      │         │    └── stats: [rows=2000]
+      │         └── filters
+      │              └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable]
+      └── 1 [type=int]
+
+memo
+SELECT i FROM t WHERE st_intersects('LINESTRING(0.5 0.5, 0.7 0.7)', g) ORDER BY i LIMIT 1
+----
+memo (optimized, ~11KB, required=[presentation: i:1])
+ ├── G1: (project G2 G3 i)
+ │    └── [presentation: i:1]
+ │         ├── best: (project G2 G3 i)
+ │         └── cost: 4258.50
+ ├── G2: (limit G4 G5 ordering=+1)
+ │    └── []
+ │         ├── best: (limit G4="[ordering: +1] [limit hint: 1.00]" G5 ordering=+1)
+ │         └── cost: 4258.48
+ ├── G3: (projections)
+ ├── G4: (select G6 G7) (select G8 G7)
+ │    ├── [ordering: +1] [limit hint: 1.00]
+ │    │    ├── best: (sort G4)
+ │    │    └── cost: 4258.46
+ │    └── []
+ │         ├── best: (select G6 G7)
+ │         └── cost: 4120.04
+ ├── G5: (const 1)
+ ├── G6: (scan t,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 3.00]
+ │    │    ├── best: (sort G6)
+ │    │    └── cost: 2578.66
+ │    └── []
+ │         ├── best: (scan t,cols=(1,2))
+ │         └── cost: 2100.02
+ ├── G7: (filters G9)
+ ├── G8: (index-join G10 t,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 4.50]
+ │    │    ├── best: (sort G8)
+ │    │    └── cost: 16083.08
+ │    └── []
+ │         ├── best: (index-join G10 t,cols=(1,2))
+ │         └── cost: 15330.03
+ ├── G9: (function G11 st_intersects)
+ ├── G10: (inverted-filter G12 g_inverted_key)
+ │    └── []
+ │         ├── best: (inverted-filter G12 g_inverted_key)
+ │         └── cost: 3150.02
+ ├── G11: (scalar-list G13 G14)
+ ├── G12: (scan t@secondary,cols=(3,5),constrained inverted)
+ │    └── []
+ │         ├── best: (scan t@secondary,cols=(3,5),constrained inverted)
+ │         └── cost: 3120.01
+ ├── G13: (const '010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F')
+ └── G14: (variable g)
+
+# Selecting from outside the polygon means the histogram will estimate
+# few rows returned, thus making a search of the inverted index favorable.
+opt
+SELECT i FROM t WHERE st_intersects('LINESTRING(100 100, 150 150)', g) ORDER BY i LIMIT 1
+----
+project
+ ├── columns: i:1(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── limit
+      ├── columns: i:1(int) g:2(geometry)
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── stats: [rows=1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── select
+      │    ├── columns: i:1(int) g:2(geometry)
+      │    ├── immutable
+      │    ├── stats: [rows=666.666667]
+      │    ├── ordering: +1
+      │    ├── limit hint: 1.00
+      │    ├── sort
+      │    │    ├── columns: i:1(int) g:2(geometry)
+      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── ordering: +1
+      │    │    ├── limit hint: 0.00
+      │    │    └── index-join t
+      │    │         ├── columns: i:1(int) g:2(geometry)
+      │    │         ├── stats: [rows=7e-07]
+      │    │         └── inverted-filter
+      │    │              ├── columns: rowid:3(int!null)
+      │    │              ├── inverted expression: /5
+      │    │              │    ├── tight: false
+      │    │              │    └── union spans: ["\x87\xff", "\x87\xff"]
+      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── key: (3)
+      │    │              └── scan t@secondary
+      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
+      │    │                   ├── inverted constraint: /5/3
+      │    │                   │    └── spans: ["\x87\xff", "\x87\xff"]
+      │    │                   ├── stats: [rows=7e-07, distinct(3)=1.99999931e-07, null(3)=0, distinct(5)=7e-07, null(5)=0]
+      │    │                   │   histogram(5)=
+      │    │                   ├── key: (3)
+      │    │                   └── fd: (3)-->(5)
+      │    └── filters
+      │         └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool, outer=(2), immutable]
+      └── 1 [type=int]
+
+memo
+SELECT i FROM t WHERE st_intersects('LINESTRING(100 100, 150 150)', g) ORDER BY i LIMIT 1
+----
+memo (optimized, ~11KB, required=[presentation: i:1])
+ ├── G1: (project G2 G3 i)
+ │    └── [presentation: i:1]
+ │         ├── best: (project G2 G3 i)
+ │         └── cost: 0.10
+ ├── G2: (limit G4 G5 ordering=+1)
+ │    └── []
+ │         ├── best: (limit G4="[ordering: +1] [limit hint: 1.00]" G5 ordering=+1)
+ │         └── cost: 0.08
+ ├── G3: (projections)
+ ├── G4: (select G6 G7) (select G8 G7)
+ │    ├── [ordering: +1] [limit hint: 1.00]
+ │    │    ├── best: (select G8="[ordering: +1] [limit hint: 0.00]" G7)
+ │    │    └── cost: 0.06
+ │    └── []
+ │         ├── best: (select G8 G7)
+ │         └── cost: 0.05
+ ├── G5: (const 1)
+ ├── G6: (scan t,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 3.00]
+ │    │    ├── best: (sort G6)
+ │    │    └── cost: 2578.66
+ │    └── []
+ │         ├── best: (scan t,cols=(1,2))
+ │         └── cost: 2100.02
+ ├── G7: (filters G9)
+ ├── G8: (index-join G10 t,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 0.00]
+ │    │    ├── best: (sort G8)
+ │    │    └── cost: 0.04
+ │    └── []
+ │         ├── best: (index-join G10 t,cols=(1,2))
+ │         └── cost: 0.03
+ ├── G9: (function G11 st_intersects)
+ ├── G10: (inverted-filter G12 g_inverted_key)
+ │    └── []
+ │         ├── best: (inverted-filter G12 g_inverted_key)
+ │         └── cost: 0.02
+ ├── G11: (scalar-list G13 G14)
+ ├── G12: (scan t@secondary,cols=(3,5),constrained inverted)
+ │    └── []
+ │         ├── best: (scan t@secondary,cols=(3,5),constrained inverted)
+ │         └── cost: 0.01
+ ├── G13: (const '010200000002000000000000000000594000000000000059400000000000C062400000000000C06240')
+ └── G14: (variable g)
+
+# Add some NULL rows.
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 1000,
+    "null_count": 50
+  },
+  {
+    "columns": ["g"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 7,
+    "null_count": 100,
+    "histo_col_type":"BYTES",
+    "histo_buckets":[{
+      "num_eq":1000,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd0555555555555555"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd0fffffff00000000"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd1000000100000000"
+    },
+    {
+      "num_eq":1000,
+      "num_range":1000,
+      "distinct_range":1,
+      "upper_bound":"\\xfd1aaaaaab00000000"
+    }]
+  }
+]'
+----
+
+# Inverted indexes don't contain NULL entries, so we expect a full scan.
+opt colstat=1 colstat=2
+SELECT * FROM t WHERE g IS NULL OR st_intersects('LINESTRING(100 100, 150 150)', g)
+----
+select
+ ├── columns: i:1(int) g:2(geometry)
+ ├── immutable
+ ├── stats: [rows=666.666667, distinct(1)=555.555556, null(1)=16.6666667, distinct(2)=7, null(2)=33.3333333]
+ ├── scan t
+ │    ├── columns: i:1(int) g:2(geometry)
+ │    └── stats: [rows=2000, distinct(1)=1000, null(1)=50, distinct(2)=7, null(2)=100]
+ └── filters
+      └── (g:2 IS NULL) OR st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool, outer=(2), immutable]
+
+memo
+SELECT * FROM t WHERE g IS NULL OR st_intersects('LINESTRING(100 100, 150 150)', g)
+----
+memo (optimized, ~4KB, required=[presentation: i:1,g:2])
+ ├── G1: (select G2 G3)
+ │    └── [presentation: i:1,g:2]
+ │         ├── best: (select G2 G3)
+ │         └── cost: 2120.04
+ ├── G2: (scan t,cols=(1,2))
+ │    └── []
+ │         ├── best: (scan t,cols=(1,2))
+ │         └── cost: 2100.02
+ ├── G3: (filters G4)
+ ├── G4: (or G5 G6)
+ ├── G5: (is G7 G8)
+ ├── G6: (function G9 st_intersects)
+ ├── G7: (variable g)
+ ├── G8: (null)
+ ├── G9: (scalar-list G10 G7)
+ └── G10: (const '010200000002000000000000000000594000000000000059400000000000C062400000000000C06240')
+
+# Repeat above tests to ensure null counts are correct.
+# TODO(mjibson): Teach logical_props_builder that st_intersects is
+# a null-rejecting filter. Since we don't have that logic yet these
+# non-zero null counts are correct.
+opt colstat=1 colstat=2
+SELECT i FROM t WHERE st_intersects('LINESTRING(0.5 0.5, 0.7 0.7)', g) ORDER BY i LIMIT 1
+----
+project
+ ├── columns: i:1(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1, distinct(1)=0.99984994, null(1)=0.025, distinct(2)=0.932505476, null(2)=0.05]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── limit
+      ├── columns: i:1(int) g:2(geometry)
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── stats: [rows=1, distinct(1)=0.99984994, null(1)=0.025, distinct(2)=0.932505476, null(2)=0.05]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── sort
+      │    ├── columns: i:1(int) g:2(geometry)
+      │    ├── immutable
+      │    ├── stats: [rows=666.666667, distinct(1)=555.555556, null(1)=16.6666667, distinct(2)=7, null(2)=33.3333333]
+      │    ├── ordering: +1
+      │    ├── limit hint: 1.00
+      │    └── select
+      │         ├── columns: i:1(int) g:2(geometry)
+      │         ├── immutable
+      │         ├── stats: [rows=666.666667, distinct(1)=555.555556, null(1)=16.6666667, distinct(2)=7, null(2)=33.3333333]
+      │         ├── scan t
+      │         │    ├── columns: i:1(int) g:2(geometry)
+      │         │    └── stats: [rows=2000, distinct(1)=1000, null(1)=50, distinct(2)=7, null(2)=100]
+      │         └── filters
+      │              └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable]
+      └── 1 [type=int]
+
+
+opt colstat=1 colstat=2
+SELECT i FROM t WHERE st_intersects('LINESTRING(100 100, 150 150)', g) ORDER BY i LIMIT 1
+----
+project
+ ├── columns: i:1(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1, distinct(1)=0.99984994, null(1)=0.025, distinct(2)=0.932505476, null(2)=0.05]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── limit
+      ├── columns: i:1(int) g:2(geometry)
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── stats: [rows=1, distinct(1)=0.99984994, null(1)=0.025, distinct(2)=0.932505476, null(2)=0.05]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── select
+      │    ├── columns: i:1(int) g:2(geometry)
+      │    ├── immutable
+      │    ├── stats: [rows=666.666667, distinct(1)=555.555556, null(1)=16.6666667, distinct(2)=7, null(2)=33.3333333]
+      │    ├── ordering: +1
+      │    ├── limit hint: 1.00
+      │    ├── sort
+      │    │    ├── columns: i:1(int) g:2(geometry)
+      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── ordering: +1
+      │    │    ├── limit hint: 0.00
+      │    │    └── index-join t
+      │    │         ├── columns: i:1(int) g:2(geometry)
+      │    │         ├── stats: [rows=7e-07]
+      │    │         └── inverted-filter
+      │    │              ├── columns: rowid:3(int!null)
+      │    │              ├── inverted expression: /5
+      │    │              │    ├── tight: false
+      │    │              │    └── union spans: ["\x87\xff", "\x87\xff"]
+      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── key: (3)
+      │    │              └── scan t@secondary
+      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
+      │    │                   ├── inverted constraint: /5/3
+      │    │                   │    └── spans: ["\x87\xff", "\x87\xff"]
+      │    │                   ├── stats: [rows=7e-07, distinct(3)=1.99999931e-07, null(3)=0, distinct(5)=7e-07, null(5)=0]
+      │    │                   │   histogram(5)=
+      │    │                   ├── key: (3)
+      │    │                   └── fd: (3)-->(5)
+      │    └── filters
+      │         └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool, outer=(2), immutable]
+      └── 1 [type=int]
+
+# Set a high null count.
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 100,
+    "null_count": 900
+  },
+  {
+    "columns": ["g"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 4,
+    "null_count": 900,
+    "histo_col_type":"BYTES",
+    "histo_buckets":[{
+      "num_eq":100,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd0555555555555555"
+    },
+    {
+      "num_eq":100,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd0fffffff00000000"
+    },
+    {
+      "num_eq":100,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd1000000100000000"
+    },
+    {
+      "num_eq":100,
+      "num_range":0,
+      "distinct_range":0,
+      "upper_bound":"\\xfd1aaaaaab00000000"
+    }]
+  }
+]'
+----
+
+opt colstat=1 colstat=2
+SELECT * FROM t WHERE st_intersects('LINESTRING(.5 .5, .7 .7)', g)
+----
+select
+ ├── columns: i:1(int) g:2(geometry)
+ ├── immutable
+ ├── stats: [rows=333.333333, distinct(1)=98.265847, null(1)=300, distinct(2)=4, null(2)=300]
+ ├── index-join t
+ │    ├── columns: i:1(int) g:2(geometry)
+ │    ├── stats: [rows=100]
+ │    └── inverted-filter
+ │         ├── columns: rowid:3(int!null)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "\xfd\x12")
+ │         │         └── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── stats: [rows=100]
+ │         ├── key: (3)
+ │         └── scan t@secondary
+ │              ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
+ │              ├── inverted constraint: /5/3
+ │              │    └── spans
+ │              │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "\xfd\x12")
+ │              │         └── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── stats: [rows=100, distinct(3)=100, null(3)=0, distinct(5)=1, null(5)=0]
+ │              │   histogram(5)=  0           100            0            0
+ │              │                <--- '\xfd1000000100000000' --- '\xfd1400000000000001'
+ │              ├── key: (3)
+ │              └── fd: (3)-->(5)
+ └── filters
+      └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable]
+
+# Force a scan of the inverted index so we can see the filtered histogram.
+opt
+SELECT i FROM t@secondary WHERE st_intersects('LINESTRING(.5 .5, .7 .7)', g)
+----
+project
+ ├── columns: i:1(int)
+ ├── immutable
+ ├── stats: [rows=333.333333]
+ └── select
+      ├── columns: i:1(int) g:2(geometry)
+      ├── immutable
+      ├── stats: [rows=333.333333]
+      ├── index-join t
+      │    ├── columns: i:1(int) g:2(geometry)
+      │    ├── stats: [rows=100]
+      │    └── inverted-filter
+      │         ├── columns: rowid:3(int!null)
+      │         ├── inverted expression: /5
+      │         │    ├── tight: false
+      │         │    └── union spans
+      │         │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "\xfd\x12")
+      │         │         └── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+      │         ├── stats: [rows=100]
+      │         ├── key: (3)
+      │         └── scan t@secondary
+      │              ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
+      │              ├── inverted constraint: /5/3
+      │              │    └── spans
+      │              │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "\xfd\x12")
+      │              │         └── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── flags: force-index=secondary
+      │              ├── stats: [rows=100, distinct(3)=100, null(3)=0, distinct(5)=1, null(5)=0]
+      │              │   histogram(5)=  0           100            0            0
+      │              │                <--- '\xfd1000000100000000' --- '\xfd1400000000000001'
+      │              ├── key: (3)
+      │              └── fd: (3)-->(5)
+      └── filters
+           └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable]

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -178,15 +179,14 @@ func (h *Histogram) CanFilter(c *constraint.Constraint) (colOffset, exactPrefix 
 	return 0, exactPrefix, false
 }
 
-// Filter filters the histogram according to the given constraint, and returns
-// a new histogram with the results. CanFilter should be called first to
-// validate that c can filter the histogram.
-func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
-	colOffset, exactPrefix, ok := h.CanFilter(c)
-	if !ok {
-		panic(errors.AssertionFailedf("column mismatch"))
-	}
-
+func (h *Histogram) filter(
+	spanCount int,
+	getSpan func(int) *constraint.Span,
+	desc bool,
+	colOffset, exactPrefix int,
+	prefix []tree.Datum,
+	columns constraint.Columns,
+) *Histogram {
 	bucketCount := h.BucketCount()
 	filtered := &Histogram{
 		evalCtx: h.evalCtx,
@@ -203,21 +203,15 @@ func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
 		panic(errors.AssertionFailedf("the first bucket should have NumRange=0"))
 	}
 
-	prefix := make([]tree.Datum, colOffset)
-	for i := range prefix {
-		prefix[i] = c.Spans.Get(0).StartKey().Value(i)
-	}
-	desc := c.Columns.Get(colOffset).Descending()
 	var iter histogramIter
 	iter.init(h, desc)
 	spanIndex := 0
-	keyCtx := constraint.KeyContext{EvalCtx: h.evalCtx, Columns: c.Columns}
+	keyCtx := constraint.KeyContext{EvalCtx: h.evalCtx, Columns: columns}
 
 	// Find the first span that may overlap with the histogram.
 	firstBucket := makeSpanFromBucket(&iter, prefix)
-	spanCount := c.Spans.Count()
 	for spanIndex < spanCount {
-		span := c.Spans.Get(spanIndex)
+		span := getSpan(spanIndex)
 		if firstBucket.StartsAfter(&keyCtx, span) {
 			spanIndex++
 			continue
@@ -229,7 +223,7 @@ func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
 	}
 
 	// Use binary search to find the first bucket that overlaps with the span.
-	span := c.Spans.Get(spanIndex)
+	span := getSpan(spanIndex)
 	bucIndex := sort.Search(bucketCount, func(i int) bool {
 		iter.setIdx(i)
 		bucket := makeSpanFromBucket(&iter, prefix)
@@ -263,7 +257,7 @@ func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
 		// Convert the bucket to a span in order to take advantage of the
 		// constraint library.
 		left := makeSpanFromBucket(&iter, prefix)
-		right := c.Spans.Get(spanIndex)
+		right := getSpan(spanIndex)
 
 		if left.StartsAfter(&keyCtx, right) {
 			spanIndex++
@@ -333,6 +327,52 @@ func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
 	}
 
 	return filtered
+}
+
+// Filter filters the histogram according to the given constraint, and returns
+// a new histogram with the results. CanFilter should be called first to
+// validate that c can filter the histogram.
+func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
+	colOffset, exactPrefix, ok := h.CanFilter(c)
+	if !ok {
+		panic(errors.AssertionFailedf("column mismatch"))
+	}
+	prefix := make([]tree.Datum, colOffset)
+	for i := range prefix {
+		prefix[i] = c.Spans.Get(0).StartKey().Value(i)
+	}
+	desc := c.Columns.Get(colOffset).Descending()
+
+	return h.filter(c.Spans.Count(), c.Spans.Get, desc, colOffset, exactPrefix, prefix, c.Columns)
+}
+
+// InvertedFilter filters the histogram according to the given inverted
+// constraint, and returns a new histogram with the results.
+func (h *Histogram) InvertedFilter(spans invertedexpr.InvertedSpans) *Histogram {
+	var columns constraint.Columns
+	columns.InitSingle(opt.MakeOrderingColumn(h.col, false /* desc */))
+	return h.filter(
+		len(spans),
+		func(idx int) *constraint.Span {
+			return makeSpanFromInvertedSpan(spans[idx])
+		},
+		false, /* desc */
+		0,     /* exactPrefix */
+		0,     /* colOffset */
+		nil,   /* prefix */
+		columns,
+	)
+}
+
+func makeSpanFromInvertedSpan(invSpan invertedexpr.InvertedSpan) *constraint.Span {
+	var span constraint.Span
+	span.Init(
+		constraint.MakeKey(tree.NewDBytes(tree.DBytes(invSpan.Start))),
+		constraint.IncludeBoundary,
+		constraint.MakeKey(tree.NewDBytes(tree.DBytes(invSpan.End))),
+		constraint.ExcludeBoundary,
+	)
+	return &span
 }
 
 func (h *Histogram) getNextLowerBound(currentUpperBound tree.Datum) tree.Datum {

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -281,6 +281,9 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 		if t.Constraint != nil {
 			fmt.Fprintf(mf.buf, ",constrained")
 		}
+		if t.InvertedConstraint != nil {
+			fmt.Fprintf(mf.buf, ",constrained inverted")
+		}
 		if t.HardLimit.IsSet() {
 			fmt.Fprintf(mf.buf, ",lim=%s", t.HardLimit)
 		}


### PR DESCRIPTION
Teach stats builder how to detect statistics on inverted
index virtual columns that are already correctly being used by
buildScan. invertedConstrainScan can then filter the histograms by the
inverted constraint.

Fixes #48220

Release note: None