### PR TITLE
opt: add rule to replace ST_MaxDistance with ST_DFullyWithin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -728,7 +728,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
@@ -1132,8 +1132,10 @@ from the given Geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="st_dfullywithinexclusive"></a><code>st_dfullywithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units exclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.</p>
 </span></td></tr>
 <tr><td><a name="st_dimension"></a><code>st_dimension(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of topological dimensions of a given Geometry.</p>
 </span></td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -728,7 +728,10 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_dfullywithinexclusive"></a><code>_st_dfullywithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, exclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.</p>
 <p>This function variant does not utilize any geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b, inclusive. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
@@ -1132,10 +1135,11 @@ from the given Geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, inclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
-<tr><td><a name="st_dfullywithinexclusive"></a><code>st_dfullywithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units exclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.</p>
+<tr><td><a name="st_dfullywithinexclusive"></a><code>st_dfullywithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, exclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_dimension"></a><code>st_dimension(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of topological dimensions of a given Geometry.</p>
 </span></td></tr>

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -25,7 +25,7 @@ func DWithin(
 	b *geo.Geography,
 	distance float64,
 	useSphereOrSpheroid UseSphereOrSpheroid,
-	exclusive geo.FnExclusivity,
+	exclusivity geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
@@ -67,12 +67,12 @@ func DWithin(
 		bRegions,
 		a.BoundingRect().Intersects(b.BoundingRect()),
 		distance,
-		exclusive,
+		exclusivity,
 	)
 	if err != nil {
 		return false, err
 	}
-	if exclusive {
+	if exclusivity == geo.FnExclusive {
 		return maybeClosestDistance < distance, nil
 	}
 	return maybeClosestDistance <= distance, nil

--- a/pkg/geo/geoindex/geoindex.go
+++ b/pkg/geo/geoindex/geoindex.go
@@ -32,19 +32,20 @@ import (
 // index scan may produce false positives. Therefore, the original function must
 // be called on the output of the index operation to filter the results.
 var RelationshipMap = map[string]RelationshipType{
-	"st_covers":           Covers,
-	"st_coveredby":        CoveredBy,
-	"st_contains":         Covers,
-	"st_containsproperly": Covers,
-	"st_crosses":          Intersects,
-	"st_dwithin":          DWithin,
-	"st_dfullywithin":     DFullyWithin,
-	"st_equals":           Intersects,
-	"st_intersects":       Intersects,
-	"st_overlaps":         Intersects,
-	"st_touches":          Intersects,
-	"st_within":           CoveredBy,
-	"st_dwithinexclusive": DWithin,
+	"st_covers":                Covers,
+	"st_coveredby":             CoveredBy,
+	"st_contains":              Covers,
+	"st_containsproperly":      Covers,
+	"st_crosses":               Intersects,
+	"st_dwithin":               DWithin,
+	"st_dfullywithin":          DFullyWithin,
+	"st_equals":                Intersects,
+	"st_intersects":            Intersects,
+	"st_overlaps":              Intersects,
+	"st_touches":               Intersects,
+	"st_within":                CoveredBy,
+	"st_dwithinexclusive":      DWithin,
+	"st_dfullywithinexclusive": DFullyWithin,
 }
 
 // RelationshipReverseMap contains a default function for each of the

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -39,7 +39,7 @@ func MinDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 	if a.SRID() != b.SRID() {
 		return 0, geo.NewMismatchingSRIDsError(a, b)
 	}
-	return minDistanceInternal(a, b, 0, geo.EmptyBehaviorOmit, false /* exclusive */)
+	return minDistanceInternal(a, b, 0, geo.EmptyBehaviorOmit, geo.FnInclusive)
 }
 
 // MaxDistance returns the maximum distance across every pair of points comprising
@@ -52,10 +52,10 @@ func MaxDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 }
 
 // DWithin determines if any part of geometry A is within D units of geometry B.
-// If exclusive is false, DWithin is equivalent to Distance(a, b) <= d.
-// Otherwise, DWithin is equivalent to Distance(a, b) < d.
+// If exclusive, DWithin is equivalent to Distance(a, b) < d. Otherwise, DWithin
+// is equivalent to Distance(a, b) <= d.
 func DWithin(
-	a *geo.Geometry, b *geo.Geometry, d float64, exclusive geo.FnExclusivity,
+	a *geo.Geometry, b *geo.Geometry, d float64, exclusivity geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
@@ -66,7 +66,7 @@ func DWithin(
 	if !a.CartesianBoundingBox().Buffer(d, d).Intersects(b.CartesianBoundingBox()) {
 		return false, nil
 	}
-	dist, err := minDistanceInternal(a, b, d, geo.EmptyBehaviorError, exclusive)
+	dist, err := minDistanceInternal(a, b, d, geo.EmptyBehaviorError, exclusivity)
 	if err != nil {
 		// In case of any empty geometries return false.
 		if geo.IsEmptyGeometryError(err) {
@@ -74,16 +74,18 @@ func DWithin(
 		}
 		return false, err
 	}
-	if exclusive {
+	if exclusivity == geo.FnExclusive {
 		return dist < d, nil
 	}
 	return dist <= d, nil
 }
 
-// DFullyWithin determines whether the maximum distance across every pair of points
-// comprising geometries A and B is within D units.
+// DFullyWithin determines whether the maximum distance across every pair of
+// points comprising geometries A and B is within D units. If exclusive,
+// DFullyWithin is equivalent to MaxDistance(a, b) < d. Otherwise, DFullyWithin
+// is equivalent to MaxDistance(a, b) <= d.
 func DFullyWithin(
-	a *geo.Geometry, b *geo.Geometry, d float64, exclusive geo.FnExclusivity,
+	a *geo.Geometry, b *geo.Geometry, d float64, exclusivity geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
@@ -94,7 +96,7 @@ func DFullyWithin(
 	if !a.CartesianBoundingBox().Buffer(d, d).Covers(b.CartesianBoundingBox()) {
 		return false, nil
 	}
-	dist, err := maxDistanceInternal(a, b, d, geo.EmptyBehaviorError, exclusive)
+	dist, err := maxDistanceInternal(a, b, d, geo.EmptyBehaviorError, exclusivity)
 	if err != nil {
 		// In case of any empty geometries return false.
 		if geo.IsEmptyGeometryError(err) {
@@ -102,7 +104,7 @@ func DFullyWithin(
 		}
 		return false, err
 	}
-	if exclusive {
+	if exclusivity == geo.FnExclusive {
 		return dist < d, nil
 	}
 	return dist <= d, nil
@@ -114,7 +116,7 @@ func LongestLineString(a *geo.Geometry, b *geo.Geometry) (*geo.Geometry, error) 
 	if a.SRID() != b.SRID() {
 		return nil, geo.NewMismatchingSRIDsError(a, b)
 	}
-	u := newGeomMaxDistanceUpdater(math.MaxFloat64, geo.FnExclusive)
+	u := newGeomMaxDistanceUpdater(math.MaxFloat64, geo.FnInclusive)
 	return distanceLineStringInternal(a, b, u, geo.EmptyBehaviorOmit)
 }
 
@@ -124,7 +126,7 @@ func ShortestLineString(a *geo.Geometry, b *geo.Geometry) (*geo.Geometry, error)
 	if a.SRID() != b.SRID() {
 		return nil, geo.NewMismatchingSRIDsError(a, b)
 	}
-	u := newGeomMinDistanceUpdater(0 /*stopAfter */, false /* exclusive */)
+	u := newGeomMinDistanceUpdater(0 /*stopAfter */, geo.FnInclusive)
 	return distanceLineStringInternal(a, b, u, geo.EmptyBehaviorOmit)
 }
 
@@ -164,9 +166,9 @@ func maxDistanceInternal(
 	b *geo.Geometry,
 	stopAfter float64,
 	emptyBehavior geo.EmptyBehavior,
-	exclusive geo.FnExclusivity,
+	exclusivity geo.FnExclusivity,
 ) (float64, error) {
-	u := newGeomMaxDistanceUpdater(stopAfter, exclusive)
+	u := newGeomMaxDistanceUpdater(stopAfter, exclusivity)
 	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox())}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
@@ -178,9 +180,9 @@ func minDistanceInternal(
 	b *geo.Geometry,
 	stopAfter float64,
 	emptyBehavior geo.EmptyBehavior,
-	exclusive geo.FnExclusivity,
+	exclusivity geo.FnExclusivity,
 ) (float64, error) {
-	u := newGeomMinDistanceUpdater(stopAfter, exclusive)
+	u := newGeomMinDistanceUpdater(stopAfter, exclusivity)
 	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox())}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
@@ -396,13 +398,13 @@ func (c *geomGeodistEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.P
 
 // geomMinDistanceUpdater finds the minimum distance using geom calculations.
 // And preserve the line's endpoints as geom.Coord which corresponds to minimum
-// distance. If exclusive is false, methods will return early if it finds a
-// minimum distance <= stopAfter. Otherwise, methods will return early if it
-// finds a minimum distance < stopAfter.
+// distance. If inclusive, methods will return early if it finds a minimum
+// distance <= stopAfter. Otherwise, methods will return early if it finds a
+// minimum distance < stopAfter.
 type geomMinDistanceUpdater struct {
 	currentValue float64
 	stopAfter    float64
-	exclusive    geo.FnExclusivity
+	exclusivity  geo.FnExclusivity
 	// coordA represents the first vertex of the edge that holds the maximum distance.
 	coordA geom.Coord
 	// coordB represents the second vertex of the edge that holds the maximum distance.
@@ -416,12 +418,12 @@ var _ geodist.DistanceUpdater = (*geomMinDistanceUpdater)(nil)
 // newGeomMinDistanceUpdater returns a new geomMinDistanceUpdater with the
 // correct arguments set up.
 func newGeomMinDistanceUpdater(
-	stopAfter float64, exclusive geo.FnExclusivity,
+	stopAfter float64, exclusivity geo.FnExclusivity,
 ) *geomMinDistanceUpdater {
 	return &geomMinDistanceUpdater{
 		currentValue:        math.MaxFloat64,
 		stopAfter:           stopAfter,
-		exclusive:           exclusive,
+		exclusivity:         exclusivity,
 		coordA:              nil,
 		coordB:              nil,
 		geometricalObjOrder: geometricalObjectsNotFlipped,
@@ -448,7 +450,7 @@ func (u *geomMinDistanceUpdater) Update(aPoint geodist.Point, bPoint geodist.Poi
 			u.coordA = a
 			u.coordB = b
 		}
-		if u.exclusive {
+		if u.exclusivity == geo.FnExclusive {
 			return dist < u.stopAfter
 		}
 		return dist <= u.stopAfter
@@ -477,12 +479,12 @@ func (u *geomMinDistanceUpdater) FlipGeometries() {
 // geomMaxDistanceUpdater finds the maximum distance using geom calculations.
 // And preserve the line's endpoints as geom.Coord which corresponds to maximum
 // distance. If exclusive, methods will return early if it finds that
-// distance > stopAfter. Otherwise, methods will return early if distance >=
+// distance >= stopAfter. Otherwise, methods will return early if distance >
 // stopAfter.
 type geomMaxDistanceUpdater struct {
 	currentValue float64
 	stopAfter    float64
-	exclusive    geo.FnExclusivity
+	exclusivity  geo.FnExclusivity
 
 	// coordA represents the first vertex of the edge that holds the maximum distance.
 	coordA geom.Coord
@@ -499,12 +501,12 @@ var _ geodist.DistanceUpdater = (*geomMaxDistanceUpdater)(nil)
 // possible value instead of 0 because there may be the case where maximum
 // distance is 0 and we may require to find the line for 0 maximum distance.
 func newGeomMaxDistanceUpdater(
-	stopAfter float64, exclusive geo.FnExclusivity,
+	stopAfter float64, exclusivity geo.FnExclusivity,
 ) *geomMaxDistanceUpdater {
 	return &geomMaxDistanceUpdater{
 		currentValue:        -math.MaxFloat64,
 		stopAfter:           stopAfter,
-		exclusive:           exclusive,
+		exclusivity:         exclusivity,
 		coordA:              nil,
 		coordB:              nil,
 		geometricalObjOrder: geometricalObjectsNotFlipped,
@@ -531,7 +533,7 @@ func (u *geomMaxDistanceUpdater) Update(aPoint geodist.Point, bPoint geodist.Poi
 			u.coordA = a
 			u.coordB = b
 		}
-		if u.exclusive {
+		if u.exclusivity == geo.FnExclusive {
 			return dist >= u.stopAfter
 		}
 		return dist > u.stopAfter

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -555,13 +555,26 @@ func TestDFullyWithin(t *testing.T) {
 				tc.expectedMaxDistance * 2,
 			} {
 				t.Run(fmt.Sprintf("dfullywithin:%f", val), func(t *testing.T) {
-					dfullywithin, err := DFullyWithin(a, b, val)
+					dfullywithin, err := DFullyWithin(a, b, val, geo.FnInclusive)
 					require.NoError(t, err)
 					require.Equal(t, expected, dfullywithin)
 
-					dfullywithin, err = DFullyWithin(a, b, val)
+					dfullywithin, err = DFullyWithin(b, a, val, geo.FnInclusive)
 					require.NoError(t, err)
 					require.Equal(t, expected, dfullywithin)
+				})
+				t.Run(fmt.Sprintf("dfullywithinexclusive:%f", val), func(t *testing.T) {
+					exclusiveExpected := expected
+					if val == tc.expectedMaxDistance {
+						exclusiveExpected = false
+					}
+					dfullywithin, err := DFullyWithin(a, b, val, geo.FnExclusive)
+					require.NoError(t, err)
+					require.Equal(t, exclusiveExpected, dfullywithin)
+
+					dfullywithin, err = DFullyWithin(b, a, val, geo.FnExclusive)
+					require.NoError(t, err)
+					require.Equal(t, exclusiveExpected, dfullywithin)
 				})
 			}
 
@@ -572,11 +585,20 @@ func TestDFullyWithin(t *testing.T) {
 			} {
 				if val > 0 {
 					t.Run(fmt.Sprintf("dfullywithin:%f", val), func(t *testing.T) {
-						dfullywithin, err := DFullyWithin(a, b, val)
+						dfullywithin, err := DFullyWithin(a, b, val, geo.FnInclusive)
 						require.NoError(t, err)
 						require.False(t, dfullywithin)
 
-						dfullywithin, err = DFullyWithin(a, b, val)
+						dfullywithin, err = DFullyWithin(b, a, val, geo.FnInclusive)
+						require.NoError(t, err)
+						require.False(t, dfullywithin)
+					})
+					t.Run(fmt.Sprintf("dfullywithinexclusive:%f", val), func(t *testing.T) {
+						dfullywithin, err := DFullyWithin(a, b, val, geo.FnExclusive)
+						require.NoError(t, err)
+						require.False(t, dfullywithin)
+
+						dfullywithin, err = DFullyWithin(b, a, val, geo.FnExclusive)
 						require.NoError(t, err)
 						require.False(t, dfullywithin)
 					})

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -256,10 +256,7 @@
 # operators (e.g. '<' vs '<=').
 [FoldCmpSTDistanceLeft, Normalize]
 (Ge | Gt | Le | Lt
-    $left:(Function
-        $args:*
-        $private:(FunctionPrivate "st_distance")
-    )
+    (Function $args:* $private:(FunctionPrivate "st_distance"))
     $right:*
 )
 =>
@@ -269,10 +266,32 @@
 [FoldCmpSTDistanceRight, Normalize]
 (Ge | Gt | Le | Lt
     $left:*
-    $right:(Function
-        $args:*
-        $private:(FunctionPrivate "st_distance")
-    )
+    (Function $args:* $private:(FunctionPrivate "st_distance"))
 )
 =>
 (MakeSTDWithinRight (OpName) $args $left)
+
+# FoldCmpSTMaxDistanceLeft is a variant of FoldCmpSTDistanceLeft that matches
+# ST_MaxDistance instead of ST_Distance.
+[FoldCmpSTMaxDistanceLeft, Normalize]
+(Ge | Gt | Le | Lt
+    (Function
+        $args:*
+        $private:(FunctionPrivate "st_maxdistance")
+    )
+    $right:*
+)
+=>
+(MakeSTDFullyWithinLeft (OpName) $args $right)
+
+# FoldCmpSTMaxDistanceRight mirrors FoldCmpSTMaxDistanceLeft.
+[FoldCmpSTMaxDistanceRight, Normalize]
+(Ge | Gt | Le | Lt
+    $left:*
+    (Function
+        $args:*
+        $private:(FunctionPrivate "st_maxdistance")
+    )
+)
+=>
+(MakeSTDFullyWithinRight (OpName) $args $left)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -895,3 +895,107 @@ select
  │    └── columns: geom:1 geog:2 val:3
  └── filters
       └── st_dwithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# --------------------------------------------------
+# FoldCmpSTMaxDistanceLeft
+# --------------------------------------------------
+
+# Case with '<=' operator.
+norm expect=FoldCmpSTMaxDistanceLeft
+SELECT * FROM geom_geog WHERE st_maxdistance(geom, 'point(0.0 0.0)') <= 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dfullywithin(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# Case with '<' operator.
+norm expect=FoldCmpSTMaxDistanceLeft
+SELECT * FROM geom_geog WHERE st_maxdistance('point(0.0 0.0)', geom) < 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dfullywithinexclusive('010100000000000000000000000000000000000000', geom:1, 5.0) [outer=(1), immutable]
+
+# Case with '>=' operator.
+norm expect=FoldCmpSTMaxDistanceLeft
+SELECT * FROM geom_geog WHERE st_maxdistance(geom, 'point(0.0 0.0)') >= 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dfullywithinexclusive(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# Case with '>' operator.
+norm expect=FoldCmpSTMaxDistanceLeft
+SELECT * FROM geom_geog WHERE st_maxdistance(geom, 'point(0.0 0.0)') > 5
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dfullywithin(geom:1, '010100000000000000000000000000000000000000', 5.0) [outer=(1), immutable]
+
+# --------------------------------------------------
+# FoldCmpSTMaxDistanceRight
+# --------------------------------------------------
+
+# Case with '<=' operator.
+norm expect=FoldCmpSTMaxDistanceRight
+SELECT * FROM geom_geog WHERE val <= st_maxdistance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dfullywithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '<' operator.
+norm expect=FoldCmpSTMaxDistanceRight
+SELECT * FROM geom_geog WHERE val < st_maxdistance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── NOT st_dfullywithin(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '>=' operator.
+norm expect=FoldCmpSTMaxDistanceRight
+SELECT * FROM geom_geog WHERE val >= st_maxdistance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dfullywithin(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]
+
+# Case with '>' operator.
+norm expect=FoldCmpSTMaxDistanceRight
+SELECT * FROM geom_geog WHERE val > st_maxdistance(geom, 'point(0.0 0.0)')
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dfullywithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3360,6 +3360,56 @@ project
            ├── st_covers(n.geom:16, c.geom:10) [outer=(10,16), immutable]
            └── st_dwithin(c.geom:10, n.geom:16, 50.0) OR st_intersects(n.geom:16, '0102000000020000000000000000000000000000000000000000000000000000000000000000000040') [outer=(10,16), immutable]
 
+opt expect=GenerateInvertedJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_DFullyWithin(c.geom, n.geom, 50)
+----
+project
+ ├── columns: name:15 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:15 n.geom:16
+      ├── key columns: [13] = [13]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
+      │    ├── inverted-expr
+      │    │    └── st_dfullywithin(c.geom:10, n.geom:16, 50.0)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_dfullywithin(c.geom:10, n.geom:16, 50.0) [outer=(10,16), immutable]
+
+opt expect=GenerateInvertedJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_DFullyWithinExclusive(c.geom, n.geom, 50)
+----
+project
+ ├── columns: name:15 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:15 n.geom:16
+      ├── key columns: [13] = [13]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
+      │    ├── inverted-expr
+      │    │    └── st_dfullywithinexclusive(c.geom:10, n.geom:16, 50.0)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_dfullywithinexclusive(c.geom:10, n.geom:16, 50.0) [outer=(10,16), immutable]
+
 opt expect=GenerateInvertedJoinsFromSelect
 SELECT
   n.name, c.boroname

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1883,7 +1883,7 @@ project
            └── st_dwithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable]
 
 # Commuted version of previous test.
-opt expect=GenerateInvertedIndexScans
+opt
 SELECT k FROM g WHERE ST_DWithinExclusive(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, 2)
 ----
 project

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1883,7 +1883,7 @@ project
            └── st_dwithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable]
 
 # Commuted version of previous test.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithinExclusive(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, 2)
 ----
 project
@@ -1913,6 +1913,37 @@ project
       │              └── fd: (1)-->(6)
       └── filters
            └── st_dwithinexclusive(geom:3, '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', 2.0) [outer=(3), immutable]
+
+opt
+SELECT k FROM g WHERE ST_DFullyWithinExclusive('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null geom:3
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      ├── index-join g
+      │    ├── columns: k:1!null geom:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /6
+      │         │    ├── tight: false
+      │         │    └── union spans: ["\x89", "\xfd ")
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom_inverted_key:6!null
+      │              ├── inverted constraint: /6/1
+      │              │    └── spans: ["\x89", "\xfd ")
+      │              ├── key: (1)
+      │              └── fd: (1)-->(6)
+      └── filters
+           └── st_dfullywithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable]
 
 # Multiple geospatial functions.
 opt

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2540,14 +2540,14 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist))
+				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist), geo.FnInclusive)
 				if err != nil {
 					return nil, err
 				}
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. " +
+				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. " +
 					"In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.",
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
@@ -3977,6 +3977,32 @@ Bottom Left.`,
 		},
 	),
 	"st_dwithinexclusive": makeSTDWithinBuiltin(geo.FnExclusive),
+	"st_dfullywithinexclusive": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_a", types.Geometry},
+				{"geometry_b", types.Geometry},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := args[0].(*tree.DGeometry)
+				b := args[1].(*tree.DGeometry)
+				dist := args[2].(*tree.DFloat)
+				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist), geo.FnExclusive)
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units exclusive. " +
+					"In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 }
 
 // returnCompatibilityFixedStringBuiltin is an overload that takes in 0 arguments

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2547,7 +2547,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units inclusive. " +
+				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, inclusive. " +
 					"In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.",
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
@@ -3997,7 +3997,7 @@ Bottom Left.`,
 				return tree.MakeDBool(tree.DBool(ret)), nil
 			},
 			Info: infoBuilder{
-				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units exclusive. " +
+				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, exclusive. " +
 					"In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.",
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
@@ -4573,9 +4573,9 @@ func stAsGeoJSONFromTuple(
 	return tree.NewDString(string(marshalledIndent)), nil
 }
 
-func makeSTDWithinBuiltin(exclusive geo.FnExclusivity) builtinDefinition {
+func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 	exclusivityStr := ", inclusive."
-	if exclusive {
+	if exclusivity == geo.FnExclusive {
 		exclusivityStr = ", exclusive."
 	}
 	return makeBuiltin(
@@ -4591,7 +4591,7 @@ func makeSTDWithinBuiltin(exclusive geo.FnExclusivity) builtinDefinition {
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DWithin(a.Geometry, b.Geometry, float64(*dist), exclusive)
+				ret, err := geomfn.DWithin(a.Geometry, b.Geometry, float64(*dist), exclusivity)
 				if err != nil {
 					return nil, err
 				}
@@ -4614,7 +4614,7 @@ func makeSTDWithinBuiltin(exclusive geo.FnExclusivity) builtinDefinition {
 				a := args[0].(*tree.DGeography)
 				b := args[1].(*tree.DGeography)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), geogfn.UseSpheroid, exclusive)
+				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), geogfn.UseSpheroid, exclusivity)
 				if err != nil {
 					return nil, err
 				}
@@ -4642,7 +4642,7 @@ func makeSTDWithinBuiltin(exclusive geo.FnExclusivity) builtinDefinition {
 				dist := args[2].(*tree.DFloat)
 				useSpheroid := args[3].(*tree.DBool)
 
-				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), toUseSphereOrSpheroid(useSpheroid), exclusive)
+				ret, err := geogfn.DWithin(a.Geography, b.Geography, float64(*dist), toUseSphereOrSpheroid(useSpheroid), exclusivity)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
`ST_DFullyWithin` is equivalent to the expression `ST_MaxDistance <= x`.
Similar reformulations can be made for different comparison operators
(<, >, >=).

This PR consists of two commits. The first commit adds a builtin function 
`ST_DFullyWithinExclusive`, which is equivalent to `ST_MaxDistance < x`
but is able to exit early.

The second commit adds two rules that replace expressions of the form
`ST_MaxDistance <= x` with either `ST_DFullyWithin` or `ST_DFullyWithinExclusive`
depending on the comparison operator used. This replacement is desirable
because the `ST_DFullyWithin` function can exit early, while `ST_MaxDistance` cannot
do the same. `ST_DFullyWithin` can also be used to generate an inverted index scan.

Release note: None