### PR TITLE
storageccl: retry file uploads

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -46,6 +47,8 @@ var ExportRequestMaxAllowedFileSizeOverage = settings.RegisterByteSizeSetting(
 	"if positive, allowed size in excess of target size for SSTs from export requests",
 	64<<20, /* 64 MiB */
 )
+
+const maxUploadRetries = 5
 
 func init() {
 	batcheval.RegisterReadOnlyCommand(roachpb.Export, declareKeysExport, evalExport)
@@ -200,7 +203,15 @@ func evalExport(
 			// Create a unique int differently.
 			nodeID := cArgs.EvalCtx.NodeID()
 			exported.Path = fmt.Sprintf("%d.sst", builtins.GenerateUniqueInt(base.SQLInstanceID(nodeID)))
-			if err := exportStore.WriteFile(ctx, exported.Path, bytes.NewReader(data)); err != nil {
+			if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxUploadRetries, func() error {
+				// We blindly retry any error here because we expect the caller to have
+				// verified the target is writable before sending ExportRequests for it.
+				if err := exportStore.WriteFile(ctx, exported.Path, bytes.NewReader(data)); err != nil {
+					log.VEventf(ctx, 1, "failed to put file: %+v", err)
+					return err
+				}
+				return nil
+			}); err != nil {
 				return result.Result{}, err
 			}
 		}

--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -138,6 +138,10 @@ func MakeS3Storage(
 	if conf.Endpoint != "" {
 		sess.Config.S3ForcePathStyle = aws.Bool(true)
 	}
+	sess.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	maxRetries := 10
+	sess.Config.MaxRetries = &maxRetries
+
 	return &s3Storage{
 		bucket:   aws.String(conf.Bucket),
 		conf:     conf,


### PR DESCRIPTION
We have seen reports that some users see EOF errors causing
BACKUPs to fail when writing SSTs to cloud-storage. Each of
the cloud-storage SDKs has its own internal retry logic and
is supposed to handle emphemeral errors. But if we're exporting
at all it means we previously were able to write the placeholder
file to that destination so any errors we do see are very likely
emphemeral, and a retry may help.

While I'm here: bump up the AWS SDK retry limit and enable retry
logging.

Release note: none.