### PR TITLE
build: push pre-release docker images to cockroachdb/cockroach-unstable

### DIFF
--- a/build/release/teamcity-publish-release.sh
+++ b/build/release/teamcity-publish-release.sh
@@ -31,7 +31,11 @@ release_branch=$(echo ${build_name} | grep -E -o '^v[0-9]+\.[0-9]+')
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET:-binaries.cockroachdb.com}"
   google_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS"
-  dockerhub_repository="docker.io/cockroachdb/cockroach"
+  if [[ -z "${PRE_RELEASE}" ]] ; then
+    dockerhub_repository="docker.io/cockroachdb/cockroach"
+  else
+    dockerhub_repository="docker.io/cockroachdb/cockroach-unstable"
+  fi
   gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
   s3_download_hostname="${bucket}"
   git_repo_for_tag="cockroachdb/cockroach"


### PR DESCRIPTION
Before: The build/release/teamcity-publish-release.sh script pushed
pre-release docker images to cockroachdb/cockroach.

Why: In the old process, we pushed pre-release images to
cockroachdb/cockroach-unstable and want to continue that unless we make
an explicit decision to publish elsewhere.

Now: Pre-release docker images are pushed to cockroachdb/cockroach-unstable

Release note: None