### PR TITLE
backupccl: fix cluster restore job description

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1036,9 +1036,10 @@ func restoreJobDescription(
 	kmsURIs []string,
 ) (string, error) {
 	r := &tree.Restore{
-		AsOf:    restore.AsOf,
-		Targets: restore.Targets,
-		From:    make([]tree.StringOrPlaceholderOptList, len(restore.From)),
+		DescriptorCoverage: restore.DescriptorCoverage,
+		AsOf:               restore.AsOf,
+		Targets:            restore.Targets,
+		From:               make([]tree.StringOrPlaceholderOptList, len(restore.From)),
 	}
 
 	var options tree.RestoreOptions


### PR DESCRIPTION
This commit plumbs the descriptor coverage back to the restore statement
that we use to create the job description. This ensures that cluster
restore job descriptions are properly formatted.

Fixes #53205.

Release note (bug fix): Previously cluster restores would appear in the
jobs table and admin UI as "RESTORE TABLE FROM ...", which was
incorrect. They now appear as "RESTORE FROM ...".