### PR TITLE
colexec: make hash table more dynamic and fix hash join in some cases

### DIFF
--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -99,7 +99,5 @@ func (op *hashAggregator) populateEqChains(
 		sel = b.Selection()
 		eqChainsCount = populateEqChains_false(op, batchLength, sel, headIDToEqChainsID)
 	}
-	copy(op.ht.probeScratch.headID[:batchLength], zeroUint64Column)
-	copy(op.ht.probeScratch.differs[:batchLength], zeroBoolColumn)
 	return eqChainsCount, sel
 }

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -285,8 +285,7 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 	// for the tuples.
 	op.ht.computeHashAndBuildChains(ctx, b)
 	op.ht.findBuckets(
-		b, op.ht.probeScratch.keys, op.ht.probeScratch.first,
-		op.ht.probeScratch.next, op.ht.checkProbeForDistinct,
+		b, op.ht.keys, op.ht.probeScratch.first, op.ht.probeScratch.next, op.ht.checkProbeForDistinct,
 	)
 
 	// Step 2: now that we have op.ht.probeScratch.headID populated we can
@@ -305,8 +304,7 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 	// against the heads of the existing groups.
 	if len(op.buckets) > 0 {
 		op.ht.findBuckets(
-			b, op.ht.probeScratch.keys, op.ht.buildScratch.first,
-			op.ht.buildScratch.next, op.ht.checkBuildForAggregation,
+			b, op.ht.keys, op.ht.buildScratch.first, op.ht.buildScratch.next, op.ht.checkBuildForAggregation,
 		)
 		for eqChainsSlot, headID := range op.ht.probeScratch.headID[:eqChainsCount] {
 			if headID != 0 {
@@ -322,8 +320,6 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 				op.scratch.eqChains[eqChainsSlot] = op.scratch.eqChains[eqChainsSlot][:0]
 			}
 		}
-		copy(op.ht.probeScratch.headID[:eqChainsCount], zeroUint64Column)
-		copy(op.ht.probeScratch.differs[:eqChainsCount], zeroBoolColumn)
 	}
 
 	// Step 4: now we go over all equality chains and check whether there are

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -84,7 +84,5 @@ func (op *hashAggregator) populateEqChains(
 		sel = b.Selection()
 		eqChainsCount = populateEqChains(op, batchLength, sel, headIDToEqChainsID, false)
 	}
-	copy(op.ht.probeScratch.headID[:batchLength], zeroUint64Column)
-	copy(op.ht.probeScratch.differs[:batchLength], zeroBoolColumn)
 	return eqChainsCount, sel
 }

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -667,6 +667,11 @@ func MakeHashJoinerSpec(
 		// conditions just yet. When we do, we'll have a separate case for that.
 		rightDistinct = true
 	case descpb.LeftAntiJoin:
+		// LEFT ANTI joins currently rely on the fact that
+		// ht.probeScratch.headID is populated in order to perform the
+		// matching. However, headID is only populated when the right side is
+		// considered to be non-distinct, so we override that information here.
+		rightDistinct = false
 	case descpb.IntersectAllJoin:
 	case descpb.ExceptAllJoin:
 	default:

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -203,6 +203,9 @@ type hashJoiner struct {
 		// that were unmatched are emitted during the emitUnmatched phase.
 		buildRowMatched []bool
 
+		// buckets is used to store the computed hash value of each key in a single
+		// probe batch.
+		buckets []uint64
 		// prevBatch, if not nil, indicates that the previous probe input batch has
 		// not been fully processed.
 		prevBatch coldata.Batch
@@ -307,7 +310,13 @@ func (hj *hashJoiner) build(ctx context.Context) {
 	hj.ht.build(ctx, hj.inputTwo)
 
 	if !hj.spec.rightDistinct {
-		hj.ht.maybeAllocateSameAndVisited()
+		// We might have duplicates in the hash table, so we need to set up
+		// same and visited slices for the prober.
+		hj.ht.same = maybeAllocateUint64Array(hj.ht.same, hj.ht.vals.Length()+1)
+		hj.ht.visited = maybeAllocateBoolArray(hj.ht.visited, hj.ht.vals.Length()+1)
+		// Since keyID = 0 is reserved for end of list, it can be marked as visited
+		// at the beginning.
+		hj.ht.visited[0] = true
 	}
 
 	if hj.spec.right.outer {
@@ -368,18 +377,6 @@ func (hj *hashJoiner) emitUnmatched() {
 	})
 }
 
-// hjInitialToCheck is a slice that contains all consequent integers in
-// [0, coldata.MaxBatchSize) range that can be used to initialize toCheck buffer
-// for most of the join types.
-var hjInitialToCheck []uint64
-
-func init() {
-	hjInitialToCheck = make([]uint64, coldata.MaxBatchSize)
-	for i := range hjInitialToCheck {
-		hjInitialToCheck[i] = uint64(i)
-	}
-}
-
 // exec is a general prober that works with non-distinct build table equality
 // columns. It returns a Batch with N + M columns where N is the number of
 // left source columns and M is the number of right source columns. The first N
@@ -406,45 +403,47 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 			}
 
 			for i, colIdx := range hj.spec.left.eqCols {
-				hj.ht.probeScratch.keys[i] = batch.ColVec(int(colIdx))
+				hj.ht.keys[i] = batch.ColVec(int(colIdx))
 			}
 
 			sel := batch.Selection()
 
 			// First, we compute the hash values for all tuples in the batch.
+			if cap(hj.probeState.buckets) < batchSize {
+				hj.probeState.buckets = make([]uint64, batchSize)
+			} else {
+				// Note that we don't need to clear old values from buckets
+				// because the correct values will be populated in
+				// computeBuckets.
+				hj.probeState.buckets = hj.probeState.buckets[:batchSize]
+			}
 			hj.ht.computeBuckets(
-				ctx, hj.ht.probeScratch.buckets, hj.ht.probeScratch.keys, batchSize, sel,
+				ctx, hj.probeState.buckets, hj.ht.keys, batchSize, sel,
 			)
 			// Then, we initialize groupID with the initial hash buckets and
 			// toCheck with all applicable indices.
+			hj.ht.probeScratch.setupLimitedSlices(batchSize, hj.ht.buildMode)
 			var nToCheck uint64
 			switch hj.spec.joinType {
 			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
 				// The setup of probing for LEFT ANTI and EXCEPT ALL joins
 				// needs a special treatment in order to reuse the same "check"
 				// functions below.
-				for i, bucket := range hj.ht.probeScratch.buckets[:batchSize] {
+				for i, bucket := range hj.probeState.buckets[:batchSize] {
+					hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
 					if hj.ht.buildScratch.first[bucket] != 0 {
 						// Non-zero "first" key indicates that there is a match of hashes
 						// and we need to include the current tuple to check whether it is
 						// an actual match.
-						hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
 						hj.ht.probeScratch.toCheck[nToCheck] = uint64(i)
 						nToCheck++
 					}
 				}
-				// We need to reset headID for all tuples in the batch to remove any
-				// leftover garbage from the previous iteration. For tuples that need
-				// to be checked, headID will be updated accordingly; for tuples that
-				// definitely don't have a match, the zero value will remain until the
-				// "collecting" and "congregation" step in which such tuple will be
-				// included into the output.
-				copy(hj.ht.probeScratch.headID[:batchSize], zeroUint64Column)
 			default:
-				for i, bucket := range hj.ht.probeScratch.buckets[:batchSize] {
+				for i, bucket := range hj.probeState.buckets[:batchSize] {
 					hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
 				}
-				copy(hj.ht.probeScratch.toCheck, hjInitialToCheck[:batchSize])
+				copy(hj.ht.probeScratch.toCheck, hashTableInitialToCheck[:batchSize])
 				nToCheck = uint64(batchSize)
 			}
 
@@ -463,7 +462,7 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 				for nToCheck > 0 {
 					// Continue searching for the build table matching keys while the toCheck
 					// array is non-empty.
-					nToCheck = hj.ht.check(hj.ht.probeScratch.keys, hj.ht.keyCols, nToCheck, sel)
+					nToCheck = hj.ht.check(hj.ht.keys, hj.ht.keyCols, nToCheck, sel)
 					hj.ht.findNext(hj.ht.buildScratch.next, nToCheck)
 				}
 

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -83,6 +83,15 @@ type hashTableProbeBuffer struct {
 	// chain.
 	next []uint64
 
+	// limitedSlicesAreAccountedFor indicates whether we have already
+	// accounted for the memory used by the slices below.
+	limitedSlicesAreAccountedFor bool
+
+	///////////////////////////////////////////////////////////////
+	// Slices below are allocated dynamically but are limited by //
+	// coldata.BatchSize() in size.                              //
+	///////////////////////////////////////////////////////////////
+
 	// headID stores the first build table keyID that matched with the probe batch
 	// key at any given index.
 	headID []uint64
@@ -95,16 +104,11 @@ type hashTableProbeBuffer struct {
 	// table.
 	distinct []bool
 
-	// keys stores the equality columns on the probe table for a single batch.
-	keys []coldata.Vec
-	// buckets is used to store the computed hash value of each key in a single
-	// batch.
-	buckets []uint64
-
 	// groupID stores the keyID that maps to the joining rows of the build table.
 	// The ith element of groupID stores the keyID of the build table that
 	// corresponds to the ith key in the probe table.
 	groupID []uint64
+
 	// toCheck stores the indices of the eqCol rows that have yet to be found or
 	// rejected.
 	toCheck []uint64
@@ -130,17 +134,9 @@ type hashTableProbeBuffer struct {
 type hashTable struct {
 	allocator *colmem.Allocator
 
-	// internalMemHelper is a utility struct that helps with memory accounting
-	// of the internal memory of the hash table (auxiliary slices).
-	internalMemHelper struct {
-		// constSlicesAreAccountedFor indicates whether we have already
-		// accounted for the memory used by the slices that are constant in
-		// size.
-		constSlicesAreAccountedFor bool
-		// dynamicSlicesNumUint64AccountedFor stores the number of uint64 from
-		// the dynamic slices that we have already accounted for.
-		dynamicSlicesNumUint64AccountedFor int64
-	}
+	// unlimitedSlicesNumUint64AccountedFor stores the number of uint64 from
+	// the unlimited slices that we have already accounted for.
+	unlimitedSlicesNumUint64AccountedFor int64
 
 	// buildScratch contains the scratch buffers required for the build table.
 	buildScratch hashTableBuildBuffer
@@ -148,8 +144,12 @@ type hashTable struct {
 	// probeScratch contains the scratch buffers required for the probe table.
 	probeScratch hashTableProbeBuffer
 
+	// keys is a scratch space that stores the equality columns (either of
+	// probe or build table, depending on the phase of algorithm).
+	keys []coldata.Vec
+
 	// same and visited are only used when the hashTable contains non-distinct
-	// keys.
+	// keys (in hashTableFullBuildMode mode).
 	//
 	// same is a densely-packed list that stores the keyID of the next key in the
 	// hash table that has the same value as the current key. The headID of the key
@@ -216,7 +216,7 @@ func newHashTable(
 	}
 	// This number was chosen after running benchmarks of all users of the hash
 	// table (hash joiner, hash aggregator, unordered distinct). The reasoning
-	// for why using coldata.BatchSize() as the initial number of buckets make
+	// for why using coldata.BatchSize() as the initial number of buckets makes
 	// sense:
 	// - on one hand, we make several other allocations that have to be at
 	// least coldata.BatchSize() in size, so we don't win much in the case of
@@ -225,6 +225,9 @@ func newHashTable(
 	// using the vast of majority of the buckets on the input with small number
 	// of tuples (a downside) while not gaining much in the case of the input
 	// with large number of tuples.
+	// TODO(yuzefovich): the comment above is no longer true because all
+	// limited slices in hashTableProbeBuffer are now allocated dynamically, so
+	// we might need to re-tune this number.
 	initialNumHashBuckets := uint64(coldata.BatchSize())
 	// Note that we don't perform memory accounting of the internal memory here
 	// and delay it till buildFromBufferedTuples in order to appease *-disk
@@ -233,20 +236,10 @@ func newHashTable(
 	// of the operators or in Init() implementations).
 	ht := &hashTable{
 		allocator: allocator,
-
 		buildScratch: hashTableBuildBuffer{
 			first: make([]uint64, initialNumHashBuckets),
 		},
-
-		probeScratch: hashTableProbeBuffer{
-			keys:    make([]coldata.Vec, len(eqCols)),
-			buckets: make([]uint64, coldata.BatchSize()),
-			groupID: make([]uint64, coldata.BatchSize()),
-			headID:  make([]uint64, coldata.BatchSize()),
-			toCheck: make([]uint64, coldata.BatchSize()),
-			differs: make([]bool, coldata.BatchSize()),
-		},
-
+		keys:              make([]coldata.Vec, len(eqCols)),
 		vals:              newAppendOnlyBufferedBatch(allocator, sourceTypes, colsToStore),
 		keyCols:           eqCols,
 		numBuckets:        initialNumHashBuckets,
@@ -258,13 +251,25 @@ func newHashTable(
 
 	if buildMode == hashTableDistinctBuildMode {
 		ht.probeScratch.first = make([]uint64, initialNumHashBuckets)
-		ht.probeScratch.next = make([]uint64, coldata.BatchSize()+1)
-		ht.buildScratch.next = make([]uint64, 1, coldata.BatchSize()+1)
-		ht.probeScratch.hashBuffer = make([]uint64, coldata.BatchSize())
-		ht.probeScratch.distinct = make([]bool, coldata.BatchSize())
+		// ht.buildScratch.next will be populated dynamically by appending to
+		// it, but we need to make sure that the special keyID=0 (which
+		// indicates the end of the hash chain) is always present.
+		ht.buildScratch.next = []uint64{0}
 	}
 
 	return ht
+}
+
+// hashTableInitialToCheck is a slice that contains all consequent integers in
+// [0, coldata.MaxBatchSize) range that can be used to initialize toCheck buffer
+// for most of the join types.
+var hashTableInitialToCheck []uint64
+
+func init() {
+	hashTableInitialToCheck = make([]uint64, coldata.MaxBatchSize)
+	for i := range hashTableInitialToCheck {
+		hashTableInitialToCheck[i] = uint64(i)
+	}
 }
 
 // shouldResize returns whether the hash table storing numTuples should be
@@ -276,19 +281,17 @@ func (ht *hashTable) shouldResize(numTuples int) bool {
 
 const sizeOfUint64 = int64(unsafe.Sizeof(uint64(0)))
 
-// accountForConstSlices checks whether we have already accounted for the
-// memory used by the slices that are constant in size and adjusts the
-// allocator accordingly if we haven't.
-func (ht *hashTable) accountForConstSlices() {
-	if ht.internalMemHelper.constSlicesAreAccountedFor {
+// accountForLimitedSlices checks whether we have already accounted for the
+// memory used by the slices that are limited by coldata.BatchSize() in size
+// and adjusts the allocator accordingly if we haven't.
+func (p *hashTableProbeBuffer) accountForLimitedSlices(allocator *colmem.Allocator) {
+	if p.limitedSlicesAreAccountedFor {
 		return
 	}
 	const sizeOfBool = int64(unsafe.Sizeof(true))
-	internalMemUsed := sizeOfUint64 * int64(cap(ht.probeScratch.buckets)+
-		cap(ht.probeScratch.groupID)+cap(ht.probeScratch.headID)+cap(ht.probeScratch.toCheck))
-	internalMemUsed += sizeOfBool * int64(cap(ht.probeScratch.differs)+cap(ht.probeScratch.distinct))
-	ht.allocator.AdjustMemoryUsage(internalMemUsed)
-	ht.internalMemHelper.constSlicesAreAccountedFor = true
+	internalMemMaxUsed := sizeOfUint64*int64(5*coldata.BatchSize()) + sizeOfBool*int64(2*coldata.BatchSize())
+	allocator.AdjustMemoryUsage(internalMemMaxUsed)
+	p.limitedSlicesAreAccountedFor = true
 }
 
 // buildFromBufferedTuples builds the hash table from already buffered tuples
@@ -302,20 +305,20 @@ func (ht *hashTable) buildFromBufferedTuples(ctx context.Context) {
 	if ht.probeScratch.first != nil {
 		ht.probeScratch.first = maybeAllocateUint64Array(ht.probeScratch.first, int(ht.numBuckets))
 	}
-	keyCols := make([]coldata.Vec, len(ht.keyCols))
-	for i, colIdx := range ht.keyCols {
-		keyCols[i] = ht.vals.ColVec(int(colIdx))
+	for i, keyCol := range ht.keyCols {
+		ht.keys[i] = ht.vals.ColVec(int(keyCol))
 	}
-	// ht.next is used to store the computed hash value of each key.
+	// ht.buildScratch.next is used to store the computed hash value of each key.
 	ht.buildScratch.next = maybeAllocateUint64Array(ht.buildScratch.next, ht.vals.Length()+1)
-	ht.computeBuckets(ctx, ht.buildScratch.next[1:], keyCols, ht.vals.Length(), nil)
+	ht.computeBuckets(ctx, ht.buildScratch.next[1:], ht.keys, ht.vals.Length(), nil /* sel */)
 	ht.buildNextChains(ctx, ht.buildScratch.first, ht.buildScratch.next, 1, uint64(ht.vals.Length()))
-	// Account for memory used by the internal auxiliary slices.
-	ht.accountForConstSlices()
+	// Account for memory used by the internal auxiliary slices that are
+	// limited in size.
+	ht.probeScratch.accountForLimitedSlices(ht.allocator)
 	// Note that if ht.probeScratch.first is nil, it'll have zero capacity.
 	newUint64Count := int64(cap(ht.buildScratch.first) + cap(ht.probeScratch.first) + cap(ht.buildScratch.next))
-	ht.allocator.AdjustMemoryUsage(sizeOfUint64 * (newUint64Count - ht.internalMemHelper.dynamicSlicesNumUint64AccountedFor))
-	ht.internalMemHelper.dynamicSlicesNumUint64AccountedFor = newUint64Count
+	ht.allocator.AdjustMemoryUsage(sizeOfUint64 * (newUint64Count - ht.unlimitedSlicesNumUint64AccountedFor))
+	ht.unlimitedSlicesNumUint64AccountedFor = newUint64Count
 }
 
 // build executes the entirety of the hash table build phase using the input
@@ -346,11 +349,11 @@ func (ht *hashTable) build(ctx context.Context, input colexecbase.Operator) {
 				break
 			}
 			ht.computeHashAndBuildChains(ctx, batch)
-			ht.removeDuplicates(batch, ht.probeScratch.keys, ht.probeScratch.first, ht.probeScratch.next, ht.checkProbeForDistinct)
+			ht.removeDuplicates(batch, ht.keys, ht.probeScratch.first, ht.probeScratch.next, ht.checkProbeForDistinct)
 			// We only check duplicates when there is at least one buffered
 			// tuple.
 			if ht.vals.Length() > 0 {
-				ht.removeDuplicates(batch, ht.probeScratch.keys, ht.buildScratch.first, ht.buildScratch.next, ht.checkBuildForDistinct)
+				ht.removeDuplicates(batch, ht.keys, ht.buildScratch.first, ht.buildScratch.next, ht.checkBuildForDistinct)
 			}
 			if batch.Length() > 0 {
 				ht.appendAllDistinct(ctx, batch)
@@ -369,12 +372,15 @@ func (ht *hashTable) build(ctx context.Context, input colexecbase.Operator) {
 func (ht *hashTable) computeHashAndBuildChains(ctx context.Context, batch coldata.Batch) {
 	srcVecs := batch.ColVecs()
 	for i, keyCol := range ht.keyCols {
-		ht.probeScratch.keys[i] = srcVecs[keyCol]
+		ht.keys[i] = srcVecs[keyCol]
 	}
 
 	batchLength := batch.Length()
-	ht.computeBuckets(ctx, ht.probeScratch.next[1:], ht.probeScratch.keys, batchLength, batch.Selection())
-	copy(ht.probeScratch.hashBuffer, ht.probeScratch.next[1:])
+	if cap(ht.probeScratch.next) < batchLength+1 {
+		ht.probeScratch.next = make([]uint64, batchLength+1)
+	}
+	ht.computeBuckets(ctx, ht.probeScratch.next[1:batchLength+1], ht.keys, batchLength, batch.Selection())
+	ht.probeScratch.hashBuffer = append(ht.probeScratch.hashBuffer[:0], ht.probeScratch.next[1:batchLength+1]...)
 
 	// We need to zero out 'first' buffer for all hash codes present in
 	// hashBuffer, and there are two possible approaches that we choose from
@@ -407,15 +413,16 @@ func (ht *hashTable) findBuckets(
 	first, next []uint64,
 	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
 ) {
-	nToCheck := uint64(batch.Length())
+	batchLength := batch.Length()
 	sel := batch.Selection()
 
-	for i := uint64(0); i < nToCheck; i++ {
-		ht.probeScratch.groupID[i] = first[ht.probeScratch.hashBuffer[i]]
-		ht.probeScratch.toCheck[i] = i
+	ht.probeScratch.setupLimitedSlices(batchLength, ht.buildMode)
+	for i, hash := range ht.probeScratch.hashBuffer[:batchLength] {
+		ht.probeScratch.groupID[i] = first[hash]
 	}
+	copy(ht.probeScratch.toCheck, hashTableInitialToCheck[:batchLength])
 
-	for nToCheck > 0 {
+	for nToCheck := uint64(batchLength); nToCheck > 0; {
 		// Continue searching for the build table matching keys while the toCheck
 		// array is non-empty.
 		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
@@ -544,34 +551,28 @@ func (ht *hashTable) buildNextChains(
 	ht.cancelChecker.checkEveryCall(ctx)
 }
 
-// maybeAllocate* methods make sure that the passed in array is allocated and
-// of the desired length.
-func maybeAllocateUint64Array(array []uint64, length int) []uint64 {
-	if array == nil || cap(array) < length {
-		return make([]uint64, length)
+// setupLimitedSlices ensures that headID, differs, distinct, groupID, and
+// toCheck are of the desired length and are setup for probing.
+// Note that if the old groupID or toCheck slices have enough capacity, they
+// are *not* zeroed out.
+func (p *hashTableProbeBuffer) setupLimitedSlices(length int, buildMode hashTableBuildMode) {
+	p.headID = maybeAllocateLimitedUint64Array(p.headID, length)
+	p.differs = maybeAllocateLimitedBoolArray(p.differs, length)
+	if buildMode == hashTableDistinctBuildMode {
+		p.distinct = maybeAllocateLimitedBoolArray(p.distinct, length)
 	}
-	array = array[:length]
-	for n := 0; n < length; n += copy(array[n:], zeroUint64Column) {
+	// Note that we don't use maybeAllocate* methods below because groupID and
+	// toCheck don't need to be zeroed out when reused.
+	if cap(p.groupID) < length {
+		p.groupID = make([]uint64, length)
+	} else {
+		p.groupID = p.groupID[:length]
 	}
-	return array
-}
-
-func maybeAllocateBoolArray(array []bool, length int) []bool {
-	if array == nil || cap(array) < length {
-		return make([]bool, length)
+	if cap(p.toCheck) < length {
+		p.toCheck = make([]uint64, length)
+	} else {
+		p.toCheck = p.toCheck[:length]
 	}
-	array = array[:length]
-	for n := 0; n < length; n += copy(array[n:], zeroBoolColumn) {
-	}
-	return array
-}
-
-func (ht *hashTable) maybeAllocateSameAndVisited() {
-	ht.same = maybeAllocateUint64Array(ht.same, ht.vals.Length()+1)
-	ht.visited = maybeAllocateBoolArray(ht.visited, ht.vals.Length()+1)
-	// Since keyID = 0 is reserved for end of list, it can be marked as visited
-	// at the beginning.
-	ht.visited[0] = true
 }
 
 // findNext determines the id of the next key inside the groupID buckets for
@@ -593,8 +594,6 @@ func (ht *hashTable) checkBuildForDistinct(
 	if probeSel == nil {
 		colexecerror.InternalError("invalid selection vector")
 	}
-	copy(ht.probeScratch.distinct, zeroBoolColumn)
-
 	ht.checkColsForDistinctTuples(probeVecs, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
@@ -624,8 +623,6 @@ func (ht *hashTable) checkBuildForAggregation(
 	if probeSel == nil {
 		colexecerror.InternalError("invalid selection vector")
 	}
-	copy(ht.probeScratch.distinct, zeroBoolColumn)
-
 	ht.checkColsForDistinctTuples(probeVecs, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
@@ -662,15 +659,13 @@ func (ht *hashTable) reset(_ context.Context) {
 	ht.vals.SetLength(0)
 	// ht.probeScratch.next, ht.same and ht.visited are reset separately before
 	// they are used (these slices are not used in all of the code paths).
-	// ht.probeScratch.buckets doesn't need to be reset because buckets are
-	// always initialized when computing the hash.
-	copy(ht.probeScratch.groupID, zeroUint64Column)
-	// ht.probeScratch.toCheck doesn't need to be reset because it is populated
-	// manually every time before checking the columns.
-	copy(ht.probeScratch.headID, zeroUint64Column)
-	copy(ht.probeScratch.differs, zeroBoolColumn)
-	copy(ht.probeScratch.distinct, zeroBoolColumn)
-	if ht.buildMode == hashTableDistinctBuildMode && cap(ht.buildScratch.next) > 0 {
+	// ht.probeScratch.headID, ht.probeScratch.differs, and
+	// ht.probeScratch.distinct are reset before they are used (these slices
+	// are limited in size by dynamically allocated).
+	// ht.probeScratch.groupID and ht.probeScratch.toCheck don't need to be
+	// reset because they are populated manually every time before checking the
+	// columns.
+	if ht.buildMode == hashTableDistinctBuildMode {
 		// In "distinct" build mode, ht.buildScratch.next is populated
 		// iteratively, whenever we find tuples that we haven't seen before. In
 		// order to reuse the same underlying memory we need to slice up that

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -460,17 +460,15 @@ func (ht *hashTable) appendAllDistinct(ctx context.Context, batch coldata.Batch)
 }
 
 // checkCols performs a column by column checkCol on the key columns.
-func (ht *hashTable) checkCols(
-	probeVecs, buildVecs []coldata.Vec, buildKeyCols []uint32, nToCheck uint64, probeSel []int,
-) {
+func (ht *hashTable) checkCols(probeVecs []coldata.Vec, nToCheck uint64, probeSel []int) {
 	switch ht.probeMode {
 	case hashTableDefaultProbeMode:
-		for i := range ht.keyCols {
-			ht.checkCol(probeVecs[i], buildVecs[buildKeyCols[i]], i, nToCheck, probeSel)
+		for i, keyCol := range ht.keyCols {
+			ht.checkCol(probeVecs[i], ht.vals.ColVec(int(keyCol)), i, nToCheck, probeSel)
 		}
 	case hashTableDeletingProbeMode:
-		for i := range ht.keyCols {
-			ht.checkColDeleting(probeVecs[i], buildVecs[buildKeyCols[i]], i, nToCheck, probeSel)
+		for i, keyCol := range ht.keyCols {
+			ht.checkColDeleting(probeVecs[i], ht.vals.ColVec(int(keyCol)), i, nToCheck, probeSel)
 		}
 	default:
 		colexecerror.InternalError(fmt.Sprintf("unsupported hash table probe mode: %d", ht.probeMode))

--- a/pkg/sql/colexec/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/hashtable_distinct.eg.go
@@ -13036,10 +13036,7 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 // list is reconstructed to only hold the indices of the eqCol keys that have
 // not been found. The new length of toCheck is returned by this function.
 func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	probeVecs := ht.keys
-	buildVecs := ht.vals.ColVecs()
-	buildKeyCols := ht.keyCols
-	ht.checkCols(probeVecs, buildVecs, buildKeyCols, nToCheck, probeSel)
+	ht.checkCols(ht.keys, nToCheck, probeSel)
 	// Select the indices that differ and put them into toCheck.
 	nDiffers := uint64(0)
 	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {

--- a/pkg/sql/colexec/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/hashtable_distinct.eg.go
@@ -13008,8 +13008,6 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 				}
 			}
 		}
-		copy(ht.probeScratch.headID[:batchLength], zeroUint64Column)
-		copy(ht.probeScratch.differs[:batchLength], zeroBoolColumn)
 	} else {
 		b.SetSelection(true)
 		sel = b.Selection()
@@ -13028,8 +13026,6 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 				}
 			}
 		}
-		copy(ht.probeScratch.headID[:batchLength], zeroUint64Column)
-		copy(ht.probeScratch.differs[:batchLength], zeroBoolColumn)
 	}
 	b.SetLength(distinctCount)
 }
@@ -13040,7 +13036,7 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 // list is reconstructed to only hold the indices of the eqCol keys that have
 // not been found. The new length of toCheck is returned by this function.
 func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	probeVecs := ht.probeScratch.keys
+	probeVecs := ht.keys
 	buildVecs := ht.vals.ColVecs()
 	buildKeyCols := ht.keyCols
 	ht.checkCols(probeVecs, buildVecs, buildKeyCols, nToCheck, probeSel)

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -442,16 +442,22 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool) { // */}}
 // key is removed from toCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of toCheck is returned by this function.
-func (ht *hashTable) check(
-	probeVecs []coldata.Vec, buildKeyCols []uint32, nToCheck uint64, probeSel []int,
-) uint64 {
-	ht.checkCols(probeVecs, ht.vals.ColVecs(), buildKeyCols, nToCheck, probeSel)
+func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []int) uint64 {
+	ht.checkCols(probeVecs, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	switch ht.probeMode {
 	case hashTableDefaultProbeMode:
-		_CHECK_BODY(true, false)
+		if ht.same != nil {
+			_CHECK_BODY(true, false)
+		} else {
+			_CHECK_BODY(false, false)
+		}
 	case hashTableDeletingProbeMode:
-		_CHECK_BODY(true, true)
+		if ht.same != nil {
+			_CHECK_BODY(true, true)
+		} else {
+			_CHECK_BODY(false, true)
+		}
 	default:
 		colexecerror.InternalError("unsupported hash table probe mode")
 	}
@@ -528,10 +534,7 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 // list is reconstructed to only hold the indices of the eqCol keys that have
 // not been found. The new length of toCheck is returned by this function.
 func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	probeVecs := ht.keys
-	buildVecs := ht.vals.ColVecs()
-	buildKeyCols := ht.keyCols
-	ht.checkCols(probeVecs, buildVecs, buildKeyCols, nToCheck, probeSel)
+	ht.checkCols(ht.keys, nToCheck, probeSel)
 	// Select the indices that differ and put them into toCheck.
 	nDiffers := uint64(0)
 	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -497,8 +497,6 @@ func _UPDATE_SEL_BODY(_USE_SEL bool) { // */}}
 			}
 		}
 	}
-	copy(ht.probeScratch.headID[:batchLength], zeroUint64Column)
-	copy(ht.probeScratch.differs[:batchLength], zeroBoolColumn)
 	// {{end}}
 	// {{/*
 } // */}}
@@ -530,7 +528,7 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 // list is reconstructed to only hold the indices of the eqCol keys that have
 // not been found. The new length of toCheck is returned by this function.
 func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	probeVecs := ht.probeScratch.keys
+	probeVecs := ht.keys
 	buildVecs := ht.vals.ColVecs()
 	buildKeyCols := ht.keyCols
 	ht.checkCols(probeVecs, buildVecs, buildKeyCols, nToCheck, probeSel)

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1520,6 +1520,20 @@ var mjTestCases = []*joinTestCase{
 			{nil, 23918},
 		},
 	},
+	{
+		description:       "LEFT ANTI join when right eq cols are key",
+		joinType:          descpb.LeftAntiJoin,
+		leftTypes:         []*types.T{types.Int},
+		rightTypes:        []*types.T{types.Int},
+		leftTuples:        tuples{{0}, {0}, {1}, {2}},
+		rightTuples:       tuples{{0}, {2}},
+		leftEqCols:        []uint32{0},
+		rightEqCols:       []uint32{0},
+		leftOutCols:       []uint32{0},
+		rightOutCols:      []uint32{},
+		rightEqColsAreKey: true,
+		expected:          tuples{{1}},
+	},
 }
 
 func TestMergeJoiner(t *testing.T) {

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1534,6 +1534,32 @@ var mjTestCases = []*joinTestCase{
 		rightEqColsAreKey: true,
 		expected:          tuples{{1}},
 	},
+	{
+		description:       "INTERSECT ALL join when right eq cols are key",
+		joinType:          descpb.IntersectAllJoin,
+		leftTypes:         []*types.T{types.Int},
+		rightTypes:        []*types.T{types.Int},
+		leftTuples:        tuples{{1}, {1}, {2}, {2}, {2}, {4}, {4}},
+		rightTuples:       tuples{{1}, {2}, {3}},
+		leftEqCols:        []uint32{0},
+		rightEqCols:       []uint32{0},
+		leftOutCols:       []uint32{0},
+		rightEqColsAreKey: true,
+		expected:          tuples{{1}, {2}},
+	},
+	{
+		description:       "EXCEPT ALL join when right eq cols are key",
+		joinType:          descpb.ExceptAllJoin,
+		leftTypes:         []*types.T{types.Int},
+		rightTypes:        []*types.T{types.Int},
+		leftTuples:        tuples{{1}, {1}, {2}, {2}, {2}, {3}, {3}},
+		rightTuples:       tuples{{1}, {2}, {3}},
+		leftEqCols:        []uint32{0},
+		rightEqCols:       []uint32{0},
+		leftOutCols:       []uint32{0},
+		rightEqColsAreKey: true,
+		expected:          tuples{{1}, {2}, {2}, {3}},
+	},
 }
 
 func TestMergeJoiner(t *testing.T) {

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -208,3 +208,49 @@ func (b *appendOnlyBufferedBatch) append(batch coldata.Batch, startIdx, endIdx i
 	}
 	b.length += endIdx - startIdx
 }
+
+// maybeAllocate* methods make sure that the passed in array is allocated, of
+// the desired length and zeroed out.
+func maybeAllocateUint64Array(array []uint64, length int) []uint64 {
+	if cap(array) < length {
+		return make([]uint64, length)
+	}
+	array = array[:length]
+	for n := 0; n < length; n += copy(array[n:], zeroUint64Column) {
+	}
+	return array
+}
+
+func maybeAllocateBoolArray(array []bool, length int) []bool {
+	if cap(array) < length {
+		return make([]bool, length)
+	}
+	array = array[:length]
+	for n := 0; n < length; n += copy(array[n:], zeroBoolColumn) {
+	}
+	return array
+}
+
+// maybeAllocateLimitedUint64Array is an optimized version of
+// maybeAllocateUint64Array that can *only* be used when length is at most
+// coldata.MaxBatchSize.
+func maybeAllocateLimitedUint64Array(array []uint64, length int) []uint64 {
+	if cap(array) < length {
+		return make([]uint64, length)
+	}
+	array = array[:length]
+	copy(array, zeroUint64Column)
+	return array
+}
+
+// maybeAllocateLimitedBoolArray is an optimized version of
+// maybeAllocateBool64Array that can *only* be used when length is at most
+// coldata.MaxBatchSize.
+func maybeAllocateLimitedBoolArray(array []bool, length int) []bool {
+	if cap(array) < length {
+		return make([]bool, length)
+	}
+	array = array[:length]
+	copy(array, zeroBoolColumn)
+	return array
+}


### PR DESCRIPTION
**colexec: make hash table more dynamic**

This commit replaces all fixed allocations of constant size in the hash
table in favor of allocating the slices dynamically which makes the hash
table more dynamic as well. This allows us to place the logic of
clearing up those slices for the next iteration in a single place which
simplifies the code a bit.

Additionally it moves `buckets` slice that is only used by the hash
joiner out of the hash table.

Release note: None

**colexec: fix LEFT ANTI hash join when right eq cols are key**

Release note (bug fix): Previously, CockroachDB could return incorrect
results when performing LEFT ANTI hash join when right equality columns
form a key when it was executed via the vectorized engine, and now this
has been fixed.

**colexec: fix set-op hash joins and optimize them a bit**

This commit fixes several problems with set-operation hash joins:
1. similar to how LEFT ANTI hash joins are handled, INTERSECT ALL and
EXCEPT ALL hash joins rely on `headID` to be populated. That step is
skipped if the right side is distinct (meaning right equality columns
form a key). This would result in incorrect output, and we now override
`rightDistinct` flag to get the desired behavior (probably sub-optimal
but correct).
2. actually, before we would get an incorrect result, we would hit an
out of bounds error because `hashTable.visited` would not have been
created previously. That slice is used by set-op joins to track which
tuples from the right side have already been "deleted" (i.e. they were
used for a match). This is now also fixed.

However, currently the information whether the right equality columns
form a key is not propagated for set-operation joins, so the bug would
not have occurred in the non-test environment.

Additionally, this commit optimizes the handling of LEFT ANTI and EXCEPT
ALL joins by not allocating `same` slice because those two join types
have separate `collectAnti*` methods that don't use that slice.

Release note: None