### PR TITLE
builtins: implement ST_IsEmpty and ST_IsCollection

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1306,6 +1306,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>
+<tr><td><a name="st_iscollection"></a><code>st_iscollection(geometry: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the geometry is of a collection type (including multi-types).</p>
+</span></td></tr>
+<tr><td><a name="st_isempty"></a><code>st_isempty(geometry: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the geometry is empty.</p>
+</span></td></tr>
 <tr><td><a name="st_isvalid"></a><code>st_isvalid(geometry: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the geometry is valid as defined by the OGC spec.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/unary_predicates.go
+++ b/pkg/geo/geomfn/unary_predicates.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+)
+
+// IsCollection returns whether the given geometry is of a collection type.
+func IsCollection(g *geo.Geometry) (bool, error) {
+	switch g.ShapeType() {
+	case geopb.ShapeType_MultiPoint, geopb.ShapeType_MultiLineString, geopb.ShapeType_MultiPolygon,
+		geopb.ShapeType_GeometryCollection:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// IsEmpty returns whether the given geometry is empty.
+func IsEmpty(g *geo.Geometry) (bool, error) {
+	return g.Empty(), nil
+}

--- a/pkg/geo/geomfn/unary_predicates_test.go
+++ b/pkg/geo/geomfn/unary_predicates_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCollection(t *testing.T) {
+	testCases := []struct {
+		wkt      string
+		expected bool
+	}{
+		{"POINT(1.0 1.0)", false},
+		{"POINT EMPTY", false},
+		{"LINESTRING(1.0 1.0, 2.0 2.0)", false},
+		{"LINESTRING EMPTY", false},
+		{"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0))", false},
+		{"POLYGON EMPTY", false},
+		{"MULTIPOINT((1.0 1.0), (2.0 2.0))", true},
+		{"MULTIPOINT EMPTY", true},
+		{"MULTILINESTRING((1.0 1.0, 2.0 2.0, 3.0 3.0), (6.0 6.0, 7.0 6.0))", true},
+		{"MULTILINESTRING EMPTY", true},
+		{"MULTIPOLYGON(((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 3.0)), ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1)))", true},
+		{"MULTIPOLYGON EMPTY", true},
+		{"GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40))", true},
+		{"GEOMETRYCOLLECTION EMPTY", true},
+		{"GEOMETRYCOLLECTION (GEOMETRYCOLLECTION(POINT (40 10),LINESTRING (10 10, 20 20, 10 40)))", true},
+		{"GEOMETRYCOLLECTION (GEOMETRYCOLLECTION EMPTY)", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeometry(tc.wkt)
+			require.NoError(t, err)
+			ret, err := IsCollection(g)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	testCases := []struct {
+		wkt      string
+		expected bool
+	}{
+		{"POINT(1.0 1.0)", false},
+		{"POINT EMPTY", true},
+		{"LINESTRING(1.0 1.0, 2.0 2.0)", false},
+		{"LINESTRING EMPTY", true},
+		{"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0))", false},
+		{"POLYGON EMPTY", true},
+		{"MULTIPOINT((1.0 1.0), (2.0 2.0))", false},
+		{"MULTIPOINT EMPTY", true},
+		{"MULTILINESTRING((1.0 1.0, 2.0 2.0, 3.0 3.0), (6.0 6.0, 7.0 6.0))", false},
+		{"MULTILINESTRING EMPTY", true},
+		{"MULTIPOLYGON(((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 3.0)), ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1)))", false},
+		{"MULTIPOLYGON EMPTY", true},
+		{"GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40))", false},
+		{"GEOMETRYCOLLECTION EMPTY", true},
+		{"GEOMETRYCOLLECTION (GEOMETRYCOLLECTION(POINT (40 10),LINESTRING (10 10, 20 20, 10 40)))", false},
+		{"GEOMETRYCOLLECTION (GEOMETRYCOLLECTION EMPTY)", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeometry(tc.wkt)
+			require.NoError(t, err)
+			ret, err := IsEmpty(g)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -963,8 +963,29 @@ Square (left)                             1     1     0     0     4     4
 Square (right)                            1     1     0     0     4     4
 Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2
 
-# Topology operators.
+# Unary predicates
+query TBB
+SELECT
+  dsc,
+  ST_IsEmpty(geom),
+  ST_IsCollection(geom)
+FROM geom_operators_test
+ORDER BY dsc
+----
+Empty GeometryCollection                  true   true
+Empty LineString                          true   false
+Empty Point                               true   false
+Faraway point                             false  false
+Line going through left and right square  false  false
+NULL                                      NULL   NULL
+Nested Geometry Collection                false  true
+Point middle of Left Square               false  false
+Point middle of Right Square              false  false
+Square (left)                             false  false
+Square (right)                            false  false
+Square overlapping left and right square  false  false
 
+# Topology operators
 query TTT
 SELECT
   a.dsc,

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2180,6 +2180,28 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	),
 
 	//
+	// Unary predicates
+	//
+	"st_iscollection": makeBuiltin(
+		defProps(),
+		geometryOverload1UnaryPredicate(
+			geomfn.IsCollection,
+			infoBuilder{
+				info: "Returns whether the geometry is of a collection type (including multi-types).",
+			},
+		),
+	),
+	"st_isempty": makeBuiltin(
+		defProps(),
+		geometryOverload1UnaryPredicate(
+			geomfn.IsEmpty,
+			infoBuilder{
+				info: "Returns whether the geometry is empty.",
+			},
+		),
+	),
+
+	//
 	// Binary functions
 	//
 	"st_azimuth": makeBuiltin(
@@ -3998,6 +4020,25 @@ func geometryOverload1(
 	}
 }
 
+// geometryOverload1UnaryPredicate hides the boilerplate for builtins
+// operating on one geometry wrapping a unary predicate.
+func geometryOverload1UnaryPredicate(
+	f func(*geo.Geometry) (bool, error), ib infoBuilder,
+) tree.Overload {
+	return geometryOverload1(
+		func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+			ret, err := f(g.Geometry)
+			if err != nil {
+				return nil, err
+			}
+			return tree.MakeDBool(tree.DBool(ret)), nil
+		},
+		types.Bool,
+		ib,
+		tree.VolatilityImmutable,
+	)
+}
+
 // geometryOverload2 hides the boilerplate for builtins operating on two geometries.
 func geometryOverload2(
 	f func(*tree.EvalContext, *tree.DGeometry, *tree.DGeometry) (tree.Datum, error),
@@ -4021,8 +4062,8 @@ func geometryOverload2(
 	}
 }
 
-// geometryOverload2 hides the boilerplate for builtins operating on two geometries
-// and the overlap wraps a binary predicate.
+// geometryOverload2BinaryPredicate hides the boilerplate for builtins
+// operating on two geometries and the overlap wraps a binary predicate.
 func geometryOverload2BinaryPredicate(
 	f func(*geo.Geometry, *geo.Geometry) (bool, error), ib infoBuilder,
 ) tree.Overload {


### PR DESCRIPTION
`ST_IsCollection` does not handle `geopb.ShapeType_Geometry` in any special way, and will always return `false` - is this sufficient?

Release note (sql change): Implement the geometry builtins `ST_IsEmpty`
and `ST_IsCollection`.

Closes #48954.
Closes #48955.