### PR TITLE
 opt: support INSERT ON CONFLICT DO UPDATE and unique partial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -886,6 +886,104 @@ DROP INDEX i2
 statement ok
 DELETE FROM u
 
+# Tests for ON CONFLICT DO UPDATE.
+
+# Error if no arbiter predicate is specified.
+statement error pgcode 42P10 there is no unique or exclusion constraint matching the ON CONFLICT specification
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = 10
+
+# Error if the arbiter predicate does not imply the partial index predicate.
+statement error pgcode 42P10 there is no unique or exclusion constraint matching the ON CONFLICT specification
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b < 0 DO UPDATE SET b = 10
+
+statement ok
+CREATE UNIQUE INDEX i2 ON u (a) WHERE b < 0
+
+# Error if the arbiter predicate does not imply the partial index predicate.
+statement error pgcode 42P10 there are multiple unique or exclusion constraints matching the ON CONFLICT specification
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b < 0 AND b > 0 DO UPDATE SET b = 10
+
+statement ok
+DROP INDEX i2
+
+# Inserting a row not contained in the unique index succeeds.
+statement ok
+INSERT INTO u VALUES (1, -1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = -10
+
+query II rowsort
+SELECT * FROM u
+----
+1  -1
+
+# Inserting a non-conflicting row succeeds.
+statement ok
+INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = 10
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+1  -1
+
+# Inserting rows that aren't contained by the unique index succeeds.
+statement ok
+INSERT INTO u VALUES (1, -10), (1, -100) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = -11;
+INSERT INTO u VALUES (1, -1000) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = -11;
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+1  -1
+1  -10
+1  -100
+1  -1000
+
+statement ok
+DELETE FROM u WHERE b IN (-10, -100, -1000)
+
+# Inserting one row conflicting and one non-conflicting row updates the first
+# and inserts the second.
+statement ok
+INSERT INTO u VALUES (1, 10), (3, 3) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = 100
+
+query II rowsort
+SELECT * FROM u
+----
+1  100
+3  3
+1  -1
+
+# Inserting multiple rows that conflict with each other errors.
+statement error pgcode 21000 UPSERT or INSERT...ON CONFLICT command cannot affect row a second time
+INSERT INTO u VALUES (4, 4), (4, 40) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = 300
+
+# Conflicting rows that satisfy the UPDATE WHERE clause should be updated. Conflicting
+# rows that don't satisfy the UPDATE WHERE clause should be ignored.
+statement ok
+INSERT INTO u VALUES (1, 11), (3, 33) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET b = 10 WHERE u.a = 1
+
+query II rowsort
+SELECT * FROM u
+----
+1  10
+3  3
+1  -1
+
+statement ok
+CREATE UNIQUE INDEX i2 ON u (a) WHERE b < 0;
+
+# There can be duplicate key errors from unique partial indexes that are not
+# arbiters.
+statement error pgcode 23505 duplicate key value \(a\)=\(1\) violates unique constraint \"i2\"
+INSERT INTO u VALUES (1, -1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = 100
+
+statement ok
+DROP INDEX i2
+
+statement ok
+DELETE from u
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 
@@ -929,7 +1027,7 @@ SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
 
 statement ok
 UPSERT INTO enum_table VALUES
-   (1, 'foo'),
+    (1, 'foo'),
     (2, 'bar'),
     (3, 'baz')
 

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -590,7 +590,7 @@ UPDATE SET b=2
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 16
+ ├── canary column: 13
  ├── fetch columns: a:13(int) b:14(int) c:15(int) rowid:16(int)
  ├── insert-mapping:
  │    ├── y:7 => a:1
@@ -606,7 +606,7 @@ upsert abc
       ├── columns: upsert_a:20(int) upsert_b:21(int!null) upsert_c:22(int!null) upsert_rowid:23(int) y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal) b_new:18(int!null) column19:19(int!null)
       ├── volatile
       ├── key: (7)
-      ├── fd: ()-->(10,12,18,19), (7)-->(11,13-17,20), (16)-->(13-15,17,21,22), (13)-->(14-17), (14,15)~~>(13,16,17), (11,16)-->(23)
+      ├── fd: ()-->(10,12,18,19), (7)-->(11,13-17,20), (16)-->(13-15,17), (13)-->(14-17,21,22), (14,15)~~>(13,16,17), (11,16)-->(23)
       ├── prune: (7,10-23)
       ├── reject-nulls: (13-17)
       ├── interesting orderings: (+16) (+13) (+14,+15,+16)
@@ -711,35 +711,35 @@ upsert abc
       │              ├── variable: b_new:18 [type=int]
       │              └── const: 1 [type=int]
       └── projections
-           ├── case [as=upsert_a:20, type=int, outer=(7,13,16)]
+           ├── case [as=upsert_a:20, type=int, outer=(7,13)]
            │    ├── true [type=bool]
            │    ├── when [type=int]
            │    │    ├── is [type=bool]
-           │    │    │    ├── variable: rowid:16 [type=int]
+           │    │    │    ├── variable: a:13 [type=int]
            │    │    │    └── null [type=unknown]
            │    │    └── variable: y:7 [type=int]
            │    └── variable: a:13 [type=int]
-           ├── case [as=upsert_b:21, type=int, outer=(10,16,18)]
+           ├── case [as=upsert_b:21, type=int, outer=(10,13,18)]
            │    ├── true [type=bool]
            │    ├── when [type=int]
            │    │    ├── is [type=bool]
-           │    │    │    ├── variable: rowid:16 [type=int]
+           │    │    │    ├── variable: a:13 [type=int]
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column10:10 [type=int]
            │    └── variable: b_new:18 [type=int]
-           ├── case [as=upsert_c:22, type=int, outer=(12,16,19)]
+           ├── case [as=upsert_c:22, type=int, outer=(12,13,19)]
            │    ├── true [type=bool]
            │    ├── when [type=int]
            │    │    ├── is [type=bool]
-           │    │    │    ├── variable: rowid:16 [type=int]
+           │    │    │    ├── variable: a:13 [type=int]
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column12:12 [type=int]
            │    └── variable: column19:19 [type=int]
-           └── case [as=upsert_rowid:23, type=int, outer=(11,16)]
+           └── case [as=upsert_rowid:23, type=int, outer=(11,13,16)]
                 ├── true [type=bool]
                 ├── when [type=int]
                 │    ├── is [type=bool]
-                │    │    ├── variable: rowid:16 [type=int]
+                │    │    ├── variable: a:13 [type=int]
                 │    │    └── null [type=unknown]
                 │    └── variable: column11:11 [type=int]
                 └── variable: rowid:16 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1843,7 +1843,7 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.1
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 17
+ ├── canary column: 20
  ├── fetch columns: k:17 i:18 f:19 s:20 j:21
  ├── insert-mapping:
  │    ├── "?column?":13 => k:1
@@ -1895,7 +1895,7 @@ upsert a
       │         ├── i:8 = i:18 [outer=(8,18), constraints=(/8: (/NULL - ]; /18: (/NULL - ]), fd=(8)==(18), (18)==(8)]
       │         └── "?column?":14 = s:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
       └── projections
-           └── CASE WHEN k:17 IS NULL THEN column15:15 ELSE 1.1 END [as=upsert_f:26, outer=(15,17)]
+           └── CASE WHEN s:20 IS NULL THEN column15:15 ELSE 1.1 END [as=upsert_f:26, outer=(15,20)]
 
 # --------------------------------------------------
 # EliminateDistinctOnValues
@@ -2235,7 +2235,7 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 12
+ ├── canary column: 15
  ├── fetch columns: k:12 i:13 f:14 s:15 j:16
  ├── insert-mapping:
  │    ├── column1:7 => k:1
@@ -2276,7 +2276,7 @@ upsert a
       │         ├── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
       │         └── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
       └── projections
-           └── CASE WHEN k:12 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,12)]
+           └── CASE WHEN s:15 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
 
 # EnsureUpsertDistinctOn is not removed when there are duplicates.
 norm expect-not=EliminateDistinctOnValues
@@ -2285,7 +2285,7 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 12
+ ├── canary column: 15
  ├── fetch columns: k:12 i:13 f:14 s:15 j:16
  ├── insert-mapping:
  │    ├── column1:7 => k:1
@@ -2343,7 +2343,7 @@ upsert a
       │         ├── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
       │         └── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
       └── projections
-           └── CASE WHEN k:12 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,12)]
+           └── CASE WHEN s:15 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
 
 # DO NOTHING case where all distinct ops can be removed.
 norm expect=EliminateDistinctOnValues

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -78,7 +78,7 @@ UPDATE SET a=5
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 15
+ ├── canary column: 12
  ├── fetch columns: a:12 b:13 c:14 rowid:15
  ├── insert-mapping:
  │    ├── x:6 => a:1
@@ -130,10 +130,10 @@ upsert abc
       │    └── projections
       │         └── b:13 + 1 [as=column18:18]
       └── projections
-           ├── CASE WHEN rowid:15 IS NULL THEN x:6 ELSE a_new:17 END [as=upsert_a:19]
-           ├── CASE WHEN rowid:15 IS NULL THEN y:7 ELSE b:13 END [as=upsert_b:20]
-           ├── CASE WHEN rowid:15 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
-           └── CASE WHEN rowid:15 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
+           ├── CASE WHEN a:12 IS NULL THEN x:6 ELSE a_new:17 END [as=upsert_a:19]
+           ├── CASE WHEN a:12 IS NULL THEN y:7 ELSE b:13 END [as=upsert_b:20]
+           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
+           └── CASE WHEN a:12 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
 
 # Set all columns, multi-column conflict.
 build
@@ -218,7 +218,7 @@ WHERE abc.a>0
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 15
+ ├── canary column: 12
  ├── fetch columns: a:12 b:13 c:14 rowid:15
  ├── insert-mapping:
  │    ├── x:6 => a:1
@@ -268,16 +268,16 @@ upsert abc
       │    │    │    │    └── filters
       │    │    │    │         └── x:6 = a:12
       │    │    │    └── filters
-      │    │    │         └── (rowid:15 IS NULL) OR (a:12 > 0)
+      │    │    │         └── (a:12 IS NULL) OR (a:12 > 0)
       │    │    └── projections
       │    │         └── 10 [as=b_new:17]
       │    └── projections
       │         └── b_new:17 + 1 [as=column18:18]
       └── projections
-           ├── CASE WHEN rowid:15 IS NULL THEN x:6 ELSE a:12 END [as=upsert_a:19]
-           ├── CASE WHEN rowid:15 IS NULL THEN y:7 ELSE b_new:17 END [as=upsert_b:20]
-           ├── CASE WHEN rowid:15 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
-           └── CASE WHEN rowid:15 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
+           ├── CASE WHEN a:12 IS NULL THEN x:6 ELSE a:12 END [as=upsert_a:19]
+           ├── CASE WHEN a:12 IS NULL THEN y:7 ELSE b_new:17 END [as=upsert_b:20]
+           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
+           └── CASE WHEN a:12 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
 
 # Use RETURNING INSERT..ON CONFLICT as a FROM clause.
 build
@@ -294,7 +294,7 @@ sort
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
       │    └── upsert abc
       │         ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null rowid:4!null
-      │         ├── canary column: 13
+      │         ├── canary column: 10
       │         ├── fetch columns: abc.a:10 abc.b:11 abc.c:12 rowid:13
       │         ├── insert-mapping:
       │         │    ├── column1:6 => abc.a:1
@@ -351,10 +351,10 @@ sort
       │              │    └── projections
       │              │         └── b_new:15 + 1 [as=column16:16]
       │              └── projections
-      │                   ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE abc.a:10 END [as=upsert_a:17]
-      │                   ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE b_new:15 END [as=upsert_b:18]
-      │                   ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
-      │                   └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
+      │                   ├── CASE WHEN abc.a:10 IS NULL THEN column1:6 ELSE abc.a:10 END [as=upsert_a:17]
+      │                   ├── CASE WHEN abc.a:10 IS NULL THEN column2:7 ELSE b_new:15 END [as=upsert_b:18]
+      │                   ├── CASE WHEN abc.a:10 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
+      │                   └── CASE WHEN abc.a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
       └── with-scan &1
            ├── columns: a:21!null b:22!null c:23!null
            └── mapping:
@@ -371,7 +371,7 @@ UPDATE SET a=tab.a*excluded.a
 ----
 upsert tab
  ├── columns: <none>
- ├── canary column: 13
+ ├── canary column: 10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -422,10 +422,10 @@ upsert tab
       │    └── projections
       │         └── b:11 + 1 [as=column16:16]
       └── projections
-           ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
-           ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
-           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
-           └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
+           ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
+           ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
+           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
+           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
 
 # Conflict columns are in different order than index key columns.
 build
@@ -732,7 +732,7 @@ UPDATE SET (b, a)=(SELECT x, y+excluded.b FROM xyz WHERE x=excluded.a)
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 13
+ ├── canary column: 10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -795,10 +795,10 @@ upsert abc
       │    └── projections
       │         └── x:15 + 1 [as=column20:20]
       └── projections
-           ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE "?column?":19 END [as=upsert_a:21]
-           ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE x:15 END [as=upsert_b:22]
-           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column20:20 END [as=upsert_c:23]
-           └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:24]
+           ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE "?column?":19 END [as=upsert_a:21]
+           ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE x:15 END [as=upsert_b:22]
+           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column20:20 END [as=upsert_c:23]
+           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:24]
 
 # Default expressions.
 build
@@ -809,7 +809,7 @@ UPDATE SET a=DEFAULT, b=DEFAULT
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 13
+ ├── canary column: 10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -862,10 +862,10 @@ upsert abc
       │    └── projections
       │         └── b_new:16 + 1 [as=column17:17]
       └── projections
-           ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:18]
-           ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE b_new:16 END [as=upsert_b:19]
-           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column17:17 END [as=upsert_c:20]
-           └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:21]
+           ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:18]
+           ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b_new:16 END [as=upsert_b:19]
+           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column17:17 END [as=upsert_c:20]
+           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:21]
 
 # ------------------------------------------------------------------------------
 # Test mutation columns.
@@ -2372,3 +2372,82 @@ insert unique_partial_indexes
            ├── column3:7 = 'foo' [as=column13:13]
            ├── column3:7 = 'bar' [as=column14:14]
            └── true [as=column15:15]
+
+exec-ddl
+DROP INDEX u4
+----
+
+# Error when two arbiter indexes are found for ON CONFLICT DO UPDATE.
+build
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO UPDATE SET b = 10
+----
+error (42P10): there are multiple unique or exclusion constraints matching the ON CONFLICT specification
+
+build
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' DO UPDATE SET b = 10
+----
+upsert unique_partial_indexes
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: a:9 b:10 c:11
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── update-mapping:
+ │    └── upsert_b:17 => b:2
+ ├── partial index put columns: column19:19 column20:20
+ ├── partial index del columns: column13:13 column14:14
+ └── project
+      ├── columns: column19:19 column20:20 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14 b_new:15!null upsert_a:16 upsert_b:17!null upsert_c:18
+      ├── project
+      │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14 b_new:15!null
+      │    ├── project
+      │    │    ├── columns: b_new:15!null column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14
+      │    │    ├── project
+      │    │    │    ├── columns: column13:13 column14:14 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │    └── ensure-upsert-distinct-on
+      │    │    │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:8
+      │    │    │    │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:8
+      │    │    │    │    │         ├── project
+      │    │    │    │    │         │    ├── columns: upsert_partial_index_distinct1:8 column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │         │    ├── values
+      │    │    │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │         │    │    └── (1, 1, 'bar')
+      │    │    │    │    │         │    └── projections
+      │    │    │    │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:8]
+      │    │    │    │    │         └── aggregations
+      │    │    │    │    │              ├── first-agg [as=column1:5]
+      │    │    │    │    │              │    └── column1:5
+      │    │    │    │    │              └── first-agg [as=column3:7]
+      │    │    │    │    │                   └── column3:7
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: a:9!null b:10 c:11!null crdb_internal_mvcc_timestamp:12
+      │    │    │    │    │    ├── scan unique_partial_indexes
+      │    │    │    │    │    │    ├── columns: a:9!null b:10 c:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    │    │    │    └── partial index predicates
+      │    │    │    │    │    │         ├── secondary: filters
+      │    │    │    │    │    │         │    └── c:11 = 'foo'
+      │    │    │    │    │    │         └── u2: filters
+      │    │    │    │    │    │              └── c:11 = 'bar'
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── c:11 = 'foo'
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column2:6 = b:10
+      │    │    │    │         └── column3:7 = 'foo'
+      │    │    │    └── projections
+      │    │    │         ├── c:11 = 'foo' [as=column13:13]
+      │    │    │         └── c:11 = 'bar' [as=column14:14]
+      │    │    └── projections
+      │    │         └── 10 [as=b_new:15]
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:5 ELSE a:9 END [as=upsert_a:16]
+      │         ├── CASE WHEN a:9 IS NULL THEN column2:6 ELSE b_new:15 END [as=upsert_b:17]
+      │         └── CASE WHEN a:9 IS NULL THEN column3:7 ELSE c:11 END [as=upsert_c:18]
+      └── projections
+           ├── upsert_c:18 = 'foo' [as=column19:19]
+           └── upsert_c:18 = 'bar' [as=column20:20]


### PR DESCRIPTION
This commit adds support for `INSERT ON CONFLICT DO UPDATE` statements
on tables with unique partial indexes. In order to use a unique partial
index as an arbiter, a `WHERE` clause must be provided that implies the
partial index's predicate expression. For example:

    CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a) WHERE b > 0)

    INSERT INTO t VALUES (1, 1)
      ON CONFLICT (a) WHERE b > 0
      DO UPDATE SET b = 10

In the event that multiple arbiter indexes are found, an error is
returned to the user. Postgres supports multiple arbiters, but this is
left as a TODO for now, until there a strong enough motivation to
justify the added complexity.

Similar to the previous commit that added support for `INSERT ON
CONFLICT DO NOTHING` for unique partial indexes, there are three primary
changes to the expression tree build by `optbuilder`:

  1. Fetched rows are filtered by the partial index predicate.

  2. Only insert rows that satisfy the partial index predicate are
  joined with fetched rows in the left outer join.

  3. A new column is projected so that the `EnsureUpsertDistinctOn`
  expression only errors when rows that satisfy the partial index
  predicate conflict with each other.

Fixes #52603

Release note: None