### PR TITLE
util/logs: request redactable logs by default 

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -34,7 +34,7 @@ eexpect ":/# "
 # is only reported on the logger which is writing first after stderr
 # is has been broken, and that may be the secondary logger.
 send "tail -F `find logs/db/logs -type l`\r"
-eexpect "error: write /dev/stderr: broken pipe"
+eexpect "error: write */dev/stderr*: broken pipe"
 interrupt
 eexpect ":/# "
 end_test
@@ -89,7 +89,7 @@ eexpect "CockroachDB node starting"
 system "($argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true)&"
 # Check the panic is reported on the server's stderr
 eexpect "a SQL panic has occurred"
-eexpect "panic: helloworld"
+eexpect "panic: *helloworld"
 eexpect "stack trace"
 eexpect ":/# "
 # Check the panic is reported on the server log file

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"flag"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/errors"
 )
@@ -152,7 +153,9 @@ func SetupRedactionAndStderrRedirects() (cleanupForTestingOnly func(), err error
 	// log entries on stderr, that's a configuration we cannot support
 	// safely. Reject it.
 	if redactableLogsRequested && mainLog.stderrThreshold.get() != Severity_NONE {
-		return nil, errors.New("cannot enable redactable logging without a logging directory")
+		return nil, errors.WithHintf(
+			errors.New("cannot enable redactable logging without a logging directory"),
+			"You can pass --%s to set up a logging directory explicitly.", cliflags.LogDir.Name)
 	}
 
 	// Configuration valid. Assign it.

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -183,3 +183,12 @@ func TestingResetActive() {
 	defer logging.mu.Unlock()
 	logging.mu.active = false
 }
+
+// RedactableLogsEnabled reports whether redaction markers were
+// actually enabled for the main logger. This is used for flag
+// telemetry; a better API would be needed for more fine grained
+// information, as each different logger may have a different
+// redaction setting.
+func RedactableLogsEnabled() bool {
+	return mainLog.redactableLogs.Get()
+}


### PR DESCRIPTION
First two commits from  #53313

This changes the default value for the `--redactable-logs` flag to
`true`. This makes server produce redactable logs by default.

Note that `--redactable-logs` only triggers redactable logs if the
caller calls `SetupRedactionAndStderrRedirects()`. This is done by
e.g. the server code. This means that even with this patch,
*unit tests* continue to produce non-redactable logs.

This commit also adds telemetry for the enablement of redactable
markers, as `server.logging.redactable_logs.{enabled,disabled}`.

Fixes #51834.


Release note (cli change): The `cockroach start`, `start-single-node`
and `demo` command now enable `--redactable-logs` by default.
This causes log files to become redactable, so that 
`cockroach debug merge-log --redact` or `cockroach debug zip --redact`
can remove sensitive information out of log files.
(Reminder: `cockroach debug zip --redact` only affects *log files*;
other items collected by the command can still contain sensitive information)