### PR TITLE
backupccl: use flat naming for full backups

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -126,7 +126,7 @@ func resolveDest(
 			}
 
 			// Pick a piece-specific suffix and update the destination path(s).
-			partName := endTime.GoTime().Format(dateBasedFolderName)
+			partName := endTime.GoTime().Format(dateBasedIncFolderName)
 			partName = path.Join(chosenSuffix, partName)
 			defaultURI, urisByLocalityKV, err = getURIsByLocalityKV(to, partName)
 			if err != nil {
@@ -260,7 +260,7 @@ func resolveBackupCollection(
 		chosenSuffix = strings.TrimPrefix(subdir, "/")
 		chosenSuffix = "/" + chosenSuffix
 	} else {
-		chosenSuffix = endTime.GoTime().Format(dateBasedFolderName)
+		chosenSuffix = endTime.GoTime().Format(dateBasedIntoFolderName)
 	}
 	return collectionURI, chosenSuffix, nil
 }

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -68,8 +68,9 @@ const (
 	// ZipType is the format of a GZipped compressed file.
 	ZipType = "application/x-gzip"
 
-	dateBasedFolderName = "/20060102/150405.00"
-	latestFileName      = "LATEST"
+	dateBasedIncFolderName  = "/20060102/150405.00"
+	dateBasedIntoFolderName = "/2006-01-02-150405.00"
+	latestFileName          = "LATEST"
 )
 
 // BackupFileDescriptors is an alias on which to implement sort's interface.

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -438,7 +438,7 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/BACKUP")
+		res, err := store.ListFiles(ctx, "/*/BACKUP")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This changes BACKUP INTO x to pick names in the form /2006-01-02-150405.00 instead of /20060102/150405.00.

Removing the / should mean if one lists the directory, the results are names that can be pasted
directly into SHOW BACKUP x IN y or RESTORE FROM x IN y.

Closes #53269.

Release note: none.