### PR TITLE
distsql: ignore ST_Union for test as it seg faults

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -125,6 +125,9 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 				execinfrapb.AggregatorSpec_PERCENTILE_CONT_IMPL:
 				// We skip percentile functions because those can only be
 				// planned as window functions.
+			case execinfrapb.AggregatorSpec_ST_UNION:
+				// We skip ST_Union for now because it seg faults in GEOS.
+				// TODO(#53254): figure out why.
 			default:
 				found = true
 			}


### PR DESCRIPTION
ST_Union seems to segfault in the GEOS world, not much I can do here.
Ignore testing for now.

Refs: #53254

Release note: None