### PR TITLE
security: Add support for OCSP

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -29,6 +29,8 @@
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>
 <tr><td><code>kv.transaction.max_intents_bytes</code></td><td>integer</td><td><code>262144</code></td><td>maximum number of bytes used to track locks in transactions</td></tr>
 <tr><td><code>kv.transaction.max_refresh_spans_bytes</code></td><td>integer</td><td><code>256000</code></td><td>maximum number of bytes used to track refresh spans in serializable transactions</td></tr>
+<tr><td><code>security.ocsp.mode</code></td><td>enumeration</td><td><code>off</code></td><td>use OCSP to check whether TLS certificates are revoked. If the OCSP<br/>server is unreachable, in strict mode all certificates will be rejected<br/>and in lax mode all certificates will be accepted. [off = 0, lax = 1, strict = 2]</td></tr>
+<tr><td><code>security.ocsp.timeout</code></td><td>duration</td><td><code>3s</code></td><td>timeout before considering the OCSP server unreachable</td></tr>
 <tr><td><code>server.auth_log.sql_connections.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)</td></tr>
 <tr><td><code>server.auth_log.sql_sessions.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)</td></tr>
 <tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic</td></tr>

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -213,7 +213,7 @@ List certificates and keys found in the certificate directory.
 
 // runListCerts loads and lists all certs.
 func runListCerts(cmd *cobra.Command, args []string) error {
-	cm, err := security.NewCertificateManager(baseCfg.SSLCertsDir)
+	cm, err := security.NewCertificateManager(baseCfg.SSLCertsDir, security.CommandTLSSettings{})
 	if err != nil {
 		return errors.Wrap(err, "cannot load certificates")
 	}

--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -352,7 +352,7 @@ func (cliCtx *cliContext) makeClientConnURL() (url.URL, error) {
 		if userName == "" {
 			userName = security.RootUser
 		}
-		sCtx := rpc.MakeSecurityContext(cliCtx.Config, roachpb.SystemTenantID)
+		sCtx := rpc.MakeSecurityContext(cliCtx.Config, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 		if err := sCtx.LoadSecurityOptions(
 			opts, userName,
 		); err != nil {

--- a/pkg/cli/interactive_tests/ocsp_ca.cnf
+++ b/pkg/cli/interactive_tests/ocsp_ca.cnf
@@ -1,0 +1,43 @@
+# OpenSSL CA configuration file
+# Copied from https://www.cockroachlabs.com/docs/stable/create-security-certificates-openssl.html#step-1-create-the-ca-key-and-certificate-pair
+# Added authorityInfoAccess line.
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+default_days = 365
+database = index.txt
+serial = serial.txt
+default_md = sha256
+copy_extensions = copy
+unique_subject = no
+
+# Used to create the CA certificate.
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+x509_extensions = extensions
+
+[ distinguished_name ]
+organizationName = Cockroach
+commonName = Cockroach CA
+
+[ extensions ]
+keyUsage = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+# Common policy for nodes and users.
+[ signing_policy ]
+organizationName = supplied
+commonName = optional
+
+# Used to sign node certificates.
+[ signing_node_req ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth,clientAuth
+
+# Used to sign client certificates.
+[ signing_client_req ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth
+authorityInfoAccess = OCSP;URI:http://127.0.0.1:1234

--- a/pkg/cli/interactive_tests/test_secure_ocsp.tcl
+++ b/pkg/cli/interactive_tests/test_secure_ocsp.tcl
@@ -1,0 +1,134 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set certs_dir "/certs"
+set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
+
+proc start_secure_server {argv certs_dir extra} {
+    report "BEGIN START SECURE SERVER"
+    system "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
+            $argv sql --certs-dir=$certs_dir -e 'select 1'"
+    report "END START SECURE SERVER"
+}
+
+proc stop_secure_server {argv certs_dir} {
+    report "BEGIN STOP SECURE SERVER"
+    system "$argv quit --certs-dir=$certs_dir"
+    report "END STOP SECURE SERVER"
+}
+
+proc expect_exit_status {expected} {
+    set status [lindex [wait] 3]
+    if {$status != $expected} {
+        report "unexpected exit status $status"
+        exit 1
+    }
+}
+
+# Create an openssl CA for client certs.
+file copy [file join [file dirname $argv0] "ocsp_ca.cnf"] "ca.cnf"
+
+report "GENERATING CA KEY"
+system "openssl genrsa -out ca.key"
+report "GENERATING CA CERT"
+system "openssl req -new -x509 -config ca.cnf -key ca.key -out ca.crt -days 365 -batch"
+system "touch index.txt; echo '01' > serial.txt"
+# $certs_dir already contains a root cert signed by the node CA. Add
+# our client CA to it instead of replacing ca.crt. This is also
+# important because this root cert doesn't have the OCSP fields set,
+# so we can still use it while we're testing OCSP errors.
+system "cat ca.crt $certs_dir/ca.crt > $certs_dir/ca-client.crt"
+
+proc create_user_cert {argv certs_dir name} {
+    report "GENERATING CERT FOR USER $name"
+    system "openssl genrsa -out $certs_dir/client.$name.key"
+    system "openssl req -new -key $certs_dir/client.$name.key -out client.$name.csr -batch -subj /O=Cockroach/CN=$name"
+    system "openssl ca -config ca.cnf -keyfile ca.key -cert ca.crt -policy signing_policy -extensions signing_client_req -out $certs_dir/client.$name.crt -outdir . -in client.$name.csr -batch"
+    # Uncomment the next line to see more details about the generated cert
+    #system "openssl x509 -in $certs_dir/client.$name.crt -text"
+    system "$argv sql --certs-dir=$certs_dir -e 'create user $name'"
+    system "$argv sql --certs-dir=$certs_dir --user=$name -e 'select 1'"
+}
+
+start_secure_server $argv $certs_dir ""
+
+# Create users and make sure they can each log in.
+create_user_cert $argv $certs_dir goofus
+create_user_cert $argv $certs_dir gallant
+
+report "REVOKING CERTIFICATE"
+system "openssl ca -config ca.cnf -keyfile ca.key -cert ca.crt -revoke $certs_dir/client.goofus.crt"
+# Cert still works without OCSP activation
+system "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'"
+
+# Enable OCSP without a running OCSP server
+system "$argv sql --certs-dir=$certs_dir -e \"set cluster setting security.ocsp.mode='lax'\""
+# Still works in lax mode,
+system "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'"
+system "$argv sql --certs-dir=$certs_dir --user=gallant -e 'select 1'"
+system "$argv sql --certs-dir=$certs_dir -e \"set cluster setting security.ocsp.mode='strict'\""
+# but fails in strict mode.
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=goofus" "-e" "select 1"
+# Unfortunately this error message comes from the go stdlib and we can't provide more information
+eexpect "bad certificate"
+expect_exit_status 1
+# In strict mode even a valid cert is rejected while the server is down.
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=gallant" "-e" "select 1"
+eexpect "bad certificate"
+expect_exit_status 1
+
+# Now start the OCSP server. Good cert works, revoked cert doesn't.
+report "STARTING OCSP SERVER"
+set ocsp_pid [spawn "openssl" "ocsp" "-port" "1234" "-CA" "ca.crt" "-index" "index.txt" "-rsigner" "ca.crt" "-rkey" "ca.key"]
+eexpect "waiting for OCSP client connections"
+start_test "GOOD CERT IN STRICT MODE"
+system "$argv sql --certs-dir=$certs_dir --user=gallant -e 'select 1'"
+end_test
+start_test "BAD CERT IN STRICT MODE"
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=goofus" "-e" "select 1"
+eexpect "bad certificate"
+expect_exit_status 1
+end_test
+
+
+# That was in strict mode. Try again in lax mode.
+system "$argv sql --certs-dir=$certs_dir -e \"set cluster setting security.ocsp.mode='lax'\""
+start_test "GOOD CERT IN LAX MODE"
+system "$argv sql --certs-dir=$certs_dir --user=gallant -e 'select 1'"
+end_test
+start_test "BAD CERT IN LAX MODE"
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=goofus" "-e" "select 1"
+eexpect "bad certificate"
+expect_exit_status 1
+end_test
+
+# Suspend the OCSP process to test timeouts (still in lax mode, so both pass)
+system "kill -STOP $ocsp_pid"
+start_test "GOOD CERT IN LAX MODE WITH STOPPED SERVER"
+system "$argv sql --certs-dir=$certs_dir --user=gallant -e 'select 1'"
+end_test
+start_test "BAD CERT IN LAX MODE WITH STOPPED SERVER"
+system "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'"
+end_test
+
+# One more time, strict mode with stopped server (so both fail)
+system "$argv sql --certs-dir=$certs_dir -e \"set cluster setting security.ocsp.mode='strict'\""
+start_test "GOOD CERT IN STRICT MODE WITH STOPPED SERVER"
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=gallant" "-e" "select 1"
+eexpect "bad certificate"
+expect_exit_status 1
+end_test
+start_test "BAD CERT IN STRICT MODE WITH STOPPED SERVER"
+spawn $argv "sql" "--certs-dir=$certs_dir" "--user=goofus" "-e" "select 1"
+eexpect "bad certificate"
+expect_exit_status 1
+end_test
+
+report "CLEANING UP OCSP SERVER"
+system "kill -CONT $ocsp_pid"
+system "kill $ocsp_pid"
+wait
+
+stop_secure_server $argv $certs_dir

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -440,7 +440,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 			// (Re-)compute the client connection URL. We cannot do this
 			// earlier (e.g. above, in the runStart function) because
 			// at this time the address and port have not been resolved yet.
-			sCtx := rpc.MakeSecurityContext(serverCfg.Config, roachpb.SystemTenantID)
+			sCtx := rpc.MakeSecurityContext(serverCfg.Config, security.ClusterTLSSettings(serverCfg.Settings), roachpb.SystemTenantID)
 			pgURL, err := sCtx.PGURL(url.User(security.RootUser))
 			if err != nil {
 				log.Errorf(ctx, "failed computing the URL: %v", err)
@@ -613,7 +613,7 @@ If problems persist, please see %s.`
 			// (Re-)compute the client connection URL. We cannot do this
 			// earlier (e.g. above, in the runStart function) because
 			// at this time the address and port have not been resolved yet.
-			sCtx := rpc.MakeSecurityContext(serverCfg.Config, roachpb.SystemTenantID)
+			sCtx := rpc.MakeSecurityContext(serverCfg.Config, security.ClusterTLSSettings(serverCfg.Settings), roachpb.SystemTenantID)
 			pgURL, err := sCtx.PGURL(url.User(security.RootUser))
 			if err != nil {
 				log.Errorf(ctx, "failed computing the URL: %v", err)

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -26,6 +26,7 @@ import (
 	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -418,7 +419,7 @@ func NewContext(opts ContextOptions) *Context {
 
 	ctx := &Context{
 		ContextOptions:  opts,
-		SecurityContext: MakeSecurityContext(opts.Config, opts.TenantID),
+		SecurityContext: MakeSecurityContext(opts.Config, security.ClusterTLSSettings(opts.Settings), opts.TenantID),
 		breakerClock: breakerClock{
 			clock: opts.Clock,
 		},

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestManagerWithEmbedded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cm, err := security.NewCertificateManager("test_certs")
+	cm, err := security.NewCertificateManager("test_certs", security.CommandTLSSettings{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,11 +104,11 @@ func TestManagerWithPrincipalMap(t *testing.T) {
 		require.NoError(t, security.SetCertPrincipalMap(strings.Split(s, ",")))
 	}
 	newCertificateManager := func() error {
-		_, err := security.NewCertificateManager(certsDir)
+		_, err := security.NewCertificateManager(certsDir, security.CommandTLSSettings{})
 		return err
 	}
 	loadUserCert := func(user string) error {
-		cm, err := security.NewCertificateManager(certsDir)
+		cm, err := security.NewCertificateManager(certsDir, security.CommandTLSSettings{})
 		if err != nil {
 			return err
 		}

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -159,7 +159,7 @@ func createCACertAndKey(
 	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func CreateNodePair(
 	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func CreateUIPair(
 	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func CreateClientPair(
 	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return err
 	}
@@ -472,7 +472,7 @@ func CreateTenantClientPair(
 	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +510,7 @@ func CreateTenantClientPair(
 
 // WriteTenantClientPair writes a TenantClientPair into certsDir.
 func WriteTenantClientPair(certsDir string, cp *TenantClientPair, overwrite bool) error {
-	cm, err := NewCertificateManagerFirstRun(certsDir)
+	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
 		return err
 	}

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -100,7 +100,7 @@ func TestRotateCerts(t *testing.T) {
 	// Test client with the same certs.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	firstSCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	firstSCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	firstClient, err := firstSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
@@ -132,7 +132,7 @@ func TestRotateCerts(t *testing.T) {
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
 
-	secondSCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	secondSCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	secondClient, err := secondSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
@@ -201,7 +201,7 @@ func TestRotateCerts(t *testing.T) {
 	// This is HTTP and succeeds because we do not ask for or verify client certificates.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	thirdSCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	thirdSCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	thirdClient, err := thirdSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)

--- a/pkg/security/certs_tenant_test.go
+++ b/pkg/security/certs_tenant_test.go
@@ -100,14 +100,14 @@ func testTenantCertificatesInner(t *testing.T, embedded bool) {
 	// the server CA and server node certs, and it will validate incoming
 	// connections based on the tenant CA.
 
-	cm, err := security.NewCertificateManager(certsDir)
+	cm, err := security.NewCertificateManager(certsDir, security.CommandTLSSettings{})
 	require.NoError(t, err)
 	serverTLSConfig, err := cm.GetServerTLSConfig()
 	require.NoError(t, err)
 
 	// Make a new CertificateManager for the tenant. We could've used this one
 	// for the server as well, but this way it's closer to reality.
-	cm, err = security.NewCertificateManager(certsDir, security.ForTenant(tenant))
+	cm, err = security.NewCertificateManager(certsDir, security.CommandTLSSettings{}, security.ForTenant(tenant))
 	require.NoError(t, err)
 
 	// The client in turn trusts the server CA and presents its tenant certs to the

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -56,7 +56,7 @@ func TestGenerateCACert(t *testing.T) {
 	certsDir, cleanup := tempDir(t)
 	defer cleanup()
 
-	cm, err := security.NewCertificateManager(certsDir)
+	cm, err := security.NewCertificateManager(certsDir, security.CommandTLSSettings{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestUseCerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	sCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	sCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -372,7 +372,7 @@ func TestUseCerts(t *testing.T) {
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
 	{
-		secondSCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+		secondSCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 		httpClient, err = secondSCtx.GetHTTPClient()
 	}
 	if err != nil {
@@ -442,7 +442,7 @@ func TestUseSplitCACerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	sCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	sCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -462,7 +462,7 @@ func TestUseSplitCACerts(t *testing.T) {
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
 	{
-		secondSCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+		secondSCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 		httpClient, err = secondSCtx.GetHTTPClient()
 	}
 	if err != nil {
@@ -566,7 +566,7 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	sCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+	sCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -586,7 +586,7 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
 	{
-		secondCtx := rpc.MakeSecurityContext(clientContext, roachpb.SystemTenantID)
+		secondCtx := rpc.MakeSecurityContext(clientContext, security.CommandTLSSettings{}, roachpb.SystemTenantID)
 		httpClient, err = secondCtx.GetHTTPClient()
 	}
 	if err != nil {

--- a/pkg/security/ocsp.go
+++ b/pkg/security/ocsp.go
@@ -1,0 +1,154 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/crypto/ocsp"
+	"golang.org/x/sync/errgroup"
+)
+
+// makeOCSPVerifier returns a function intended for use with
+// tls.Config.VerifyPeerCertificate. If enabled, any certificate
+// containing an OCSP url will be verified.
+//
+// TODO(bdarnell): Use VerifyConnection instead of VerifyPeerCertificate (in Go 1.15)
+// This is necessary to support OCSP stapling.
+func makeOCSPVerifier(settings TLSSettings) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if !settings.ocspEnabled() {
+			return nil
+		}
+
+		return contextutil.RunWithTimeout(context.Background(), "OCSP verification", settings.ocspTimeout(),
+			func(ctx context.Context) error {
+				errG, gCtx := errgroup.WithContext(ctx)
+				for _, chain := range verifiedChains {
+					// Ignore the last cert in the chain; it's the root and if it
+					// has an issuer we don't have it so we can't do an OCSP check
+					// on it.
+					for i := 0; i < len(chain)-1; i++ {
+						cert := chain[i]
+						if len(cert.OCSPServer) > 0 {
+							issuer := chain[i+1]
+							errG.Go(func() error {
+								return verifyOCSP(gCtx, settings, cert, issuer)
+							})
+						}
+					}
+				}
+
+				return errG.Wait()
+			})
+	}
+}
+
+func verifyOCSP(ctx context.Context, settings TLSSettings, cert, issuer *x509.Certificate) error {
+	if len(cert.OCSPServer) == 0 {
+		return nil
+	}
+	var errs []error
+	for _, url := range cert.OCSPServer {
+		ok, err := queryOCSP(ctx, url, cert, issuer)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !ok {
+			return errors.Newf("OCSP server says cert is revoked: %v", cert)
+		}
+		return nil
+	}
+
+	if settings.ocspStrict() {
+		switch len(errs) {
+		case 0:
+			panic("can't happen: OCSP failed but errs is empty")
+		case 1:
+			return errors.Wrap(errs[0], "OCSP check failed in strict mode")
+		default:
+			// TODO(bdarnell): If there were more than two servers, this
+			// drops subsequent messages on the floor.
+			return errors.Wrap(errors.CombineErrors(errs[0], errs[1]), "OCSP check failed in strict mode")
+		}
+	}
+	// Non-strict mode: log errors and continue.
+	log.Warningf(ctx, "OCSP check failed in non-strict mode: %v", errs)
+	return nil
+}
+
+// queryOCSP sends an OCSP request for the given cert to a server. If
+// the server returns a valid OCSP response with status "good",
+// returns (true, nil). If it returns a valid response with status
+// "revoked", returns (false, nil). All other outcomes return a
+// non-nil error.
+func queryOCSP(ctx context.Context, url string, cert, issuer *x509.Certificate) (bool, error) {
+	ocspReq, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{
+		// OCSP defaults to SHA1, so this option might be incompatible
+		// with older OCSP servers. But it seems unlikely that anyone who
+		// cares enough about security to opt into OCSP would still be
+		// using one.
+		Hash: crypto.SHA256,
+	})
+	if err != nil {
+		return false, err
+	}
+	// TODO(bdarnell): If len(ocspReq) < 255, the RFC says it MAY be
+	// sent as a GET instead of a POST, which permits caching in the
+	// HTTP layer.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(ocspReq))
+	if err != nil {
+		return false, err
+	}
+	httpReq.Header.Add("Content-Type", "application/ocsp-request")
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return false, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		return false, errors.Newf("OCSP server returned status code %v", errors.Safe(httpResp.StatusCode))
+	}
+	if ct := httpResp.Header.Get("Content-Type"); ct != "application/ocsp-response" {
+		return false, errors.Newf("OCSP server returned unexpected content-type %q", errors.Safe(ct))
+	}
+
+	httpBody, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		return false, err
+	}
+
+	ocspResp, err := ocsp.ParseResponseForCert(httpBody, cert, issuer)
+	if err != nil {
+		return false, err
+	}
+	if ocspResp == nil {
+		return false, errors.Newf("OCSP response for cert %v not found", cert)
+	}
+	switch ocspResp.Status {
+	case ocsp.Good:
+		return true, nil
+	case ocsp.Revoked:
+		return false, nil
+	default:
+		return false, errors.Newf("OCSP returned status %v", errors.Safe(ocspResp.Status))
+	}
+}

--- a/pkg/security/tls_settings.go
+++ b/pkg/security/tls_settings.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+)
+
+const (
+	ocspOff    = 0
+	ocspLax    = 1
+	ocspStrict = 2
+)
+
+// TLSSettings allows for customization of TLS behavior. It's called
+// "settings" instead of "config" to avoid ambiguity with the standard
+// library's tls.Config. It is backed by cluster settings in a running
+// node, but may be configured differently in CLI tools.
+type TLSSettings interface {
+	ocspEnabled() bool
+	ocspStrict() bool
+	ocspTimeout() time.Duration
+}
+
+var ocspMode = settings.RegisterPublicEnumSetting("security.ocsp.mode",
+	`use OCSP to check whether TLS certificates are revoked. If the OCSP
+server is unreachable, in strict mode all certificates will be rejected
+and in lax mode all certificates will be accepted.`,
+	"off", map[int64]string{ocspOff: "off", ocspLax: "lax", ocspStrict: "strict"})
+
+// TODO(bdarnell): 3 seconds is the same as base.NetworkTimeout, but
+// we can't use it here due to import cycles. We need a real
+// no-dependencies base package for constants like this.
+var ocspTimeout = settings.RegisterPublicNonNegativeDurationSetting("security.ocsp.timeout",
+	"timeout before considering the OCSP server unreachable", 3*time.Second)
+
+type clusterTLSSettings struct {
+	settings *cluster.Settings
+}
+
+var _ TLSSettings = clusterTLSSettings{}
+
+func (c clusterTLSSettings) ocspEnabled() bool {
+	return ocspMode.Get(&c.settings.SV) != ocspOff
+}
+
+func (c clusterTLSSettings) ocspStrict() bool {
+	return ocspMode.Get(&c.settings.SV) == ocspStrict
+}
+
+func (c clusterTLSSettings) ocspTimeout() time.Duration {
+	return ocspTimeout.Get(&c.settings.SV)
+}
+
+// ClusterTLSSettings creates a TLSSettings backed by the
+// given cluster settings.
+func ClusterTLSSettings(settings *cluster.Settings) TLSSettings {
+	return clusterTLSSettings{settings}
+}
+
+// CommandTLSSettings defines the TLS settings for command-line tools.
+// OCSP is not currently supported in this mode.
+type CommandTLSSettings struct{}
+
+var _ TLSSettings = CommandTLSSettings{}
+
+func (CommandTLSSettings) ocspEnabled() bool {
+	return false
+}
+
+func (CommandTLSSettings) ocspStrict() bool {
+	return false
+}
+
+func (CommandTLSSettings) ocspTimeout() time.Duration {
+	return 0
+}

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestLoadTLSConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cm, err := security.NewCertificateManager(security.EmbeddedCertsDir)
+	cm, err := security.NewCertificateManager(security.EmbeddedCertsDir, security.CommandTLSSettings{})
 	require.NoError(t, err)
 	config, err := cm.GetServerTLSConfig()
 	require.NoError(t, err)

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -959,7 +959,8 @@ func TestLintClusterSettingNames(t *testing.T) {
 			if strings.ToLower(desc[0:1]) != desc[0:1] {
 				t.Errorf("%s: description %q must not start with capital", varName, desc)
 			}
-			if strings.Contains(desc, ". ") != (desc[len(desc)-1] == '.') {
+			if sType != "e" && strings.Contains(desc, ". ") != (desc[len(desc)-1] == '.') {
+				// TODO(knz): this check doesn't work with the way enum values are added to their descriptions.
 				t.Errorf("%s: description %q must end with period if and only if it contains a secondary sentence", varName, desc)
 			}
 		}


### PR DESCRIPTION
This adds support for certificate revocation for organizations who run
an OCSP server for their CA.

Closes #29641

Release note (security update): Certificate revocation is now
supported via OSCP and the setting `security.ocsp.mode`.

Still a WIP: includes the plumbing and the implementation, but I'm still working on tests. 