### PR TITLE
build: add libgeos libs to docker image for publish release

### DIFF
--- a/build/release/teamcity-publish-release.sh
+++ b/build/release/teamcity-publish-release.sh
@@ -91,7 +91,7 @@ docker_login
 
 # TODO: update publish-artifacts with option to leave one or more cockroach binaries in the local filesystem
 curl -f -s -S -o- "https://${s3_download_hostname}/cockroach-${build_name}.linux-amd64.tgz" | tar ixfz - --strip-components 1
-cp cockroach build/deploy
+cp cockroach lib/libgeos.so lib/libgeos_c.so build/deploy
 
 docker build --no-cache --tag=${dockerhub_repository}:{"$build_name",latest,latest-"${release_branch}"} --tag=${gcr_repository}:${build_name} build/deploy
 


### PR DESCRIPTION
Before: The script was written to be backportable (without adding the
libgeos libs to the docker image).

Why: Geospatial arrived in master (20.2) and the libgeos libs need to be
included with the docker image.

Now: The libs are included in the docker image generated in the
teamcity-publish-release.sh script.

Release note: None