### PR TITLE
opt: store and display mutation arbiter indexes in opt tests and EXPLAIN

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -786,6 +786,7 @@ func (e *distSQLSpecExecFactory) ConstructShowTrace(
 func (e *distSQLSpecExecFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
+	arbiters cat.IndexOrdinals,
 	insertCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
@@ -822,6 +823,7 @@ func (e *distSQLSpecExecFactory) ConstructUpdate(
 func (e *distSQLSpecExecFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
+	arbiters cat.IndexOrdinals,
 	canaryCol exec.NodeColumnOrdinal,
 	insertCols exec.TableColumnOrdinalSet,
 	fetchCols exec.TableColumnOrdinalSet,

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -19,6 +19,9 @@ import (
 // IndexOrdinal identifies an index (in the context of a Table).
 type IndexOrdinal = int
 
+// IndexOrdinals identifies a list of indexes (in the context of a Table).
+type IndexOrdinals = []IndexOrdinal
+
 // PrimaryIndex selects the primary index of a table when calling the
 // Table.Index method. Every table is guaranteed to have a unique primary
 // index, even if it meant adding a hidden unique rowid column.

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -96,6 +96,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	node, err := b.factory.ConstructInsert(
 		input.root,
 		tab,
+		ins.Arbiters,
 		insertOrds,
 		returnOrds,
 		checkOrds,
@@ -394,6 +395,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	node, err := b.factory.ConstructUpsert(
 		input.root,
 		tab,
+		ups.Arbiters,
 		canaryCol,
 		insertColOrds,
 		fetchColOrds,

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1124,3 +1124,57 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t@primary
 ·     spans          [/10 - /10] [/20 - /20] [/30 - /30] [/40 - /40] … (4 more)
+
+
+# UPSERT and INSERT ON CONFLICT include arbiters.
+
+statement ok
+CREATE TABLE u (
+  k INT PRIMARY KEY,
+  v INT,
+  UNIQUE INDEX (v),
+  FAMILY "primary" (k, v)
+)
+
+query TTT
+EXPLAIN UPSERT INTO u VALUES (1, 1)
+----
+·                             distribution      local
+·                             vectorized        false
+upsert                        ·                 ·
+ │                            into              u(k, v)
+ │                            auto commit       ·
+ │                            arbiter indexes   primary
+ └── cross join (left outer)  ·                 ·
+      ├── values              ·                 ·
+      │                       size              2 columns, 1 row
+      └── scan                ·                 ·
+·                             missing stats     ·
+·                             table             u@primary
+·                             spans             [/1 - /1]
+·                             locking strength  for update
+
+query TTT
+EXPLAIN INSERT INTO u VALUES (1, 1) ON CONFLICT DO NOTHING
+----
+·                                            distribution           local
+·                                            vectorized             false
+insert                                       ·                      ·
+ │                                           into                   u(k, v)
+ │                                           auto commit            ·
+ │                                           arbiter indexes        primary, u_v_key
+ └── filter                                  ·                      ·
+      │                                      filter                 k IS NULL
+      └── lookup join (left outer)           ·                      ·
+           │                                 table                  u@u_v_key
+           │                                 equality               (column2) = (v)
+           │                                 equality cols are key  ·
+           └── filter                        ·                      ·
+                │                            filter                 k IS NULL
+                └── cross join (left outer)  ·                      ·
+                     ├── values              ·                      ·
+                     │                       size                   2 columns, 1 row
+                     └── scan                ·                      ·
+·                                            missing stats          ·
+·                                            table                  u@primary
+·                                            spans                  [/1 - /1]

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -90,6 +90,7 @@ upsert                              ·                      ·
  │                                  estimated row count    0 (missing stats)
  │                                  into                   kv(k, v)
  │                                  auto commit            ·
+ │                                  arbiter indexes        primary
  └── lookup join (inner)            ·                      ·
       │                             estimated row count    2 (missing stats)
       │                             table                  kv@primary
@@ -140,6 +141,7 @@ upsert                                  ·                    ·
  │                                      estimated row count  0 (missing stats)
  │                                      into                 indexed(a, b, c, d)
  │                                      auto commit          ·
+ │                                      arbiter indexes      primary
  └── project                            ·                    ·
       └── render                        ·                    ·
            │                            estimated row count  1 (missing stats)
@@ -177,6 +179,7 @@ upsert                                   ·                      ·
  │                                       estimated row count    0 (missing stats)
  │                                       into                   indexed(a, b, c, d)
  │                                       auto commit            ·
+ │                                       arbiter indexes        primary
  └── project                             ·                      ·
       └── render                         ·                      ·
            │                             estimated row count    4 (missing stats)
@@ -450,6 +453,7 @@ EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 upsert                         ·                      ·                   ()                     ·
  │                             estimated row count    0 (missing stats)   ·                      ·
  │                             into                   table38627(a, b)    ·                      ·
+ │                             arbiter indexes        primary             ·                      ·
  └── project                   ·                      ·                   (a, b, a, b, c, b, a)  ·
       └── lookup join (inner)  ·                      ·                   (a, b, a, b, c)        ·
            │                   estimated row count    1 (missing stats)   ·                      ·
@@ -483,6 +487,7 @@ upsert                                   ·                      ·             
  │                                       estimated row count    0 (missing stats)                            ·                                                  ·
  │                                       into                   tdup(x, y, z)                                ·                                                  ·
  │                                       auto commit            ·                                            ·                                                  ·
+ │                                       arbiter indexes        tdup_y_z_key                                 ·                                                  ·
  └── project                             ·                      ·                                            (column1, column2, column3, x, y, z, upsert_z, x)  ·
       └── render                         ·                      ·                                            (upsert_z, column1, column2, column3, x, y, z)     ·
            │                             estimated row count    2 (missing stats)                            ·                                                  ·
@@ -531,6 +536,7 @@ upsert                                   ·                    ·               
  │                                       estimated row count  0 (missing stats)                      ·                                ·
  │                                       into                 target(a, b, c)                        ·                                ·
  │                                       auto commit          ·                                      ·                                ·
+ │                                       arbiter indexes      target_b_c_key                         ·                                ·
  └── project                             ·                    ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
       └── render                         ·                    ·                                      (upsert_b, x, y, z, a, b, c)     ·
            │                             estimated row count  311 (missing stats)                    ·                                ·

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -587,6 +587,17 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.AutoCommit {
 			ob.Attr("auto commit", "")
 		}
+		if len(a.Arbiters) > 0 {
+			var sb strings.Builder
+			for i, idx := range a.Arbiters {
+				index := a.Table.Index(idx)
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(string(index.Name()))
+			}
+			ob.Attr("arbiter indexes", sb.String())
+		}
 
 	case insertFastPathOp:
 		a := n.args.(*insertFastPathArgs)
@@ -614,6 +625,17 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		)
 		if a.AutoCommit {
 			ob.Attr("auto commit", "")
+		}
+		if len(a.Arbiters) > 0 {
+			var sb strings.Builder
+			for i, idx := range a.Arbiters {
+				index := a.Table.Index(idx)
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(string(index.Name()))
+			}
+			ob.Attr("arbiter indexes", sb.String())
 		}
 
 	case updateOp:

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -379,6 +379,7 @@ define ShowTrace {
 define Insert {
     Input exec.Node
     Table cat.Table
+    Arbiters cat.IndexOrdinals
     InsertCols exec.TableColumnOrdinalSet
     ReturnCols exec.TableColumnOrdinalSet
     CheckCols exec.CheckOrdinalSet
@@ -476,6 +477,7 @@ define Update {
 define Upsert {
     Input exec.Node
     Table cat.Table
+    Arbiters cat.IndexOrdinals
     CanaryCol exec.NodeColumnOrdinal
     InsertCols exec.TableColumnOrdinalSet
     FetchCols exec.TableColumnOrdinalSet

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -527,6 +527,15 @@ func (h *hasher) HashIndexOrdinal(val cat.IndexOrdinal) {
 	h.HashInt(val)
 }
 
+func (h *hasher) HashIndexOrdinals(val cat.IndexOrdinals) {
+	hash := h.hash
+	for _, ord := range val {
+		hash ^= internHash(ord)
+		hash *= prime64
+	}
+	h.hash = hash
+}
+
 func (h *hasher) HashViewDeps(val opt.ViewDeps) {
 	// Hash the length and address of the first element.
 	h.HashInt(len(val))
@@ -894,6 +903,18 @@ func (h *hasher) IsScheduleCommandEqual(l, r tree.ScheduleCommand) bool {
 
 func (h *hasher) IsIndexOrdinalEqual(l, r cat.IndexOrdinal) bool {
 	return l == r
+}
+
+func (h *hasher) IsIndexOrdinalsEqual(l, r cat.IndexOrdinals) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i] != r[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *hasher) IsViewDepsEqual(l, r opt.ViewDeps) bool {

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -33,7 +33,8 @@ project
  ├── prune: (1-3)
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
-      ├── canary column: 15
+      ├── arbiter indexes: secondary
+      ├── canary column: rowid:15(int)
       ├── fetch columns: a:12(int) b:13(int) c:14(int) rowid:15(int)
       ├── insert-mapping:
       │    ├── x:6 => a:1
@@ -220,6 +221,7 @@ project
  ├── prune: (1-3)
  └── insert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
+      ├── arbiter indexes: primary secondary secondary
       ├── insert-mapping:
       │    ├── x:6 => a:1
       │    ├── y:7 => b:2
@@ -443,7 +445,8 @@ project
  ├── prune: (19)
  ├── upsert abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
- │    ├── canary column: 13
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: rowid:13(int)
  │    ├── fetch columns: a:10(int) b:11(int) c:12(int) rowid:13(int)
  │    ├── insert-mapping:
  │    │    ├── column1:6 => a:1
@@ -590,7 +593,8 @@ UPDATE SET b=2
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 13
+ ├── arbiter indexes: secondary
+ ├── canary column: a:13(int)
  ├── fetch columns: a:13(int) b:14(int) c:15(int) rowid:16(int)
  ├── insert-mapping:
  │    ├── y:7 => a:1

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -95,7 +95,8 @@ with &1
  ├── fd: ()-->(20)
  ├── upsert xyz
  │    ├── columns: xyz.x:1(string!null) xyz.y:2(int!null) xyz.z:3(float)
- │    ├── canary column: 11
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: xyz.x:11(string)
  │    ├── fetch columns: xyz.x:11(string) xyz.y:12(int) xyz.z:13(float)
  │    ├── insert-mapping:
  │    │    ├── b:6 => xyz.x:1
@@ -245,7 +246,8 @@ ON CONFLICT (v) DO UPDATE SET v=1
 ----
 upsert uv
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: u:10(int)
  ├── fetch columns: u:10(int) v:11(int)
  ├── insert-mapping:
  │    ├── column9:9 => u:1
@@ -328,7 +330,8 @@ ON CONFLICT (n, o) DO UPDATE SET o = 5
 ----
 upsert mno
  ├── columns: <none>
- ├── canary column: 9
+ ├── arbiter indexes: secondary
+ ├── canary column: m:9(int)
  ├── fetch columns: m:9(int) n:10(int) o:11(int)
  ├── insert-mapping:
  │    ├── m:5 => m:1

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -91,7 +91,8 @@ RETURNING *
 ----
 upsert xy
  ├── columns: x:1!null y:2
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: x:6
  ├── fetch columns: x:6 y:7
  ├── insert-mapping:
  │    ├── column1:4 => x:1

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -726,6 +726,7 @@ ON CONFLICT (c1) DO NOTHING
 ----
 insert nullablecols
  ├── columns: <none>
+ ├── arbiter indexes: secondary
  ├── insert-mapping:
  │    ├── i:7 => c1:1
  │    ├── i:7 => c2:2
@@ -785,7 +786,8 @@ ON CONFLICT (c1) DO UPDATE SET c3=1
 ----
 upsert nullablecols
  ├── columns: <none>
- ├── canary column: 21
+ ├── arbiter indexes: secondary
+ ├── canary column: rowid:21
  ├── fetch columns: c1:18 c2:19 c3:20 rowid:21
  ├── insert-mapping:
  │    ├── i:7 => c1:1
@@ -1002,6 +1004,7 @@ ON CONFLICT (x) DO NOTHING
 ----
 insert xy
  ├── columns: <none>
+ ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── y:5 => x:1
  │    └── column7:7 => y:2
@@ -1055,7 +1058,8 @@ ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: x:8
  ├── fetch columns: x:8 y:9
  ├── insert-mapping:
  │    ├── y:5 => x:1
@@ -1110,6 +1114,7 @@ ON CONFLICT (x) DO NOTHING
 ----
 insert xy
  ├── columns: <none>
+ ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── y:5 => x:1
  │    └── column7:7 => y:2
@@ -1158,7 +1163,8 @@ ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: x:8
  ├── fetch columns: x:8 y:9
  ├── insert-mapping:
  │    ├── y:5 => x:1
@@ -1214,7 +1220,8 @@ ON CONFLICT (a, b, c) DO UPDATE SET a=1
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: primary
+ ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13
  ├── insert-mapping:
  │    ├── "?column?":9 => a:1
@@ -1264,7 +1271,8 @@ ON CONFLICT (a, b, c) DO UPDATE SET c=2
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12
  ├── insert-mapping:
  │    ├── "?column?":9 => a:1
@@ -1735,6 +1743,7 @@ ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: si_idx
  ├── insert-mapping:
  │    ├── "?column?":13 => k:1
  │    ├── i:8 => i:2
@@ -1843,7 +1852,8 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.1
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 20
+ ├── arbiter indexes: si_idx
+ ├── canary column: s:20
  ├── fetch columns: k:17 i:18 f:19 s:20 j:21
  ├── insert-mapping:
  │    ├── "?column?":13 => k:1
@@ -2186,6 +2196,7 @@ ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: si_idx
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
@@ -2235,7 +2246,8 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 15
+ ├── arbiter indexes: si_idx
+ ├── canary column: s:15
  ├── fetch columns: k:12 i:13 f:14 s:15 j:16
  ├── insert-mapping:
  │    ├── column1:7 => k:1
@@ -2285,7 +2297,8 @@ ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 15
+ ├── arbiter indexes: si_idx
+ ├── canary column: s:15
  ├── fetch columns: k:12 i:13 f:14 s:15 j:16
  ├── insert-mapping:
  │    ├── column1:7 => k:1
@@ -2352,6 +2365,7 @@ ON CONFLICT DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: primary si_idx fi_idx
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
@@ -2435,6 +2449,7 @@ ON CONFLICT DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: primary si_idx fi_idx
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column10:10 => i:2
@@ -2544,6 +2559,7 @@ ON CONFLICT DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: primary si_idx fi_idx
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
@@ -2655,6 +2671,7 @@ ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
  ├── columns: <none>
+ ├── arbiter indexes: si_idx
  ├── insert-mapping:
  │    ├── i:8 => k:1
  │    ├── i:8 => i:2

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2068,7 +2068,8 @@ INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1
 ----
 upsert a
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
  ├── fetch columns: k:10 i:11 f:12 s:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -2119,7 +2120,8 @@ INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1 RET
 ----
 upsert a
  ├── columns: k:1!null i:2 f:3 s:4
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
  ├── fetch columns: k:10 i:11 f:12 s:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -2179,7 +2181,8 @@ UPSERT INTO family (a, b) VALUES (1, 2)
 ----
 upsert "family"
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11
  ├── insert-mapping:
  │    ├── column1:7 => a:1
@@ -2227,7 +2230,8 @@ project
  ├── fd: ()-->(5)
  └── upsert "family"
       ├── columns: a:1!null e:5
-      ├── canary column: 12
+      ├── arbiter indexes: primary
+      ├── canary column: a:12
       ├── fetch columns: a:12 c:14 d:15 e:16
       ├── insert-mapping:
       │    ├── column1:7 => a:1
@@ -2285,7 +2289,8 @@ INSERT INTO family VALUES (1, 2, 3, 4) ON CONFLICT (a) DO UPDATE SET d=10
 ----
 upsert "family"
  ├── columns: <none>
- ├── canary column: 12
+ ├── arbiter indexes: primary
+ ├── canary column: a:12
  ├── fetch columns: a:12 c:14 d:15
  ├── insert-mapping:
  │    ├── column1:7 => a:1
@@ -2335,7 +2340,8 @@ INSERT INTO mutation VALUES (1, 2, 3) ON CONFLICT (a) DO UPDATE SET b=10
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: primary
+ ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14 e:15
  ├── insert-mapping:
  │    ├── column1:7 => a:1
@@ -2677,7 +2683,8 @@ project
  ├── fd: ()-->(1-3)
  └── upsert returning_test
       ├── columns: a:1 b:2 c:3 rowid:8!null
-      ├── canary column: 22
+      ├── arbiter indexes: secondary
+      ├── canary column: rowid:22
       ├── fetch columns: a:15 b:16 c:17 rowid:22
       ├── insert-mapping:
       │    ├── column1:10 => a:1
@@ -2774,7 +2781,8 @@ project
  ├── fd: ()-->(1-4)
  └── upsert returning_test
       ├── columns: a:1!null b:2!null c:3!null d:4 rowid:8!null
-      ├── canary column: 22
+      ├── arbiter indexes: primary
+      ├── canary column: rowid:22
       ├── fetch columns: a:15 b:16 c:17 d:18 rowid:22
       ├── insert-mapping:
       │    ├── column1:10 => a:1

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -141,6 +141,11 @@ define MutationPrivate {
     # overwrites an existing row.
     CanaryCol ColumnID
 
+    # Arbiters is used only with the Insert and Upsert operators. It identifies
+    # the unique indexes used to detect conflicts for UPSERT and INSERT ON
+    # CONFLICT statements.
+    Arbiters IndexOrdinals
+
     # ReturnCols are the set of columns returned by the mutation operator when
     # the RETURNING clause has been specified. By default, the return columns
     # include all columns in the table, including hidden columns, but not

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -670,6 +670,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 ) {
 	// Determine the set of arbiter indexes to use to check for conflicts.
 	arbiterIndexes := mb.arbiterIndexes(conflictOrds, arbiterPredicate)
+	mb.arbiters = arbiterIndexes.Ordered()
 
 	insertColSet := mb.outScope.expr.Relational().OutputCols
 	insertColScope := mb.outScope.replace()
@@ -827,6 +828,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 ) {
 	// Determine the set of arbiter indexes to use to check for conflicts.
 	arbiterIndexes := mb.arbiterIndexes(conflictOrds, arbiterPredicate)
+	mb.arbiters = arbiterIndexes.Ordered()
 
 	// TODO(mgartner): Add support for multiple arbiter indexes, similar to
 	// buildInputForDoNothing.

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -128,6 +128,10 @@ type mutationBuilder struct {
 	// an insert; otherwise it's an update.
 	canaryColID opt.ColumnID
 
+	// arbiters stores the ordinals of indexes that are used to detect conflicts
+	// for UPSERT and INSERT ON CONFLICT statements.
+	arbiters cat.IndexOrdinals
+
 	// roundedDecimalCols is the set of columns that have already been rounded.
 	// Keeping this set avoids rounding the same column multiple times.
 	roundedDecimalCols opt.ColSet
@@ -853,6 +857,7 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 		FetchCols:           checkEmptyList(mb.fetchColIDs),
 		UpdateCols:          checkEmptyList(mb.updateColIDs),
 		CanaryCol:           mb.canaryColID,
+		Arbiters:            mb.arbiters,
 		CheckCols:           checkEmptyList(mb.checkColIDs),
 		PartialIndexPutCols: checkEmptyList(mb.partialIndexPutColIDs),
 		PartialIndexDelCols: checkEmptyList(mb.partialIndexDelColIDs),

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -37,6 +37,7 @@ INSERT INTO child VALUES (100, 1), (200, 1) ON CONFLICT DO NOTHING
 ----
 insert child
  ├── columns: <none>
+ ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── column1:4 => c:1
  │    └── column2:5 => child.p:2

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -66,7 +66,8 @@ UPSERT INTO c1(c) VALUES (100), (200)
 ----
 upsert c1
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: c:8
  ├── fetch columns: c:8 c1.p:9 i:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
@@ -152,7 +153,8 @@ INSERT INTO c1 VALUES (100, 1), (200, 1) ON CONFLICT (c) DO UPDATE SET p = exclu
 ----
 upsert c1
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: c:8
  ├── fetch columns: c:8 c1.p:9 i:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
@@ -211,7 +213,8 @@ INSERT INTO c1 SELECT u, v FROM uv ON CONFLICT (c) DO UPDATE SET i = c1.c + 1
 ----
 upsert c1
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: c:10
  ├── fetch columns: c:10 c1.p:11 i:12
  ├── insert-mapping:
  │    ├── u:5 => c:1
@@ -274,7 +277,8 @@ INSERT INTO c2 VALUES (1), (2) ON CONFLICT (c) DO UPDATE SET c = 1
 ----
 upsert c2
  ├── columns: <none>
- ├── canary column: 4
+ ├── arbiter indexes: primary
+ ├── canary column: c:4
  ├── fetch columns: c:4
  ├── insert-mapping:
  │    └── column1:3 => c:1
@@ -356,7 +360,8 @@ UPSERT INTO c3(c) VALUES (100), (200)
 ----
 upsert c3
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: c:6
  ├── fetch columns: c:6 c3.p:7
  ├── insert-mapping:
  │    ├── column1:4 => c:1
@@ -413,7 +418,8 @@ INSERT INTO c4 SELECT x, y, z FROM xyzw ON CONFLICT (a) DO UPDATE SET other = 1
 ----
 upsert c4
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: secondary
+ ├── canary column: c:11
  ├── fetch columns: c:11 a:12 c4.other:13
  ├── insert-mapping:
  │    ├── x:5 => c:1
@@ -472,7 +478,8 @@ INSERT INTO c4 SELECT x, y, z FROM xyzw ON CONFLICT (a) DO UPDATE SET a = 5
 ----
 upsert c4
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: secondary
+ ├── canary column: c:11
  ├── fetch columns: c:11 a:12 c4.other:13
  ├── insert-mapping:
  │    ├── x:5 => c:1
@@ -623,7 +630,8 @@ UPSERT INTO cpq(c,p) SELECT x,y FROM xyzw
 ----
 upsert cpq
  ├── columns: <none>
- ├── canary column: 14
+ ├── arbiter indexes: primary
+ ├── canary column: c:14
  ├── fetch columns: c:14 cpq.p:15 cpq.q:16 cpq.other:17
  ├── insert-mapping:
  │    ├── x:6 => c:1
@@ -689,7 +697,8 @@ UPSERT INTO cpq(c) SELECT x FROM xyzw
 ----
 upsert cpq
  ├── columns: <none>
- ├── canary column: 15
+ ├── arbiter indexes: primary
+ ├── canary column: c:15
  ├── fetch columns: c:15 cpq.p:16 cpq.q:17 cpq.other:18
  ├── insert-mapping:
  │    ├── x:6 => c:1
@@ -793,7 +802,8 @@ INSERT INTO cpq VALUES (1), (2) ON CONFLICT (c) DO UPDATE SET p = 10
 ----
 upsert cpq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: c:10
  ├── fetch columns: c:10 cpq.p:11 cpq.q:12 cpq.other:13
  ├── insert-mapping:
  │    ├── column1:6 => c:1
@@ -921,7 +931,8 @@ UPSERT INTO cmulti(a,b,c) SELECT x,y,z FROM xyzw
 ----
 upsert cmulti
  ├── columns: <none>
- ├── canary column: 13
+ ├── arbiter indexes: primary
+ ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15 d:16
  ├── insert-mapping:
  │    ├── x:6 => a:1
@@ -1018,7 +1029,8 @@ UPSERT INTO p1 VALUES (1, 1), (2, 2)
 ----
 upsert p1
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 other:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1053,7 +1065,8 @@ INSERT INTO p1 VALUES (100, 1), (200, 1) ON CONFLICT (p) DO UPDATE SET p = exclu
 ----
 upsert p1
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p1.p:6
  ├── fetch columns: p1.p:6 other:7
  ├── insert-mapping:
  │    ├── column1:4 => p1.p:1
@@ -1113,7 +1126,8 @@ INSERT INTO p1 VALUES (100, 1), (200, 1) ON CONFLICT (p) DO UPDATE SET other = p
 ----
 upsert p1
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 other:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1160,7 +1174,8 @@ UPSERT INTO p2 VALUES (1, 1), (2, 2)
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 p2.fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1216,7 +1231,8 @@ INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (p) DO UPDATE SET p = excluded.
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1256,7 +1272,8 @@ INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (p) DO UPDATE SET fk = excluded
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 p2.fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1317,7 +1334,8 @@ INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (fk) DO UPDATE SET p = excluded
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: p2_fk_key
+ ├── canary column: p:6
  ├── fetch columns: p:6 fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1355,7 +1373,8 @@ INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (fk) DO UPDATE SET fk = exclude
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: p2_fk_key
+ ├── canary column: p:6
  ├── fetch columns: p:6 p2.fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1416,7 +1435,8 @@ UPSERT INTO p2(p) VALUES (1), (2)
 ----
 upsert p2
  ├── columns: <none>
- ├── canary column: 6
+ ├── arbiter indexes: primary
+ ├── canary column: p:6
  ├── fetch columns: p:6 fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
@@ -1456,7 +1476,8 @@ UPSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2)
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
  ├── fetch columns: k:10 pq.p:11 pq.q:12 pq.other:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1544,7 +1565,8 @@ UPSERT INTO pq (k) VALUES (1), (2)
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: k:8
  ├── fetch columns: k:8 p:9 q:10 other:11
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1584,7 +1606,8 @@ UPSERT INTO pq (k,q) VALUES (1, 1), (2, 2)
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 9
+ ├── arbiter indexes: primary
+ ├── canary column: k:9
  ├── fetch columns: k:9 pq.p:10 pq.q:11 pq.other:12
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1674,7 +1697,8 @@ INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (p,q) DO UPDATE SET
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: k:10
  ├── fetch columns: k:10 p:11 q:12 other:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1719,7 +1743,8 @@ INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (p,q) DO UPDATE SET
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: k:10
  ├── fetch columns: k:10 pq.p:11 pq.q:12 pq.other:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1811,7 +1836,8 @@ INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (k) DO UPDATE SET o
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
  ├── fetch columns: k:10 p:11 q:12 other:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1857,7 +1883,8 @@ INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (k) DO UPDATE SET q
 ----
 upsert pq
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
  ├── fetch columns: k:10 pq.p:11 pq.q:12 pq.other:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1975,7 +2002,8 @@ UPSERT INTO tab2 VALUES (1,NULL,NULL), (2,2,2)
 ----
 upsert tab2
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: c:8
  ├── fetch columns: c:8 d:9 tab2.e:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
@@ -2048,7 +2076,8 @@ INSERT INTO tab2 VALUES (1,1,1) ON CONFLICT (c) DO UPDATE SET e = tab2.e + 1
 ----
 upsert tab2
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: c:8
  ├── fetch columns: c:8 d:9 tab2.e:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
@@ -2126,7 +2155,8 @@ INSERT INTO tab2 VALUES (1,1,1) ON CONFLICT (e) DO UPDATE SET d = tab2.d + 1
 ----
 upsert tab2
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: tab2_e_key
+ ├── canary column: c:8
  ├── fetch columns: c:8 d:9 e:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
@@ -2198,7 +2228,8 @@ UPSERT INTO self SELECT x, y, z, w FROM xyzw
 ----
 upsert self
  ├── columns: <none>
- ├── canary column: 12
+ ├── arbiter indexes: primary
+ ├── canary column: a:12
  ├── fetch columns: a:12 self.b:13 self.c:14 self.d:15
  ├── insert-mapping:
  │    ├── x:6 => a:1

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -228,7 +228,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -310,7 +311,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -399,7 +401,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: secondary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -610,7 +613,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -358,7 +358,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -492,7 +493,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -629,7 +631,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: secondary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -280,7 +280,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -383,7 +384,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: primary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
@@ -489,7 +491,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 root
  ├── upsert parent_multi
  │    ├── columns: <none>
- │    ├── canary column: 8
+ │    ├── arbiter indexes: secondary
+ │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -54,7 +54,8 @@ UPSERT INTO kj VALUES (1, '{"a": 2}')
 ----
 upsert kj
  ├── columns: <none>
- ├── canary column: 7
+ ├── arbiter indexes: primary
+ ├── canary column: k:7
  ├── fetch columns: k:7 j:8
  ├── insert-mapping:
  │    ├── column1:5 => k:1
@@ -86,6 +87,7 @@ INSERT INTO kj VALUES (1, '{"a": 2}') ON CONFLICT (k) DO NOTHING
 ----
 insert kj
  ├── columns: <none>
+ ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── column1:5 => k:1
  │    └── column2:6 => j:2
@@ -116,7 +118,8 @@ INSERT INTO kj VALUES (1, '{"a": 2}') ON CONFLICT (k) DO UPDATE SET j = '{"a": 3
 ----
 upsert kj
  ├── columns: <none>
- ├── canary column: 7
+ ├── arbiter indexes: primary
+ ├── canary column: k:7
  ├── fetch columns: k:7 j:8
  ├── insert-mapping:
  │    ├── column1:5 => k:1

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -78,7 +78,8 @@ UPDATE SET a=5
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 12
+ ├── arbiter indexes: secondary
+ ├── canary column: a:12
  ├── fetch columns: a:12 b:13 c:14 rowid:15
  ├── insert-mapping:
  │    ├── x:6 => a:1
@@ -147,7 +148,8 @@ project
  ├── columns: a:1!null b:2 c:3
  └── upsert abc
       ├── columns: a:1!null b:2 c:3 rowid:4!null
-      ├── canary column: 14
+      ├── arbiter indexes: secondary
+      ├── canary column: rowid:14
       ├── fetch columns: a:11 b:12 c:13 rowid:14
       ├── insert-mapping:
       │    ├── x:6 => a:1
@@ -218,7 +220,8 @@ WHERE abc.a>0
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 12
+ ├── arbiter indexes: secondary
+ ├── canary column: a:12
  ├── fetch columns: a:12 b:13 c:14 rowid:15
  ├── insert-mapping:
  │    ├── x:6 => a:1
@@ -294,7 +297,8 @@ sort
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
       │    └── upsert abc
       │         ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null rowid:4!null
-      │         ├── canary column: 10
+      │         ├── arbiter indexes: secondary
+      │         ├── canary column: abc.a:10
       │         ├── fetch columns: abc.a:10 abc.b:11 abc.c:12 rowid:13
       │         ├── insert-mapping:
       │         │    ├── column1:6 => abc.a:1
@@ -371,7 +375,8 @@ UPDATE SET a=tab.a*excluded.a
 ----
 upsert tab
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -436,7 +441,8 @@ UPDATE SET a=5
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 13
+ ├── arbiter indexes: secondary
+ ├── canary column: rowid:13
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -530,6 +536,7 @@ ON CONFLICT DO NOTHING
 ----
 insert xyz
  ├── columns: <none>
+ ├── arbiter indexes: primary secondary secondary
  ├── insert-mapping:
  │    ├── column1:5 => x:1
  │    ├── column2:6 => y:2
@@ -605,6 +612,7 @@ ON CONFLICT (y, z) DO NOTHING
 ----
 insert xyz
  ├── columns: <none>
+ ├── arbiter indexes: secondary
  ├── insert-mapping:
  │    ├── column1:5 => x:1
  │    ├── column2:6 => y:2
@@ -649,7 +657,8 @@ project
  ├── columns: "?column?":18!null "?column?":19
  ├── upsert xyz
  │    ├── columns: x:1!null y:2 z:3!null
- │    ├── canary column: 8
+ │    ├── arbiter indexes: secondary
+ │    ├── canary column: x:8
  │    ├── fetch columns: x:8 y:9 z:10
  │    ├── insert-mapping:
  │    │    ├── column1:5 => x:1
@@ -732,7 +741,8 @@ UPDATE SET (b, a)=(SELECT x, y+excluded.b FROM xyz WHERE x=excluded.a)
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -809,7 +819,8 @@ UPDATE SET a=DEFAULT, b=DEFAULT
 ----
 upsert abc
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 rowid:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -879,7 +890,8 @@ UPDATE SET m=mutation.m+1
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: primary
+ ├── canary column: m:11
  ├── fetch columns: m:11 n:12 o:13 p:14 q:15
  ├── insert-mapping:
  │    ├── column1:7 => m:1
@@ -949,7 +961,8 @@ UPSERT INTO xyz VALUES (1)
 ----
 upsert xyz
  ├── columns: <none>
- ├── canary column: 7
+ ├── arbiter indexes: primary
+ ├── canary column: x:7
  ├── fetch columns: x:7 y:8 z:9
  ├── insert-mapping:
  │    ├── column1:5 => x:1
@@ -1005,7 +1018,8 @@ with &1
  │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
  │    └── upsert abc
  │         ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null rowid:4!null
- │         ├── canary column: 13
+ │         ├── arbiter indexes: primary
+ │         ├── canary column: rowid:13
  │         ├── fetch columns: abc.a:10 abc.b:11 abc.c:12 rowid:13
  │         ├── insert-mapping:
  │         │    ├── column1:6 => abc.a:1
@@ -1069,7 +1083,8 @@ UPSERT INTO xyz (z, x, y) VALUES (1, 2, 3)
 ----
 upsert xyz
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: x:8
  ├── fetch columns: x:8 y:9 z:10
  ├── insert-mapping:
  │    ├── column2:6 => x:1
@@ -1123,7 +1138,8 @@ UPSERT INTO checks (a, b, c) VALUES (1, 2, 3)
 ----
 upsert checks
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -1180,7 +1196,8 @@ UPSERT INTO mutation (m, n) VALUES (1, 2)
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: primary
+ ├── canary column: m:11
  ├── fetch columns: m:11 n:12 o:13 p:14 q:15
  ├── insert-mapping:
  │    ├── column1:7 => m:1
@@ -1237,7 +1254,8 @@ UPSERT INTO mutation VALUES (1, 2)
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 11
+ ├── arbiter indexes: primary
+ ├── canary column: m:11
  ├── fetch columns: m:11 n:12 o:13 p:14 q:15
  ├── insert-mapping:
  │    ├── column1:7 => m:1
@@ -1303,7 +1321,8 @@ INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=3, c=4
 ----
 upsert checks
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -1375,6 +1394,7 @@ INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO NOTHING
 ----
 insert checks
  ├── columns: <none>
+ ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1431,7 +1451,8 @@ UPSERT INTO checks (a, b) VALUES (1, 2)
 ----
 upsert checks
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
@@ -1498,7 +1519,8 @@ ON CONFLICT (a) DO UPDATE SET a=excluded.a, b=(SELECT x FROM xyz WHERE x=checks.
 ----
 upsert checks
  ├── columns: <none>
- ├── canary column: 13
+ ├── arbiter indexes: primary
+ ├── canary column: checks.a:13
  ├── fetch columns: checks.a:13 checks.b:14 checks.c:15 d:16
  ├── insert-mapping:
  │    ├── abc.a:6 => checks.a:1
@@ -1584,7 +1606,8 @@ ON CONFLICT (z, y) DO UPDATE SET y=5
 ----
 upsert xyz
  ├── columns: <none>
- ├── canary column: 10
+ ├── arbiter indexes: secondary
+ ├── canary column: x:10
  ├── fetch columns: x:10 y:11 z:12
  ├── insert-mapping:
  │    ├── a:5 => x:1
@@ -1633,7 +1656,8 @@ UPSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95])
 ----
 upsert decimals
  ├── columns: <none>
- ├── canary column: 14
+ ├── arbiter indexes: primary
+ ├── canary column: decimals.a:14
  ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
@@ -1710,7 +1734,8 @@ UPSERT INTO decimals (a) VALUES (1.1)
 ----
 upsert decimals
  ├── columns: <none>
- ├── canary column: 14
+ ├── arbiter indexes: primary
+ ├── canary column: decimals.a:14
  ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
@@ -1790,7 +1815,8 @@ DO UPDATE SET b=ARRAY[0.99]
 ----
 upsert decimals
  ├── columns: <none>
- ├── canary column: 14
+ ├── arbiter indexes: primary
+ ├── canary column: decimals.a:14
  ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
@@ -1893,6 +1919,7 @@ INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert partial_indexes
  ├── columns: <none>
+ ├── arbiter indexes: primary secondary
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
@@ -1965,7 +1992,8 @@ INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SE
 ----
 upsert partial_indexes
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: secondary
+ ├── canary column: a:8
  ├── fetch columns: a:8 b:9 c:10
  ├── insert-mapping:
  │    ├── column1:5 => a:1
@@ -2029,7 +2057,8 @@ UPSERT INTO partial_indexes VALUES (2, 1, 'bar')
 ----
 upsert partial_indexes
  ├── columns: <none>
- ├── canary column: 8
+ ├── arbiter indexes: primary
+ ├── canary column: a:8
  ├── fetch columns: a:8 b:9 c:10
  ├── insert-mapping:
  │    ├── column1:5 => a:1
@@ -2108,6 +2137,7 @@ INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert unique_partial_indexes
  ├── columns: <none>
+ ├── arbiter indexes: primary secondary
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
@@ -2188,6 +2218,7 @@ INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c 
 ----
 insert unique_partial_indexes
  ├── columns: <none>
+ ├── arbiter indexes: secondary u2
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
@@ -2284,6 +2315,7 @@ INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c 
 ----
 insert unique_partial_indexes
  ├── columns: <none>
+ ├── arbiter indexes: u3
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
@@ -2345,6 +2377,7 @@ INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c 
 ----
 insert unique_partial_indexes
  ├── columns: <none>
+ ├── arbiter indexes: u4
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
@@ -2388,7 +2421,8 @@ INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c 
 ----
 upsert unique_partial_indexes
  ├── columns: <none>
- ├── canary column: 9
+ ├── arbiter indexes: secondary
+ ├── canary column: a:9
  ├── fetch columns: a:9 b:10 c:11
  ├── insert-mapping:
  │    ├── column1:5 => a:1

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -232,6 +232,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"JobCommand":        {fullName: "tree.JobCommand", passByVal: true},
 		"ScheduleCommand":   {fullName: "tree.ScheduleCommand", passByVal: true},
 		"IndexOrdinal":      {fullName: "cat.IndexOrdinal", passByVal: true},
+		"IndexOrdinals":     {fullName: "cat.IndexOrdinals", passByVal: true},
 		"ViewDeps":          {fullName: "opt.ViewDeps", passByVal: true},
 		"LockingItem":       {fullName: "tree.LockingItem", isPointer: true},
 		"MaterializeClause": {fullName: "tree.MaterializeClause", passByVal: true},
@@ -321,7 +322,7 @@ func (m *metadata) typeOf(e lang.Expr) *typeDef {
 func (m *metadata) lookupType(friendlyName string) *typeDef {
 	res, ok := m.types[friendlyName]
 	if !ok {
-		panic(fmt.Sprintf("%s is not registered as a valid type in metadata.go", friendlyName))
+		panic(fmt.Sprintf("%s is not registered as a valid type in optgen/metadata.go", friendlyName))
 	}
 	return res
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/validator.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/validator.go
@@ -46,7 +46,7 @@ func (v *validator) validate(compiled *lang.CompiledExpr) []error {
 		for _, field := range define.Fields {
 			typ := md.typeOf(field)
 			if typ == nil {
-				format := "%s is not registered as a valid type in metadata.go"
+				format := "%s is not registered as a valid type in optgen/metadata.go"
 				v.addErrorf(field.Source(), format, field.Type)
 				continue
 			}

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1260,7 +1260,8 @@ VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C
 ----
 upsert transactions
  ├── columns: <none>
- ├── canary column: 16
+ ├── arbiter indexes: transactionsprimarykey
+ ├── canary column: dealerid:16
  ├── fetch columns: dealerid:16 isbuy:17 date:18 accountname:19 customername:20 operationid:21 version:22
  ├── insert-mapping:
  │    ├── column1:9 => dealerid:1
@@ -1315,7 +1316,8 @@ FROM updates
 ----
 upsert transactiondetails
  ├── columns: <none>
- ├── canary column: 22
+ ├── arbiter indexes: detailsprimarykey
+ ├── canary column: transactiondetails.dealerid:22
  ├── fetch columns: transactiondetails.dealerid:22 transactiondetails.isbuy:23 transactiondate:24 cardid:25 quantity:26 transactiondetails.sellprice:27 transactiondetails.buyprice:28 transactiondetails.version:29
  ├── insert-mapping:
  │    ├── "?column?":12 => transactiondetails.dealerid:2

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1265,7 +1265,8 @@ VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C
 ----
 upsert transactions
  ├── columns: <none>
- ├── canary column: 19
+ ├── arbiter indexes: transactionsprimarykey
+ ├── canary column: dealerid:19
  ├── fetch columns: dealerid:19 isbuy:20 date:21 accountname:22 customername:23 operationid:24 version:25 olddate:26 extra:27
  ├── insert-mapping:
  │    ├── column1:11 => dealerid:1
@@ -1322,7 +1323,8 @@ FROM updates
 ----
 upsert transactiondetails
  ├── columns: <none>
- ├── canary column: 26
+ ├── arbiter indexes: detailsprimarykey
+ ├── canary column: transactiondetails.dealerid:26
  ├── fetch columns: transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondate:28 cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 transactiondetails.discount:34 transactiondetails.extra:35
  ├── insert-mapping:
  │    ├── "?column?":14 => transactiondetails.dealerid:2

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1787,7 +1787,8 @@ sort
       ├── volatile, mutations
       ├── upsert abc
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
-      │    ├── canary column: 9
+      │    ├── arbiter indexes: primary
+      │    ├── canary column: abc.a:9
       │    ├── fetch columns: abc.a:9 abc.b:10 abc.c:11
       │    ├── insert-mapping:
       │    │    ├── x:5 => abc.a:1

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1190,6 +1190,7 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 func (ef *execFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
+	arbiters cat.IndexOrdinals,
 	insertColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
@@ -1444,6 +1445,7 @@ func (ef *execFactory) ConstructUpdate(
 func (ef *execFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
+	arbiters cat.IndexOrdinals,
 	canaryCol exec.NodeColumnOrdinal,
 	insertColOrdSet exec.TableColumnOrdinalSet,
 	fetchColOrdSet exec.TableColumnOrdinalSet,


### PR DESCRIPTION
#### opt: store mutation arbiter indexes and display in opt tests

This commit adds the list of arbiter indexes to opt test expression
trees. In order to facilitate this, the list of index ordinals that are
arbiters are stored on `MutationPrivate` for `Upsert` and `Insert`
expressions.

This commit also formats the canary column for `UPSERT`s like other
columns, instead of a plain column ID.

Additionally, the `optgen` error message produced when referencing a
type in an `*.opt` file that has not been registered is now less
ambiguous. With the previous error message it was unclear if it was
referencing `opt/metadata.go` or `optgen/metadata.go`.

Release justification: low-risk update to new functionality

Release note: None

#### opt: display arbiter indexes in EXPLAIN output

This commit adds a list of arbiter indexes to EXPLAIN output for UPSERT
and INSERT ON CONFLICT statements. These arbiters are used to detect
conflicts.

Release justification: low-risk update to new functionality

Release note (sql change): The output of EXPLAIN for UPSERT and INSERT
ON CONFLICT statements now includes  a list of arbiter indexes. These
arbiters are the indexes used for detecting conflicts between the insert
row and the existing rows in the table.
