### PR TITLE
backupccl: include all schemas when backing up databases

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -567,6 +567,7 @@ func backupPlanHook(
 
 		var tables []catalog.TableDescriptor
 		statsFiles := make(map[descpb.ID]string)
+		// TODO(pbardea): Let's check the privs for UDTs and UDSs here.
 		for _, desc := range targetDescs {
 			switch desc := desc.(type) {
 			case catalog.DatabaseDescriptor:

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -842,7 +842,7 @@ func loadSQLDescsFromBackupsAtTime(
 		desc := catalogkv.UnwrapDescriptorRaw(context.TODO(), raw)
 		var isObject bool
 		switch desc.(type) {
-		case catalog.TableDescriptor, catalog.TypeDescriptor:
+		case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor:
 			isObject = true
 		}
 		if isObject && byID[desc.GetParentID()] == nil {

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -66,6 +66,8 @@ type descriptorResolver struct {
 	descByID map[descpb.ID]catalog.Descriptor
 	// Map: db name -> dbID
 	dbsByName map[string]descpb.ID
+	// Map: dbID -> schema name -> schemaID
+	schemasByName map[descpb.ID]map[string]descpb.ID
 	// Map: dbID -> schema name -> obj name -> obj ID
 	objsByName map[descpb.ID]map[string]map[string]descpb.ID
 }
@@ -114,9 +116,10 @@ func (r *descriptorResolver) LookupObject(
 // known set of descriptors.
 func newDescriptorResolver(descs []catalog.Descriptor) (*descriptorResolver, error) {
 	r := &descriptorResolver{
-		descByID:   make(map[descpb.ID]catalog.Descriptor),
-		dbsByName:  make(map[string]descpb.ID),
-		objsByName: make(map[descpb.ID]map[string]map[string]descpb.ID),
+		descByID:      make(map[descpb.ID]catalog.Descriptor),
+		schemasByName: make(map[descpb.ID]map[string]descpb.ID),
+		dbsByName:     make(map[string]descpb.ID),
+		objsByName:    make(map[descpb.ID]map[string]map[string]descpb.ID),
 	}
 
 	// Iterate to find the databases first. We need that because we also
@@ -130,8 +133,10 @@ func newDescriptorResolver(descs []catalog.Descriptor) (*descriptorResolver, err
 			}
 			r.dbsByName[desc.GetName()] = desc.GetID()
 			r.objsByName[desc.GetID()] = make(map[string]map[string]descpb.ID)
+			r.schemasByName[desc.GetID()] = make(map[string]descpb.ID)
 			// Always add an entry for the public schema.
 			r.objsByName[desc.GetID()][tree.PublicSchema] = make(map[string]descpb.ID)
+			r.schemasByName[desc.GetID()][tree.PublicSchema] = keys.PublicSchemaID
 		}
 
 		// Incidentally, also remember all the descriptors by ID.
@@ -151,6 +156,13 @@ func newDescriptorResolver(descs []catalog.Descriptor) (*descriptorResolver, err
 			}
 			schemaMap[sc.GetName()] = make(map[string]descpb.ID)
 			r.objsByName[sc.GetParentID()] = schemaMap
+
+			schemaNameMap := r.schemasByName[sc.GetParentID()]
+			if schemaNameMap == nil {
+				schemaNameMap = make(map[string]descpb.ID)
+			}
+			schemaNameMap[sc.GetName()] = sc.GetID()
+			r.schemasByName[sc.GetParentID()] = schemaNameMap
 		}
 	}
 
@@ -235,9 +247,6 @@ func descriptorsMatchingTargets(
 	descriptors []catalog.Descriptor,
 	targets tree.TargetList,
 ) (descriptorsMatched, error) {
-	// TODO(dan): once CockroachDB supports schemas in addition to
-	// catalogs, then this method will need to support it.
-
 	ret := descriptorsMatched{}
 
 	resolver, err := newDescriptorResolver(descriptors)
@@ -265,11 +274,37 @@ func descriptorsMatchingTargets(
 	}
 
 	alreadyRequestedSchemas := make(map[descpb.ID]struct{})
-	maybeAddSchemaDesc := func(id descpb.ID) {
+	maybeAddSchemaDesc := func(id descpb.ID, requirePublic bool) error {
+		// Only add user defined schemas.
+		if id == keys.PublicSchemaID {
+			return nil
+		}
 		if _, ok := alreadyRequestedSchemas[id]; !ok {
+			schemaDesc := resolver.descByID[id]
+			if err := catalog.FilterDescriptorState(schemaDesc); err != nil {
+				if requirePublic {
+					return errors.Wrapf(err, "schema %d was expected to be PUBLIC", id)
+				}
+				// If the schema is not public, but we don't require it to be, ignore
+				// it.
+				return nil
+			}
 			alreadyRequestedSchemas[id] = struct{}{}
 			ret.descs = append(ret.descs, resolver.descByID[id])
 		}
+
+		return nil
+	}
+	getSchemaIDByName := func(scName string, dbID descpb.ID) (descpb.ID, error) {
+		schemas, ok := resolver.schemasByName[dbID]
+		if !ok {
+			return 0, errors.Newf("database with ID %d not found", dbID)
+		}
+		schemaID, ok := schemas[scName]
+		if !ok {
+			return 0, errors.Newf("schema with name %s not found in DB %d", scName, dbID)
+		}
+		return schemaID, nil
 	}
 
 	alreadyRequestedTypes := make(map[descpb.ID]struct{})
@@ -342,10 +377,10 @@ func descriptorsMatchingTargets(
 				alreadyRequestedTables[tableDesc.GetID()] = struct{}{}
 				ret.descs = append(ret.descs, tableDesc)
 			}
-			// If this table is a member of a user defined schema, then request the
-			// user defined schema.
-			if tableDesc.GetParentSchemaID() != keys.PublicSchemaID {
-				maybeAddSchemaDesc(tableDesc.GetParentSchemaID())
+			// Since the table was directly requested, so is the schema. If the table
+			// is PUBLIC, we expect the schema to also be PUBLIC.
+			if err := maybeAddSchemaDesc(tableDesc.GetParentSchemaID(), true /* requirePublic */); err != nil {
+				return ret, err
 			}
 			// Get all the types used by this table.
 			typeIDs, err := tableDesc.GetAllReferencedTypeIDs(getTypeByID)
@@ -386,7 +421,15 @@ func descriptorsMatchingTargets(
 
 	// Then process the database expansions.
 	for dbID := range alreadyExpandedDBs {
-		for _, schemas := range resolver.objsByName[dbID] {
+		for schemaName, schemas := range resolver.objsByName[dbID] {
+			schemaID, err := getSchemaIDByName(schemaName, dbID)
+			if err != nil {
+				return ret, err
+			}
+			if err := maybeAddSchemaDesc(schemaID, false /* requirePublic */); err != nil {
+				return ret, err
+			}
+
 			for _, id := range schemas {
 				desc := resolver.descByID[id]
 				switch desc := desc.(type) {
@@ -403,7 +446,12 @@ func descriptorsMatchingTargets(
 					// If this table is a member of a user defined schema, then request the
 					// user defined schema.
 					if desc.GetParentSchemaID() != keys.PublicSchemaID {
-						maybeAddSchemaDesc(desc.GetParentSchemaID())
+						// Note, that although we're processing the database expansions,
+						// since the table is in a PUBLIC state, we also expect the schema
+						// to be in a similar state.
+						if err := maybeAddSchemaDesc(desc.GetParentSchemaID(), true /* requirePublic */); err != nil {
+							return ret, err
+						}
 					}
 					// Get all the types used by this table.
 					typeIDs, err := desc.GetAllReferencedTypeIDs(getTypeByID)


### PR DESCRIPTION
Now when backing up a database, all schemas will
be included. Previously, if no table was referencing a schema, it would
not be included.

Release note (bug fix): Now when backing up a database, all schemas will
be included. Previously, if no table was referencing a schema, it would
not be included.

Release justification: bug fix