### PR TITLE
builtins: implement ST_CoordDim

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1099,6 +1099,8 @@ from the given Geometry.</p>
 <tr><td><a name="st_convexhull"></a><code>st_convexhull(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a geometry that represents the Convex Hull of the given geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
+<tr><td><a name="st_coorddim"></a><code>st_coorddim(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of coordinate dimensions of a given Geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_coveredby"></a><code>st_coveredby(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geography_a is outside geography_b.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -2662,30 +2662,31 @@ Square (right)                            POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
 Square overlapping left and right square  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 
 # basic metadata
-query TTTIIII
+query TTTIIIII
 SELECT
   a.dsc,
   GeometryType(a.geom),
   ST_GeometryType(a.geom),
   ST_NDims(a.geom),
+  ST_CoordDim(a.geom),
   ST_Dimension(a.geom),
   ST_NPoints(a.geom),
   ST_NumGeometries(a.geom)
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  GeometryCollection  ST_GeometryCollection  0     0     0     0
-Empty LineString                          LineString          ST_LineString          2     1     0     0
-Empty Point                               Point               ST_Point               2     0     0     0
-Faraway point                             Point               ST_Point               2     0     1     1
-Line going through left and right square  LineString          ST_LineString          2     1     2     1
-NULL                                      NULL                NULL                   NULL  NULL  NULL  NULL
-Nested Geometry Collection                GeometryCollection  ST_GeometryCollection  2     0     1     1
-Point middle of Left Square               Point               ST_Point               2     0     1     1
-Point middle of Right Square              Point               ST_Point               2     0     1     1
-Square (left)                             Polygon             ST_Polygon             2     2     5     1
-Square (right)                            Polygon             ST_Polygon             2     2     5     1
-Square overlapping left and right square  Polygon             ST_Polygon             2     2     5     1
+Empty GeometryCollection                  GeometryCollection  ST_GeometryCollection  0     0     0     0     0
+Empty LineString                          LineString          ST_LineString          2     2     1     0     0
+Empty Point                               Point               ST_Point               2     2     0     0     0
+Faraway point                             Point               ST_Point               2     2     0     1     1
+Line going through left and right square  LineString          ST_LineString          2     2     1     2     1
+NULL                                      NULL                NULL                   NULL  NULL  NULL  NULL  NULL
+Nested Geometry Collection                GeometryCollection  ST_GeometryCollection  2     2     0     1     1
+Point middle of Left Square               Point               ST_Point               2     2     0     1     1
+Point middle of Right Square              Point               ST_Point               2     2     0     1     1
+Square (left)                             Polygon             ST_Polygon             2     2     2     5     1
+Square (right)                            Polygon             ST_Polygon             2     2     2     5     1
+Square overlapping left and right square  Polygon             ST_Polygon             2     2     2     5     1
 
 query TTTT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4164,6 +4164,7 @@ func initGeoBuiltins() {
 	}{
 		{"geomfromewkt", "st_geomfromewkt"},
 		{"geomfromewkb", "st_geomfromewkb"},
+		{"st_coorddim", "st_ndims"},
 		{"st_geogfromtext", "st_geographyfromtext"},
 		{"st_geomfromtext", "st_geometryfromtext"},
 		{"st_numinteriorring", "st_numinteriorrings"},


### PR DESCRIPTION
Release note (sql change): Implement the geometry builtin `ST_CoordDim` as alias
for `ST_NDims`.

Closes #48910.