### PR TITLE
backupccl: only test for writability in base of backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -817,7 +817,11 @@ func backupPlanHook(
 		}
 		// TODO (pbardea): For partitioned backups, also add verification for other
 		// stores we are writing to in addition to the default.
-		if err := verifyWriteableDestination(ctx, defaultStore, defaultURI); err != nil {
+		baseURI := collectionURI
+		if baseURI == "" {
+			baseURI = defaultURI
+		}
+		if err := verifyWriteableDestination(ctx, p.User(), makeCloudStorage, baseURI); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -945,22 +945,31 @@ func checkForPreviousBackup(
 // We don't require DELETE permissions on their backup directory, so we do not
 // enforce that this file be deleted.
 func verifyWriteableDestination(
-	ctx context.Context, exportStore cloud.ExternalStorage, writeable string,
+	ctx context.Context,
+	user string,
+	makeCloudStorage cloud.ExternalStorageFromURIFactory,
+	baseURI string,
 ) error {
+	baseStore, err := makeCloudStorage(ctx, baseURI, user)
+	if err != nil {
+		return err
+	}
+	defer baseStore.Close()
+
 	// Write arbitrary bytes to a sentinel file in the backup directory to ensure
 	// that we're able to write to this directory.
 	arbitraryBytes := bytes.NewReader([]byte("✇"))
-	if err := exportStore.WriteFile(ctx, BackupSentinelWriteFile, arbitraryBytes); err != nil {
-		return errors.Wrapf(err, "writing sentinel file to %s", writeable)
+	if err := baseStore.WriteFile(ctx, BackupSentinelWriteFile, arbitraryBytes); err != nil {
+		return errors.Wrapf(err, "writing sentinel file to %s", baseURI)
 	}
 
-	if err := exportStore.Delete(ctx, BackupSentinelWriteFile); err != nil {
+	if err := baseStore.Delete(ctx, BackupSentinelWriteFile); err != nil {
 		// Don't require that we're able to clean up the sentinel file. Nothing
 		// should check for it's existence so it should be fine to leave it around.
 		// Let's still log if we can't clean up.
 		log.Warningf(ctx,
 			"could not clean up sentinel backup %s file in %s: %+v",
-			BackupSentinelWriteFile, writeable, err)
+			BackupSentinelWriteFile, baseURI, err)
 	}
 
 	return nil


### PR DESCRIPTION
During backup planning, we test that we can write to the backup
destination. However, if we were backing up to a collection we would
create the subdirectory during planning. If the transaction which ran
the planning (e.g. a detached backup) were rollbacked, we would leave
behind empty backup folders.

We should only need to check that we can write to the base of the
collection.

Release note: None