### PR TITLE
backupccl: add scheduled jobs to cluster backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -80,6 +80,7 @@ var fullClusterSystemTables = []string{
 	systemschema.UITable.Name,
 	systemschema.CommentsTable.Name,
 	systemschema.JobsTable.Name,
+	systemschema.ScheduledJobsTable.Name,
 	// Table statistics are backed up in the backup descriptor for now.
 }
 


### PR DESCRIPTION
This commit includes the scheduled jobs table in cluster backups.

Closes #52404.

Release note (enterprise change): Scheduled jobs are now included in
cluster backups.