### PR TITLE
sql/kv: avoid expensive heap allocations with inverted joins

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -562,7 +562,9 @@ func (sr *txnSpanRefresher) appendRefreshSpans(
 	}
 
 	ba.RefreshSpanIterate(br, func(span roachpb.Span) {
-		log.VEventf(ctx, 3, "recording span to refresh: %s", span)
+		if log.ExpensiveLogEnabled(ctx, 3) {
+			log.VEventf(ctx, 3, "recording span to refresh: %s", span.String())
+		}
 		sr.refreshFootprint.insert(span)
 	})
 	return nil

--- a/pkg/sql/opt/invertedexpr/expression.go
+++ b/pkg/sql/opt/invertedexpr/expression.go
@@ -383,12 +383,12 @@ func (s *SpanExpression) ToProto() *SpanExpressionProto {
 }
 
 func getProtoSpans(spans []InvertedSpan) []SpanExpressionProto_Span {
-	out := make([]SpanExpressionProto_Span, 0, len(spans))
+	out := make([]SpanExpressionProto_Span, len(spans))
 	for i := range spans {
-		out = append(out, SpanExpressionProto_Span{
+		out[i] = SpanExpressionProto_Span{
 			Start: spans[i].Start,
 			End:   spans[i].End,
-		})
+		}
 	}
 	return out
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -311,9 +311,9 @@ func (ij *invertedJoiner) generateSpan(enc []byte) (roachpb.Span, error) {
 	return span, err
 }
 
-func (ij *invertedJoiner) generateSpans(invertedSpans []invertedSpan) (roachpb.Spans, error) {
-	var spans []roachpb.Span
-	for _, span := range invertedSpans {
+func (ij *invertedJoiner) generateSpans(invertedSpans []invertedSpan) ([]roachpb.Span, error) {
+	spans := make([]roachpb.Span, len(invertedSpans))
+	for i, span := range invertedSpans {
 		startSpan, err := ij.generateSpan(span.Start)
 		if err != nil {
 			return nil, err
@@ -324,7 +324,7 @@ func (ij *invertedJoiner) generateSpans(invertedSpans []invertedSpan) (roachpb.S
 			return nil, err
 		}
 		startSpan.EndKey = endSpan.Key
-		spans = append(spans, startSpan)
+		spans[i] = startSpan
 	}
 	return spans, nil
 }


### PR DESCRIPTION
This PR contains three optimizations that reduce heap allocations by
inverted join operations. These were found by profiling the following
geospatial query:
```sql
SELECT Count(census.blkid), Count(subways.name)
FROM nyc_census_blocks AS census
JOIN nyc_subway_stations AS subways
ON ST_Intersects(subways.geom, census.geom);
```

Combined, these three commits speed up the query by a little over **3%**.

```
name                                old ms    new ms    delta
Test/postgis_geometry_tutorial/nyc  139 ±12%  135 ±11%  -3.04%  (p=0.000 n=241+243)
```

#### sql/rowexec: avoid heap allocations in batchedInvertedExprEvaluator

This commit restructures the slice manipulation performed in
`(*batchedInvertedExprEvaluator).init` to avoid heap allocations. Before
the change, this method used to contain the first and fifth most
expensive memory allocations by total allocation size (`alloc_space`)
in a geospatial query of interest:
```
----------------------------------------------------------+-------------
                                         3994.06MB   100% |   github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*invertedJoiner).readInput /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_joiner.go:418
 3994.06MB 10.70% 10.70%  3994.06MB 10.70%                | github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*batchedInvertedExprEvaluator).init /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_expr_evaluator.go:366
----------------------------------------------------------+-------------

----------------------------------------------------------+-------------
                                          954.07MB   100% |   github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*invertedJoiner).readInput /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_joiner.go:418
  954.07MB  4.61% 41.71%   954.07MB  4.61%                | github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*batchedInvertedExprEvaluator).init /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_expr_evaluator.go:409
----------------------------------------------------------+-------------
```

The largest offender here was the `routingSpans` slice, which made no
attempt to recycle memory. The other offender was the `pendingSpans`
slice. We made an attempt to recycle the memory in this slice, except
we truncated it from the front instead of the back, so we ended us
not actually recycling anything.

This commit addresses this in two ways. First, it updates the `pendingSpans`
slice to point into the `routingSpans` slice so the two can share memory.
`pendingSpans` becomes a mutable window into `routingSpans`, so it no
longer requires its own heap allocation. Next, the commit updates the
memory recycling to recycle `routingSpans` instead of `pendingSpans`.
Since we never truncate `routingSpans` from the front, the recycling
now works.

With these two changes, the two heap allocations, which used to account
for **15.31%** of total allocated space combined drops to a single heap
allocation that accounts for only **2.43%** of total allocated space on
the geospatial query.

```
----------------------------------------------------------+-------------
                                          182.62MB   100% |   github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*invertedJoiner).readInput /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_joiner.go:418
  182.62MB  2.43% 58.36%   182.62MB  2.43%                | github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*batchedInvertedExprEvaluator).init /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/inverted_expr_evaluator.go:366
----------------------------------------------------------+-------------
```

#### sql: properly copy span slices

This commit fixes two locations where we not optimally performing copies
from one slice to another.

In `invertedJoiner.generateSpans`, we were not pre-allocating the
destination slice and were using append instead of direct assignment,
which is measurably slower due to the extra writes to the slice header.

In `getProtoSpans`, we again were appending to a slice with zero length
and sufficient capacity instead of assigning to a slice with sufficient
length.

#### kv: check for expensive logging before VEventf in appendRefreshSpans

Before this change, we called VEventf directly with the refresh span
corresponding to each request in a batch. This caused each span object
to allocate while passing through an `interface{}`. This could be seen
in heap profiles, where it accounted for **1.89%** of total allocated
memory (`alloc_space`) in a geospatial query of interest:

```
----------------------------------------------------------+-------------
                                          142.01MB   100% |   github.com/cockroachdb/cockroach/pkg/roachpb.(*BatchRequest).RefreshSpanIterate /go/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch.go:407
  142.01MB  1.89% 68.71%   142.01MB  1.89%                | github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord.(*txnSpanRefresher).appendRefreshSpans.func1 /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go:510
----------------------------------------------------------+-------------
```

This commit adds a guard around the VEventf to avoid the allocation.