### PR TITLE
colexec: minor improvements to the hash table

### DIFF
--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -153,6 +153,12 @@ func (op *hashAggregator) Init() {
 	op.scratch.eqChains = make([][]int, coldata.BatchSize())
 	op.scratch.intSlice = make([]int, coldata.BatchSize())
 	op.scratch.anotherIntSlice = make([]int, coldata.BatchSize())
+	// The hash table only needs to store the grouping columns to be able to
+	// perform the equality check.
+	colsToStore := make([]int, len(op.spec.GroupCols))
+	for i := range colsToStore {
+		colsToStore[i] = int(op.spec.GroupCols[i])
+	}
 	// This number was chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
 	const hashTableLoadFactor = 0.25
@@ -161,6 +167,7 @@ func (op *hashAggregator) Init() {
 		hashTableLoadFactor,
 		op.inputTypes,
 		op.spec.GroupCols,
+		colsToStore,
 		true, /* allowNullEquality */
 		hashTableDistinctBuildMode,
 		hashTableDefaultProbeMode,

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -234,6 +234,10 @@ func (hj *hashJoiner) Init() {
 		hashTableLoadFactor,
 		hj.spec.right.sourceTypes,
 		hj.spec.right.eqCols,
+		// Store all columns from the right source since we need to be able to
+		// export the full batches when falling back to the external hash
+		// joiner.
+		nil, /* colsToStore */
 		allowNullEquality,
 		hashTableFullBuildMode,
 		probeMode,

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -367,6 +367,18 @@ func (hj *hashJoiner) emitUnmatched() {
 	hj.output.SetLength(nResults)
 }
 
+// hjInitialToCheck is a slice that contains all consequent integers in
+// [0, coldata.BatchSize()) range that can be used to initialize toCheck buffer
+// for most of the join types.
+var hjInitialToCheck []uint64
+
+func init() {
+	hjInitialToCheck = make([]uint64, coldata.BatchSize())
+	for i := range hjInitialToCheck {
+		hjInitialToCheck[i] = uint64(i)
+	}
+}
+
 // exec is a general prober that works with non-distinct build table equality
 // columns. It returns a Batch with N + M columns where N is the number of
 // left source columns and M is the number of right source columns. The first N
@@ -398,25 +410,24 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 
 			sel := batch.Selection()
 
+			// First, we compute the hash values for all tuples in the batch.
+			hj.ht.computeBuckets(
+				ctx, hj.ht.probeScratch.buckets, hj.ht.probeScratch.keys, batchSize, sel,
+			)
+			// Then, we initialize groupID with the initial hash buckets and
+			// toCheck with all applicable indices.
 			var nToCheck uint64
 			switch hj.spec.joinType {
 			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
 				// The setup of probing for LEFT ANTI and EXCEPT ALL joins
 				// needs a special treatment in order to reuse the same "check"
 				// functions below.
-				//
-				// First, we compute the hash values for all tuples in the batch.
-				hj.ht.computeBuckets(
-					ctx, hj.ht.probeScratch.buckets, hj.ht.probeScratch.keys, batchSize, sel,
-				)
-				// Then, we iterate over all tuples to see whether there is at least
-				// one tuple in the hash table that has the same hash value.
-				for i := 0; i < batchSize; i++ {
-					if hj.ht.buildScratch.first[hj.ht.probeScratch.buckets[i]] != 0 {
+				for i, bucket := range hj.ht.probeScratch.buckets[:batchSize] {
+					if hj.ht.buildScratch.first[bucket] != 0 {
 						// Non-zero "first" key indicates that there is a match of hashes
 						// and we need to include the current tuple to check whether it is
 						// an actual match.
-						hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[hj.ht.probeScratch.buckets[i]]
+						hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
 						hj.ht.probeScratch.toCheck[nToCheck] = uint64(i)
 						nToCheck++
 					}
@@ -429,14 +440,14 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 				// included into the output.
 				copy(hj.ht.probeScratch.headID[:batchSize], zeroUint64Column)
 			default:
-				// Initialize groupID with the initial hash buckets and toCheck with all
-				// applicable indices.
-				hj.ht.lookupInitial(ctx, batchSize, sel)
+				for i, bucket := range hj.ht.probeScratch.buckets[:batchSize] {
+					hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
+				}
+				copy(hj.ht.probeScratch.toCheck, hjInitialToCheck[:batchSize])
 				nToCheck = uint64(batchSize)
 			}
 
 			var nResults int
-
 			if hj.spec.rightDistinct {
 				for nToCheck > 0 {
 					// Continue searching along the hash table next chains for the corresponding

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -570,17 +570,6 @@ func (ht *hashTable) maybeAllocateSameAndVisited() {
 	ht.visited[0] = true
 }
 
-// lookupInitial finds the corresponding hash table buckets for the equality
-// column of the batch and stores the results in groupID. It also initializes
-// toCheck with all indices in the range [0, batchSize).
-func (ht *hashTable) lookupInitial(ctx context.Context, batchSize int, sel []int) {
-	ht.computeBuckets(ctx, ht.probeScratch.buckets, ht.probeScratch.keys, batchSize, sel)
-	for i := 0; i < batchSize; i++ {
-		ht.probeScratch.groupID[i] = ht.buildScratch.first[ht.probeScratch.buckets[i]]
-		ht.probeScratch.toCheck[i] = uint64(i)
-	}
-}
-
 // findNext determines the id of the next key inside the groupID buckets for
 // each equality column key in toCheck.
 func (ht *hashTable) findNext(next []uint64, nToCheck uint64) {

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -127,7 +127,7 @@ func newAllSpooler(
 
 func (p *allSpooler) init() {
 	p.input.Init()
-	p.bufferedTuples = newAppendOnlyBufferedBatch(p.allocator, p.inputTypes)
+	p.bufferedTuples = newAppendOnlyBufferedBatch(p.allocator, p.inputTypes, nil /* colsToStore */)
 	p.windowedBatch = p.allocator.NewMemBatchWithFixedCapacity(p.inputTypes, 0 /* size */)
 }
 

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -278,7 +278,7 @@ func newChunker(
 
 func (s *chunker) init() {
 	s.input.Init()
-	s.bufferedTuples = newAppendOnlyBufferedBatch(s.allocator, s.inputTypes)
+	s.bufferedTuples = newAppendOnlyBufferedBatch(s.allocator, s.inputTypes, nil /* colsToStore */)
 	s.partitionCol = make([]bool, coldata.BatchSize())
 	s.chunks = make([]int, 0, 16)
 }

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -98,7 +98,7 @@ type topKSorter struct {
 
 func (t *topKSorter) Init() {
 	t.input.Init()
-	t.topK = newAppendOnlyBufferedBatch(t.allocator, t.inputTypes)
+	t.topK = newAppendOnlyBufferedBatch(t.allocator, t.inputTypes, nil /* colsToStore */)
 	t.comparators = make([]vecComparator, len(t.inputTypes))
 	for i, typ := range t.inputTypes {
 		t.comparators[i] = GetVecComparator(typ, 2)

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -33,6 +33,9 @@ func NewUnorderedDistinct(
 		hashTableLoadFactor,
 		typs,
 		distinctCols,
+		// Store all columns from the source since the unordered distinct
+		// doesn't change the schema.
+		nil,  /* colsToStore */
 		true, /* allowNullEquality */
 		hashTableDistinctBuildMode,
 		hashTableDefaultProbeMode,


### PR DESCRIPTION
**colexec: clean up hash table a little bit**

Release note: None

**colexec: store only grouping cols in hash table in hash aggregator**

Hash aggregator is using the hash table only to be able to perform the
equality checks against "heads" of the aggregation groups on the
grouping columns. This observation allows us to optimize the behavior of
the hash table so that only the grouping columns are actually stored in
`hashTable.vals` which gives us 1-4% improvement in the throughput as
well as reduces the memory footprint. All other users of the hash table
need to store the full batches so they are not affected by this change.

Release note: None