### PR TITLE
geo/geomfn: implement ST_RemovePoint

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1538,6 +1538,8 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_relatematch"></a><code>st_relatematch(intersection_matrix: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the given DE-9IM intersection matrix satisfies the given pattern.</p>
 </span></td></tr>
+<tr><td><a name="st_removepoint"></a><code>st_removepoint(line_string: geometry, index: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Removes the Point at the given 0-based index and returns the modified LineString geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_reverse"></a><code>st_reverse(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified geometry by reversing the order of its vertices.</p>
 </span></td></tr>
 <tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by taking in a Geometry as the factor</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4361,6 +4361,23 @@ LINESTRING (0 0, 1 1, 10 10)
 LINESTRING (0 0, 1 1, 2 2, 10 10)
 LINESTRING (10 10, 1 1, 2 2, 3 3)
 
+subtest remove_point_test
+
+query T
+SELECT
+  ST_AsText(ST_RemovePoint(ls::geometry, i))
+FROM ( VALUES
+  ('LINESTRING(0 0, 1 1, 2 2)', 2),
+  ('LINESTRING(0 0, 1 1, 2 2, 3 3)', 0),
+  ('LINESTRING(0 0, 1 1, 2 2, 3 3)', 1)
+  )
+ t(ls, i) ;
+----
+LINESTRING (0 0, 1 1)
+LINESTRING (1 1, 2 2, 3 3)
+LINESTRING (0 0, 2 2, 3 3)
+
+
 subtest reverse_test
 
 query TT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3299,6 +3299,31 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_removepoint": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"line_string", types.Geometry},
+				{"index", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				lineString := args[0].(*tree.DGeometry)
+				index := int(*args[1].(*tree.DInt))
+
+				ret, err := geomfn.RemovePoint(lineString.Geometry, index)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Removes the Point at the given 0-based index and returns the modified LineString geometry.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_reverse": makeBuiltin(
 		defProps(),
 		tree.Overload{


### PR DESCRIPTION
Implement ST_RemovePoint on arguments {geometry, int4}, which should adopt PostGIS behaviour.

Release note (sql change): Implemented geometry builtin `ST_RemovePoint`

Closes #49016 