### PR TITLE
backupccl: use year and month nested naming for full backups

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -126,7 +126,7 @@ func resolveDest(
 			}
 
 			// Pick a piece-specific suffix and update the destination path(s).
-			partName := endTime.GoTime().Format(dateBasedFolderName)
+			partName := endTime.GoTime().Format(dateBasedIncFolderName)
 			partName = path.Join(chosenSuffix, partName)
 			defaultURI, urisByLocalityKV, err = getURIsByLocalityKV(to, partName)
 			if err != nil {
@@ -260,7 +260,7 @@ func resolveBackupCollection(
 		chosenSuffix = strings.TrimPrefix(subdir, "/")
 		chosenSuffix = "/" + chosenSuffix
 	} else {
-		chosenSuffix = endTime.GoTime().Format(dateBasedFolderName)
+		chosenSuffix = endTime.GoTime().Format(dateBasedIntoFolderName)
 	}
 	return collectionURI, chosenSuffix, nil
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -521,7 +521,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 	// Find the backup times in the collection and try RESTORE'ing to each, and
 	// within each also check if we can restore to individual times captured with
 	// incremental backups that were appended to that backup.
-	full1, full2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "[0-9]*", "[0-9]*", "BACKUP"))
+	full1, full2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "*/*/*/BACKUP"))
 	runRestores(collections, full1, full2)
 
 	// Find the full-backups written to the specified subdirectories, and within
@@ -563,7 +563,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
-	matches, err := filepath.Glob(path.Join(tmpDir, "[0-9]*", "[0-9]*", "BACKUP"))
+	matches, err := filepath.Glob(path.Join(tmpDir, "*/*/*/BACKUP"))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 	for i := range matches {
@@ -2077,7 +2077,7 @@ CREATE TABLE d.t1 (x d.farewell);
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' 
+RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
   AS OF SYSTEM TIME %s
 `, ts1))
 			sqlDB.ExpectErr(t, `pq: type "d.public.farewell" already exists`,

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -68,8 +68,9 @@ const (
 	// ZipType is the format of a GZipped compressed file.
 	ZipType = "application/x-gzip"
 
-	dateBasedFolderName = "/20060102/150405.00"
-	latestFileName      = "LATEST"
+	dateBasedIncFolderName  = "/20060102/150405.00"
+	dateBasedIntoFolderName = "/2006/01/02-150405.00"
+	latestFileName          = "LATEST"
 )
 
 // BackupFileDescriptors is an alias on which to implement sort's interface.

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -438,7 +438,7 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/BACKUP")
+		res, err := store.ListFiles(ctx, "/*/*/*/BACKUP")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This changes BACKUP INTO x to pick names in the form /2006/01/02-150405.00 instead of /20060102/150405.00.

Using path separators after the year and after the month should mean that most tools for browsing
the storage location using "folder" semantics will allow browsing to specific times without
paging though a large folder, as we'd expect 12 entries in each year and about 30 in each
month for the common case of daily full backups (incrementals are nested in the full to which
they were added already).

Closes #53268.

Release note: none.