### PR TITLE
release-20.1: storageccl: retry file uploads

### DIFF
--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -134,6 +134,10 @@ func makeS3Storage(
 	if conf.Endpoint != "" {
 		sess.Config.S3ForcePathStyle = aws.Bool(true)
 	}
+	sess.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	maxRetries := 10
+	sess.Config.MaxRetries = &maxRetries
+
 	return &s3Storage{
 		bucket:   aws.String(conf.Bucket),
 		conf:     conf,


### PR DESCRIPTION
Backport 1/1 commits from #53155.

/cc @cockroachdb/release

---

We have seen reports that some users see EOF errors causing
BACKUPs to fail when writing SSTs to cloud-storage. Each of
the cloud-storage SDKs has its own internal retry logic and
is supposed to handle emphemeral errors. But if we're exporting
at all it means we previously were able to write the placeholder
file to that destination so any errors we do see are very likely
emphemeral, and a retry may help.

While I'm here: bump up the AWS SDK retry limit and enable retry
logging.

Release note: none.
