### PR TITLE
colexec: fix recent problem with hash joiner

### DIFF
--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -369,12 +369,12 @@ func (hj *hashJoiner) emitUnmatched() {
 }
 
 // hjInitialToCheck is a slice that contains all consequent integers in
-// [0, coldata.BatchSize()) range that can be used to initialize toCheck buffer
+// [0, coldata.MaxBatchSize) range that can be used to initialize toCheck buffer
 // for most of the join types.
 var hjInitialToCheck []uint64
 
 func init() {
-	hjInitialToCheck = make([]uint64, coldata.BatchSize())
+	hjInitialToCheck = make([]uint64, coldata.MaxBatchSize)
 	for i := range hjInitialToCheck {
 		hjInitialToCheck[i] = uint64(i)
 	}


### PR DESCRIPTION
#53169 has just introduced an optimization in populating of `toCheck`
slice by having a default `hjInitialToCheck` slice pre-populated.
However, it could be of insufficient length due to randomization of
`coldata.BatchSize()` which is now fixed.

Release note: None