### PR TITLE
partialidx: fix panic with two var comparison within conjunctions

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -585,7 +585,7 @@ func (im *Implicator) twoVarComparisonImpliesTwoVarComparison(
 		// pred's operator, then e is an exact match to pred and it should be
 		// removed from the remaining filters. For example, (a > b) and
 		// (b < a) both individually imply (a > b) with no remaining filters.
-		if e.Op() == pred.Op() || commutedOp(e.Op()) == pred.Op() {
+		if exactMatches != nil && (e.Op() == pred.Op() || commutedOp(e.Op()) == pred.Op()) {
 			exactMatches[e] = struct{}{}
 		}
 		return true, true

--- a/pkg/sql/opt/partialidx/testdata/implicator/or-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/or-expr
@@ -239,6 +239,14 @@ predtest vars=(bool, bool, bool)
 ----
 false
 
+predtest vars=(int, int, int, int)
+@1 > @2 OR @3 > @4
+=>
+@2 < @1 OR @4 < @3
+----
+true
+└── remaining filters: (@1 > @2) OR (@3 > @4)
+
 # Combination conjunction and disjunction filters
 
 predtest vars=(int)


### PR DESCRIPTION
This commit fixes a panic that is produced when trying to prove
implication with a disjunction of two-variable comparisons. The panic
only occurs when the comparisons are equivalent, but not exactly the
same. For example:

    a > b OR c > d
    =>
    b < a OR c < d

Release note: None