### PR TITLE
catalog/*: rename implementations of descriptors

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -183,7 +183,7 @@ func spansForAllTableIndexes(
 		// backups and OFFLINE tables.
 		rawTbl := descpb.TableFromDescriptor(rev.Desc, hlc.Timestamp{})
 		if rawTbl != nil && rawTbl.State != descpb.TableDescriptor_DROP {
-			tbl := tabledesc.NewImmutableTableDescriptor(*rawTbl)
+			tbl := tabledesc.NewImmutable(*rawTbl)
 			for _, idx := range tbl.AllNonDropIndexes() {
 				key := tableAndIndex{tableID: tbl.ID, indexID: idx.ID}
 				if !added[key] {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -299,7 +299,7 @@ func WriteDescriptors(
 			// the users on the restoring cluster match the ones that were on the
 			// cluster that was backed up. So we wipe the privileges on the database.
 			if descCoverage != tree.AllDescriptors {
-				if mut, ok := desc.(*dbdesc.MutableDatabaseDescriptor); ok {
+				if mut, ok := desc.(*dbdesc.Mutable); ok {
 					mut.Privileges = descpb.NewDefaultPrivilegeDescriptor(security.AdminRole)
 				} else {
 					log.Fatalf(ctx, "wrong type for table %d, %T, expected Mutable",
@@ -822,7 +822,7 @@ func createImportingDescriptors(
 			oldTableIDs = append(oldTableIDs, mut.GetID())
 		case catalog.DatabaseDescriptor:
 			if rewrite, ok := details.DescriptorRewrites[desc.GetID()]; ok {
-				rewriteDesc := dbdesc.NewInitialDatabaseDescriptorWithPrivileges(
+				rewriteDesc := dbdesc.NewInitialWithPrivileges(
 					rewrite.ID, desc.GetName(), desc.GetPrivileges())
 				databases = append(databases, rewriteDesc)
 			}
@@ -839,7 +839,7 @@ func createImportingDescriptors(
 		}
 	}
 	if details.DescriptorCoverage == tree.AllDescriptors {
-		databases = append(databases, dbdesc.NewInitialDatabaseDescriptor(
+		databases = append(databases, dbdesc.NewInitial(
 			descpb.ID(tempSystemDBID), restoreTempSystemDB, security.AdminRole))
 	}
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -806,7 +806,7 @@ func createImportingDescriptors(
 	details := r.job.Details().(jobspb.RestoreDetails)
 
 	var schemas []*schemadesc.Mutable
-	var types []*typedesc.MutableTypeDescriptor
+	var types []*typedesc.Mutable
 	// Store the tables as both the concrete mutable structs and the interface
 	// to deal with the lack of slice covariance in go. We want the slice of
 	// mutable descriptors for rewriting but ultimately want to return the
@@ -829,7 +829,7 @@ func createImportingDescriptors(
 		case catalog.SchemaDescriptor:
 			schemas = append(schemas, schemadesc.NewMutableCreatedSchemaDescriptor(*desc.SchemaDesc()))
 		case catalog.TypeDescriptor:
-			types = append(types, typedesc.NewMutableCreatedTypeDescriptor(*desc.TypeDesc()))
+			types = append(types, typedesc.NewCreatedMutable(*desc.TypeDesc()))
 		}
 	}
 	tempSystemDBID := keys.MinNonPredefinedUserDescID
@@ -862,7 +862,7 @@ func createImportingDescriptors(
 	// For each type, we might be writing the type in the backup, or we could be
 	// remapping to an existing type descriptor. Split up the descriptors into
 	// these two groups.
-	var typesToWrite []*typedesc.MutableTypeDescriptor
+	var typesToWrite []*typedesc.Mutable
 	existingTypeIDs := make(map[descpb.ID]struct{})
 	for i := range types {
 		typ := types[i]
@@ -948,7 +948,7 @@ func createImportingDescriptors(
 					if err != nil {
 						return err
 					}
-					typDesc := desc.(*typedesc.MutableTypeDescriptor)
+					typDesc := desc.(*typedesc.Mutable)
 					typDesc.AddReferencingDescriptorID(table.GetID())
 					if err := catalogkv.WriteDescToBatch(
 						ctx,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -805,7 +805,7 @@ func createImportingDescriptors(
 ) {
 	details := r.job.Details().(jobspb.RestoreDetails)
 
-	var schemas []*schemadesc.MutableSchemaDescriptor
+	var schemas []*schemadesc.Mutable
 	var types []*typedesc.MutableTypeDescriptor
 	// Store the tables as both the concrete mutable structs and the interface
 	// to deal with the lack of slice covariance in go. We want the slice of
@@ -881,7 +881,7 @@ func createImportingDescriptors(
 	}
 
 	// Collect all schemas that are going to be restored.
-	var schemasToWrite []*schemadesc.MutableSchemaDescriptor
+	var schemasToWrite []*schemadesc.Mutable
 	var writtenSchemas []catalog.SchemaDescriptor
 	for i := range schemas {
 		sc := schemas[i]

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1304,7 +1304,7 @@ func (r *restoreResumer) dropDescriptors(
 	for _, tbl := range details.TableDescs {
 		tablesToGC = append(tablesToGC, tbl.ID)
 		tableToDrop := tabledesc.NewMutableExistingTableDescriptor(*tbl)
-		prev := tableToDrop.Immutable().(catalog.TableDescriptor)
+		prev := tableToDrop.ImmutableCopy().(catalog.TableDescriptor)
 		tableToDrop.Version++
 		tableToDrop.State = descpb.TableDescriptor_DROP
 		err := catalogkv.RemovePublicTableNamespaceEntry(ctx, txn, keys.SystemSQLCodec, tbl.ParentID, tbl.Name)

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -159,7 +159,7 @@ func allocateDescriptorRewrites(
 	ctx context.Context,
 	p sql.PlanHookState,
 	databasesByID map[descpb.ID]*dbdesc.MutableDatabaseDescriptor,
-	schemasByID map[descpb.ID]*schemadesc.MutableSchemaDescriptor,
+	schemasByID map[descpb.ID]*schemadesc.Mutable,
 	tablesByID map[descpb.ID]*tabledesc.MutableTableDescriptor,
 	typesByID map[descpb.ID]*typedesc.MutableTypeDescriptor,
 	restoreDBs []catalog.DatabaseDescriptor,
@@ -771,9 +771,7 @@ func rewriteTypeDescs(
 
 // rewriteSchemaDescs rewrites all ID's in the input slice of SchemaDescriptors
 // using the input ID rewrite mapping.
-func rewriteSchemaDescs(
-	schemas []*schemadesc.MutableSchemaDescriptor, descriptorRewrites DescRewriteMap,
-) error {
+func rewriteSchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites DescRewriteMap) error {
 	for _, sc := range schemas {
 		rewrite, ok := descriptorRewrites[sc.ID]
 		if !ok {
@@ -1311,14 +1309,14 @@ func doRestorePlan(
 	}
 
 	databasesByID := make(map[descpb.ID]*dbdesc.MutableDatabaseDescriptor)
-	schemasByID := make(map[descpb.ID]*schemadesc.MutableSchemaDescriptor)
+	schemasByID := make(map[descpb.ID]*schemadesc.Mutable)
 	tablesByID := make(map[descpb.ID]*tabledesc.MutableTableDescriptor)
 	typesByID := make(map[descpb.ID]*typedesc.MutableTypeDescriptor)
 	for _, desc := range sqlDescs {
 		switch desc := desc.(type) {
 		case *dbdesc.MutableDatabaseDescriptor:
 			databasesByID[desc.GetID()] = desc
-		case *schemadesc.MutableSchemaDescriptor:
+		case *schemadesc.Mutable:
 			schemasByID[desc.ID] = desc
 		case *tabledesc.MutableTableDescriptor:
 			tablesByID[desc.ID] = desc
@@ -1351,7 +1349,7 @@ func doRestorePlan(
 		return err
 	}
 
-	var schemas []*schemadesc.MutableSchemaDescriptor
+	var schemas []*schemadesc.Mutable
 	for i := range schemasByID {
 		schemas = append(schemas, schemasByID[i])
 	}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -158,7 +158,7 @@ func maybeFilterMissingViews(
 func allocateDescriptorRewrites(
 	ctx context.Context,
 	p sql.PlanHookState,
-	databasesByID map[descpb.ID]*dbdesc.MutableDatabaseDescriptor,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
 	schemasByID map[descpb.ID]*schemadesc.Mutable,
 	tablesByID map[descpb.ID]*tabledesc.Mutable,
 	typesByID map[descpb.ID]*typedesc.Mutable,
@@ -1306,13 +1306,13 @@ func doRestorePlan(
 		}
 	}
 
-	databasesByID := make(map[descpb.ID]*dbdesc.MutableDatabaseDescriptor)
+	databasesByID := make(map[descpb.ID]*dbdesc.Mutable)
 	schemasByID := make(map[descpb.ID]*schemadesc.Mutable)
 	tablesByID := make(map[descpb.ID]*tabledesc.Mutable)
 	typesByID := make(map[descpb.ID]*typedesc.Mutable)
 	for _, desc := range sqlDescs {
 		switch desc := desc.(type) {
-		case *dbdesc.MutableDatabaseDescriptor:
+		case *dbdesc.Mutable:
 			databasesByID[desc.GetID()] = desc
 		case *schemadesc.Mutable:
 			schemasByID[desc.ID] = desc

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -161,7 +161,7 @@ func allocateDescriptorRewrites(
 	databasesByID map[descpb.ID]*dbdesc.MutableDatabaseDescriptor,
 	schemasByID map[descpb.ID]*schemadesc.Mutable,
 	tablesByID map[descpb.ID]*tabledesc.Mutable,
-	typesByID map[descpb.ID]*typedesc.MutableTypeDescriptor,
+	typesByID map[descpb.ID]*typedesc.Mutable,
 	restoreDBs []catalog.DatabaseDescriptor,
 	descriptorCoverage tree.DescriptorCoverage,
 	opts tree.RestoreOptions,
@@ -541,7 +541,7 @@ func allocateDescriptorRewrites(
 						return err
 					}
 					// If the collided object isn't a type, then error out.
-					existingType, isType := desc.(*typedesc.ImmutableTypeDescriptor)
+					existingType, isType := desc.(*typedesc.Immutable)
 					if !isType {
 						return sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), typ.Name)
 					}
@@ -737,9 +737,7 @@ func rewriteIDsInTypesT(typ *types.T, descriptorRewrites DescRewriteMap) {
 
 // rewriteTypeDescs rewrites all ID's in the input slice of TypeDescriptors
 // using the input ID rewrite mapping.
-func rewriteTypeDescs(
-	types []*typedesc.MutableTypeDescriptor, descriptorRewrites DescRewriteMap,
-) error {
+func rewriteTypeDescs(types []*typedesc.Mutable, descriptorRewrites DescRewriteMap) error {
 	for _, typ := range types {
 		rewrite, ok := descriptorRewrites[typ.ID]
 		if !ok {
@@ -1311,7 +1309,7 @@ func doRestorePlan(
 	databasesByID := make(map[descpb.ID]*dbdesc.MutableDatabaseDescriptor)
 	schemasByID := make(map[descpb.ID]*schemadesc.Mutable)
 	tablesByID := make(map[descpb.ID]*tabledesc.Mutable)
-	typesByID := make(map[descpb.ID]*typedesc.MutableTypeDescriptor)
+	typesByID := make(map[descpb.ID]*typedesc.Mutable)
 	for _, desc := range sqlDescs {
 		switch desc := desc.(type) {
 		case *dbdesc.MutableDatabaseDescriptor:
@@ -1320,7 +1318,7 @@ func doRestorePlan(
 			schemasByID[desc.ID] = desc
 		case *tabledesc.Mutable:
 			tablesByID[desc.ID] = desc
-		case *typedesc.MutableTypeDescriptor:
+		case *typedesc.Mutable:
 			typesByID[desc.ID] = desc
 		}
 	}
@@ -1357,7 +1355,7 @@ func doRestorePlan(
 	for _, desc := range filteredTablesByID {
 		tables = append(tables, desc)
 	}
-	var types []*typedesc.MutableTypeDescriptor
+	var types []*typedesc.Mutable
 	for _, desc := range typesByID {
 		types = append(types, desc)
 	}

--- a/pkg/ccl/backupccl/restore_schema_change_creation.go
+++ b/pkg/ccl/backupccl/restore_schema_change_creation.go
@@ -152,7 +152,7 @@ func createSchemaChangeJobsFromMutations(
 	codec keys.SQLCodec,
 	txn *kv.Txn,
 	username string,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 ) ([]*jobs.StartableJob, error) {
 	mutationJobs := make([]descpb.TableDescriptor_MutationJob, 0, len(tableDesc.Mutations))
 	newJobs := make([]*jobs.StartableJob, 0, len(tableDesc.Mutations))

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -291,7 +291,7 @@ func backupShowerDefault(
 								IgnoreComments: true,
 							}
 							schema, err := p.ShowCreate(ctx, dbName, manifest.Descriptors,
-								tabledesc.NewImmutableTableDescriptor(*table), displayOptions)
+								tabledesc.NewImmutable(*table), displayOptions)
 							if err != nil {
 								continue
 							}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -684,9 +684,9 @@ func fullClusterTargetsBackup(
 // full cluster backup, and all the user databases.
 func fullClusterTargets(
 	allDescs []catalog.Descriptor,
-) ([]catalog.Descriptor, []*dbdesc.ImmutableDatabaseDescriptor, error) {
+) ([]catalog.Descriptor, []*dbdesc.Immutable, error) {
 	fullClusterDescs := make([]catalog.Descriptor, 0, len(allDescs))
-	fullClusterDBs := make([]*dbdesc.ImmutableDatabaseDescriptor, 0)
+	fullClusterDBs := make([]*dbdesc.Immutable, 0)
 
 	systemTablesToBackup := make(map[string]struct{}, len(fullClusterSystemTables))
 	for _, tableName := range fullClusterSystemTables {
@@ -696,7 +696,7 @@ func fullClusterTargets(
 	for _, desc := range allDescs {
 		switch desc := desc.(type) {
 		case catalog.DatabaseDescriptor:
-			dbDesc := dbdesc.NewImmutableDatabaseDescriptor(*desc.DatabaseDesc())
+			dbDesc := dbdesc.NewImmutable(*desc.DatabaseDesc())
 			fullClusterDescs = append(fullClusterDescs, desc)
 			if dbDesc.GetID() != systemschema.SystemDB.GetID() {
 				// The only database that isn't being fully backed up is the system DB.

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -56,12 +56,12 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		mkDB := func(id descpb.ID, name string) *dbdesc.ImmutableDatabaseDescriptor {
 			return &dbdesc.NewInitialDatabaseDescriptor(id, name, security.AdminRole).ImmutableDatabaseDescriptor
 		}
-		mkTyp := func(desc typDesc) *typedesc.ImmutableTypeDescriptor {
+		mkTyp := func(desc typDesc) *typedesc.Immutable {
 			// Set a default parent schema for the type descriptors.
 			if desc.ParentSchemaID == descpb.InvalidID {
 				desc.ParentSchemaID = keys.PublicSchemaID
 			}
-			return typedesc.NewImmutableTypeDescriptor(desc)
+			return typedesc.NewImmutable(desc)
 		}
 		mkSchema := func(desc scDesc) *schemadesc.Immutable {
 			return schemadesc.NewImmutable(desc)

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -63,8 +63,8 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 			}
 			return typedesc.NewImmutableTypeDescriptor(desc)
 		}
-		mkSchema := func(desc scDesc) *schemadesc.ImmutableSchemaDescriptor {
-			return schemadesc.NewImmutableSchemaDescriptor(desc)
+		mkSchema := func(desc scDesc) *schemadesc.Immutable {
+			return schemadesc.NewImmutable(desc)
 		}
 		toOid := typedesc.TypeIDToOID
 		typeExpr := "'hello'::@100015 = 'hello'::@100015"

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -37,7 +37,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// TODO(ajwerner): There should be a constructor for an ImmutableTableDescriptor
+	// TODO(ajwerner): There should be a constructor for an Immutable
 	// and really all of the leasable descriptor types which includes its initial
 	// DescriptorMeta. This refactoring precedes the actual adoption of
 	// DescriptorMeta.
@@ -48,8 +48,8 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		type tbDesc = descpb.TableDescriptor
 		type typDesc = descpb.TypeDescriptor
 		ts1 := hlc.Timestamp{WallTime: 1}
-		mkTable := func(descriptor tbDesc) *tabledesc.ImmutableTableDescriptor {
-			desc := tabledesc.NewImmutableTableDescriptor(descriptor)
+		mkTable := func(descriptor tbDesc) *tabledesc.Immutable {
+			desc := tabledesc.NewImmutable(descriptor)
 			desc.ModificationTime = ts1
 			return desc
 		}

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -53,8 +53,8 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 			desc.ModificationTime = ts1
 			return desc
 		}
-		mkDB := func(id descpb.ID, name string) *dbdesc.ImmutableDatabaseDescriptor {
-			return &dbdesc.NewInitialDatabaseDescriptor(id, name, security.AdminRole).ImmutableDatabaseDescriptor
+		mkDB := func(id descpb.ID, name string) *dbdesc.Immutable {
+			return &dbdesc.NewInitial(id, name, security.AdminRole).Immutable
 		}
 		mkTyp := func(desc typDesc) *typedesc.Immutable {
 			// Set a default parent schema for the type descriptors.

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -123,7 +123,7 @@ func parseAvroSchema(j string) (*avroDataRecord, error) {
 		}
 		tableDesc.Columns = append(tableDesc.Columns, *colDesc)
 	}
-	return tableToAvroSchema(tabledesc.NewImmutableTableDescriptor(tableDesc), avroSchemaNoSuffix)
+	return tableToAvroSchema(tabledesc.NewImmutable(tableDesc), avroSchemaNoSuffix)
 }
 
 func avroFieldMetadataToColDesc(metadata string) (*descpb.ColumnDescriptor, error) {

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -17,9 +17,7 @@ import (
 )
 
 // ValidateTable validates that a table descriptor can be watched by a CHANGEFEED.
-func ValidateTable(
-	targets jobspb.ChangefeedTargets, tableDesc *tabledesc.ImmutableTableDescriptor,
-) error {
+func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc *tabledesc.Immutable) error {
 	t, ok := targets[tableDesc.ID]
 	if !ok {
 		return errors.Errorf(`unwatched table: %s`, tableDesc.Name)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -83,7 +83,7 @@ func TestKVFeed(t *testing.T) {
 		spans              []roachpb.Span
 		events             []roachpb.RangeFeedEvent
 
-		descs []*tabledesc.ImmutableTableDescriptor
+		descs []*tabledesc.Immutable
 
 		expScans  []hlc.Timestamp
 		expEvents int
@@ -192,7 +192,7 @@ func TestKVFeed(t *testing.T) {
 				ts(2),
 				ts(3),
 			},
-			descs: []*tabledesc.ImmutableTableDescriptor{
+			descs: []*tabledesc.Immutable{
 				makeTableDesc(42, 1, ts(1), 2),
 				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
 			},
@@ -216,7 +216,7 @@ func TestKVFeed(t *testing.T) {
 			expScans: []hlc.Timestamp{
 				ts(2),
 			},
-			descs: []*tabledesc.ImmutableTableDescriptor{
+			descs: []*tabledesc.Immutable{
 				makeTableDesc(42, 1, ts(1), 2),
 				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
 			},
@@ -241,7 +241,7 @@ func TestKVFeed(t *testing.T) {
 			expScans: []hlc.Timestamp{
 				ts(2),
 			},
-			descs: []*tabledesc.ImmutableTableDescriptor{
+			descs: []*tabledesc.Immutable{
 				makeTableDesc(42, 1, ts(1), 2),
 				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(4), 1)),
 			},
@@ -267,9 +267,7 @@ type rawTableFeed struct {
 	events []schemafeed.TableEvent
 }
 
-func newRawTableFeed(
-	descs []*tabledesc.ImmutableTableDescriptor, initialHighWater hlc.Timestamp,
-) rawTableFeed {
+func newRawTableFeed(descs []*tabledesc.Immutable, initialHighWater hlc.Timestamp) rawTableFeed {
 	sort.Slice(descs, func(i, j int) bool {
 		if descs[i].ID != descs[j].ID {
 			return descs[i].ID < descs[j].ID

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -51,8 +51,8 @@ func newRowFetcherCache(codec keys.SQLCodec, leaseMgr *lease.Manager) *rowFetche
 
 func (c *rowFetcherCache) TableDescForKey(
 	ctx context.Context, key roachpb.Key, ts hlc.Timestamp,
-) (*tabledesc.ImmutableTableDescriptor, error) {
-	var tableDesc *tabledesc.ImmutableTableDescriptor
+) (*tabledesc.Immutable, error) {
+	var tableDesc *tabledesc.Immutable
 	key, err := c.codec.StripTenantPrefix(key)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (c *rowFetcherCache) TableDescForKey(
 			// its usage, none of them should ever be terminal.
 			return nil, MarkRetryableError(err)
 		}
-		tableDesc = desc.(*tabledesc.ImmutableTableDescriptor)
+		tableDesc = desc.(*tabledesc.Immutable)
 		// Immediately release the lease, since we only need it for the exact
 		// timestamp requested.
 		if err := c.leaseMgr.Release(tableDesc); err != nil {
@@ -97,7 +97,7 @@ func (c *rowFetcherCache) TableDescForKey(
 }
 
 func (c *rowFetcherCache) RowFetcherForTableDesc(
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 ) (*row.Fetcher, error) {
 	idVer := idVersion{id: tableDesc.ID, version: tableDesc.Version}
 	if rf, ok := c.fetchers[idVer]; ok {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -25,7 +25,7 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 
 	ctx := context.Background()
 	ts := func(wt int64) hlc.Timestamp { return hlc.Timestamp{WallTime: wt} }
-	validateFn := func(_ context.Context, desc *tabledesc.ImmutableTableDescriptor) error {
+	validateFn := func(_ context.Context, desc *tabledesc.Immutable) error {
 		if desc.Name != `` {
 			return errors.Newf("descriptor: %s", desc.Name)
 		}
@@ -67,8 +67,8 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	require.Equal(t, ts(3), m.highWater())
 
 	// validates
-	require.NoError(t, m.ingestDescriptors(ctx, ts(3), ts(4), []*tabledesc.ImmutableTableDescriptor{
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: 0}),
+	require.NoError(t, m.ingestDescriptors(ctx, ts(3), ts(4), []*tabledesc.Immutable{
+		tabledesc.NewImmutable(descpb.TableDescriptor{ID: 0}),
 	}, validateFn))
 	require.Equal(t, ts(4), m.highWater())
 
@@ -107,8 +107,8 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	require.EqualError(t, <-errCh8, `context canceled`)
 
 	// does not validate, high-water does not change
-	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(10), []*tabledesc.ImmutableTableDescriptor{
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: 0, Name: `whoops!`}),
+	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(10), []*tabledesc.Immutable{
+		tabledesc.NewImmutable(descpb.TableDescriptor{ID: 0, Name: `whoops!`}),
 	}, validateFn), `descriptor: whoops!`)
 	require.Equal(t, ts(7), m.highWater())
 
@@ -124,8 +124,8 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	requireChannelEmpty(t, errCh9)
 
 	// turns out ts 10 is not a tight bound. ts 9 also has an error
-	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(9), []*tabledesc.ImmutableTableDescriptor{
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: 0, Name: `oh no!`}),
+	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(9), []*tabledesc.Immutable{
+		tabledesc.NewImmutable(descpb.TableDescriptor{ID: 0, Name: `oh no!`}),
 	}, validateFn), `descriptor: oh no!`)
 	require.Equal(t, ts(7), m.highWater())
 	require.EqualError(t, <-errCh9, `descriptor: oh no!`)

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -23,7 +23,7 @@ import (
 // MakeTableDesc makes a generic table descriptor with the provided properties.
 func MakeTableDesc(
 	tableID descpb.ID, version descpb.DescriptorVersion, modTime hlc.Timestamp, cols int,
-) *tabledesc.ImmutableTableDescriptor {
+) *tabledesc.Immutable {
 	td := descpb.TableDescriptor{
 		Name:             "foo",
 		ID:               tableID,
@@ -35,7 +35,7 @@ func MakeTableDesc(
 		td.Columns = append(td.Columns, *MakeColumnDesc(td.NextColumnID))
 		td.NextColumnID++
 	}
-	return tabledesc.NewImmutableTableDescriptor(td)
+	return tabledesc.NewImmutable(td)
 }
 
 // MakeColumnDesc makes a generic column descriptor with the provided id.
@@ -49,10 +49,8 @@ func MakeColumnDesc(id descpb.ColumnID) *descpb.ColumnDescriptor {
 }
 
 // AddColumnDropBackfillMutation adds a mutation to desc to drop a column.
-// Yes, this does modify an ImmutableTableDescriptor.
-func AddColumnDropBackfillMutation(
-	desc *tabledesc.ImmutableTableDescriptor,
-) *tabledesc.ImmutableTableDescriptor {
+// Yes, this does modify an Immutable.
+func AddColumnDropBackfillMutation(desc *tabledesc.Immutable) *tabledesc.Immutable {
 	desc.Mutations = append(desc.Mutations, descpb.DescriptorMutation{
 		State:     descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 		Direction: descpb.DescriptorMutation_DROP,
@@ -61,10 +59,8 @@ func AddColumnDropBackfillMutation(
 }
 
 // AddNewColumnBackfillMutation adds a mutation to desc to add a column.
-// Yes, this does modify an ImmutableTableDescriptor.
-func AddNewColumnBackfillMutation(
-	desc *tabledesc.ImmutableTableDescriptor,
-) *tabledesc.ImmutableTableDescriptor {
+// Yes, this does modify an Immutable.
+func AddNewColumnBackfillMutation(desc *tabledesc.Immutable) *tabledesc.Immutable {
 	desc.Mutations = append(desc.Mutations, descpb.DescriptorMutation{
 		Descriptor_: &descpb.DescriptorMutation_Column{Column: MakeColumnDesc(desc.NextColumnID)},
 		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -86,7 +86,7 @@ func hasNewColumnDropBackfillMutation(e TableEvent) (res bool) {
 	return !dropMutationExists(e.Before) && dropMutationExists(e.After)
 }
 
-func dropMutationExists(desc *tabledesc.ImmutableTableDescriptor) bool {
+func dropMutationExists(desc *tabledesc.Immutable) bool {
 	for _, m := range desc.Mutations {
 		if m.Direction == descpb.DescriptorMutation_DROP &&
 			m.State == descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY {
@@ -108,7 +108,7 @@ func newColumnNoBackfill(e TableEvent) (res bool) {
 		!e.Before.HasColumnBackfillMutation()
 }
 
-func pkChangeMutationExists(desc *tabledesc.ImmutableTableDescriptor) bool {
+func pkChangeMutationExists(desc *tabledesc.Immutable) bool {
 	for _, m := range desc.Mutations {
 		if m.Direction == descpb.DescriptorMutation_ADD && m.GetPrimaryKeySwap() != nil {
 			return true

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -73,7 +73,7 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter end of add NULL-able computed column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: func() *tabledesc.ImmutableTableDescriptor {
+				Before: func() *tabledesc.Immutable {
 					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1))
 					col := td.Mutations[0].GetColumn()
 					col.Nullable = true

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -111,7 +111,7 @@ func TestCloudStorageSink(t *testing.T) {
 	user := security.RootUser
 
 	t.Run(`golden`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -146,8 +146,8 @@ func TestCloudStorageSink(t *testing.T) {
 		for _, compression := range []string{"", "gzip"} {
 			opts[changefeedbase.OptCompression] = compression
 			t.Run("compress="+compression, func(t *testing.T) {
-				t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
-				t2 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t2`})
+				t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
+				t2 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t2`})
 
 				testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 				sf := span.MakeFrontier(testSpan)
@@ -222,7 +222,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`multi-node`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
@@ -303,7 +303,7 @@ func TestCloudStorageSink(t *testing.T) {
 	// This test is also sufficient for verifying the behavior of a multi-node
 	// changefeed using this sink. Ditto job restarts.
 	t.Run(`zombie`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -344,7 +344,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`bucketing`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -432,7 +432,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`file-ordering`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -491,7 +491,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`ordering-among-schema-versions`, func(t *testing.T) {
-		t1 := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -54,8 +54,8 @@ func TestKafkaSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *tabledesc.ImmutableTableDescriptor {
-		return tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
+	table := func(name string) *tabledesc.Immutable {
+		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()
@@ -144,8 +144,8 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *tabledesc.ImmutableTableDescriptor {
-		return tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
+	table := func(name string) *tabledesc.Immutable {
+		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()
@@ -183,8 +183,8 @@ func TestSQLSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *tabledesc.ImmutableTableDescriptor {
-		return tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
+	table := func(name string) *tabledesc.Immutable {
+		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -121,11 +121,11 @@ func makeInputConverter(
 	kvCh chan row.KVBatch,
 ) (inputConverter, error) {
 	injectTimeIntoEvalCtx(evalCtx, spec.WalltimeNanos)
-	var singleTable *tabledesc.ImmutableTableDescriptor
+	var singleTable *tabledesc.Immutable
 	var singleTableTargetCols tree.NameList
 	if len(spec.Tables) == 1 {
 		for _, table := range spec.Tables {
-			singleTable = tabledesc.NewImmutableTableDescriptor(*table.Desc)
+			singleTable = tabledesc.NewImmutable(*table.Desc)
 			singleTableTargetCols = make(tree.NameList, len(table.TargetCols))
 			for i, colName := range table.TargetCols {
 				singleTableTargetCols[i] = tree.Name(colName)

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -881,7 +881,7 @@ func newTestSpec(t *testing.T, format roachpb.IOFileFormat, inputs ...string) te
 
 	// Initialize table descriptor for import. We need valid descriptor to run
 	// converters, even though we don't actually import anything in this test.
-	var descr *tabledesc.MutableTableDescriptor
+	var descr *tabledesc.Mutable
 	switch format.Format {
 	case roachpb.IOFileFormat_CSV:
 		descr = descForTable(t,

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -216,7 +216,7 @@ func ensureRequiredPrivileges(
 	ctx context.Context,
 	requiredPrivileges []privilege.Kind,
 	p sql.PlanHookState,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 ) error {
 	for _, priv := range requiredPrivileges {
 		err := p.CheckPrivilege(ctx, desc, priv)
@@ -599,7 +599,7 @@ func importPlanHook(
 		}
 
 		var tableDetails []jobspb.ImportDetails_Table
-		var tableDescs []*tabledesc.MutableTableDescriptor // parallel with tableDetails
+		var tableDescs []*tabledesc.Mutable // parallel with tableDetails
 		jobDesc, err := importJobDescription(p, importStmt, nil, filenamePatterns, opts)
 		if err != nil {
 			return err
@@ -673,7 +673,7 @@ func importPlanHook(
 					}
 				}
 			}
-			tableDescs = []*tabledesc.MutableTableDescriptor{found}
+			tableDescs = []*tabledesc.Mutable{found}
 			tableDetails = []jobspb.ImportDetails_Table{{Desc: &found.TableDescriptor, IsNew: false, TargetCols: intoCols}}
 		} else {
 			seqVals := make(map[descpb.ID]int64)
@@ -751,7 +751,7 @@ func importPlanHook(
 				if err != nil {
 					return err
 				}
-				tableDescs = []*tabledesc.MutableTableDescriptor{tbl}
+				tableDescs = []*tabledesc.Mutable{tbl}
 				descStr, err := importJobDescription(p, importStmt, create.Defs, filenamePatterns, opts)
 				if err != nil {
 					return err
@@ -953,9 +953,9 @@ func prepareNewTableDescsForIngestion(
 	importTables []jobspb.ImportDetails_Table,
 	parentID descpb.ID,
 ) ([]*descpb.TableDescriptor, error) {
-	newMutableTableDescriptors := make([]*tabledesc.MutableTableDescriptor, len(importTables))
+	newMutableTableDescriptors := make([]*tabledesc.Mutable, len(importTables))
 	for i := range importTables {
-		newMutableTableDescriptors[i] = tabledesc.NewMutableExistingTableDescriptor(*importTables[i].Desc)
+		newMutableTableDescriptors[i] = tabledesc.NewExistingMutable(*importTables[i].Desc)
 	}
 
 	// Verification steps have passed, generate a new table ID if we're
@@ -1044,8 +1044,8 @@ func prepareExistingTableDescForIngestion(
 	}
 
 	// TODO(dt): Ensure no other schema changes can start during ingest.
-	importing := tabledesc.NewMutableExistingTableDescriptor(*desc)
-	existing := importing.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
+	importing := tabledesc.NewExistingMutable(*desc)
+	existing := importing.ImmutableCopy().(*tabledesc.Immutable)
 	importing.Version++
 	// Take the table offline for import.
 	// TODO(dt): audit everywhere we get table descs (leases or otherwise) to
@@ -1225,7 +1225,7 @@ func (r *importResumer) Resume(
 		// case we can cheaply clear-range instead of revert-range to cleanup.
 		for i := range details.Tables {
 			if !details.Tables[i].IsNew {
-				tblSpan := tabledesc.NewImmutableTableDescriptor(*details.Tables[i].Desc).TableSpan(keys.TODOSQLCodec)
+				tblSpan := tabledesc.NewImmutable(*details.Tables[i].Desc).TableSpan(keys.TODOSQLCodec)
 				res, err := p.ExecCfg().DB.Scan(ctx, tblSpan.Key, tblSpan.EndKey, 1 /* maxRows */)
 				if err != nil {
 					return errors.Wrap(err, "checking if existing table is empty")
@@ -1325,8 +1325,8 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 		}
 		b := txn.NewBatch()
 		for _, tbl := range details.Tables {
-			newTableDesc := tabledesc.NewMutableExistingTableDescriptor(*tbl.Desc)
-			prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
+			newTableDesc := tabledesc.NewExistingMutable(*tbl.Desc)
+			prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.Immutable)
 			newTableDesc.Version++
 			newTableDesc.State = descpb.TableDescriptor_PUBLIC
 			newTableDesc.OfflineReason = ""
@@ -1453,14 +1453,14 @@ func (r *importResumer) dropTables(
 		return nil
 	}
 
-	var revert []*tabledesc.ImmutableTableDescriptor
-	var empty []*tabledesc.ImmutableTableDescriptor
+	var revert []*tabledesc.Immutable
+	var empty []*tabledesc.Immutable
 	for _, tbl := range details.Tables {
 		if !tbl.IsNew {
 			if tbl.WasEmpty {
-				empty = append(empty, tabledesc.NewImmutableTableDescriptor(*tbl.Desc))
+				empty = append(empty, tabledesc.NewImmutable(*tbl.Desc))
 			} else {
-				revert = append(revert, tabledesc.NewImmutableTableDescriptor(*tbl.Desc))
+				revert = append(revert, tabledesc.NewImmutable(*tbl.Desc))
 			}
 		}
 	}
@@ -1494,8 +1494,8 @@ func (r *importResumer) dropTables(
 	dropTime := int64(1)
 	tablesToGC := make([]descpb.ID, 0, len(details.Tables))
 	for _, tbl := range details.Tables {
-		newTableDesc := tabledesc.NewMutableExistingTableDescriptor(*tbl.Desc)
-		prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
+		newTableDesc := tabledesc.NewExistingMutable(*tbl.Desc)
+		prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.Immutable)
 		newTableDesc.Version++
 		if tbl.IsNew {
 			newTableDesc.State = descpb.TableDescriptor_DROP

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1045,7 +1045,7 @@ func prepareExistingTableDescForIngestion(
 
 	// TODO(dt): Ensure no other schema changes can start during ingest.
 	importing := tabledesc.NewMutableExistingTableDescriptor(*desc)
-	existing := importing.Immutable().(*tabledesc.ImmutableTableDescriptor)
+	existing := importing.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
 	importing.Version++
 	// Take the table offline for import.
 	// TODO(dt): audit everywhere we get table descs (leases or otherwise) to
@@ -1326,7 +1326,7 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 		b := txn.NewBatch()
 		for _, tbl := range details.Tables {
 			newTableDesc := tabledesc.NewMutableExistingTableDescriptor(*tbl.Desc)
-			prevTableDesc := newTableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor)
+			prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
 			newTableDesc.Version++
 			newTableDesc.State = descpb.TableDescriptor_PUBLIC
 			newTableDesc.OfflineReason = ""
@@ -1495,7 +1495,7 @@ func (r *importResumer) dropTables(
 	tablesToGC := make([]descpb.ID, 0, len(details.Tables))
 	for _, tbl := range details.Tables {
 		newTableDesc := tabledesc.NewMutableExistingTableDescriptor(*tbl.Desc)
-		prevTableDesc := newTableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor)
+		prevTableDesc := newTableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor)
 		newTableDesc.Version++
 		if tbl.IsNew {
 			newTableDesc.State = descpb.TableDescriptor_DROP

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1735,7 +1735,7 @@ func TestImportCSVStmt(t *testing.T) {
 		// it was created in.
 		dbID := sqlutils.QueryDatabaseID(t, sqlDB.DB, "failedimport")
 		tableID := descpb.ID(dbID + 1)
-		var td *tabledesc.ImmutableTableDescriptor
+		var td *tabledesc.Immutable
 		if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 			td, err = catalogkv.MustGetTableDescByID(ctx, txn, keys.SystemSQLCodec, tableID)
 			return err
@@ -3223,7 +3223,7 @@ func BenchmarkCSVConvertRecord(b *testing.B) {
 
 	importCtx := &parallelImportContext{
 		evalCtx:   &evalCtx,
-		tableDesc: tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
+		tableDesc: tableDesc.ImmutableCopy().(*tabledesc.Immutable),
 		kvCh:      kvCh,
 	}
 
@@ -3873,7 +3873,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 		RowSeparator:   '\n',
 		FieldSeparator: '\t',
 	}, kvCh, 0, 0,
-		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
+		tableDesc.ImmutableCopy().(*tabledesc.Immutable), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 
 	producer := &csvBenchmarkStream{
@@ -3976,7 +3976,7 @@ func BenchmarkPgCopyConvertRecord(b *testing.B) {
 		Null:       `\N`,
 		MaxRowSize: 4096,
 	}, kvCh, 0, 0,
-		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
+		tableDesc.ImmutableCopy().(*tabledesc.Immutable), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 
 	producer := &csvBenchmarkStream{

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -3223,7 +3223,7 @@ func BenchmarkCSVConvertRecord(b *testing.B) {
 
 	importCtx := &parallelImportContext{
 		evalCtx:   &evalCtx,
-		tableDesc: tableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor),
+		tableDesc: tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
 		kvCh:      kvCh,
 	}
 
@@ -3873,7 +3873,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 		RowSeparator:   '\n',
 		FieldSeparator: '\t',
 	}, kvCh, 0, 0,
-		tableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
+		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 
 	producer := &csvBenchmarkStream{
@@ -3976,7 +3976,7 @@ func BenchmarkPgCopyConvertRecord(b *testing.B) {
 		Null:       `\N`,
 		MaxRowSize: 4096,
 	}, kvCh, 0, 0,
-		tableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
+		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 
 	producer := &csvBenchmarkStream{

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -83,7 +83,7 @@ type fkHandler struct {
 // NoFKs is used by formats that do not support FKs.
 var NoFKs = fkHandler{resolver: make(fkResolver)}
 
-// MakeSimpleTableDescriptor creates a MutableTableDescriptor from a CreateTable parse
+// MakeSimpleTableDescriptor creates a Mutable from a CreateTable parse
 // node without the full machinery. Many parts of the syntax are unsupported
 // (see the implementation and TestMakeSimpleTableDescriptorErrors for details),
 // but this is enough for our csv IMPORT and for some unit tests.
@@ -99,7 +99,7 @@ func MakeSimpleTableDescriptor(
 	parentID, parentSchemaID, tableID descpb.ID,
 	fks fkHandler,
 	walltime int64,
-) (*tabledesc.MutableTableDescriptor, error) {
+) (*tabledesc.Mutable, error) {
 	create.HoistConstraints()
 	if create.IfNotExists {
 		return nil, unimplemented.NewWithIssueDetailf(42846, "import.if-no-exists", "unsupported IF NOT EXISTS")
@@ -147,7 +147,7 @@ func MakeSimpleTableDescriptor(
 		Context:  ctx,
 		Sequence: &importSequenceOperators{},
 	}
-	affected := make(map[descpb.ID]*tabledesc.MutableTableDescriptor)
+	affected := make(map[descpb.ID]*tabledesc.Mutable)
 
 	tableDesc, err := sql.NewTableDesc(
 		ctx,
@@ -180,7 +180,7 @@ func MakeSimpleTableDescriptor(
 // creation. sql.NewTableDesc and ResolveFK set the table to the ADD state
 // and mark references an validated. This function sets the table to PUBLIC
 // and the FKs to unvalidated.
-func fixDescriptorFKState(tableDesc *tabledesc.MutableTableDescriptor) error {
+func fixDescriptorFKState(tableDesc *tabledesc.Mutable) error {
 	tableDesc.State = descpb.TableDescriptor_PUBLIC
 	for i := range tableDesc.OutboundFKs {
 		tableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated
@@ -249,7 +249,7 @@ func (so *importSequenceOperators) SetSequenceValue(
 	return errSequenceOperators
 }
 
-type fkResolver map[string]*tabledesc.MutableTableDescriptor
+type fkResolver map[string]*tabledesc.Mutable
 
 var _ resolver.SchemaResolver = fkResolver{}
 
@@ -315,6 +315,6 @@ func (r fkResolver) LookupSchema(
 // Implements the sql.SchemaResolver interface.
 func (r fkResolver) LookupTableByID(
 	ctx context.Context, id descpb.ID,
-) (*tabledesc.ImmutableTableDescriptor, error) {
+) (*tabledesc.Immutable, error) {
 	return nil, errSchemaResolver
 }

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -448,7 +448,7 @@ var _ inputConverter = &avroInputReader{}
 
 func newAvroInputReader(
 	kvCh chan row.KVBatch,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	avroOpts roachpb.AvroOptions,
 	walltime int64,
 	parallelism int,

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -200,7 +200,7 @@ func newTestHelper(t *testing.T, gens ...avroGen) *testHelper {
 	return &testHelper{
 		schemaJSON: string(schemaJSON),
 		schemaTable: descForTable(t, createStmt, 10, 20, NoFKs).
-			Immutable().(*tabledesc.ImmutableTableDescriptor),
+			ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
 		codec:    codec,
 		gens:     gens,
 		settings: st,
@@ -591,7 +591,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	require.NoError(b, err)
 
 	avro, err := newAvroInputReader(kvCh,
-		tableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor),
+		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
 		avroOpts, 0, 0, &evalCtx)
 	require.NoError(b, err)
 

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -142,7 +142,7 @@ func (g *intArrGen) Gen() interface{} {
 // A testHelper to generate avro data.
 type testHelper struct {
 	schemaJSON  string
-	schemaTable *tabledesc.ImmutableTableDescriptor
+	schemaTable *tabledesc.Immutable
 	codec       *goavro.Codec
 	gens        []avroGen
 	settings    *cluster.Settings
@@ -200,7 +200,7 @@ func newTestHelper(t *testing.T, gens ...avroGen) *testHelper {
 	return &testHelper{
 		schemaJSON: string(schemaJSON),
 		schemaTable: descForTable(t, createStmt, 10, 20, NoFKs).
-			ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
+			ImmutableCopy().(*tabledesc.Immutable),
 		codec:    codec,
 		gens:     gens,
 		settings: st,
@@ -591,7 +591,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	require.NoError(b, err)
 
 	avro, err := newAvroInputReader(kvCh,
-		tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
+		tableDesc.ImmutableCopy().(*tabledesc.Immutable),
 		avroOpts, 0, 0, &evalCtx)
 	require.NoError(b, err)
 

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -394,13 +394,13 @@ func newImportRowError(err error, row string, num int64) error {
 
 // parallelImportContext describes state associated with the import.
 type parallelImportContext struct {
-	walltime   int64                               // Import time stamp.
-	numWorkers int                                 // Parallelism
-	batchSize  int                                 // Number of records to batch
-	evalCtx    *tree.EvalContext                   // Evaluation context.
-	tableDesc  *tabledesc.ImmutableTableDescriptor // Table descriptor we're importing into.
-	targetCols tree.NameList                       // List of columns to import.  nil if importing all columns.
-	kvCh       chan row.KVBatch                    // Channel for sending KV batches.
+	walltime   int64                // Import time stamp.
+	numWorkers int                  // Parallelism
+	batchSize  int                  // Number of records to batch
+	evalCtx    *tree.EvalContext    // Evaluation context.
+	tableDesc  *tabledesc.Immutable // Table descriptor we're importing into.
+	targetCols tree.NameList        // List of columns to import.  nil if importing all columns.
+	kvCh       chan row.KVBatch     // Channel for sending KV batches.
 }
 
 // importFileContext describes state specific to a file being imported.

--- a/pkg/ccl/importccl/read_import_base_test.go
+++ b/pkg/ccl/importccl/read_import_base_test.go
@@ -135,7 +135,7 @@ func TestParallelImportProducerHandlesConsumerErrors(t *testing.T) {
 		numWorkers: 1,
 		batchSize:  2,
 		evalCtx:    testEvalCtx,
-		tableDesc:  tabledesc.NewImmutableTableDescriptor(descr),
+		tableDesc:  tabledesc.NewImmutable(descr),
 		kvCh:       kvCh,
 	}
 
@@ -174,7 +174,7 @@ func TestParallelImportProducerHandlesCancellation(t *testing.T) {
 		numWorkers: 1,
 		batchSize:  2,
 		evalCtx:    testEvalCtx,
-		tableDesc:  tabledesc.NewImmutableTableDescriptor(descr),
+		tableDesc:  tabledesc.NewImmutable(descr),
 		kvCh:       kvCh,
 	}
 

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -36,7 +36,7 @@ func newCSVInputReader(
 	opts roachpb.CSVOptions,
 	walltime int64,
 	parallelism int,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	targetCols tree.NameList,
 	evalCtx *tree.EvalContext,
 ) *csvInputReader {

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -134,7 +134,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed: true,
-		resolver: fkResolver(map[string]*tabledesc.MutableTableDescriptor{
+		resolver: fkResolver(map[string]*tabledesc.Mutable{
 			referencedSimple.Name: referencedSimple,
 		}),
 	}
@@ -214,8 +214,8 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		ctx := context.Background()
 		semaCtx := tree.MakeSemaContext()
 		tableName := &descpb.AnonymousTable
-		expectedDesc := tabledesc.NewImmutableTableDescriptor(*expected)
-		gotDesc := tabledesc.NewImmutableTableDescriptor(*got)
+		expectedDesc := tabledesc.NewImmutable(*expected)
+		gotDesc := tabledesc.NewImmutable(*got)
 		e, err := schemaexpr.FormatIndexForDisplay(ctx, expectedDesc, tableName, &expected.Indexes[i], &semaCtx)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -37,7 +37,7 @@ func newMysqloutfileReader(
 	kvCh chan row.KVBatch,
 	walltime int64,
 	parallelism int,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	targetCols tree.NameList,
 	evalCtx *tree.EvalContext,
 ) (*mysqloutfileReader, error) {

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -43,7 +43,7 @@ func newPgCopyReader(
 	kvCh chan row.KVBatch,
 	walltime int64,
 	parallelism int,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	targetCols tree.NameList,
 	evalCtx *tree.EvalContext,
 ) (*pgCopyReader, error) {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -224,7 +224,7 @@ func readPostgresCreateTable(
 	walltime int64,
 	fks fkHandler,
 	max int,
-) ([]*tabledesc.MutableTableDescriptor, error) {
+) ([]*tabledesc.Mutable, error) {
 	// Modify the CreateTable stmt with the various index additions. We do this
 	// instead of creating a full table descriptor first and adding indexes
 	// later because MakeSimpleTableDescriptor calls the sql package which calls
@@ -239,7 +239,7 @@ func readPostgresCreateTable(
 	for {
 		stmt, err := ps.Next()
 		if err == io.EOF {
-			ret := make([]*tabledesc.MutableTableDescriptor, 0, len(createTbl))
+			ret := make([]*tabledesc.Mutable, 0, len(createTbl))
 			owner := security.AdminRole
 			if params.SessionData() != nil {
 				owner = params.SessionData().User
@@ -263,7 +263,7 @@ func readPostgresCreateTable(
 				fks.resolver[desc.Name] = desc
 				ret = append(ret, desc)
 			}
-			backrefs := make(map[descpb.ID]*tabledesc.MutableTableDescriptor)
+			backrefs := make(map[descpb.ID]*tabledesc.Mutable)
 			for _, create := range createTbl {
 				if create == nil {
 					continue
@@ -549,7 +549,7 @@ func newPgDumpReader(
 	colMap := make(map[*row.DatumRowConverter](map[string]int))
 	for name, table := range descs {
 		if table.Desc.IsTable() {
-			tableDesc := tabledesc.NewImmutableTableDescriptor(*table.Desc)
+			tableDesc := tabledesc.NewImmutable(*table.Desc)
 			colSubMap := make(map[string]int, len(table.TargetCols))
 			targetCols := make(tree.NameList, len(table.TargetCols))
 			for i, colName := range table.TargetCols {
@@ -566,7 +566,7 @@ func newPgDumpReader(
 			colMap[conv] = colSubMap
 			tableDescs[name] = tableDesc
 		} else if table.Desc.IsSequence() {
-			seqDesc := tabledesc.NewImmutableTableDescriptor(*table.Desc)
+			seqDesc := tabledesc.NewImmutable(*table.Desc)
 			tableDescs[name] = seqDesc
 		}
 	}

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -35,14 +35,14 @@ import (
 
 type workloadReader struct {
 	evalCtx *tree.EvalContext
-	table   *tabledesc.ImmutableTableDescriptor
+	table   *tabledesc.Immutable
 	kvCh    chan row.KVBatch
 }
 
 var _ inputConverter = &workloadReader{}
 
 func newWorkloadReader(
-	kvCh chan row.KVBatch, table *tabledesc.ImmutableTableDescriptor, evalCtx *tree.EvalContext,
+	kvCh chan row.KVBatch, table *tabledesc.Immutable, evalCtx *tree.EvalContext,
 ) *workloadReader {
 	return &workloadReader{evalCtx: evalCtx, table: table, kvCh: kvCh}
 }
@@ -177,7 +177,7 @@ func (w *workloadReader) readFiles(
 
 // WorkloadKVConverter converts workload.BatchedTuples to []roachpb.KeyValues.
 type WorkloadKVConverter struct {
-	tableDesc      *tabledesc.ImmutableTableDescriptor
+	tableDesc      *tabledesc.Immutable
 	rows           workload.BatchedTuples
 	batchIdxAtomic int64
 	batchEnd       int
@@ -193,7 +193,7 @@ type WorkloadKVConverter struct {
 // range of batches, emitted converted kvs to the given channel.
 func NewWorkloadKVConverter(
 	fileID int32,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	rows workload.BatchedTuples,
 	batchStart, batchEnd int,
 	kvCh chan row.KVBatch,

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -36,7 +36,7 @@ import (
 
 func descForTable(
 	t *testing.T, create string, parent, id descpb.ID, fks fkHandler,
-) *tabledesc.MutableTableDescriptor {
+) *tabledesc.Mutable {
 	t.Helper()
 	parsed, err := parser.Parse(create)
 	if err != nil {

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -150,7 +150,7 @@ func (replaceMinMaxValVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr
 func createPartitioningImpl(
 	ctx context.Context,
 	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
 	colOffset int,
@@ -250,7 +250,7 @@ func createPartitioning(
 	ctx context.Context,
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
 ) (descpb.PartitioningDescriptor, error) {

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -95,7 +95,7 @@ type partitioningTest struct {
 		createStmt string
 
 		// tableDesc is the TableDescriptor created by `createStmt`.
-		tableDesc *tabledesc.MutableTableDescriptor
+		tableDesc *tabledesc.Mutable
 
 		// zoneConfigStmt contains SQL that effects the zone configs described
 		// by `configs`.

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -55,12 +55,12 @@ func (p prefixRewriter) rewriteKey(key []byte) ([]byte, bool) {
 // and splits.
 type KeyRewriter struct {
 	prefixes prefixRewriter
-	descs    map[descpb.ID]*tabledesc.ImmutableTableDescriptor
+	descs    map[descpb.ID]*tabledesc.Immutable
 }
 
 // MakeKeyRewriterFromRekeys makes a KeyRewriter from Rekey protos.
 func MakeKeyRewriterFromRekeys(rekeys []roachpb.ImportRequest_TableRekey) (*KeyRewriter, error) {
-	descs := make(map[descpb.ID]*tabledesc.ImmutableTableDescriptor)
+	descs := make(map[descpb.ID]*tabledesc.Immutable)
 	for _, rekey := range rekeys {
 		var desc descpb.Descriptor
 		if err := protoutil.Unmarshal(rekey.NewDesc, &desc); err != nil {
@@ -70,15 +70,13 @@ func MakeKeyRewriterFromRekeys(rekeys []roachpb.ImportRequest_TableRekey) (*KeyR
 		if table == nil {
 			return nil, errors.New("expected a table descriptor")
 		}
-		descs[descpb.ID(rekey.OldID)] = tabledesc.NewImmutableTableDescriptor(*table)
+		descs[descpb.ID(rekey.OldID)] = tabledesc.NewImmutable(*table)
 	}
 	return MakeKeyRewriter(descs)
 }
 
 // MakeKeyRewriter makes a KeyRewriter from a map of descs keyed by original ID.
-func MakeKeyRewriter(
-	descs map[descpb.ID]*tabledesc.ImmutableTableDescriptor,
-) (*KeyRewriter, error) {
+func MakeKeyRewriter(descs map[descpb.ID]*tabledesc.Immutable) (*KeyRewriter, error) {
 	var prefixes prefixRewriter
 	seenPrefixes := make(map[string]bool)
 	for oldID, desc := range descs {

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -61,7 +61,7 @@ func TestPrefixRewriter(t *testing.T) {
 func TestKeyRewriter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	desc := tabledesc.NewMutableCreatedTableDescriptor(systemschema.NamespaceTable.TableDescriptor)
+	desc := tabledesc.NewCreatedMutable(systemschema.NamespaceTable.TableDescriptor)
 	oldID := desc.ID
 	newID := desc.ID + 1
 	desc.ID = newID
@@ -119,7 +119,7 @@ func TestKeyRewriter(t *testing.T) {
 
 	t.Run("multi", func(t *testing.T) {
 		desc.ID = oldID + 10
-		desc2 := tabledesc.NewMutableCreatedTableDescriptor(desc.TableDescriptor)
+		desc2 := tabledesc.NewCreatedMutable(desc.TableDescriptor)
 		desc2.ID += 10
 		newKr, err := MakeKeyRewriterFromRekeys([]roachpb.ImportRequest_TableRekey{
 			{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
@@ -148,7 +148,7 @@ func TestKeyRewriter(t *testing.T) {
 }
 
 func mustMarshalDesc(t *testing.T, tableDesc *descpb.TableDescriptor) []byte {
-	desc := tabledesc.NewImmutableTableDescriptor(*tableDesc).DescriptorProto()
+	desc := tabledesc.NewImmutable(*tableDesc).DescriptorProto()
 	// Set the timestamp to a non-zero value.
 	descpb.TableFromDescriptor(desc, hlc.Timestamp{WallTime: 1})
 	bytes, err := protoutil.Marshal(desc)

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -49,7 +49,7 @@ func ToTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	return tableDesc.Immutable().(*tabledesc.ImmutableTableDescriptor), nil
+	return tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil
 }
 
 // ToSSTable constructs a single sstable with the kvs necessary to represent a

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -32,7 +32,7 @@ import (
 // Table.
 func ToTableDescriptor(
 	t workload.Table, tableID descpb.ID, ts time.Time,
-) (*tabledesc.ImmutableTableDescriptor, error) {
+) (*tabledesc.Immutable, error) {
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 	stmt, err := parser.ParseOne(fmt.Sprintf(`CREATE TABLE "%s" %s`, t.Name, t.Schema))
@@ -49,7 +49,7 @@ func ToTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	return tableDesc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor), nil
+	return tableDesc.ImmutableCopy().(*tabledesc.Immutable), nil
 }
 
 // ToSSTable constructs a single sstable with the kvs necessary to represent a

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -206,7 +206,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		if err := protoutil.Unmarshal(bytes, &desc); err != nil {
 			return err
 		}
-		table := tabledesc.NewImmutableTableDescriptor(*descpb.TableFromDescriptor(&desc, hlc.Timestamp{}))
+		table := tabledesc.NewImmutable(*descpb.TableFromDescriptor(&desc, hlc.Timestamp{}))
 
 		fn := func(kv storage.MVCCKeyValue) (string, error) {
 			var v roachpb.Value

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -149,7 +149,7 @@ func (s *SystemConfig) getSystemTenantDesc(key roachpb.Key) *roachpb.Value {
 		// configs through proper channels.
 		//
 		// Getting here outside tests is impossible.
-		desc := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{}).DescriptorProto()
+		desc := tabledesc.NewImmutable(descpb.TableDescriptor{}).DescriptorProto()
 		var val roachpb.Value
 		if err := val.SetProto(desc); err != nil {
 			panic(err)

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -68,7 +68,7 @@ func sqlKV(tableID uint32, indexID, descID uint64) roachpb.KeyValue {
 func descriptor(descID uint64) roachpb.KeyValue {
 	id := descpb.ID(descID)
 	k := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, id)
-	v := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: id})
+	v := tabledesc.NewImmutable(descpb.TableDescriptor{ID: id})
 	kv := roachpb.KeyValue{Key: k}
 	if err := kv.Value.SetProto(v.DescriptorProto()); err != nil {
 		panic(err)

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -68,7 +68,7 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 		const junkDescriptorID = 42
 		require.GreaterOrEqual(t, keys.MaxReservedDescID, junkDescriptorID)
 		junkDescriptorKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, junkDescriptorID)
-		junkDescriptor := dbdesc.NewInitialDatabaseDescriptor(
+		junkDescriptor := dbdesc.NewInitial(
 			junkDescriptorID, "junk", security.AdminRole)
 		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			if err := txn.SetSystemConfigTrigger(true /* forSystemTenant */); err != nil {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1323,7 +1323,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 			// We don't care about the value, just the key.
 			id := descpb.ID(i)
 			key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, id)
-			desc := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: id})
+			desc := tabledesc.NewImmutable(descpb.TableDescriptor{ID: id})
 			if err := txn.Put(ctx, key, desc.DescriptorProto()); err != nil {
 				return err
 			}
@@ -1392,7 +1392,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		// the descriptor we add. We don't care about the value, just the key.
 		id := descpb.ID(userTableMax)
 		k := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, id)
-		desc := tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ID: id})
+		desc := tabledesc.NewImmutable(descpb.TableDescriptor{ID: id})
 		return txn.Put(ctx, k, desc.DescriptorProto())
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -219,13 +219,13 @@ func TestGossipAfterAbortOfSystemConfigTransactionAfterFailureDueToIntents(t *te
 	txB := db.NewTxn(ctx, "b")
 
 	require.NoError(t, txA.SetSystemConfigTrigger(true /* forSystemTenant */))
-	db1000 := dbdesc.NewInitialDatabaseDescriptor(1000, "1000", security.AdminRole)
+	db1000 := dbdesc.NewInitial(1000, "1000", security.AdminRole)
 	require.NoError(t, txA.Put(ctx,
 		keys.SystemSQLCodec.DescMetadataKey(1000),
 		db1000.DescriptorProto()))
 
 	require.NoError(t, txB.SetSystemConfigTrigger(true /* forSystemTenant */))
-	db2000 := dbdesc.NewInitialDatabaseDescriptor(2000, "2000", security.AdminRole)
+	db2000 := dbdesc.NewInitial(2000, "2000", security.AdminRole)
 	require.NoError(t, txB.Put(ctx,
 		keys.SystemSQLCodec.DescMetadataKey(2000),
 		db2000.DescriptorProto()))

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -863,7 +863,7 @@ func generateTableZone(t table, tableDesc descpb.TableDescriptor) (*zonepb.ZoneC
 		var err error
 		tableZone.SubzoneSpans, err = sql.GenerateSubzoneSpans(
 			nil, uuid.UUID{} /* clusterID */, keys.SystemSQLCodec,
-			tabledesc.NewImmutableTableDescriptor(tableDesc), tableZone.Subzones, false /* hasNewSubzones */)
+			tabledesc.NewImmutable(tableDesc), tableZone.Subzones, false /* hasNewSubzones */)
 		if err != nil {
 			return nil, errors.Wrap(err, "error generating subzone spans")
 		}

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -762,7 +762,7 @@ func compileTestCase(tc baseReportTestCase) (compiledTestCase, error) {
 			}
 		}
 		sysCfgBuilder.addDBDesc(dbID,
-			&dbdesc.NewInitialDatabaseDescriptor(descpb.ID(dbID), db.name, security.AdminRole).ImmutableDatabaseDescriptor)
+			&dbdesc.NewInitial(descpb.ID(dbID), db.name, security.AdminRole).Immutable)
 
 		for _, table := range db.tables {
 			tableID := objectCounter
@@ -1095,7 +1095,7 @@ func (b *systemConfigBuilder) addTableDesc(id int, tableDesc descpb.TableDescrip
 }
 
 // addTableDesc adds a database descriptor to the SystemConfig.
-func (b *systemConfigBuilder) addDBDesc(id int, dbDesc *dbdesc.ImmutableDatabaseDescriptor) {
+func (b *systemConfigBuilder) addDBDesc(id int, dbDesc *dbdesc.Immutable) {
 	// Write the table to the SystemConfig, in the descriptors table.
 	k := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(id))
 	var v roachpb.Value

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -565,7 +565,7 @@ func TestSystemConfigGossip(t *testing.T) {
 
 	key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, keys.MaxReservedDescID)
 	valAt := func(i int) *descpb.Descriptor {
-		return dbdesc.NewInitialDatabaseDescriptor(
+		return dbdesc.NewInitial(
 			descpb.ID(i), "foo", security.AdminRole,
 		).DescriptorProto()
 	}

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -26,7 +26,7 @@ func (p *planner) addColumnImpl(
 	params runParams,
 	n *alterTableNode,
 	tn *tree.TableName,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	t *tree.AlterTableAddColumn,
 ) error {
 	d := t.ColumnDef

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -55,7 +55,7 @@ var alterColTypeInCombinationNotSupportedErr = unimplemented.NewWithIssuef(
 // which conversion to use and applies the type conversion.
 func AlterColumnType(
 	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	t *tree.AlterTableAlterColumnType,
 	params runParams,
@@ -136,7 +136,7 @@ func AlterColumnType(
 
 func alterColumnTypeGeneral(
 	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	toType *types.T,
 	using tree.Expr,

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -19,7 +19,7 @@ import (
 
 type alterDatabaseOwnerNode struct {
 	n    *tree.AlterDatabaseOwner
-	desc *dbdesc.MutableDatabaseDescriptor
+	desc *dbdesc.Mutable
 }
 
 // AlterDatabaseOwner transforms a tree.AlterDatabaseOwner into a plan node.

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -25,7 +25,7 @@ import (
 
 type alterIndexNode struct {
 	n         *tree.AlterIndex
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 	indexDesc *descpb.IndexDescriptor
 }
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -29,9 +29,7 @@ import (
 )
 
 func (p *planner) AlterPrimaryKey(
-	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
-	alterPKNode *tree.AlterTableAlterPrimaryKey,
+	ctx context.Context, tableDesc *tabledesc.Mutable, alterPKNode *tree.AlterTableAlterPrimaryKey,
 ) error {
 	// Make sure that all nodes in the cluster are able to perform primary key changes before proceeding.
 	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.VersionPrimaryKeyChanges) {

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -30,7 +30,7 @@ import (
 type alterSchemaNode struct {
 	n    *tree.AlterSchema
 	db   *dbdesc.MutableDatabaseDescriptor
-	desc *schemadesc.MutableSchemaDescriptor
+	desc *schemadesc.Mutable
 }
 
 // Use to satisfy the linter.
@@ -77,7 +77,7 @@ func (n *alterSchemaNode) startExec(params runParams) error {
 func (p *planner) alterSchemaOwner(
 	ctx context.Context,
 	db *dbdesc.MutableDatabaseDescriptor,
-	scDesc *schemadesc.MutableSchemaDescriptor,
+	scDesc *schemadesc.Mutable,
 	newOwner string,
 	jobDesc string,
 ) error {
@@ -111,7 +111,7 @@ func (p *planner) alterSchemaOwner(
 func (p *planner) renameSchema(
 	ctx context.Context,
 	db *dbdesc.MutableDatabaseDescriptor,
-	desc *schemadesc.MutableSchemaDescriptor,
+	desc *schemadesc.Mutable,
 	newName string,
 	jobDesc string,
 ) error {

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -29,7 +29,7 @@ import (
 
 type alterSchemaNode struct {
 	n    *tree.AlterSchema
-	db   *dbdesc.MutableDatabaseDescriptor
+	db   *dbdesc.Mutable
 	desc *schemadesc.Mutable
 }
 
@@ -76,7 +76,7 @@ func (n *alterSchemaNode) startExec(params runParams) error {
 
 func (p *planner) alterSchemaOwner(
 	ctx context.Context,
-	db *dbdesc.MutableDatabaseDescriptor,
+	db *dbdesc.Mutable,
 	scDesc *schemadesc.Mutable,
 	newOwner string,
 	jobDesc string,
@@ -109,11 +109,7 @@ func (p *planner) alterSchemaOwner(
 }
 
 func (p *planner) renameSchema(
-	ctx context.Context,
-	db *dbdesc.MutableDatabaseDescriptor,
-	desc *schemadesc.Mutable,
-	newName string,
-	jobDesc string,
+	ctx context.Context, db *dbdesc.Mutable, desc *schemadesc.Mutable, newName string, jobDesc string,
 ) error {
 	// Check that there isn't a name collision with the new name.
 	found, err := p.schemaExists(ctx, db.ID, newName)

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -23,7 +23,7 @@ import (
 
 type alterSequenceNode struct {
 	n       *tree.AlterSequence
-	seqDesc *tabledesc.MutableTableDescriptor
+	seqDesc *tabledesc.Mutable
 }
 
 // AlterSequence transforms a tree.AlterSequence into a plan node.

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -260,7 +260,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						return err
 					}
 				}
-				affected := make(map[descpb.ID]*tabledesc.MutableTableDescriptor)
+				affected := make(map[descpb.ID]*tabledesc.Mutable)
 
 				// If there are any FKs, we will need to update the table descriptor of the
 				// depended-on table (to register this table against its DependedOnBy field).
@@ -563,7 +563,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if err := n.tableDesc.DropConstraint(
 				params.ctx,
 				name, details,
-				func(desc *tabledesc.MutableTableDescriptor, ref *descpb.ForeignKeyConstraint) error {
+				func(desc *tabledesc.Mutable, ref *descpb.ForeignKeyConstraint) error {
 					return params.p.removeFKBackReference(params.ctx, desc, ref)
 				}, params.ExecCfg().Settings); err != nil {
 				return err
@@ -806,7 +806,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 }
 
 func (p *planner) setAuditMode(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor, auditMode tree.AuditMode,
+	ctx context.Context, desc *tabledesc.Mutable, auditMode tree.AuditMode,
 ) (bool, error) {
 	// An auditing config change is itself auditable!
 	// We record the event even if the permission check below fails:
@@ -831,9 +831,7 @@ func (n *alterTableNode) Close(context.Context)        {}
 // addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given table descriptor, but sets up
 // the index with ExtraColumnIDs from the given index, rather than the table's primary key.
 func addIndexMutationWithSpecificPrimaryKey(
-	table *tabledesc.MutableTableDescriptor,
-	toAdd *descpb.IndexDescriptor,
-	primary *descpb.IndexDescriptor,
+	table *tabledesc.Mutable, toAdd *descpb.IndexDescriptor, primary *descpb.IndexDescriptor,
 ) error {
 	// Reset the ID so that a call to AllocateIDs will set up the index.
 	toAdd.ID = 0
@@ -858,7 +856,7 @@ func addIndexMutationWithSpecificPrimaryKey(
 // dependencies on sequences change, it updates them as well.
 func applyColumnMutation(
 	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	mut tree.ColumnMutationCmd,
 	params runParams,
@@ -1124,11 +1122,11 @@ func (p *planner) removeColumnComment(
 // don't have to manually take care of updating both table descriptors.
 func (p *planner) updateFKBackReferenceName(
 	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	ref *descpb.ForeignKeyConstraint,
 	newName string,
 ) error {
-	var referencedTableDesc *tabledesc.MutableTableDescriptor
+	var referencedTableDesc *tabledesc.Mutable
 	// We don't want to lookup/edit a second copy of the same table.
 	if tableDesc.ID == ref.ReferencedTableID {
 		referencedTableDesc = tableDesc

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -24,7 +24,7 @@ import (
 
 type alterTableSetSchemaNode struct {
 	newSchema string
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 	n         *tree.AlterTableSetSchema
 }
 

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -26,7 +26,7 @@ import (
 
 type alterTypeNode struct {
 	n    *tree.AlterType
-	desc *typedesc.MutableTypeDescriptor
+	desc *typedesc.Mutable
 }
 
 // alterTypeNode implements planNode. We set n here to satisfy the linter.
@@ -194,7 +194,7 @@ func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName stri
 // newName and newSchemaID may be the same as the current name and schemaid.
 func (p *planner) performRenameTypeDesc(
 	ctx context.Context,
-	desc *typedesc.MutableTypeDescriptor,
+	desc *typedesc.Mutable,
 	newName string,
 	newSchemaID descpb.ID,
 	jobDesc string,

--- a/pkg/sql/catalog/accessors/logical_schema_accessors.go
+++ b/pkg/sql/catalog/accessors/logical_schema_accessors.go
@@ -123,7 +123,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 			if flags.RequireMutable {
 				return nil, errors.Newf("cannot use mutable descriptor of aliased type %s.%s", schema, object)
 			}
-			return typedesc.MakeSimpleAliasTypeDescriptor(alias), nil
+			return typedesc.MakeSimpleAlias(alias), nil
 		}
 	}
 

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -33,8 +33,8 @@ type MutableDescriptor interface {
 	OriginalName() string
 	OriginalID() descpb.ID
 	OriginalVersion() descpb.DescriptorVersion
-	// Immutable returns an immutable copy of this descriptor.
-	Immutable() Descriptor
+	// ImmutableCopy returns an immutable copy of this descriptor.
+	ImmutableCopy() Descriptor
 	// IsNew returns whether the descriptor was created in this transaction.
 	IsNew() bool
 }

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -307,7 +307,7 @@ func unwrapDescriptor(
 		}
 		return dbDesc, nil
 	case typ != nil:
-		return typedesc.NewImmutableTypeDescriptor(*typ), nil
+		return typedesc.NewImmutable(*typ), nil
 	case schema != nil:
 		return schemadesc.NewImmutable(*schema), nil
 	default:
@@ -342,7 +342,7 @@ func unwrapDescriptorMutable(
 		}
 		return dbDesc, nil
 	case typ != nil:
-		return typedesc.NewMutableExistingTypeDescriptor(*typ), nil
+		return typedesc.NewExistingMutable(*typ), nil
 	case schema != nil:
 		return schemadesc.NewMutableExisting(*schema), nil
 	default:
@@ -642,7 +642,7 @@ func UnwrapDescriptorRaw(ctx context.Context, desc *descpb.Descriptor) catalog.M
 	case database != nil:
 		return dbdesc.NewMutableExistingDatabaseDescriptor(*database)
 	case typ != nil:
-		return typedesc.NewMutableExistingTypeDescriptor(*typ)
+		return typedesc.NewExistingMutable(*typ)
 	case schema != nil:
 		return schemadesc.NewMutableExisting(*schema)
 	default:

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -301,7 +301,7 @@ func unwrapDescriptor(
 		}
 		return tabledesc.NewImmutable(*table), nil
 	case database != nil:
-		dbDesc := dbdesc.NewImmutableDatabaseDescriptor(*database)
+		dbDesc := dbdesc.NewImmutable(*database)
 		if err := dbDesc.Validate(); err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func unwrapDescriptorMutable(
 		}
 		return mutTable, nil
 	case database != nil:
-		dbDesc := dbdesc.NewMutableExistingDatabaseDescriptor(*database)
+		dbDesc := dbdesc.NewExistingMutable(*database)
 		if err := dbDesc.Validate(); err != nil {
 			return nil, err
 		}
@@ -496,13 +496,13 @@ func GetDatabaseID(
 // found" condition to return an error, use mustGetDatabaseDescByID() instead.
 func GetDatabaseDescByID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id descpb.ID,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+) (*dbdesc.Immutable, error) {
 	desc, err := GetDescriptorByID(ctx, txn, codec, id, Immutable,
 		DatabaseDescriptorKind, false /* required */)
 	if err != nil || desc == nil {
 		return nil, err
 	}
-	return desc.(*dbdesc.ImmutableDatabaseDescriptor), nil
+	return desc.(*dbdesc.Immutable), nil
 }
 
 // MustGetTableDescByID looks up the table descriptor given its ID,
@@ -522,13 +522,13 @@ func MustGetTableDescByID(
 // returning an error if the descriptor is not found.
 func MustGetDatabaseDescByID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id descpb.ID,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+) (*dbdesc.Immutable, error) {
 	desc, err := GetDescriptorByID(ctx, txn, codec, id, Immutable,
 		DatabaseDescriptorKind, true /* required */)
 	if err != nil || desc == nil {
 		return nil, err
 	}
-	return desc.(*dbdesc.ImmutableDatabaseDescriptor), nil
+	return desc.(*dbdesc.Immutable), nil
 }
 
 // MustGetSchemaDescByID looks up the schema descriptor given its ID,
@@ -553,7 +553,7 @@ func MustGetSchemaDescByID(
 // rather than making a round trip for each ID.
 func GetDatabaseDescriptorsFromIDs(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID,
-) ([]*dbdesc.ImmutableDatabaseDescriptor, error) {
+) ([]*dbdesc.Immutable, error) {
 	b := txn.NewBatch()
 	for _, id := range ids {
 		key := catalogkeys.MakeDescMetadataKey(codec, id)
@@ -562,7 +562,7 @@ func GetDatabaseDescriptorsFromIDs(
 	if err := txn.Run(ctx, b); err != nil {
 		return nil, err
 	}
-	results := make([]*dbdesc.ImmutableDatabaseDescriptor, 0, len(ids))
+	results := make([]*dbdesc.Immutable, 0, len(ids))
 	for i := range b.Results {
 		result := &b.Results[i]
 		if result.Err != nil {
@@ -590,7 +590,7 @@ func GetDatabaseDescriptorsFromIDs(
 			)
 		}
 		descpb.MaybeSetDescriptorModificationTimeFromMVCCTimestamp(ctx, desc, result.Rows[0].Value.Timestamp)
-		results = append(results, dbdesc.NewImmutableDatabaseDescriptor(*db))
+		results = append(results, dbdesc.NewImmutable(*db))
 	}
 	return results, nil
 }
@@ -640,7 +640,7 @@ func UnwrapDescriptorRaw(ctx context.Context, desc *descpb.Descriptor) catalog.M
 	case table != nil:
 		return tabledesc.NewExistingMutable(*table)
 	case database != nil:
-		return dbdesc.NewMutableExistingDatabaseDescriptor(*database)
+		return dbdesc.NewExistingMutable(*database)
 	case typ != nil:
 		return typedesc.NewExistingMutable(*typ)
 	case schema != nil:

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -292,14 +292,14 @@ func unwrapDescriptor(
 		desc.GetDatabase(), desc.GetType(), desc.GetSchema()
 	switch {
 	case table != nil:
-		immTable, err := tabledesc.NewFilledInImmutableTableDescriptor(ctx, dg, table)
+		immTable, err := tabledesc.NewFilledInImmutable(ctx, dg, table)
 		if err != nil {
 			return nil, err
 		}
 		if err := immTable.Validate(ctx, dg); err != nil {
 			return nil, err
 		}
-		return tabledesc.NewImmutableTableDescriptor(*table), nil
+		return tabledesc.NewImmutable(*table), nil
 	case database != nil:
 		dbDesc := dbdesc.NewImmutableDatabaseDescriptor(*database)
 		if err := dbDesc.Validate(); err != nil {
@@ -327,7 +327,7 @@ func unwrapDescriptorMutable(
 		desc.GetDatabase(), desc.GetType(), desc.GetSchema()
 	switch {
 	case table != nil:
-		mutTable, err := tabledesc.NewFilledInMutableExistingTableDescriptor(ctx, dg, false /* skipFKsWithMissingTable */, table)
+		mutTable, err := tabledesc.NewFilledInExistingMutable(ctx, dg, false /* skipFKsWithMissingTable */, table)
 		if err != nil {
 			return nil, err
 		}
@@ -509,13 +509,13 @@ func GetDatabaseDescByID(
 // returning an error if the table is not found.
 func MustGetTableDescByID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id descpb.ID,
-) (*tabledesc.ImmutableTableDescriptor, error) {
+) (*tabledesc.Immutable, error) {
 	desc, err := GetDescriptorByID(ctx, txn, codec, id, Immutable,
 		TableDescriptorKind, true /* required */)
 	if err != nil || desc == nil {
 		return nil, err
 	}
-	return desc.(*tabledesc.ImmutableTableDescriptor), nil
+	return desc.(*tabledesc.Immutable), nil
 }
 
 // MustGetDatabaseDescByID looks up the database descriptor given its ID,
@@ -638,7 +638,7 @@ func UnwrapDescriptorRaw(ctx context.Context, desc *descpb.Descriptor) catalog.M
 		desc.GetDatabase(), desc.GetType(), desc.GetSchema()
 	switch {
 	case table != nil:
-		return tabledesc.NewMutableExistingTableDescriptor(*table)
+		return tabledesc.NewExistingMutable(*table)
 	case database != nil:
 		return dbdesc.NewMutableExistingDatabaseDescriptor(*database)
 	case typ != nil:

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -309,7 +309,7 @@ func unwrapDescriptor(
 	case typ != nil:
 		return typedesc.NewImmutableTypeDescriptor(*typ), nil
 	case schema != nil:
-		return schemadesc.NewImmutableSchemaDescriptor(*schema), nil
+		return schemadesc.NewImmutable(*schema), nil
 	default:
 		return nil, nil
 	}
@@ -344,7 +344,7 @@ func unwrapDescriptorMutable(
 	case typ != nil:
 		return typedesc.NewMutableExistingTypeDescriptor(*typ), nil
 	case schema != nil:
-		return schemadesc.NewMutableExistingSchemaDescriptor(*schema), nil
+		return schemadesc.NewMutableExisting(*schema), nil
 	default:
 		return nil, nil
 	}
@@ -535,12 +535,12 @@ func MustGetDatabaseDescByID(
 // returning an error if the descriptor is not found.
 func MustGetSchemaDescByID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id descpb.ID,
-) (*schemadesc.ImmutableSchemaDescriptor, error) {
+) (*schemadesc.Immutable, error) {
 	desc, err := GetAnyDescriptorByID(ctx, txn, codec, id, Immutable)
 	if err != nil || desc == nil {
 		return nil, err
 	}
-	sc, ok := desc.(*schemadesc.ImmutableSchemaDescriptor)
+	sc, ok := desc.(*schemadesc.Immutable)
 	if !ok {
 		return nil, errors.Newf("descriptor with id %d was not a schema", id)
 	}
@@ -644,7 +644,7 @@ func UnwrapDescriptorRaw(ctx context.Context, desc *descpb.Descriptor) catalog.M
 	case typ != nil:
 		return typedesc.NewMutableExistingTypeDescriptor(*typ)
 	case schema != nil:
-		return schemadesc.NewMutableExistingSchemaDescriptor(*schema)
+		return schemadesc.NewMutableExisting(*schema)
 	default:
 		log.Fatalf(ctx, "failed to unwrap descriptor of type %T", desc.Union)
 		return nil // unreachable

--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -50,7 +50,7 @@ func (a UncachedPhysicalAccessor) GetDatabaseDesc(
 ) (desc catalog.DatabaseDescriptor, err error) {
 	if name == systemschema.SystemDatabaseName {
 		if flags.RequireMutable {
-			return dbdesc.NewMutableExistingDatabaseDescriptor(
+			return dbdesc.NewExistingMutable(
 				*systemschema.MakeSystemDatabaseDesc().DatabaseDesc()), nil
 		}
 		return systemschema.MakeSystemDatabaseDesc(), nil

--- a/pkg/sql/catalog/catalogkv/test_utils.go
+++ b/pkg/sql/catalog/catalogkv/test_utils.go
@@ -67,10 +67,10 @@ func TestingGetMutableExistingTableDescriptor(
 // This function should be moved wherever TestingGetTableDescriptor is moved.
 func TestingGetTypeDescriptor(
 	kvDB *kv.DB, codec keys.SQLCodec, database string, object string,
-) *typedesc.ImmutableTypeDescriptor {
+) *typedesc.Immutable {
 	desc, ok := testingGetObjectDescriptor(
 		kvDB, codec, tree.TypeObject, false /* mutable */, database, object,
-	).(*typedesc.ImmutableTypeDescriptor)
+	).(*typedesc.Immutable)
 	if !ok {
 		return nil
 	}

--- a/pkg/sql/catalog/catalogkv/test_utils.go
+++ b/pkg/sql/catalog/catalogkv/test_utils.go
@@ -30,7 +30,7 @@ import (
 // removing it altogether.
 func TestingGetTableDescriptor(
 	kvDB *kv.DB, codec keys.SQLCodec, database string, table string,
-) *tabledesc.ImmutableTableDescriptor {
+) *tabledesc.Immutable {
 	return TestingGetImmutableTableDescriptor(kvDB, codec, database, table)
 }
 
@@ -38,24 +38,24 @@ func TestingGetTableDescriptor(
 // directly from the KV layer.
 func TestingGetImmutableTableDescriptor(
 	kvDB *kv.DB, codec keys.SQLCodec, database string, table string,
-) *tabledesc.ImmutableTableDescriptor {
+) *tabledesc.Immutable {
 	desc, ok := testingGetObjectDescriptor(
 		kvDB, codec, tree.TableObject, false /* mutable */, database, table,
-	).(*tabledesc.ImmutableTableDescriptor)
+	).(*tabledesc.Immutable)
 	if !ok {
 		return nil
 	}
 	return desc
 }
 
-// TestingGetMutableExistingTableDescriptor retrieves a MutableTableDescriptor
+// TestingGetMutableExistingTableDescriptor retrieves a Mutable
 // directly from the KV layer.
 func TestingGetMutableExistingTableDescriptor(
 	kvDB *kv.DB, codec keys.SQLCodec, database string, table string,
-) *tabledesc.MutableTableDescriptor {
+) *tabledesc.Mutable {
 	desc, ok := testingGetObjectDescriptor(
 		kvDB, codec, tree.TableObject, true /* mutable */, database, table,
-	).(*tabledesc.MutableTableDescriptor)
+	).(*tabledesc.Mutable)
 	if !ok {
 		return nil
 	}

--- a/pkg/sql/catalog/database/database.go
+++ b/pkg/sql/catalog/database/database.go
@@ -74,7 +74,7 @@ func (dc *Cache) setID(name string, id descpb.ID) {
 // getCachedDatabaseDesc looks up the database descriptor from the descriptor cache,
 // given its name. Returns nil and no error if the name is not present in the
 // cache.
-func (dc *Cache) getCachedDatabaseDesc(name string) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+func (dc *Cache) getCachedDatabaseDesc(name string) (*dbdesc.Immutable, error) {
 	dbID, err := dc.GetCachedDatabaseID(name)
 	if dbID == descpb.InvalidID || err != nil {
 		return nil, err
@@ -85,9 +85,7 @@ func (dc *Cache) getCachedDatabaseDesc(name string) (*dbdesc.ImmutableDatabaseDe
 
 // getCachedDatabaseDescByID looks up the database descriptor from the descriptor cache,
 // given its ID.
-func (dc *Cache) getCachedDatabaseDescByID(
-	id descpb.ID,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+func (dc *Cache) getCachedDatabaseDescByID(id descpb.ID) (*dbdesc.Immutable, error) {
 	if id == keys.SystemDatabaseID {
 		// We can't return a direct reference to SystemDB, because the
 		// caller expects a private object that can be modified in-place.
@@ -110,7 +108,7 @@ func (dc *Cache) getCachedDatabaseDescByID(
 	if dbDesc == nil {
 		return nil, pgerror.Newf(pgcode.WrongObjectType, "[%d] is not a database", id)
 	}
-	database := dbdesc.NewImmutableDatabaseDescriptor(*dbDesc)
+	database := dbdesc.NewImmutable(*dbDesc)
 	if err := database.Validate(); err != nil {
 		return nil, err
 	}
@@ -125,7 +123,7 @@ func (dc *Cache) GetDatabaseDesc(
 	txnRunner func(context.Context, func(context.Context, *kv.Txn) error) error,
 	name string,
 	required bool,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+) (*dbdesc.Immutable, error) {
 	// Lookup the database in the cache first, falling back to the KV store if it
 	// isn't present. The cache might cause the usage of a recently renamed
 	// database, but that's a race that could occur anyways.
@@ -151,7 +149,7 @@ func (dc *Cache) GetDatabaseDesc(
 				return err
 			}
 			if descI != nil {
-				desc = descI.(*dbdesc.ImmutableDatabaseDescriptor)
+				desc = descI.(*dbdesc.Immutable)
 			}
 			return nil
 		}); err != nil {
@@ -168,7 +166,7 @@ func (dc *Cache) GetDatabaseDesc(
 // if it exists in the cache, otherwise falls back to KV operations.
 func (dc *Cache) GetDatabaseDescByID(
 	ctx context.Context, txn *kv.Txn, id descpb.ID,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+) (*dbdesc.Immutable, error) {
 	desc, err := dc.getCachedDatabaseDescByID(id)
 	if desc == nil || err != nil {
 		if err != nil {

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -23,39 +23,37 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
-var _ catalog.DatabaseDescriptor = (*ImmutableDatabaseDescriptor)(nil)
-var _ catalog.DatabaseDescriptor = (*MutableDatabaseDescriptor)(nil)
-var _ catalog.MutableDescriptor = (*MutableDatabaseDescriptor)(nil)
+var _ catalog.DatabaseDescriptor = (*Immutable)(nil)
+var _ catalog.DatabaseDescriptor = (*Mutable)(nil)
+var _ catalog.MutableDescriptor = (*Mutable)(nil)
 
-// ImmutableDatabaseDescriptor wraps a database descriptor and provides methods
+// Immutable wraps a database descriptor and provides methods
 // on it.
-type ImmutableDatabaseDescriptor struct {
+type Immutable struct {
 	descpb.DatabaseDescriptor
 }
 
-// MutableDatabaseDescriptor wraps a database descriptor and provides methods
+// Mutable wraps a database descriptor and provides methods
 // on it. It can be mutated and generally has not been committed.
-type MutableDatabaseDescriptor struct {
-	ImmutableDatabaseDescriptor
+type Mutable struct {
+	Immutable
 
-	ClusterVersion *ImmutableDatabaseDescriptor
+	ClusterVersion *Immutable
 }
 
-// NewInitialDatabaseDescriptor constructs a new DatabaseDescriptor for an
-// initial version from an id and name.
-func NewInitialDatabaseDescriptor(
-	id descpb.ID, name string, owner string,
-) *MutableDatabaseDescriptor {
-	return NewInitialDatabaseDescriptorWithPrivileges(id, name,
+// NewInitial constructs a new Mutable for an initial version from an id and
+// name with default privileges.
+func NewInitial(id descpb.ID, name string, owner string) *Mutable {
+	return NewInitialWithPrivileges(id, name,
 		descpb.NewDefaultPrivilegeDescriptor(owner))
 }
 
-// NewInitialDatabaseDescriptorWithPrivileges constructs a new DatabaseDescriptor for an
-// initial version from an id and name.
-func NewInitialDatabaseDescriptorWithPrivileges(
+// NewInitialWithPrivileges constructs a new Mutable for an initial version
+// from an id and name and custom privileges.
+func NewInitialWithPrivileges(
 	id descpb.ID, name string, privileges *descpb.PrivilegeDescriptor,
-) *MutableDatabaseDescriptor {
-	return NewMutableCreatedDatabaseDescriptor(descpb.DatabaseDescriptor{
+) *Mutable {
+	return NewCreatedMutable(descpb.DatabaseDescriptor{
 		Name:       name,
 		ID:         id,
 		Version:    1,
@@ -63,90 +61,86 @@ func NewInitialDatabaseDescriptorWithPrivileges(
 	})
 }
 
-func makeImmutableDatabaseDescriptor(desc descpb.DatabaseDescriptor) ImmutableDatabaseDescriptor {
-	return ImmutableDatabaseDescriptor{DatabaseDescriptor: desc}
+func makeImmutable(desc descpb.DatabaseDescriptor) Immutable {
+	return Immutable{DatabaseDescriptor: desc}
 }
 
-// NewImmutableDatabaseDescriptor makes a new database descriptor.
-func NewImmutableDatabaseDescriptor(desc descpb.DatabaseDescriptor) *ImmutableDatabaseDescriptor {
-	ret := makeImmutableDatabaseDescriptor(desc)
+// NewImmutable makes a new immutable database descriptor.
+func NewImmutable(desc descpb.DatabaseDescriptor) *Immutable {
+	ret := makeImmutable(desc)
 	return &ret
 }
 
-// NewMutableCreatedDatabaseDescriptor returns a MutableDatabaseDescriptor from
-// the given database descriptor with a nil cluster version. This is for a
-// database that is created in the same transaction.
-func NewMutableCreatedDatabaseDescriptor(
-	desc descpb.DatabaseDescriptor,
-) *MutableDatabaseDescriptor {
-	return &MutableDatabaseDescriptor{
-		ImmutableDatabaseDescriptor: makeImmutableDatabaseDescriptor(desc),
+// NewCreatedMutable returns a Mutable from the given database descriptor with
+// a nil cluster version. This is for a database that is created in the same
+// transaction.
+func NewCreatedMutable(desc descpb.DatabaseDescriptor) *Mutable {
+	return &Mutable{
+		Immutable: makeImmutable(desc),
 	}
 }
 
-// NewMutableExistingDatabaseDescriptor returns a MutableDatabaseDescriptor from the
-// given database descriptor with the cluster version also set to the descriptor.
-// This is for databases that already exist.
-func NewMutableExistingDatabaseDescriptor(
-	desc descpb.DatabaseDescriptor,
-) *MutableDatabaseDescriptor {
-	return &MutableDatabaseDescriptor{
-		ImmutableDatabaseDescriptor: makeImmutableDatabaseDescriptor(*protoutil.Clone(&desc).(*descpb.DatabaseDescriptor)),
-		ClusterVersion:              NewImmutableDatabaseDescriptor(desc),
+// NewExistingMutable returns a Mutable from the given database descriptor with
+// the cluster version also set to the descriptor. This is for databases that
+// already exist.
+func NewExistingMutable(desc descpb.DatabaseDescriptor) *Mutable {
+	return &Mutable{
+		Immutable:      makeImmutable(*protoutil.Clone(&desc).(*descpb.DatabaseDescriptor)),
+		ClusterVersion: NewImmutable(desc),
 	}
 }
 
 // TypeName returns the plain type of this descriptor.
-func (desc *ImmutableDatabaseDescriptor) TypeName() string {
+func (desc *Immutable) TypeName() string {
 	return "database"
 }
 
 // DatabaseDesc implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) DatabaseDesc() *descpb.DatabaseDescriptor {
+func (desc *Immutable) DatabaseDesc() *descpb.DatabaseDescriptor {
 	return &desc.DatabaseDescriptor
 }
 
 // SetDrainingNames implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) SetDrainingNames(names []descpb.NameInfo) {
+func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names
 }
 
 // GetParentID implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) GetParentID() descpb.ID {
+func (desc *Immutable) GetParentID() descpb.ID {
 	return keys.RootNamespaceID
 }
 
 // GetParentSchemaID implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) GetParentSchemaID() descpb.ID {
+func (desc *Immutable) GetParentSchemaID() descpb.ID {
 	return keys.RootNamespaceID
 }
 
 // NameResolutionResult implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) NameResolutionResult() {}
+func (desc *Immutable) NameResolutionResult() {}
 
 // GetAuditMode is part of the DescriptorProto interface.
 // This is a stub until per-database auditing is enabled.
-func (desc *ImmutableDatabaseDescriptor) GetAuditMode() descpb.TableDescriptor_AuditMode {
+func (desc *Immutable) GetAuditMode() descpb.TableDescriptor_AuditMode {
 	return descpb.TableDescriptor_DISABLED
 }
 
 // Adding implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) Adding() bool {
+func (desc *Immutable) Adding() bool {
 	return false
 }
 
 // Offline implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) Offline() bool {
+func (desc *Immutable) Offline() bool {
 	return false
 }
 
 // GetOfflineReason implements the Descriptor interface.
-func (desc *ImmutableDatabaseDescriptor) GetOfflineReason() string {
+func (desc *Immutable) GetOfflineReason() string {
 	return ""
 }
 
 // DescriptorProto wraps a DatabaseDescriptor in a Descriptor.
-func (desc *ImmutableDatabaseDescriptor) DescriptorProto() *descpb.Descriptor {
+func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
 		Union: &descpb.Descriptor_Database{
 			Database: &desc.DatabaseDescriptor,
@@ -155,14 +149,14 @@ func (desc *ImmutableDatabaseDescriptor) DescriptorProto() *descpb.Descriptor {
 }
 
 // SetName sets the name on the descriptor.
-func (desc *MutableDatabaseDescriptor) SetName(name string) {
+func (desc *Mutable) SetName(name string) {
 	desc.Name = name
 }
 
 // Validate validates that the database descriptor is well formed.
 // Checks include validate the database name, and verifying that there
 // is at least one read and write user.
-func (desc *ImmutableDatabaseDescriptor) Validate() error {
+func (desc *Immutable) Validate() error {
 	if err := catalog.ValidateName(desc.GetName(), "descriptor"); err != nil {
 		return err
 	}
@@ -185,10 +179,10 @@ func (desc *ImmutableDatabaseDescriptor) Validate() error {
 //  to have this implementation only visible there? Maybe by creating a type
 //  alias for database descriptor in the backupccl package, and then defining
 //  SchemaMeta on it?
-func (desc *ImmutableDatabaseDescriptor) SchemaMeta() {}
+func (desc *Immutable) SchemaMeta() {}
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) MaybeIncrementVersion() {
+func (desc *Mutable) MaybeIncrementVersion() {
 	// Already incremented, no-op.
 	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
@@ -198,7 +192,7 @@ func (desc *MutableDatabaseDescriptor) MaybeIncrementVersion() {
 }
 
 // OriginalName implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) OriginalName() string {
+func (desc *Mutable) OriginalName() string {
 	if desc.ClusterVersion == nil {
 		return ""
 	}
@@ -206,7 +200,7 @@ func (desc *MutableDatabaseDescriptor) OriginalName() string {
 }
 
 // OriginalID implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) OriginalID() descpb.ID {
+func (desc *Mutable) OriginalID() descpb.ID {
 	if desc.ClusterVersion == nil {
 		return descpb.InvalidID
 	}
@@ -214,7 +208,7 @@ func (desc *MutableDatabaseDescriptor) OriginalID() descpb.ID {
 }
 
 // OriginalVersion implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) OriginalVersion() descpb.DescriptorVersion {
+func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 	if desc.ClusterVersion == nil {
 		return 0
 	}
@@ -222,19 +216,19 @@ func (desc *MutableDatabaseDescriptor) OriginalVersion() descpb.DescriptorVersio
 }
 
 // ImmutableCopy implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) ImmutableCopy() catalog.Descriptor {
+func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutableDatabaseDescriptor(*protoutil.Clone(desc.DatabaseDesc()).(*descpb.DatabaseDescriptor))
+	return NewImmutable(*protoutil.Clone(desc.DatabaseDesc()).(*descpb.DatabaseDescriptor))
 }
 
 // IsNew implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) IsNew() bool {
+func (desc *Mutable) IsNew() bool {
 	return desc.ClusterVersion == nil
 }
 
 // AddDrainingName adds a draining name to the DatabaseDescriptor's slice of
 // draining names.
-func (desc *MutableDatabaseDescriptor) AddDrainingName(name descpb.NameInfo) {
+func (desc *Mutable) AddDrainingName(name descpb.NameInfo) {
 	desc.DrainingNames = append(desc.DrainingNames, name)
 }

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -24,6 +24,8 @@ import (
 )
 
 var _ catalog.DatabaseDescriptor = (*ImmutableDatabaseDescriptor)(nil)
+var _ catalog.DatabaseDescriptor = (*MutableDatabaseDescriptor)(nil)
+var _ catalog.MutableDescriptor = (*MutableDatabaseDescriptor)(nil)
 
 // ImmutableDatabaseDescriptor wraps a database descriptor and provides methods
 // on it.
@@ -219,8 +221,8 @@ func (desc *MutableDatabaseDescriptor) OriginalVersion() descpb.DescriptorVersio
 	return desc.ClusterVersion.Version
 }
 
-// Immutable implements the MutableDescriptor interface.
-func (desc *MutableDatabaseDescriptor) Immutable() catalog.Descriptor {
+// ImmutableCopy implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableDatabaseDescriptor(*protoutil.Clone(desc.DatabaseDesc()).(*descpb.DatabaseDescriptor))

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -27,7 +27,7 @@ func TestMakeDatabaseDesc(t *testing.T) {
 		t.Fatal(err)
 	}
 	const id = 17
-	desc := NewInitialDatabaseDescriptor(id, string(stmt.AST.(*tree.CreateDatabase).Name), security.AdminRole)
+	desc := NewInitial(id, string(stmt.AST.(*tree.CreateDatabase).Name), security.AdminRole)
 	if desc.GetName() != "test" {
 		t.Fatalf("expected Name == test, got %s", desc.GetName())
 	}

--- a/pkg/sql/catalog/descpb/constraint.go
+++ b/pkg/sql/catalog/descpb/constraint.go
@@ -100,7 +100,7 @@ const (
 // ConstraintDetail describes a constraint.
 //
 // TODO(ajwerner): Lift this up a level of abstraction next to the
-// ImmutableTableDescriptor and have it store those for the ReferencedTable.
+// Immutable and have it store those for the ReferencedTable.
 type ConstraintDetail struct {
 	Kind        ConstraintType
 	Columns     []string

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -79,7 +79,7 @@ type DatabaseDescriptor interface {
 }
 
 // SchemaDescriptor will eventually be called schemadesc.Descriptor.
-// It is implemented by ImmutableSchemaDescriptor.
+// It is implemented by Immutable.
 type SchemaDescriptor interface {
 	Descriptor
 	SchemaDesc() *descpb.SchemaDescriptor

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -65,7 +65,7 @@ type Descriptor interface {
 }
 
 // DatabaseDescriptor will eventually be called dbdesc.Descriptor.
-// It is implemented by ImmutableDatabaseDescriptor.
+// It is implemented by Immutable.
 type DatabaseDescriptor interface {
 	Descriptor
 

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1095,7 +1095,7 @@ func (tc *Collection) AddUncommittedDescriptor(desc catalog.MutableDescriptor) e
 	}
 	tbl := uncommittedDescriptor{
 		mutable:   desc,
-		immutable: desc.Immutable(),
+		immutable: desc.ImmutableCopy(),
 	}
 	for i, d := range tc.uncommittedDescriptors {
 		if d.mutable.GetID() == desc.GetID() {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -855,15 +855,15 @@ func (tc *Collection) getMutableDescriptorByID(
 	return desc.(catalog.MutableDescriptor), nil
 }
 
-// GetMutableSchemaDescriptorByID gets a MutableSchemaDescriptor by ID.
+// GetMutableSchemaDescriptorByID gets a Mutable by ID.
 func (tc *Collection) GetMutableSchemaDescriptorByID(
 	ctx context.Context, scID descpb.ID, txn *kv.Txn,
-) (*schemadesc.MutableSchemaDescriptor, error) {
+) (*schemadesc.Mutable, error) {
 	desc, err := tc.getMutableDescriptorByID(ctx, scID, txn)
 	if err != nil {
 		return nil, err
 	}
-	return desc.(*schemadesc.MutableSchemaDescriptor), nil
+	return desc.(*schemadesc.Mutable), nil
 }
 
 // ResolveSchemaByID looks up a schema by ID.
@@ -905,7 +905,7 @@ func (tc *Collection) ResolveSchemaByID(
 		return catalog.ResolvedSchema{}, err
 	}
 
-	schemaDesc, ok := desc.(*schemadesc.ImmutableSchemaDescriptor)
+	schemaDesc, ok := desc.(*schemadesc.Immutable)
 	if !ok {
 		return catalog.ResolvedSchema{}, pgerror.Newf(pgcode.WrongObjectType, "descriptor %d was not a schema", schemaID)
 	}
@@ -1342,14 +1342,14 @@ func (tc *Collection) GetAllDescriptors(
 		// so collect the needed information to set up metadata in those types.
 		dbDescs := make(map[descpb.ID]*dbdesc.ImmutableDatabaseDescriptor)
 		typDescs := make(map[descpb.ID]*typedesc.ImmutableTypeDescriptor)
-		schemaDescs := make(map[descpb.ID]*schemadesc.ImmutableSchemaDescriptor)
+		schemaDescs := make(map[descpb.ID]*schemadesc.Immutable)
 		for _, desc := range descs {
 			switch desc := desc.(type) {
 			case *dbdesc.ImmutableDatabaseDescriptor:
 				dbDescs[desc.GetID()] = desc
 			case *typedesc.ImmutableTypeDescriptor:
 				typDescs[desc.GetID()] = desc
-			case *schemadesc.ImmutableSchemaDescriptor:
+			case *schemadesc.Immutable:
 				schemaDescs[desc.GetID()] = desc
 			}
 		}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -467,7 +467,7 @@ func (m *Manager) PublishMultiple(
 		case err == nil || errors.Is(err, ErrDidntUpdateDescriptor):
 			immutDescs := make(map[descpb.ID]catalog.Descriptor)
 			for id, desc := range descs {
-				immutDescs[id] = desc.Immutable()
+				immutDescs[id] = desc.ImmutableCopy()
 			}
 			return immutDescs, nil
 		case errors.Is(err, errLeaseVersionChanged):

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -82,7 +82,7 @@ func TestTableSet(t *testing.T) {
 		switch op := d.op.(type) {
 		case insert:
 			s := &descriptorVersionState{
-				Descriptor: tabledesc.NewImmutableTableDescriptor(
+				Descriptor: tabledesc.NewImmutable(
 					descpb.TableDescriptor{Version: op.version},
 				),
 			}
@@ -91,7 +91,7 @@ func TestTableSet(t *testing.T) {
 
 		case remove:
 			s := &descriptorVersionState{
-				Descriptor: tabledesc.NewImmutableTableDescriptor(
+				Descriptor: tabledesc.NewImmutable(
 					descpb.TableDescriptor{Version: op.version},
 				),
 			}
@@ -160,7 +160,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 
-	var tables []tabledesc.ImmutableTableDescriptor
+	var tables []tabledesc.Immutable
 	var expiration hlc.Timestamp
 	getLeases := func() {
 		for i := 0; i < 3; i++ {
@@ -171,7 +171,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 			if err != nil {
 				t.Fatal(err)
 			}
-			tables = append(tables, *table.(*tabledesc.ImmutableTableDescriptor))
+			tables = append(tables, *table.(*tabledesc.Immutable))
 			expiration = exp
 			if err := leaseManager.Release(table); err != nil {
 				t.Fatal(err)
@@ -333,7 +333,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if lease.GetID() != tableDesc.ID {
 		t.Fatalf("new name has wrong ID: %d (expected: %d)", lease.GetID(), tableDesc.ID)
 	}
-	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor)); err != nil {
+	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.Immutable)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +360,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if lease.GetID() != tableDesc.ID {
 		t.Fatalf("new name has wrong ID: %d (expected: %d)", lease.GetID(), tableDesc.ID)
 	}
-	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor)); err != nil {
+	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.Immutable)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -393,7 +393,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	if lease := leaseManager.names.get(tableDesc.ParentID, tableDesc.GetParentSchemaID(), tableName, s.Clock().Now()); lease == nil {
 		t.Fatalf("name cache has no unexpired entry for (%d, %s)", tableDesc.ParentID, tableName)
 	} else {
-		if err := leaseManager.Release(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor)); err != nil {
+		if err := leaseManager.Release(lease.Descriptor.(*tabledesc.Immutable)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -444,7 +444,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("name cache has no unexpired entry for (%d, %s)", tableDesc.ParentID, tableName)
 	}
 
-	tracker := removalTracker.TrackRemoval(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor))
+	tracker := removalTracker.TrackRemoval(lease.Descriptor.(*tabledesc.Immutable))
 
 	// Acquire another lease.
 	if _, err := acquireNodeLease(context.Background(), leaseManager, tableDesc.ID); err != nil {
@@ -460,7 +460,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("same lease %s", newLease.expiration.GoTime())
 	}
 
-	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor)); err != nil {
+	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.Immutable)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -469,7 +469,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatal(err)
 	}
 
-	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.ImmutableTableDescriptor)); err != nil {
+	if err := leaseManager.Release(lease.Descriptor.(*tabledesc.Immutable)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -551,7 +551,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	// Release.
 	// tableChan acts as a barrier, synchronizing the two routines at every
 	// iteration.
-	tableChan := make(chan *tabledesc.ImmutableTableDescriptor)
+	tableChan := make(chan *tabledesc.Immutable)
 	errChan := make(chan error)
 	go func() {
 		for table := range tableChan {
@@ -573,7 +573,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		if err != nil {
 			t.Fatal(err)
 		}
-		table := desc.(*tabledesc.ImmutableTableDescriptor)
+		table := desc.(*tabledesc.Immutable)
 		// This test will need to wait until leases are removed from the store
 		// before creating new leases because the jitter used in the leases'
 		// expiration causes duplicate key errors when trying to create new
@@ -742,7 +742,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 
 	// Result is a struct for moving results to the main result routine.
 	type Result struct {
-		table *tabledesc.ImmutableTableDescriptor
+		table *tabledesc.Immutable
 		exp   hlc.Timestamp
 		err   error
 	}
@@ -756,7 +756,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 		acquireChan chan Result,
 	) {
 		table, e, err := m.Acquire(ctx, m.storage.clock.Now(), descID)
-		acquireChan <- Result{err: err, exp: e, table: table.(*tabledesc.ImmutableTableDescriptor)}
+		acquireChan <- Result{err: err, exp: e, table: table.(*tabledesc.Immutable)}
 	}
 
 	testCases := []struct {
@@ -859,7 +859,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 						return
 					}
 					table, e, err := m.Acquire(ctx, s.Clock().Now(), descID)
-					acquireChan <- Result{err: err, exp: e, table: table.(*tabledesc.ImmutableTableDescriptor)}
+					acquireChan <- Result{err: err, exp: e, table: table.(*tabledesc.Immutable)}
 				}(ctx, leaseManager, acquireResultChan)
 
 			} else {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -457,7 +457,7 @@ func TestLeaseManagerPublishIllegalVersionChange(testingT *testing.T) {
 
 	if _, err := t.node(1).Publish(
 		context.Background(), keys.LeaseTableID, func(desc catalog.MutableDescriptor) error {
-			table := desc.(*tabledesc.MutableTableDescriptor)
+			table := desc.(*tabledesc.Mutable)
 			table.Version++
 			return nil
 		}, nil); !testutils.IsError(err, "updated version") {
@@ -465,7 +465,7 @@ func TestLeaseManagerPublishIllegalVersionChange(testingT *testing.T) {
 	}
 	if _, err := t.node(1).Publish(
 		context.Background(), keys.LeaseTableID, func(desc catalog.MutableDescriptor) error {
-			table := desc.(*tabledesc.MutableTableDescriptor)
+			table := desc.(*tabledesc.Mutable)
 			table.Version--
 			return nil
 		}, nil); !testutils.IsError(err, "updated version") {
@@ -1669,7 +1669,7 @@ CREATE TABLE t.test0 (k CHAR PRIMARY KEY, v CHAR);
 			if err != nil {
 				t.Fatalf("error while publishing: %v", err)
 			}
-			table := desc.(*tabledesc.ImmutableTableDescriptor)
+			table := desc.(*tabledesc.Immutable)
 
 			// Wait a little time to give a chance to other goroutines to
 			// race past.

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -131,7 +131,7 @@ func ResolveMutableExistingTableObject(
 // object name.
 func ResolveMutableType(
 	ctx context.Context, sc SchemaResolver, un *tree.UnresolvedObjectName, required bool,
-) (*tree.TypeName, *typedesc.MutableTypeDescriptor, error) {
+) (*tree.TypeName, *typedesc.Mutable, error) {
 	lookupFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
 		RequireMutable:    true,
@@ -142,7 +142,7 @@ func ResolveMutableType(
 		return nil, nil, err
 	}
 	tn := tree.MakeNewQualifiedTypeName(prefix.Catalog(), prefix.Schema(), un.Object())
-	return &tn, desc.(*typedesc.MutableTypeDescriptor), nil
+	return &tn, desc.(*typedesc.Mutable), nil
 }
 
 // ResolveExistingObject resolves an object with the given flags.
@@ -173,9 +173,9 @@ func ResolveExistingObject(
 			return nil, prefix, sqlerrors.NewUndefinedTypeError(&resolvedTn)
 		}
 		if lookupFlags.RequireMutable {
-			return obj.(*typedesc.MutableTypeDescriptor), prefix, nil
+			return obj.(*typedesc.Mutable), prefix, nil
 		}
-		return obj.(*typedesc.ImmutableTypeDescriptor), prefix, nil
+		return obj.(*typedesc.Immutable), prefix, nil
 	case tree.TableObject:
 		table, ok := obj.(catalog.TableDescriptor)
 		if !ok {

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -47,7 +47,7 @@ type SchemaResolver interface {
 	CurrentSearchPath() sessiondata.SearchPath
 	CommonLookupFlags(required bool) tree.CommonLookupFlags
 	ObjectLookupFlags(required bool, requireMutable bool) tree.ObjectLookupFlags
-	LookupTableByID(ctx context.Context, id descpb.ID) (*tabledesc.ImmutableTableDescriptor, error)
+	LookupTableByID(ctx context.Context, id descpb.ID) (*tabledesc.Immutable, error)
 }
 
 // ErrNoPrimaryKey is returned when resolving a table object and the
@@ -83,7 +83,7 @@ func GetObjectNames(
 // if no object is found.
 func ResolveExistingTableObject(
 	ctx context.Context, sc SchemaResolver, tn *tree.TableName, lookupFlags tree.ObjectLookupFlags,
-) (res *tabledesc.ImmutableTableDescriptor, err error) {
+) (res *tabledesc.Immutable, err error) {
 	// TODO: As part of work for #34240, an UnresolvedObjectName should be
 	//  passed as an argument to this function.
 	un := tn.ToUnresolvedObjectName()
@@ -92,7 +92,7 @@ func ResolveExistingTableObject(
 		return nil, err
 	}
 	tn.ObjectNamePrefix = prefix
-	return desc.(*tabledesc.ImmutableTableDescriptor), nil
+	return desc.(*tabledesc.Immutable), nil
 }
 
 // ResolveMutableExistingTableObject looks up an existing mutable object.
@@ -108,7 +108,7 @@ func ResolveMutableExistingTableObject(
 	tn *tree.TableName,
 	required bool,
 	requiredType tree.RequiredTableKind,
-) (res *tabledesc.MutableTableDescriptor, err error) {
+) (res *tabledesc.Mutable, err error) {
 	lookupFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags:    tree.CommonLookupFlags{Required: required},
 		RequireMutable:       true,
@@ -123,7 +123,7 @@ func ResolveMutableExistingTableObject(
 		return nil, err
 	}
 	tn.ObjectNamePrefix = prefix
-	return desc.(*tabledesc.MutableTableDescriptor), nil
+	return desc.(*tabledesc.Mutable), nil
 }
 
 // ResolveMutableType resolves a type descriptor for mutable access. It
@@ -205,10 +205,10 @@ func ResolveExistingObject(
 		}
 
 		if lookupFlags.RequireMutable {
-			return descI.(*tabledesc.MutableTableDescriptor), prefix, nil
+			return descI.(*tabledesc.Mutable), prefix, nil
 		}
 
-		return descI.(*tabledesc.ImmutableTableDescriptor), prefix, nil
+		return descI.(*tabledesc.Immutable), prefix, nil
 	default:
 		return nil, prefix, errors.AssertionFailedf(
 			"unknown desired object kind %d", lookupFlags.DesiredObjectKind)

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -24,17 +24,16 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var _ catalog.SchemaDescriptor = (*ImmutableSchemaDescriptor)(nil)
-var _ catalog.SchemaDescriptor = (*MutableSchemaDescriptor)(nil)
-var _ catalog.MutableDescriptor = (*MutableSchemaDescriptor)(nil)
+var _ catalog.SchemaDescriptor = (*Immutable)(nil)
+var _ catalog.SchemaDescriptor = (*Mutable)(nil)
+var _ catalog.MutableDescriptor = (*Mutable)(nil)
 
-// ImmutableSchemaDescriptor wraps a Schema descriptor and provides methods
-// on it.
-type ImmutableSchemaDescriptor struct {
+// Immutable wraps a Schema descriptor and provides methods on it.
+type Immutable struct {
 	descpb.SchemaDescriptor
 }
 
-// MutableSchemaDescriptor is a mutable reference to a SchemaDescriptor.
+// Mutable is a mutable reference to a SchemaDescriptor.
 //
 // Note: Today this isn't actually ever mutated but rather exists for a future
 // where we anticipate having a mutable copy of Schema descriptors. There's a
@@ -42,88 +41,88 @@ type ImmutableSchemaDescriptor struct {
 // descriptor type. Maybe it makes no sense but we're running with it for the
 // moment. This is an intermediate state on the road to descriptors being
 // handled outside of the catalog entirely as interfaces.
-type MutableSchemaDescriptor struct {
-	ImmutableSchemaDescriptor
+type Mutable struct {
+	Immutable
 
-	ClusterVersion *ImmutableSchemaDescriptor
+	ClusterVersion *Immutable
 }
 
-// NewMutableExistingSchemaDescriptor returns a MutableSchemaDescriptor from the
+// NewMutableExisting returns a Mutable from the
 // given schema descriptor with the cluster version also set to the descriptor.
 // This is for schemas that already exist.
-func NewMutableExistingSchemaDescriptor(desc descpb.SchemaDescriptor) *MutableSchemaDescriptor {
-	return &MutableSchemaDescriptor{
-		ImmutableSchemaDescriptor: makeImmutableSchemaDescriptor(*protoutil.Clone(&desc).(*descpb.SchemaDescriptor)),
-		ClusterVersion:            NewImmutableSchemaDescriptor(desc),
+func NewMutableExisting(desc descpb.SchemaDescriptor) *Mutable {
+	return &Mutable{
+		Immutable:      makeImmutable(*protoutil.Clone(&desc).(*descpb.SchemaDescriptor)),
+		ClusterVersion: NewImmutable(desc),
 	}
 }
 
-// NewImmutableSchemaDescriptor makes a new Schema descriptor.
-func NewImmutableSchemaDescriptor(desc descpb.SchemaDescriptor) *ImmutableSchemaDescriptor {
-	m := makeImmutableSchemaDescriptor(desc)
+// NewImmutable makes a new Schema descriptor.
+func NewImmutable(desc descpb.SchemaDescriptor) *Immutable {
+	m := makeImmutable(desc)
 	return &m
 }
 
-func makeImmutableSchemaDescriptor(desc descpb.SchemaDescriptor) ImmutableSchemaDescriptor {
-	return ImmutableSchemaDescriptor{SchemaDescriptor: desc}
+func makeImmutable(desc descpb.SchemaDescriptor) Immutable {
+	return Immutable{SchemaDescriptor: desc}
 }
 
 // Reference these functions to defeat the linter.
 var (
-	_ = NewImmutableSchemaDescriptor
+	_ = NewImmutable
 )
 
-// NewMutableCreatedSchemaDescriptor returns a MutableSchemaDescriptor from the
+// NewMutableCreatedSchemaDescriptor returns a Mutable from the
 // given SchemaDescriptor with the cluster version being the zero schema. This
 // is for a schema that is created within the current transaction.
-func NewMutableCreatedSchemaDescriptor(desc descpb.SchemaDescriptor) *MutableSchemaDescriptor {
-	return &MutableSchemaDescriptor{
-		ImmutableSchemaDescriptor: makeImmutableSchemaDescriptor(desc),
+func NewMutableCreatedSchemaDescriptor(desc descpb.SchemaDescriptor) *Mutable {
+	return &Mutable{
+		Immutable: makeImmutable(desc),
 	}
 }
 
 // SetDrainingNames implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) SetDrainingNames(names []descpb.NameInfo) {
+func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names
 }
 
 // GetParentSchemaID implements the Descriptor interface.
-func (desc *ImmutableSchemaDescriptor) GetParentSchemaID() descpb.ID {
+func (desc *Immutable) GetParentSchemaID() descpb.ID {
 	return keys.RootNamespaceID
 }
 
 // GetAuditMode implements the DescriptorProto interface.
-func (desc *ImmutableSchemaDescriptor) GetAuditMode() descpb.TableDescriptor_AuditMode {
+func (desc *Immutable) GetAuditMode() descpb.TableDescriptor_AuditMode {
 	return descpb.TableDescriptor_DISABLED
 }
 
 // TypeName implements the DescriptorProto interface.
-func (desc *ImmutableSchemaDescriptor) TypeName() string {
+func (desc *Immutable) TypeName() string {
 	return "schema"
 }
 
 // SchemaDesc implements the Descriptor interface.
-func (desc *ImmutableSchemaDescriptor) SchemaDesc() *descpb.SchemaDescriptor {
+func (desc *Immutable) SchemaDesc() *descpb.SchemaDescriptor {
 	return &desc.SchemaDescriptor
 }
 
 // Adding implements the Descriptor interface.
-func (desc *ImmutableSchemaDescriptor) Adding() bool {
+func (desc *Immutable) Adding() bool {
 	return false
 }
 
 // Offline implements the Descriptor interface.
-func (desc *ImmutableSchemaDescriptor) Offline() bool {
+func (desc *Immutable) Offline() bool {
 	return false
 }
 
 // GetOfflineReason implements the Descriptor interface.
-func (desc *ImmutableSchemaDescriptor) GetOfflineReason() string {
+func (desc *Immutable) GetOfflineReason() string {
 	return ""
 }
 
 // DescriptorProto wraps a SchemaDescriptor in a Descriptor.
-func (desc *ImmutableSchemaDescriptor) DescriptorProto() *descpb.Descriptor {
+func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
 		Union: &descpb.Descriptor_Schema{
 			Schema: &desc.SchemaDescriptor,
@@ -132,10 +131,10 @@ func (desc *ImmutableSchemaDescriptor) DescriptorProto() *descpb.Descriptor {
 }
 
 // NameResolutionResult implements the ObjectDescriptor interface.
-func (desc *ImmutableSchemaDescriptor) NameResolutionResult() {}
+func (desc *Immutable) NameResolutionResult() {}
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) MaybeIncrementVersion() {
+func (desc *Mutable) MaybeIncrementVersion() {
 	// Already incremented, no-op.
 	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
@@ -145,7 +144,7 @@ func (desc *MutableSchemaDescriptor) MaybeIncrementVersion() {
 }
 
 // OriginalName implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) OriginalName() string {
+func (desc *Mutable) OriginalName() string {
 	if desc.ClusterVersion == nil {
 		return ""
 	}
@@ -153,7 +152,7 @@ func (desc *MutableSchemaDescriptor) OriginalName() string {
 }
 
 // OriginalID implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) OriginalID() descpb.ID {
+func (desc *Mutable) OriginalID() descpb.ID {
 	if desc.ClusterVersion == nil {
 		return descpb.InvalidID
 	}
@@ -161,7 +160,7 @@ func (desc *MutableSchemaDescriptor) OriginalID() descpb.ID {
 }
 
 // OriginalVersion implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) OriginalVersion() descpb.DescriptorVersion {
+func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 	if desc.ClusterVersion == nil {
 		return 0
 	}
@@ -169,20 +168,20 @@ func (desc *MutableSchemaDescriptor) OriginalVersion() descpb.DescriptorVersion 
 }
 
 // ImmutableCopy implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) ImmutableCopy() catalog.Descriptor {
+func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutableSchemaDescriptor(*protoutil.Clone(desc.SchemaDesc()).(*descpb.SchemaDescriptor))
+	return NewImmutable(*protoutil.Clone(desc.SchemaDesc()).(*descpb.SchemaDescriptor))
 }
 
 // IsNew implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) IsNew() bool {
+func (desc *Mutable) IsNew() bool {
 	return desc.ClusterVersion == nil
 }
 
 // SetName sets the name of the schema. It handles installing a draining name
 // for the old name of the descriptor.
-func (desc *MutableSchemaDescriptor) SetName(name string) {
+func (desc *Mutable) SetName(name string) {
 	desc.DrainingNames = append(desc.DrainingNames, descpb.NameInfo{
 		ParentID:       desc.ParentID,
 		ParentSchemaID: keys.RootNamespaceID,

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -26,6 +26,7 @@ import (
 
 var _ catalog.SchemaDescriptor = (*ImmutableSchemaDescriptor)(nil)
 var _ catalog.SchemaDescriptor = (*MutableSchemaDescriptor)(nil)
+var _ catalog.MutableDescriptor = (*MutableSchemaDescriptor)(nil)
 
 // ImmutableSchemaDescriptor wraps a Schema descriptor and provides methods
 // on it.
@@ -37,7 +38,7 @@ type ImmutableSchemaDescriptor struct {
 //
 // Note: Today this isn't actually ever mutated but rather exists for a future
 // where we anticipate having a mutable copy of Schema descriptors. There's a
-// large amount of space to question this `Mutable|Immutable` version of each
+// large amount of space to question this `Mutable|ImmutableCopy` version of each
 // descriptor type. Maybe it makes no sense but we're running with it for the
 // moment. This is an intermediate state on the road to descriptors being
 // handled outside of the catalog entirely as interfaces.
@@ -167,8 +168,8 @@ func (desc *MutableSchemaDescriptor) OriginalVersion() descpb.DescriptorVersion 
 	return desc.ClusterVersion.Version
 }
 
-// Immutable implements the MutableDescriptor interface.
-func (desc *MutableSchemaDescriptor) Immutable() catalog.Descriptor {
+// ImmutableCopy implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableSchemaDescriptor(*protoutil.Clone(desc.SchemaDesc()).(*descpb.SchemaDescriptor))

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -367,8 +367,8 @@ const SystemDatabaseName = "system"
 
 // MakeSystemDatabaseDesc constructs a copy of the system database
 // descriptor.
-func MakeSystemDatabaseDesc() *dbdesc.ImmutableDatabaseDescriptor {
-	return dbdesc.NewImmutableDatabaseDescriptor(descpb.DatabaseDescriptor{
+func MakeSystemDatabaseDesc() *dbdesc.Immutable {
+	return dbdesc.NewImmutable(descpb.DatabaseDescriptor{
 		Name:    SystemDatabaseName,
 		ID:      keys.SystemDatabaseID,
 		Version: 1,

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -392,7 +392,7 @@ var (
 	NamespaceTableName = "namespace"
 
 	// DeprecatedNamespaceTable is the descriptor for the deprecated namespace table.
-	DeprecatedNamespaceTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	DeprecatedNamespaceTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    NamespaceTableName,
 		ID:                      keys.DeprecatedNamespaceTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -437,7 +437,7 @@ var (
 	//
 	// TODO(solon): in 20.2, we should change the Name of this descriptor
 	// back to "namespace".
-	NamespaceTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	NamespaceTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "namespace2",
 		ID:                      keys.NamespaceTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -473,7 +473,7 @@ var (
 	})
 
 	// DescriptorTable is the descriptor for the descriptor table.
-	DescriptorTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	DescriptorTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name: "descriptor",
 		ID:   keys.DescriptorTableID,
 		Privileges: descpb.NewCustomSuperuserPrivilegeDescriptor(
@@ -507,7 +507,7 @@ var (
 	trueBoolString  = "true"
 
 	// UsersTable is the descriptor for the users table.
-	UsersTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	UsersTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "users",
 		ID:                      keys.UsersTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -534,7 +534,7 @@ var (
 	})
 
 	// ZonesTable is the descriptor for the zones table.
-	ZonesTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ZonesTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "zones",
 		ID:                      keys.ZonesTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -569,7 +569,7 @@ var (
 
 	// SettingsTable is the descriptor for the settings table.
 	// It contains all cluster settings for which a value has been set.
-	SettingsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	SettingsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "settings",
 		ID:                      keys.SettingsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -600,7 +600,7 @@ var (
 	})
 
 	// DescIDSequence is the descriptor for the descriptor ID sequence.
-	DescIDSequence = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	DescIDSequence = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "descriptor_id_seq",
 		ID:                      keys.DescIDSequenceID,
 		ParentID:                keys.SystemDatabaseID,
@@ -634,7 +634,7 @@ var (
 		FormatVersion: descpb.InterleavedFormatVersion,
 	})
 
-	TenantsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	TenantsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "tenants",
 		ID:                      keys.TenantsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -674,7 +674,7 @@ var (
 // suggestions on writing and maintaining them.
 var (
 	// LeaseTable is the descriptor for the leases table.
-	LeaseTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	LeaseTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "lease",
 		ID:                      keys.LeaseTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -710,7 +710,7 @@ var (
 	uuidV4String = "uuid_v4()"
 
 	// EventLogTable is the descriptor for the event log table.
-	EventLogTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	EventLogTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "eventlog",
 		ID:                      keys.EventLogTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -752,7 +752,7 @@ var (
 	uniqueRowIDString = "unique_rowid()"
 
 	// RangeEventTable is the descriptor for the range log table.
-	RangeEventTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	RangeEventTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "rangelog",
 		ID:                      keys.RangeEventTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -794,7 +794,7 @@ var (
 	})
 
 	// UITable is the descriptor for the ui table.
-	UITable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	UITable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "ui",
 		ID:                      keys.UITableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -824,7 +824,7 @@ var (
 	nowTZString = "now():::TIMESTAMPTZ"
 
 	// JobsTable is the descriptor for the jobs table.
-	JobsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	JobsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "jobs",
 		ID:                      keys.JobsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -900,7 +900,7 @@ var (
 	})
 
 	// WebSessions table to authenticate sessions over stateless connections.
-	WebSessionsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	WebSessionsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "web_sessions",
 		ID:                      keys.WebSessionsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -966,7 +966,7 @@ var (
 	})
 
 	// TableStatistics table to hold statistics about columns and column groups.
-	TableStatisticsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	TableStatisticsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "table_statistics",
 		ID:                      keys.TableStatisticsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1022,7 +1022,7 @@ var (
 	latLonDecimal = types.MakeDecimal(18, 15)
 
 	// LocationsTable is the descriptor for the locations table.
-	LocationsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	LocationsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "locations",
 		ID:                      keys.LocationsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1061,7 +1061,7 @@ var (
 	})
 
 	// RoleMembersTable is the descriptor for the role_members table.
-	RoleMembersTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	RoleMembersTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "role_members",
 		ID:                      keys.RoleMembersTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1128,7 +1128,7 @@ var (
 	})
 
 	// CommentsTable is the descriptor for the comments table.
-	CommentsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	CommentsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "comments",
 		ID:                      keys.CommentsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1162,7 +1162,7 @@ var (
 		NextMutationID: 1,
 	})
 
-	ReportsMetaTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ReportsMetaTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "reports_meta",
 		ID:                      keys.ReportsMetaTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1204,7 +1204,7 @@ var (
 	// TODO(andrei): In 20.1 we should add a foreign key reference to the
 	// reports_meta table. Until then, it would cost us having to create an index
 	// on report_id.
-	ReplicationConstraintStatsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ReplicationConstraintStatsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "replication_constraint_stats",
 		ID:                      keys.ReplicationConstraintStatsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1258,7 +1258,7 @@ var (
 	// TODO(andrei): In 20.1 we should add a foreign key reference to the
 	// reports_meta table. Until then, it would cost us having to create an index
 	// on report_id.
-	ReplicationCriticalLocalitiesTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ReplicationCriticalLocalitiesTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "replication_critical_localities",
 		ID:                      keys.ReplicationCriticalLocalitiesTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1309,7 +1309,7 @@ var (
 	// TODO(andrei): In 20.1 we should add a foreign key reference to the
 	// reports_meta table. Until then, it would cost us having to create an index
 	// on report_id.
-	ReplicationStatsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ReplicationStatsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "replication_stats",
 		ID:                      keys.ReplicationStatsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1358,7 +1358,7 @@ var (
 		NextMutationID: 1,
 	})
 
-	ProtectedTimestampsMetaTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ProtectedTimestampsMetaTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "protected_ts_meta",
 		ID:                      keys.ProtectedTimestampsMetaTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1410,7 +1410,7 @@ var (
 		NextMutationID: 1,
 	})
 
-	ProtectedTimestampsRecordsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ProtectedTimestampsRecordsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "protected_ts_records",
 		ID:                      keys.ProtectedTimestampsRecordsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1453,7 +1453,7 @@ var (
 	})
 
 	// RoleOptionsTable is the descriptor for the role_options table.
-	RoleOptionsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	RoleOptionsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "role_options",
 		ID:                      keys.RoleOptionsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1490,7 +1490,7 @@ var (
 		NextMutationID: 1,
 	})
 
-	StatementBundleChunksTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	StatementBundleChunksTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "statement_bundle_chunks",
 		ID:                      keys.StatementBundleChunksTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1520,7 +1520,7 @@ var (
 
 	// TODO(andrei): Add a foreign key reference to the statement_diagnostics table when
 	// it no longer requires us to create an index on statement_diagnostics_id.
-	StatementDiagnosticsRequestsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	StatementDiagnosticsRequestsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "statement_diagnostics_requests",
 		ID:                      keys.StatementDiagnosticsRequestsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1564,7 +1564,7 @@ var (
 		NextMutationID: 1,
 	})
 
-	StatementDiagnosticsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	StatementDiagnosticsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "statement_diagnostics",
 		ID:                      keys.StatementDiagnosticsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1598,7 +1598,7 @@ var (
 	})
 
 	// ScheduledJobsTable is the descriptor for the scheduled jobs table.
-	ScheduledJobsTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	ScheduledJobsTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "scheduled_jobs",
 		ID:                      keys.ScheduledJobsTableID,
 		ParentID:                keys.SystemDatabaseID,
@@ -1656,7 +1656,7 @@ var (
 	})
 
 	// SqllivenessTable is the descriptor for the sqlliveness table.
-	SqllivenessTable = tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	SqllivenessTable = tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:                    "sqlliveness",
 		ID:                      keys.SqllivenessID,
 		ParentID:                keys.SystemDatabaseID,

--- a/pkg/sql/catalog/systemschema/system_test.go
+++ b/pkg/sql/catalog/systemschema/system_test.go
@@ -30,7 +30,7 @@ func TestShouldSplitAtDesc(t *testing.T) {
 		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT"}):                           false,
 		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
 		dbdesc.NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                             false,
-		typedesc.NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                             false,
+		typedesc.NewCreatedMutable(descpb.TypeDescriptor{}):                                           false,
 		schemadesc.NewImmutable(descpb.SchemaDescriptor{}):                                            false,
 	} {
 		var rawDesc roachpb.Value

--- a/pkg/sql/catalog/systemschema/system_test.go
+++ b/pkg/sql/catalog/systemschema/system_test.go
@@ -31,7 +31,7 @@ func TestShouldSplitAtDesc(t *testing.T) {
 		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
 		dbdesc.NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                                            false,
 		typedesc.NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                                            false,
-		schemadesc.NewImmutableSchemaDescriptor(descpb.SchemaDescriptor{}):                                           false,
+		schemadesc.NewImmutable(descpb.SchemaDescriptor{}):                                                           false,
 	} {
 		var rawDesc roachpb.Value
 		require.NoError(t, rawDesc.SetProto(inner.DescriptorProto()))

--- a/pkg/sql/catalog/systemschema/system_test.go
+++ b/pkg/sql/catalog/systemschema/system_test.go
@@ -29,7 +29,7 @@ func TestShouldSplitAtDesc(t *testing.T) {
 		tabledesc.NewImmutable(descpb.TableDescriptor{}):                                              true,
 		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT"}):                           false,
 		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
-		dbdesc.NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                             false,
+		dbdesc.NewInitial(42, "db", security.AdminRole):                                               false,
 		typedesc.NewCreatedMutable(descpb.TypeDescriptor{}):                                           false,
 		schemadesc.NewImmutable(descpb.SchemaDescriptor{}):                                            false,
 	} {

--- a/pkg/sql/catalog/systemschema/system_test.go
+++ b/pkg/sql/catalog/systemschema/system_test.go
@@ -26,12 +26,12 @@ import (
 
 func TestShouldSplitAtDesc(t *testing.T) {
 	for inner, should := range map[catalog.Descriptor]bool{
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{}):                                              true,
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT"}):                           false,
-		tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
-		dbdesc.NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                                            false,
-		typedesc.NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                                            false,
-		schemadesc.NewImmutable(descpb.SchemaDescriptor{}):                                                           false,
+		tabledesc.NewImmutable(descpb.TableDescriptor{}):                                              true,
+		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT"}):                           false,
+		tabledesc.NewImmutable(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
+		dbdesc.NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                             false,
+		typedesc.NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                             false,
+		schemadesc.NewImmutable(descpb.SchemaDescriptor{}):                                            false,
 	} {
 		var rawDesc roachpb.Value
 		require.NoError(t, rawDesc.SetProto(inner.DescriptorProto()))

--- a/pkg/sql/catalog/tabledesc/helpers_test.go
+++ b/pkg/sql/catalog/tabledesc/helpers_test.go
@@ -16,13 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 )
 
-func (desc *ImmutableTableDescriptor) ValidateCrossReferences(
-	ctx context.Context, dg catalog.DescGetter,
-) error {
+func (desc *Immutable) ValidateCrossReferences(ctx context.Context, dg catalog.DescGetter) error {
 	return desc.validateCrossReferences(ctx, dg)
 }
 
-func (desc *ImmutableTableDescriptor) ValidatePartitioning() error {
+func (desc *Immutable) ValidatePartitioning() error {
 	return desc.validatePartitioning()
 }
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -40,10 +40,10 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-// MutableTableDescriptor is a custom type for TableDescriptors
+// Mutable is a custom type for TableDescriptors
 // going through schema mutations.
-type MutableTableDescriptor struct {
-	ImmutableTableDescriptor
+type Mutable struct {
+	Immutable
 
 	// ClusterVersion represents the version of the table descriptor read from the store.
 	ClusterVersion descpb.TableDescriptor
@@ -69,52 +69,51 @@ var ErrMissingPrimaryKey = errors.New("table must contain a primary key")
 // collected mutations list.
 var ErrIndexGCMutationsList = errors.New("index in GC mutations list")
 
-// NewMutableCreatedTableDescriptor returns a MutableTableDescriptor from the
+// NewCreatedMutable returns a Mutable from the
 // given TableDescriptor with the cluster version being the zero table. This
 // is for a table that is created in the transaction.
-func NewMutableCreatedTableDescriptor(tbl descpb.TableDescriptor) *MutableTableDescriptor {
-	return &MutableTableDescriptor{ImmutableTableDescriptor: MakeImmutableTableDescriptor(tbl)}
+func NewCreatedMutable(tbl descpb.TableDescriptor) *Mutable {
+	return &Mutable{Immutable: MakeImmutable(tbl)}
 }
 
-// NewMutableExistingTableDescriptor returns a MutableTableDescriptor from the
+// NewExistingMutable returns a Mutable from the
 // given TableDescriptor with the cluster version also set to the descriptor.
 // This is for an existing table.
-func NewMutableExistingTableDescriptor(tbl descpb.TableDescriptor) *MutableTableDescriptor {
-	m := NewMutableCreatedTableDescriptor(tbl)
+func NewExistingMutable(tbl descpb.TableDescriptor) *Mutable {
+	m := NewCreatedMutable(tbl)
 	m.ClusterVersion = tbl
 	return m
 }
 
-// NewFilledInMutableExistingTableDescriptor will construct a
-// MutableTableDescriptor and potentially perform post-serialization upgrades.
+// NewFilledInExistingMutable will construct a Mutable and potentially perform
+// post-serialization upgrades.
 //
 // If skipFKsWithMissingTable is true, the foreign key representation upgrade
 // may not fully complete if the other table cannot be found in the ProtoGetter
 // but no error will be returned.
-func NewFilledInMutableExistingTableDescriptor(
+func NewFilledInExistingMutable(
 	ctx context.Context,
 	dg catalog.DescGetter,
 	skipFKsWithMissingTable bool,
 	tbl *descpb.TableDescriptor,
-) (*MutableTableDescriptor, error) {
-	desc, err := makeFilledInImmutableTableDescriptor(ctx, dg, tbl, skipFKsWithMissingTable)
+) (*Mutable, error) {
+	desc, err := makeFilledInImmutable(ctx, dg, tbl, skipFKsWithMissingTable)
 	if err != nil {
 		return nil, err
 	}
-	m := &MutableTableDescriptor{ImmutableTableDescriptor: desc}
+	m := &Mutable{Immutable: desc}
 	m.ClusterVersion = *tbl
 	return m, nil
 }
 
-// MakeImmutableTableDescriptor returns a ImmutableTableDescriptor from the
-// given TableDescriptor.
-func MakeImmutableTableDescriptor(tbl descpb.TableDescriptor) ImmutableTableDescriptor {
+// MakeImmutable returns an Immutable from the given TableDescriptor.
+func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 	publicAndNonPublicCols := tbl.Columns
 	publicAndNonPublicIndexes := tbl.Indexes
 
 	readableCols := tbl.Columns
 
-	desc := ImmutableTableDescriptor{TableDescriptor: tbl}
+	desc := Immutable{TableDescriptor: tbl}
 
 	if len(tbl.Mutations) > 0 {
 		publicAndNonPublicCols = make([]descpb.ColumnDescriptor, 0, len(tbl.Columns)+len(tbl.Mutations))
@@ -187,19 +186,18 @@ func MakeImmutableTableDescriptor(tbl descpb.TableDescriptor) ImmutableTableDesc
 	return desc
 }
 
-// NewImmutableTableDescriptor returns a ImmutableTableDescriptor from the
-// given TableDescriptor.
-func NewImmutableTableDescriptor(tbl descpb.TableDescriptor) *ImmutableTableDescriptor {
-	desc := MakeImmutableTableDescriptor(tbl)
+// NewImmutable returns a Immutable from the given TableDescriptor.
+func NewImmutable(tbl descpb.TableDescriptor) *Immutable {
+	desc := MakeImmutable(tbl)
 	return &desc
 }
 
-// NewFilledInImmutableTableDescriptor will construct an
-// ImmutableTableDescriptor and potentially perform post-serialization upgrades.
-func NewFilledInImmutableTableDescriptor(
+// NewFilledInImmutable will construct an Immutable and potentially perform
+// post-deserialization upgrades.
+func NewFilledInImmutable(
 	ctx context.Context, dg catalog.DescGetter, tbl *descpb.TableDescriptor,
-) (*ImmutableTableDescriptor, error) {
-	desc, err := makeFilledInImmutableTableDescriptor(ctx, dg, tbl, false /* skipFKsWithMissingTable */)
+) (*Immutable, error) {
+	desc, err := makeFilledInImmutable(ctx, dg, tbl, false /* skipFKsWithMissingTable */)
 	if err != nil {
 		return nil, err
 	}
@@ -224,17 +222,17 @@ type PostDeserializationTableDescriptorChanges struct {
 	UpgradedForeignKeyRepresentation bool
 }
 
-func makeFilledInImmutableTableDescriptor(
+func makeFilledInImmutable(
 	ctx context.Context,
 	dg catalog.DescGetter,
 	tbl *descpb.TableDescriptor,
 	skipFKsWithMissingTable bool,
-) (ImmutableTableDescriptor, error) {
+) (Immutable, error) {
 	changes, err := maybeFillInDescriptor(ctx, dg, tbl, skipFKsWithMissingTable)
 	if err != nil {
-		return ImmutableTableDescriptor{}, err
+		return Immutable{}, err
 	}
-	desc := MakeImmutableTableDescriptor(*tbl)
+	desc := MakeImmutable(*tbl)
 	desc.postDeserializationChanges = changes
 	return desc, nil
 }
@@ -248,18 +246,18 @@ func FindIndexPartitionByName(
 }
 
 // TypeName returns the plain type of this descriptor.
-func (desc *ImmutableTableDescriptor) TypeName() string {
+func (desc *Immutable) TypeName() string {
 	return "relation"
 }
 
 // SetName implements the DescriptorProto interface.
-func (desc *MutableTableDescriptor) SetName(name string) {
+func (desc *Mutable) SetName(name string) {
 	desc.Name = name
 }
 
 // GetPrimaryIndex returns a pointer to the primary index of the table
 // descriptor.
-func (desc *ImmutableTableDescriptor) GetPrimaryIndex() *descpb.IndexDescriptor {
+func (desc *Immutable) GetPrimaryIndex() *descpb.IndexDescriptor {
 	return &desc.PrimaryIndex
 }
 
@@ -267,7 +265,7 @@ func (desc *ImmutableTableDescriptor) GetPrimaryIndex() *descpb.IndexDescriptor 
 // one. If the descriptor was created before the field was added, then the
 // descriptor belongs to a table under the `public` physical schema. The static
 // public schema ID is returned in that case.
-func (desc *ImmutableTableDescriptor) GetParentSchemaID() descpb.ID {
+func (desc *Immutable) GetParentSchemaID() descpb.ID {
 	parentSchemaID := desc.GetUnexposedParentSchemaID()
 	if parentSchemaID == descpb.InvalidID {
 		parentSchemaID = keys.PublicSchemaID
@@ -281,16 +279,14 @@ func (desc *ImmutableTableDescriptor) GetParentSchemaID() descpb.ID {
 // primary keys, column families, and indexes (unlike virtual tables).
 // Sequences count as physical tables because their values are stored in
 // the KV layer.
-func (desc *ImmutableTableDescriptor) IsPhysicalTable() bool {
+func (desc *Immutable) IsPhysicalTable() bool {
 	return desc.IsSequence() || (desc.IsTable() && !desc.IsVirtualTable()) || desc.MaterializedView()
 }
 
 // FindIndexByID finds an index (active or inactive) with the specified ID.
 // Must return a pointer to the IndexDescriptor in the TableDescriptor, so that
 // callers can use returned values to modify the TableDesc.
-func (desc *ImmutableTableDescriptor) FindIndexByID(
-	id descpb.IndexID,
-) (*descpb.IndexDescriptor, error) {
+func (desc *Immutable) FindIndexByID(id descpb.IndexID) (*descpb.IndexDescriptor, error) {
 	if desc.PrimaryIndex.ID == id {
 		return desc.GetPrimaryIndex(), nil
 	}
@@ -317,7 +313,7 @@ func (desc *ImmutableTableDescriptor) FindIndexByID(
 // given index. If a secondary index doesn't store any columns, then it only
 // has one k/v pair, but if it stores some columns, it can return up to one
 // k/v pair per family in the table, just like a primary index.
-func (desc *ImmutableTableDescriptor) KeysPerRow(indexID descpb.IndexID) (int, error) {
+func (desc *Immutable) KeysPerRow(indexID descpb.IndexID) (int, error) {
 	if desc.PrimaryIndex.ID == indexID {
 		return len(desc.Families), nil
 	}
@@ -333,7 +329,7 @@ func (desc *ImmutableTableDescriptor) KeysPerRow(indexID descpb.IndexID) (int, e
 
 // AllNonDropColumns returns all the columns, including those being added
 // in the mutations.
-func (desc *ImmutableTableDescriptor) AllNonDropColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) AllNonDropColumns() []descpb.ColumnDescriptor {
 	cols := make([]descpb.ColumnDescriptor, 0, len(desc.Columns)+len(desc.Mutations))
 	cols = append(cols, desc.Columns...)
 	for _, m := range desc.Mutations {
@@ -349,7 +345,7 @@ func (desc *ImmutableTableDescriptor) AllNonDropColumns() []descpb.ColumnDescrip
 // allocateName sets desc.Name to a value that is not EqualName to any
 // of tableDesc's indexes. allocateName roughly follows PostgreSQL's
 // convention for automatically-named indexes.
-func allocateIndexName(tableDesc *MutableTableDescriptor, idx *descpb.IndexDescriptor) {
+func allocateIndexName(tableDesc *Mutable, idx *descpb.IndexDescriptor) {
 	segments := make([]string, 0, len(idx.ColumnNames)+2)
 	segments = append(segments, tableDesc.Name)
 	segments = append(segments, idx.ColumnNames...)
@@ -375,7 +371,7 @@ func allocateIndexName(tableDesc *MutableTableDescriptor, idx *descpb.IndexDescr
 
 // AllNonDropIndexes returns all the indexes, including those being added
 // in the mutations.
-func (desc *ImmutableTableDescriptor) AllNonDropIndexes() []*descpb.IndexDescriptor {
+func (desc *Immutable) AllNonDropIndexes() []*descpb.IndexDescriptor {
 	indexes := make([]*descpb.IndexDescriptor, 0, 1+len(desc.Indexes)+len(desc.Mutations))
 	if desc.IsPhysicalTable() {
 		indexes = append(indexes, &desc.PrimaryIndex)
@@ -396,7 +392,7 @@ func (desc *ImmutableTableDescriptor) AllNonDropIndexes() []*descpb.IndexDescrip
 // AllActiveAndInactiveChecks returns all check constraints, including both
 // "active" ones on the table descriptor which are being enforced for all
 // writes, and "inactive" ones queued in the mutations list.
-func (desc *ImmutableTableDescriptor) AllActiveAndInactiveChecks() []*descpb.TableDescriptor_CheckConstraint {
+func (desc *Immutable) AllActiveAndInactiveChecks() []*descpb.TableDescriptor_CheckConstraint {
 	// A check constraint could be both on the table descriptor and in the
 	// list of mutations while the constraint is validated for existing rows. In
 	// that case, the constraint is in the Validating state, and we avoid
@@ -426,7 +422,7 @@ func (desc *ImmutableTableDescriptor) AllActiveAndInactiveChecks() []*descpb.Tab
 // should be assigned to, given the set of columns it's computed from.
 //
 // This is currently the column family of the first column in the set of index columns.
-func GetColumnFamilyForShard(desc *MutableTableDescriptor, idxColumns []string) string {
+func GetColumnFamilyForShard(desc *Mutable, idxColumns []string) string {
 	for _, f := range desc.Families {
 		for _, fCol := range f.ColumnNames {
 			if fCol == idxColumns[0] {
@@ -442,7 +438,7 @@ func GetColumnFamilyForShard(desc *MutableTableDescriptor, idxColumns []string) 
 // writes, and "inactive" ones queued in the mutations list. An error is
 // returned if multiple foreign keys (including mutations) are found for the
 // same index.
-func (desc *ImmutableTableDescriptor) AllActiveAndInactiveForeignKeys() []*descpb.ForeignKeyConstraint {
+func (desc *Immutable) AllActiveAndInactiveForeignKeys() []*descpb.ForeignKeyConstraint {
 	fks := make([]*descpb.ForeignKeyConstraint, 0, len(desc.OutboundFKs))
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
@@ -463,9 +459,7 @@ func (desc *ImmutableTableDescriptor) AllActiveAndInactiveForeignKeys() []*descp
 }
 
 // ForeachPublicColumn runs a function on all public columns.
-func (desc *ImmutableTableDescriptor) ForeachPublicColumn(
-	f func(column *descpb.ColumnDescriptor) error,
-) error {
+func (desc *Immutable) ForeachPublicColumn(f func(column *descpb.ColumnDescriptor) error) error {
 	for i := range desc.Columns {
 		if err := f(&desc.Columns[i]); err != nil {
 			return err
@@ -476,9 +470,7 @@ func (desc *ImmutableTableDescriptor) ForeachPublicColumn(
 
 // ForeachNonDropColumn runs a function on all public columns and columns
 // currently being added.
-func (desc *ImmutableTableDescriptor) ForeachNonDropColumn(
-	f func(column *descpb.ColumnDescriptor) error,
-) error {
+func (desc *Immutable) ForeachNonDropColumn(f func(column *descpb.ColumnDescriptor) error) error {
 	if err := desc.ForeachPublicColumn(f); err != nil {
 		return err
 	}
@@ -497,9 +489,7 @@ func (desc *ImmutableTableDescriptor) ForeachNonDropColumn(
 
 // ForeachNonDropIndex runs a function on all indexes, including those being
 // added in the mutations.
-func (desc *ImmutableTableDescriptor) ForeachNonDropIndex(
-	f func(*descpb.IndexDescriptor) error,
-) error {
+func (desc *Immutable) ForeachNonDropIndex(f func(*descpb.IndexDescriptor) error) error {
 	if err := desc.ForeachIndex(catalog.IndexOpts{AddMutations: true}, func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error {
 		return f(idxDesc)
 	}); err != nil {
@@ -509,7 +499,7 @@ func (desc *ImmutableTableDescriptor) ForeachNonDropIndex(
 }
 
 // ForeachIndex runs a function on the set of indexes as specified by opts.
-func (desc *ImmutableTableDescriptor) ForeachIndex(
+func (desc *Immutable) ForeachIndex(
 	opts catalog.IndexOpts, f func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error,
 ) error {
 	if desc.IsPhysicalTable() || opts.NonPhysicalPrimaryIndex {
@@ -541,7 +531,7 @@ func (desc *ImmutableTableDescriptor) ForeachIndex(
 
 // ForeachDependedOnBy runs a function on all indexes, including those being
 // added in the mutations.
-func (desc *ImmutableTableDescriptor) ForeachDependedOnBy(
+func (desc *Immutable) ForeachDependedOnBy(
 	f func(dep *descpb.TableDescriptor_Reference) error,
 ) error {
 	for i := range desc.DependedOnBy {
@@ -554,7 +544,7 @@ func (desc *ImmutableTableDescriptor) ForeachDependedOnBy(
 
 // ForeachOutboundFK calls f for every outbound foreign key in desc until an
 // error is returned.
-func (desc *ImmutableTableDescriptor) ForeachOutboundFK(
+func (desc *Immutable) ForeachOutboundFK(
 	f func(constraint *descpb.ForeignKeyConstraint) error,
 ) error {
 	for i := range desc.OutboundFKs {
@@ -567,9 +557,7 @@ func (desc *ImmutableTableDescriptor) ForeachOutboundFK(
 
 // ForeachInboundFK calls f for every inbound foreign key in desc until an
 // error is returned.
-func (desc *ImmutableTableDescriptor) ForeachInboundFK(
-	f func(fk *descpb.ForeignKeyConstraint) error,
-) error {
+func (desc *Immutable) ForeachInboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error {
 	for i := range desc.InboundFKs {
 		if err := f(&desc.InboundFKs[i]); err != nil {
 			return err
@@ -579,15 +567,13 @@ func (desc *ImmutableTableDescriptor) ForeachInboundFK(
 }
 
 // NumFamilies returns the number of column families in the descriptor.
-func (desc *ImmutableTableDescriptor) NumFamilies() int {
+func (desc *Immutable) NumFamilies() int {
 	return len(desc.Families)
 }
 
 // ForeachFamily calls f for every column family key in desc until an
 // error is returned.
-func (desc *ImmutableTableDescriptor) ForeachFamily(
-	f func(family *descpb.ColumnFamilyDescriptor) error,
-) error {
+func (desc *Immutable) ForeachFamily(f func(family *descpb.ColumnFamilyDescriptor) error) error {
 	for i := range desc.Families {
 		if err := f(&desc.Families[i]); err != nil {
 			return err
@@ -901,13 +887,13 @@ func maybeUpgradeToFamilyFormatVersion(desc *descpb.TableDescriptor) bool {
 // within a TableDescriptor. The closure takes in a string pointer so that
 // it can mutate the TableDescriptor if desired.
 func ForEachExprStringInTableDesc(descI catalog.TableDescriptor, f func(expr *string) error) error {
-	desc, ok := descI.(*ImmutableTableDescriptor)
+	desc, ok := descI.(*Immutable)
 	if !ok {
-		mut, ok := descI.(*MutableTableDescriptor)
+		mut, ok := descI.(*Mutable)
 		if !ok {
 			return errors.AssertionFailedf("unexpected type of table %T", descI)
 		}
-		desc = &mut.ImmutableTableDescriptor
+		desc = &mut.Immutable
 	}
 	// Helpers for each schema element type that can contain an expression.
 	doCol := func(c *descpb.ColumnDescriptor) error {
@@ -982,7 +968,7 @@ func ForEachExprStringInTableDesc(descI catalog.TableDescriptor, f func(expr *st
 // GetAllReferencedTypeIDs returns all user defined type descriptor IDs that
 // this table references. It takes in a function that returns the TypeDescriptor
 // with the desired ID.
-func (desc *ImmutableTableDescriptor) GetAllReferencedTypeIDs(
+func (desc *Immutable) GetAllReferencedTypeIDs(
 	getType func(descpb.ID) (catalog.TypeDescriptor, error),
 ) (descpb.IDs, error) {
 	// All serialized expressions within a table descriptor are serialized
@@ -1042,7 +1028,7 @@ func (desc *ImmutableTableDescriptor) GetAllReferencedTypeIDs(
 	return result, nil
 }
 
-func (desc *MutableTableDescriptor) initIDs() {
+func (desc *Mutable) initIDs() {
 	if desc.NextColumnID == 0 {
 		desc.NextColumnID = 1
 	}
@@ -1056,7 +1042,7 @@ func (desc *MutableTableDescriptor) initIDs() {
 
 // MaybeFillColumnID assigns a column ID to the given column if the said column has an ID
 // of 0.
-func (desc *MutableTableDescriptor) MaybeFillColumnID(
+func (desc *Mutable) MaybeFillColumnID(
 	c *descpb.ColumnDescriptor, columnNames map[string]descpb.ColumnID,
 ) {
 	desc.initIDs()
@@ -1072,7 +1058,7 @@ func (desc *MutableTableDescriptor) MaybeFillColumnID(
 
 // AllocateIDs allocates column, family, and index ids for any column, family,
 // or index which has an ID of 0.
-func (desc *MutableTableDescriptor) AllocateIDs() error {
+func (desc *Mutable) AllocateIDs() error {
 	// Only tables with physical data can have / need a primary key.
 	if desc.IsPhysicalTable() {
 		if err := desc.ensurePrimaryKey(); err != nil {
@@ -1114,7 +1100,7 @@ func (desc *MutableTableDescriptor) AllocateIDs() error {
 	return err
 }
 
-func (desc *MutableTableDescriptor) ensurePrimaryKey() error {
+func (desc *Mutable) ensurePrimaryKey() error {
 	if len(desc.PrimaryIndex.ColumnNames) == 0 && desc.IsPhysicalTable() {
 		// Ensure a Primary Key exists.
 		nameExists := func(name string) bool {
@@ -1142,7 +1128,7 @@ func (desc *MutableTableDescriptor) ensurePrimaryKey() error {
 	return nil
 }
 
-func (desc *MutableTableDescriptor) allocateIndexIDs(columnNames map[string]descpb.ColumnID) error {
+func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) error {
 	if desc.NextIndexID == 0 {
 		desc.NextIndexID = 1
 	}
@@ -1253,9 +1239,7 @@ func (desc *MutableTableDescriptor) allocateIndexIDs(columnNames map[string]desc
 	return nil
 }
 
-func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(
-	columnNames map[string]descpb.ColumnID,
-) {
+func (desc *Mutable) allocateColumnFamilyIDs(columnNames map[string]descpb.ColumnID) {
 	if desc.NextFamilyID == 0 {
 		if len(desc.Families) == 0 {
 			desc.Families = []descpb.ColumnFamilyDescriptor{
@@ -1372,7 +1356,7 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(
 //
 // Current heuristics:
 //  - Put all columns in family 0.
-func fitColumnToFamily(desc *MutableTableDescriptor, col descpb.ColumnDescriptor) (int, bool) {
+func fitColumnToFamily(desc *Mutable, col descpb.ColumnDescriptor) (int, bool) {
 	// Fewer column families means fewer kv entries, which is generally faster.
 	// On the other hand, an update to any column in a family requires that they
 	// all are read and rewritten, so large (or numerous) columns that are not
@@ -1402,7 +1386,7 @@ func fitColumnToFamily(desc *MutableTableDescriptor, col descpb.ColumnDescriptor
 }
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) MaybeIncrementVersion() {
+func (desc *Mutable) MaybeIncrementVersion() {
 	// Already incremented, no-op.
 	if desc.Version == desc.ClusterVersion.Version+1 {
 		return
@@ -1416,23 +1400,23 @@ func (desc *MutableTableDescriptor) MaybeIncrementVersion() {
 }
 
 // OriginalName implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) OriginalName() string {
+func (desc *Mutable) OriginalName() string {
 	return desc.ClusterVersion.Name
 }
 
 // OriginalID implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) OriginalID() descpb.ID {
+func (desc *Mutable) OriginalID() descpb.ID {
 	return desc.ClusterVersion.ID
 }
 
 // OriginalVersion implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) OriginalVersion() descpb.DescriptorVersion {
+func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 	return desc.ClusterVersion.Version
 }
 
 // Validate validates that the table descriptor is well formed. Checks include
 // both single table and cross table invariants.
-func (desc *ImmutableTableDescriptor) Validate(ctx context.Context, dg catalog.DescGetter) error {
+func (desc *Immutable) Validate(ctx context.Context, dg catalog.DescGetter) error {
 	err := desc.ValidateTable()
 	if err != nil {
 		return err
@@ -1445,9 +1429,7 @@ func (desc *ImmutableTableDescriptor) Validate(ctx context.Context, dg catalog.D
 
 // validateCrossReferences validates that each reference to another table is
 // resolvable and that the necessary back references exist.
-func (desc *ImmutableTableDescriptor) validateCrossReferences(
-	ctx context.Context, dg catalog.DescGetter,
-) error {
+func (desc *Immutable) validateCrossReferences(ctx context.Context, dg catalog.DescGetter) error {
 	// Check that parent DB exists.
 	{
 		db, err := dg.GetDesc(ctx, desc.ParentID)
@@ -1613,7 +1595,7 @@ func (desc *ImmutableTableDescriptor) validateCrossReferences(
 }
 
 // ValidateIndexNameIsUnique validates that the index name does not exist.
-func (desc *ImmutableTableDescriptor) ValidateIndexNameIsUnique(indexName string) error {
+func (desc *Immutable) ValidateIndexNameIsUnique(indexName string) error {
 	for _, index := range desc.AllNonDropIndexes() {
 		if indexName == index.Name {
 			return sqlerrors.NewRelationAlreadyExistsError(indexName)
@@ -1628,7 +1610,7 @@ func (desc *ImmutableTableDescriptor) ValidateIndexNameIsUnique(indexName string
 // are consistent. Use Validate to validate that cross-table references are
 // correct.
 // If version is supplied, the descriptor is checked for version incompatibilities.
-func (desc *ImmutableTableDescriptor) ValidateTable() error {
+func (desc *Immutable) ValidateTable() error {
 	if err := catalog.ValidateName(desc.Name, "table"); err != nil {
 		return err
 	}
@@ -1831,9 +1813,7 @@ func (desc *ImmutableTableDescriptor) ValidateTable() error {
 	return desc.Privileges.Validate(desc.GetID(), privilege.Table)
 }
 
-func (desc *ImmutableTableDescriptor) validateColumnFamilies(
-	columnIDs map[descpb.ColumnID]string,
-) error {
+func (desc *Immutable) validateColumnFamilies(columnIDs map[descpb.ColumnID]string) error {
 	if len(desc.Families) < 1 {
 		return fmt.Errorf("at least 1 column family must be specified")
 	}
@@ -1911,9 +1891,7 @@ func (desc *ImmutableTableDescriptor) validateColumnFamilies(
 // IDs are unique, and the family of the primary key is 0. This does not check
 // if indexes are unique (i.e. same set of columns, direction, and uniqueness)
 // as there are practical uses for them.
-func (desc *ImmutableTableDescriptor) validateTableIndexes(
-	columnNames map[string]descpb.ColumnID,
-) error {
+func (desc *Immutable) validateTableIndexes(columnNames map[string]descpb.ColumnID) error {
 	if len(desc.PrimaryIndex.ColumnIDs) == 0 {
 		return ErrMissingPrimaryKey
 	}
@@ -1998,9 +1976,7 @@ func (desc *ImmutableTableDescriptor) validateTableIndexes(
 // column. This is because the sharded index is based on a hidden computed shard column
 // under the hood and we don't support transitively computed columns (computed column A
 // based on another computed column B).
-func (desc *ImmutableTableDescriptor) ensureShardedIndexNotComputed(
-	index *descpb.IndexDescriptor,
-) error {
+func (desc *Immutable) ensureShardedIndexNotComputed(index *descpb.IndexDescriptor) error {
 	for _, colName := range index.Sharded.ColumnNames {
 		col, _, err := desc.FindColumnByName(tree.Name(colName))
 		if err != nil {
@@ -2016,7 +1992,7 @@ func (desc *ImmutableTableDescriptor) ensureShardedIndexNotComputed(
 
 // PrimaryKeyString returns the pretty-printed primary key declaration for a
 // table descriptor.
-func (desc *ImmutableTableDescriptor) PrimaryKeyString() string {
+func (desc *Immutable) PrimaryKeyString() string {
 	var primaryKeyString strings.Builder
 	primaryKeyString.WriteString("PRIMARY KEY (%s)")
 	if desc.PrimaryIndex.IsSharded() {
@@ -2034,7 +2010,7 @@ func (desc *ImmutableTableDescriptor) PrimaryKeyString() string {
 // tuples match the corresponding column types, and that range partitions are
 // stored sorted by upper bound. colOffset is non-zero for subpartitions and
 // indicates how many index columns to skip over.
-func (desc *ImmutableTableDescriptor) validatePartitioningDescriptor(
+func (desc *Immutable) validatePartitioningDescriptor(
 	a *rowenc.DatumAlloc,
 	idxDesc *descpb.IndexDescriptor,
 	partDesc *descpb.PartitioningDescriptor,
@@ -2180,9 +2156,7 @@ func (ps partitionInterval) Range() interval.Range {
 
 // FindIndexesWithPartition returns all IndexDescriptors (potentially including
 // the primary index) which have a partition with the given name.
-func (desc *ImmutableTableDescriptor) FindIndexesWithPartition(
-	name string,
-) []*descpb.IndexDescriptor {
+func (desc *Immutable) FindIndexesWithPartition(name string) []*descpb.IndexDescriptor {
 	var indexes []*descpb.IndexDescriptor
 	for _, idx := range desc.AllNonDropIndexes() {
 		if FindIndexPartitionByName(idx, name) != nil {
@@ -2194,7 +2168,7 @@ func (desc *ImmutableTableDescriptor) FindIndexesWithPartition(
 
 // validatePartitioning validates that any PartitioningDescriptors contained in
 // table indexes are well-formed. See validatePartitioningDesc for details.
-func (desc *ImmutableTableDescriptor) validatePartitioning() error {
+func (desc *Immutable) validatePartitioning() error {
 	partitionNames := make(map[string]string)
 
 	a := &rowenc.DatumAlloc{}
@@ -2238,7 +2212,7 @@ func notIndexableError(cols []descpb.ColumnDescriptor, inverted bool) error {
 	return unimplemented.NewWithIssueDetailf(35730, typInfo, "%s", msg)
 }
 
-func checkColumnsValidForIndex(tableDesc *MutableTableDescriptor, indexColNames []string) error {
+func checkColumnsValidForIndex(tableDesc *Mutable, indexColNames []string) error {
 	invalidColumns := make([]descpb.ColumnDescriptor, 0, len(indexColNames))
 	for _, indexCol := range indexColNames {
 		for _, col := range tableDesc.AllNonDropColumns() {
@@ -2255,9 +2229,7 @@ func checkColumnsValidForIndex(tableDesc *MutableTableDescriptor, indexColNames 
 	return nil
 }
 
-func checkColumnsValidForInvertedIndex(
-	tableDesc *MutableTableDescriptor, indexColNames []string,
-) error {
+func checkColumnsValidForInvertedIndex(tableDesc *Mutable, indexColNames []string) error {
 	if len((indexColNames)) > 1 {
 		return unimplemented.NewWithIssue(48100,
 			"indexing more than one column with an inverted index is not supported")
@@ -2279,17 +2251,17 @@ func checkColumnsValidForInvertedIndex(
 }
 
 // AddColumn adds a column to the table.
-func (desc *MutableTableDescriptor) AddColumn(col *descpb.ColumnDescriptor) {
+func (desc *Mutable) AddColumn(col *descpb.ColumnDescriptor) {
 	desc.Columns = append(desc.Columns, *col)
 }
 
 // AddFamily adds a family to the table.
-func (desc *MutableTableDescriptor) AddFamily(fam descpb.ColumnFamilyDescriptor) {
+func (desc *Mutable) AddFamily(fam descpb.ColumnFamilyDescriptor) {
 	desc.Families = append(desc.Families, fam)
 }
 
 // AddIndex adds an index to the table.
-func (desc *MutableTableDescriptor) AddIndex(idx descpb.IndexDescriptor, primary bool) error {
+func (desc *Mutable) AddIndex(idx descpb.IndexDescriptor, primary bool) error {
 	if idx.Type == descpb.IndexDescriptor_FORWARD {
 		if err := checkColumnsValidForIndex(desc, idx.ColumnNames); err != nil {
 			return err
@@ -2326,7 +2298,7 @@ func (desc *MutableTableDescriptor) AddIndex(idx descpb.IndexDescriptor, primary
 // ifNotExists) is specified.
 //
 // AllocateIDs must be called before the TableDescriptor will be valid.
-func (desc *MutableTableDescriptor) AddColumnToFamilyMaybeCreate(
+func (desc *Mutable) AddColumnToFamilyMaybeCreate(
 	col string, family string, create bool, ifNotExists bool,
 ) error {
 	idx := int(-1)
@@ -2356,7 +2328,7 @@ func (desc *MutableTableDescriptor) AddColumnToFamilyMaybeCreate(
 }
 
 // RemoveColumnFromFamily removes a colID from the family it's assigned to.
-func (desc *MutableTableDescriptor) RemoveColumnFromFamily(colID descpb.ColumnID) {
+func (desc *Mutable) RemoveColumnFromFamily(colID descpb.ColumnID) {
 	for i := range desc.Families {
 		for j, c := range desc.Families[i].ColumnIDs {
 			if c == colID {
@@ -2379,9 +2351,7 @@ func (desc *MutableTableDescriptor) RemoveColumnFromFamily(colID descpb.ColumnID
 
 // RenameColumnDescriptor updates all references to a column name in
 // a table descriptor including indexes and families.
-func (desc *MutableTableDescriptor) RenameColumnDescriptor(
-	column *descpb.ColumnDescriptor, newColName string,
-) {
+func (desc *Mutable) RenameColumnDescriptor(column *descpb.ColumnDescriptor, newColName string) {
 	colID := column.ID
 	column.Name = newColName
 
@@ -2418,7 +2388,7 @@ func (desc *MutableTableDescriptor) RenameColumnDescriptor(
 
 // FindActiveColumnsByNames finds all requested columns (in the requested order)
 // or returns an error.
-func (desc *ImmutableTableDescriptor) FindActiveColumnsByNames(
+func (desc *Immutable) FindActiveColumnsByNames(
 	names tree.NameList,
 ) ([]descpb.ColumnDescriptor, error) {
 	cols := make([]descpb.ColumnDescriptor, len(names))
@@ -2435,9 +2405,7 @@ func (desc *ImmutableTableDescriptor) FindActiveColumnsByNames(
 // FindColumnByName finds the column with the specified name. It returns
 // an active column or a column from the mutation list. It returns true
 // if the column is being dropped.
-func (desc *ImmutableTableDescriptor) FindColumnByName(
-	name tree.Name,
-) (*descpb.ColumnDescriptor, bool, error) {
+func (desc *Immutable) FindColumnByName(name tree.Name) (*descpb.ColumnDescriptor, bool, error) {
 	for i := range desc.Columns {
 		c := &desc.Columns[i]
 		if c.Name == string(name) {
@@ -2458,9 +2426,7 @@ func (desc *ImmutableTableDescriptor) FindColumnByName(
 // FindActiveOrNewColumnByName finds the column with the specified name.
 // It returns either an active column or a column that was added in the
 // same transaction that is currently running.
-func (desc *MutableTableDescriptor) FindActiveOrNewColumnByName(
-	name tree.Name,
-) (*descpb.ColumnDescriptor, error) {
+func (desc *Mutable) FindActiveOrNewColumnByName(name tree.Name) (*descpb.ColumnDescriptor, error) {
 	for i := range desc.Columns {
 		c := &desc.Columns[i]
 		if c.Name == string(name) {
@@ -2480,9 +2446,7 @@ func (desc *MutableTableDescriptor) FindActiveOrNewColumnByName(
 }
 
 // FindColumnMutationByName finds the mutation on the specified column.
-func (desc *ImmutableTableDescriptor) FindColumnMutationByName(
-	name tree.Name,
-) *descpb.DescriptorMutation {
+func (desc *Immutable) FindColumnMutationByName(name tree.Name) *descpb.DescriptorMutation {
 	for i := range desc.Mutations {
 		m := &desc.Mutations[i]
 		if c := m.GetColumn(); c != nil {
@@ -2496,16 +2460,14 @@ func (desc *ImmutableTableDescriptor) FindColumnMutationByName(
 
 // ColumnIdxMap returns a map from Column ID to the ordinal position of that
 // column.
-func (desc *ImmutableTableDescriptor) ColumnIdxMap() map[descpb.ColumnID]int {
+func (desc *Immutable) ColumnIdxMap() map[descpb.ColumnID]int {
 	return desc.ColumnIdxMapWithMutations(false)
 }
 
 // ColumnIdxMapWithMutations returns a map from Column ID to the ordinal
 // position of that column, optionally including mutation columns if the input
 // bool is true.
-func (desc *ImmutableTableDescriptor) ColumnIdxMapWithMutations(
-	mutations bool,
-) map[descpb.ColumnID]int {
+func (desc *Immutable) ColumnIdxMapWithMutations(mutations bool) map[descpb.ColumnID]int {
 	colIdxMap := make(map[descpb.ColumnID]int, len(desc.Columns))
 	for i := range desc.Columns {
 		id := desc.Columns[i].ID
@@ -2525,9 +2487,7 @@ func (desc *ImmutableTableDescriptor) ColumnIdxMapWithMutations(
 }
 
 // FindActiveColumnByName finds an active column with the specified name.
-func (desc *ImmutableTableDescriptor) FindActiveColumnByName(
-	name string,
-) (*descpb.ColumnDescriptor, error) {
+func (desc *Immutable) FindActiveColumnByName(name string) (*descpb.ColumnDescriptor, error) {
 	for i := range desc.Columns {
 		c := &desc.Columns[i]
 		if c.Name == name {
@@ -2538,9 +2498,7 @@ func (desc *ImmutableTableDescriptor) FindActiveColumnByName(
 }
 
 // FindColumnByID finds the column with specified ID.
-func (desc *ImmutableTableDescriptor) FindColumnByID(
-	id descpb.ColumnID,
-) (*descpb.ColumnDescriptor, error) {
+func (desc *Immutable) FindColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error) {
 	for i := range desc.Columns {
 		c := &desc.Columns[i]
 		if c.ID == id {
@@ -2558,9 +2516,7 @@ func (desc *ImmutableTableDescriptor) FindColumnByID(
 }
 
 // FindActiveColumnByID finds the active column with specified ID.
-func (desc *ImmutableTableDescriptor) FindActiveColumnByID(
-	id descpb.ColumnID,
-) (*descpb.ColumnDescriptor, error) {
+func (desc *Immutable) FindActiveColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error) {
 	for i := range desc.Columns {
 		c := &desc.Columns[i]
 		if c.ID == id {
@@ -2572,7 +2528,7 @@ func (desc *ImmutableTableDescriptor) FindActiveColumnByID(
 
 // ContainsUserDefinedTypes returns whether or not this table descriptor has
 // any columns of user defined types.
-func (desc *ImmutableTableDescriptor) ContainsUserDefinedTypes() bool {
+func (desc *Immutable) ContainsUserDefinedTypes() bool {
 	return len(desc.columnsWithUDTs) > 0
 }
 
@@ -2580,9 +2536,7 @@ func (desc *ImmutableTableDescriptor) ContainsUserDefinedTypes() bool {
 // with user defined type metadata have the same versions of metadata as in the
 // other descriptor. Note that this function is only valid on two descriptors
 // representing the same table at the same version.
-func (desc *ImmutableTableDescriptor) UserDefinedTypeColsHaveSameVersion(
-	otherDesc *ImmutableTableDescriptor,
-) bool {
+func (desc *Immutable) UserDefinedTypeColsHaveSameVersion(otherDesc *Immutable) bool {
 	for _, idx := range desc.columnsWithUDTs {
 		this, other := desc.publicAndNonPublicCols[idx].Type, otherDesc.publicAndNonPublicCols[idx].Type
 		if this.TypeMeta.Version != other.TypeMeta.Version {
@@ -2596,7 +2550,7 @@ func (desc *ImmutableTableDescriptor) UserDefinedTypeColsHaveSameVersion(
 // column may be undergoing a schema change and is marked nullable regardless
 // of its configuration. It returns true if the column is undergoing a
 // schema change.
-func (desc *ImmutableTableDescriptor) FindReadableColumnByID(
+func (desc *Immutable) FindReadableColumnByID(
 	id descpb.ColumnID,
 ) (*descpb.ColumnDescriptor, bool, error) {
 	for i := range desc.ReadableColumns {
@@ -2609,9 +2563,7 @@ func (desc *ImmutableTableDescriptor) FindReadableColumnByID(
 }
 
 // FindFamilyByID finds the family with specified ID.
-func (desc *ImmutableTableDescriptor) FindFamilyByID(
-	id descpb.FamilyID,
-) (*descpb.ColumnFamilyDescriptor, error) {
+func (desc *Immutable) FindFamilyByID(id descpb.FamilyID) (*descpb.ColumnFamilyDescriptor, error) {
 	for i := range desc.Families {
 		family := &desc.Families[i]
 		if family.ID == id {
@@ -2623,7 +2575,7 @@ func (desc *ImmutableTableDescriptor) FindFamilyByID(
 
 // FindIndexByName finds the index with the specified name in the active
 // list or the mutations list. It returns true if the index is being dropped.
-func (desc *ImmutableTableDescriptor) FindIndexByName(
+func (desc *Immutable) FindIndexByName(
 	name string,
 ) (_ *descpb.IndexDescriptor, dropped bool, _ error) {
 	if desc.IsPhysicalTable() && desc.PrimaryIndex.Name == name {
@@ -2646,7 +2598,7 @@ func (desc *ImmutableTableDescriptor) FindIndexByName(
 }
 
 // FindCheckByName finds the check constraint with the specified name.
-func (desc *ImmutableTableDescriptor) FindCheckByName(
+func (desc *Immutable) FindCheckByName(
 	name string,
 ) (*descpb.TableDescriptor_CheckConstraint, error) {
 	for _, c := range desc.Checks {
@@ -2660,7 +2612,7 @@ func (desc *ImmutableTableDescriptor) FindCheckByName(
 // NamesForColumnIDs returns the names for the given column ids, or an error
 // if one or more column ids was missing. Note - this allocates! It's not for
 // hot path code.
-func (desc *ImmutableTableDescriptor) NamesForColumnIDs(ids descpb.ColumnIDs) ([]string, error) {
+func (desc *Immutable) NamesForColumnIDs(ids descpb.ColumnIDs) ([]string, error) {
 	names := make([]string, len(ids))
 	for i, id := range ids {
 		col, err := desc.FindColumnByID(id)
@@ -2673,9 +2625,7 @@ func (desc *ImmutableTableDescriptor) NamesForColumnIDs(ids descpb.ColumnIDs) ([
 }
 
 // RenameIndexDescriptor renames an index descriptor.
-func (desc *MutableTableDescriptor) RenameIndexDescriptor(
-	index *descpb.IndexDescriptor, name string,
-) error {
+func (desc *Mutable) RenameIndexDescriptor(index *descpb.IndexDescriptor, name string) error {
 	id := index.ID
 	if id == desc.PrimaryIndex.ID {
 		desc.PrimaryIndex.Name = name
@@ -2698,11 +2648,11 @@ func (desc *MutableTableDescriptor) RenameIndexDescriptor(
 
 // DropConstraint drops a constraint, either by removing it from the table
 // descriptor or by queuing a mutation for a schema change.
-func (desc *MutableTableDescriptor) DropConstraint(
+func (desc *Mutable) DropConstraint(
 	ctx context.Context,
 	name string,
 	detail descpb.ConstraintDetail,
-	removeFK func(*MutableTableDescriptor, *descpb.ForeignKeyConstraint) error,
+	removeFK func(*Mutable, *descpb.ForeignKeyConstraint) error,
 	settings *cluster.Settings,
 ) error {
 	switch detail.Kind {
@@ -2783,11 +2733,11 @@ func (desc *MutableTableDescriptor) DropConstraint(
 }
 
 // RenameConstraint renames a constraint.
-func (desc *MutableTableDescriptor) RenameConstraint(
+func (desc *Mutable) RenameConstraint(
 	detail descpb.ConstraintDetail,
 	oldName, newName string,
 	dependentViewRenameError func(string, descpb.ID) error,
-	renameFK func(*MutableTableDescriptor, *descpb.ForeignKeyConstraint, string) error,
+	renameFK func(*Mutable, *descpb.ForeignKeyConstraint, string) error,
 ) error {
 	switch detail.Kind {
 	case descpb.ConstraintTypePK, descpb.ConstraintTypeUnique:
@@ -2836,9 +2786,7 @@ func (desc *MutableTableDescriptor) RenameConstraint(
 
 // FindActiveIndexByID returns the index with the specified ID, or nil if it
 // does not exist. It only searches active indexes.
-func (desc *ImmutableTableDescriptor) FindActiveIndexByID(
-	id descpb.IndexID,
-) *descpb.IndexDescriptor {
+func (desc *Immutable) FindActiveIndexByID(id descpb.IndexID) *descpb.IndexDescriptor {
 	if desc.PrimaryIndex.ID == id {
 		return &desc.PrimaryIndex
 	}
@@ -2856,7 +2804,7 @@ func (desc *ImmutableTableDescriptor) FindActiveIndexByID(
 // the index is a secondary index.
 // The primary index has an index of 0 and the first secondary index
 // (if it exists) has an index of 1.
-func (desc *ImmutableTableDescriptor) FindIndexByIndexIdx(
+func (desc *Immutable) FindIndexByIndexIdx(
 	indexIdx int,
 ) (index *descpb.IndexDescriptor, isSecondary bool, err error) {
 	// indexIdx is 0 for the primary index, or 1 to <num-indexes> for a
@@ -2875,7 +2823,7 @@ func (desc *ImmutableTableDescriptor) FindIndexByIndexIdx(
 // GetIndexMutationCapabilities returns:
 // 1. Whether the index is a mutation
 // 2. if so, is it in state DELETE_AND_WRITE_ONLY
-func (desc *ImmutableTableDescriptor) GetIndexMutationCapabilities(id descpb.IndexID) (bool, bool) {
+func (desc *Immutable) GetIndexMutationCapabilities(id descpb.IndexID) (bool, bool) {
 	for _, mutation := range desc.Mutations {
 		if mutationIndex := mutation.GetIndex(); mutationIndex != nil {
 			if mutationIndex.ID == id {
@@ -2890,9 +2838,7 @@ func (desc *ImmutableTableDescriptor) GetIndexMutationCapabilities(id descpb.Ind
 // FindFKByName returns the FK constraint on the table with the given name.
 // Must return a pointer to the FK in the TableDescriptor, so that
 // callers can use returned values to modify the TableDesc.
-func (desc *ImmutableTableDescriptor) FindFKByName(
-	name string,
-) (*descpb.ForeignKeyConstraint, error) {
+func (desc *Immutable) FindFKByName(name string) (*descpb.ForeignKeyConstraint, error) {
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
 		if fk.Name == name {
@@ -2904,7 +2850,7 @@ func (desc *ImmutableTableDescriptor) FindFKByName(
 
 // IsInterleaved returns true if any part of this this table is interleaved with
 // another table's data.
-func (desc *ImmutableTableDescriptor) IsInterleaved() bool {
+func (desc *Immutable) IsInterleaved() bool {
 	for _, index := range desc.AllNonDropIndexes() {
 		if index.IsInterleaved() {
 			return true
@@ -2915,7 +2861,7 @@ func (desc *ImmutableTableDescriptor) IsInterleaved() bool {
 
 // IsPrimaryIndexDefaultRowID returns whether or not the table's primary
 // index is the default primary key on the hidden rowid column.
-func (desc *ImmutableTableDescriptor) IsPrimaryIndexDefaultRowID() bool {
+func (desc *Immutable) IsPrimaryIndexDefaultRowID() bool {
 	if len(desc.PrimaryIndex.ColumnIDs) != 1 {
 		return false
 	}
@@ -2936,7 +2882,7 @@ func (desc *ImmutableTableDescriptor) IsPrimaryIndexDefaultRowID() bool {
 //               marked as validated.
 // Unvalidated - The constraint has not yet been added, and needs to be added
 //               for the first time.
-func (desc *MutableTableDescriptor) MakeMutationComplete(m descpb.DescriptorMutation) error {
+func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 	switch m.Direction {
 	case descpb.DescriptorMutation_ADD:
 		switch t := m.Descriptor_.(type) {
@@ -3101,9 +3047,7 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m descpb.DescriptorMuta
 	return nil
 }
 
-func (desc *MutableTableDescriptor) performComputedColumnSwap(
-	swap *descpb.ComputedColumnSwap,
-) error {
+func (desc *Mutable) performComputedColumnSwap(swap *descpb.ComputedColumnSwap) error {
 	// Get the old and new columns from the descriptor.
 	oldCol, err := desc.FindColumnByID(swap.OldColumnId)
 	if err != nil {
@@ -3201,7 +3145,7 @@ func (desc *MutableTableDescriptor) performComputedColumnSwap(
 }
 
 // AddCheckMutation adds a check constraint mutation to desc.Mutations.
-func (desc *MutableTableDescriptor) AddCheckMutation(
+func (desc *Mutable) AddCheckMutation(
 	ck *descpb.TableDescriptor_CheckConstraint, direction descpb.DescriptorMutation_Direction,
 ) {
 	m := descpb.DescriptorMutation{
@@ -3216,7 +3160,7 @@ func (desc *MutableTableDescriptor) AddCheckMutation(
 }
 
 // AddForeignKeyMutation adds a foreign key constraint mutation to desc.Mutations.
-func (desc *MutableTableDescriptor) AddForeignKeyMutation(
+func (desc *Mutable) AddForeignKeyMutation(
 	fk *descpb.ForeignKeyConstraint, direction descpb.DescriptorMutation_Direction,
 ) {
 	m := descpb.DescriptorMutation{
@@ -3282,7 +3226,7 @@ func MakeNotNullCheckConstraint(
 // treated like other check constraints being added, until the completion of the
 // schema change, at which the check constraint is deleted. This function
 // mutates inuseNames to add the new constraint name.
-func (desc *MutableTableDescriptor) AddNotNullMutation(
+func (desc *Mutable) AddNotNullMutation(
 	ck *descpb.TableDescriptor_CheckConstraint, direction descpb.DescriptorMutation_Direction,
 ) {
 	m := descpb.DescriptorMutation{
@@ -3302,7 +3246,7 @@ func (desc *MutableTableDescriptor) AddNotNullMutation(
 // AddColumnMutation adds a column mutation to desc.Mutations. Callers must take
 // care not to further mutate the column descriptor, since this method retains
 // a pointer to it.
-func (desc *MutableTableDescriptor) AddColumnMutation(
+func (desc *Mutable) AddColumnMutation(
 	c *descpb.ColumnDescriptor, direction descpb.DescriptorMutation_Direction,
 ) {
 	m := descpb.DescriptorMutation{
@@ -3313,7 +3257,7 @@ func (desc *MutableTableDescriptor) AddColumnMutation(
 }
 
 // AddIndexMutation adds an index mutation to desc.Mutations.
-func (desc *MutableTableDescriptor) AddIndexMutation(
+func (desc *Mutable) AddIndexMutation(
 	idx *descpb.IndexDescriptor, direction descpb.DescriptorMutation_Direction,
 ) error {
 
@@ -3337,7 +3281,7 @@ func (desc *MutableTableDescriptor) AddIndexMutation(
 }
 
 // AddPrimaryKeySwapMutation adds a PrimaryKeySwap mutation to the table descriptor.
-func (desc *MutableTableDescriptor) AddPrimaryKeySwapMutation(swap *descpb.PrimaryKeySwap) {
+func (desc *Mutable) AddPrimaryKeySwapMutation(swap *descpb.PrimaryKeySwap) {
 	m := descpb.DescriptorMutation{
 		Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{PrimaryKeySwap: swap},
 		Direction:   descpb.DescriptorMutation_ADD,
@@ -3347,9 +3291,7 @@ func (desc *MutableTableDescriptor) AddPrimaryKeySwapMutation(swap *descpb.Prima
 
 // AddMaterializedViewRefreshMutation adds a MaterializedViewRefreshMutation to
 // the table descriptor.
-func (desc *MutableTableDescriptor) AddMaterializedViewRefreshMutation(
-	refresh *descpb.MaterializedViewRefresh,
-) {
+func (desc *Mutable) AddMaterializedViewRefreshMutation(refresh *descpb.MaterializedViewRefresh) {
 	m := descpb.DescriptorMutation{
 		Descriptor_: &descpb.DescriptorMutation_MaterializedViewRefresh{MaterializedViewRefresh: refresh},
 		Direction:   descpb.DescriptorMutation_ADD,
@@ -3358,7 +3300,7 @@ func (desc *MutableTableDescriptor) AddMaterializedViewRefreshMutation(
 }
 
 // AddComputedColumnSwapMutation adds a ComputedColumnSwap mutation to the table descriptor.
-func (desc *MutableTableDescriptor) AddComputedColumnSwapMutation(swap *descpb.ComputedColumnSwap) {
+func (desc *Mutable) AddComputedColumnSwapMutation(swap *descpb.ComputedColumnSwap) {
 	m := descpb.DescriptorMutation{
 		Descriptor_: &descpb.DescriptorMutation_ComputedColumnSwap{ComputedColumnSwap: swap},
 		Direction:   descpb.DescriptorMutation_ADD,
@@ -3366,7 +3308,7 @@ func (desc *MutableTableDescriptor) AddComputedColumnSwapMutation(swap *descpb.C
 	desc.addMutation(m)
 }
 
-func (desc *MutableTableDescriptor) addMutation(m descpb.DescriptorMutation) {
+func (desc *Mutable) addMutation(m descpb.DescriptorMutation) {
 	switch m.Direction {
 	case descpb.DescriptorMutation_ADD:
 		m.State = descpb.DescriptorMutation_DELETE_ONLY
@@ -3392,16 +3334,14 @@ const IgnoreConstraints = false
 // table descriptor returned should include newly added constraints.
 const IncludeConstraints = true
 
-// MakeFirstMutationPublic creates a MutableTableDescriptor from the
-// ImmutableTableDescriptor by making the first mutation public.
+// MakeFirstMutationPublic creates a Mutable from the
+// Immutable by making the first mutation public.
 // This is super valuable when trying to run SQL over data associated
 // with a schema mutation that is still not yet public: Data validation,
 // error reporting.
-func (desc *ImmutableTableDescriptor) MakeFirstMutationPublic(
-	includeConstraints bool,
-) (*MutableTableDescriptor, error) {
+func (desc *Immutable) MakeFirstMutationPublic(includeConstraints bool) (*Mutable, error) {
 	// Clone the ImmutableTable descriptor because we want to create an ImmutableCopy one.
-	table := NewMutableExistingTableDescriptor(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))
+	table := NewExistingMutable(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))
 	mutationID := desc.Mutations[0].MutationID
 	i := 0
 	for _, mutation := range desc.Mutations {
@@ -3432,13 +3372,13 @@ func ColumnNeedsBackfill(desc *descpb.ColumnDescriptor) bool {
 }
 
 // HasPrimaryKey returns true if the table has a primary key.
-func (desc *ImmutableTableDescriptor) HasPrimaryKey() bool {
+func (desc *Immutable) HasPrimaryKey() bool {
 	return !desc.PrimaryIndex.Disabled
 }
 
 // HasColumnBackfillMutation returns whether the table has any queued column
 // mutations that require a backfill.
-func (desc *ImmutableTableDescriptor) HasColumnBackfillMutation() bool {
+func (desc *Immutable) HasColumnBackfillMutation() bool {
 	for _, m := range desc.Mutations {
 		col := m.GetColumn()
 		if col == nil {
@@ -3457,12 +3397,12 @@ func (desc *ImmutableTableDescriptor) HasColumnBackfillMutation() bool {
 
 // IsNew returns true if the table was created in the current
 // transaction.
-func (desc *MutableTableDescriptor) IsNew() bool {
+func (desc *Mutable) IsNew() bool {
 	return desc.ClusterVersion.ID == descpb.InvalidID
 }
 
 // VisibleColumns returns all non hidden columns.
-func (desc *ImmutableTableDescriptor) VisibleColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) VisibleColumns() []descpb.ColumnDescriptor {
 	var cols []descpb.ColumnDescriptor
 	for i := range desc.Columns {
 		col := &desc.Columns[i]
@@ -3474,15 +3414,13 @@ func (desc *ImmutableTableDescriptor) VisibleColumns() []descpb.ColumnDescriptor
 }
 
 // ColumnTypes returns the types of all columns.
-func (desc *ImmutableTableDescriptor) ColumnTypes() []*types.T {
+func (desc *Immutable) ColumnTypes() []*types.T {
 	return desc.ColumnTypesWithMutations(false)
 }
 
 // ColumnsWithMutations returns all column descriptors, optionally including
 // mutation columns.
-func (desc *ImmutableTableDescriptor) ColumnsWithMutations(
-	includeMutations bool,
-) []descpb.ColumnDescriptor {
+func (desc *Immutable) ColumnsWithMutations(includeMutations bool) []descpb.ColumnDescriptor {
 	n := len(desc.Columns)
 	columns := desc.Columns[:n:n] // immutable on append
 	if includeMutations {
@@ -3497,7 +3435,7 @@ func (desc *ImmutableTableDescriptor) ColumnsWithMutations(
 
 // ColumnTypesWithMutations returns the types of all columns, optionally
 // including mutation columns, which will be returned if the input bool is true.
-func (desc *ImmutableTableDescriptor) ColumnTypesWithMutations(mutations bool) []*types.T {
+func (desc *Immutable) ColumnTypesWithMutations(mutations bool) []*types.T {
 	columns := desc.ColumnsWithMutations(mutations)
 	types := make([]*types.T, len(columns))
 	for i := range columns {
@@ -3518,7 +3456,7 @@ func ColumnsSelectors(cols []descpb.ColumnDescriptor) tree.SelectExprs {
 }
 
 // InvalidateFKConstraints sets all FK constraints to un-validated.
-func (desc *ImmutableTableDescriptor) InvalidateFKConstraints() {
+func (desc *Immutable) InvalidateFKConstraints() {
 	// We don't use GetConstraintInfo because we want to edit the passed desc.
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
@@ -3528,7 +3466,7 @@ func (desc *ImmutableTableDescriptor) InvalidateFKConstraints() {
 
 // AllIndexSpans returns the Spans for each index in the table, including those
 // being added in the mutations.
-func (desc *ImmutableTableDescriptor) AllIndexSpans(codec keys.SQLCodec) roachpb.Spans {
+func (desc *Immutable) AllIndexSpans(codec keys.SQLCodec) roachpb.Spans {
 	var spans roachpb.Spans
 	err := desc.ForeachNonDropIndex(func(index *descpb.IndexDescriptor) error {
 		spans = append(spans, desc.IndexSpan(codec, index.ID))
@@ -3542,21 +3480,19 @@ func (desc *ImmutableTableDescriptor) AllIndexSpans(codec keys.SQLCodec) roachpb
 
 // PrimaryIndexSpan returns the Span that corresponds to the entire primary
 // index; can be used for a full table scan.
-func (desc *ImmutableTableDescriptor) PrimaryIndexSpan(codec keys.SQLCodec) roachpb.Span {
+func (desc *Immutable) PrimaryIndexSpan(codec keys.SQLCodec) roachpb.Span {
 	return desc.IndexSpan(codec, desc.PrimaryIndex.ID)
 }
 
 // IndexSpan returns the Span that corresponds to an entire index; can be used
 // for a full index scan.
-func (desc *ImmutableTableDescriptor) IndexSpan(
-	codec keys.SQLCodec, indexID descpb.IndexID,
-) roachpb.Span {
+func (desc *Immutable) IndexSpan(codec keys.SQLCodec, indexID descpb.IndexID) roachpb.Span {
 	prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(codec, desc, indexID))
 	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }
 
 // TableSpan returns the Span that corresponds to the entire table.
-func (desc *ImmutableTableDescriptor) TableSpan(codec keys.SQLCodec) roachpb.Span {
+func (desc *Immutable) TableSpan(codec keys.SQLCodec) roachpb.Span {
 	// TODO(jordan): Why does IndexSpan consider interleaves but TableSpan does
 	// not? Should it?
 	prefix := codec.TablePrefix(uint32(desc.ID))
@@ -3570,7 +3506,7 @@ func (desc *ImmutableTableDescriptor) TableSpan(codec keys.SQLCodec) roachpb.Spa
 // TODO(nvanbenschoten): we can remove this in v2.1 and replace it with a sql
 // migration to backfill all descpb.TableDescriptor_CheckConstraint.ColumnIDs slices.
 // See #22322.
-func (desc *ImmutableTableDescriptor) ColumnsUsed(
+func (desc *Immutable) ColumnsUsed(
 	cc *descpb.TableDescriptor_CheckConstraint,
 ) ([]descpb.ColumnID, error) {
 	if len(cc.ColumnIDs) > 0 {
@@ -3618,7 +3554,7 @@ func (desc *ImmutableTableDescriptor) ColumnsUsed(
 
 // CheckConstraintUsesColumn returns whether the check constraint uses the
 // specified column.
-func (desc *ImmutableTableDescriptor) CheckConstraintUsesColumn(
+func (desc *Immutable) CheckConstraintUsesColumn(
 	cc *descpb.TableDescriptor_CheckConstraint, colID descpb.ColumnID,
 ) (bool, error) {
 	colsUsed, err := desc.ColumnsUsed(cc)
@@ -3633,7 +3569,7 @@ func (desc *ImmutableTableDescriptor) CheckConstraintUsesColumn(
 
 // GetFamilyOfColumn returns the ColumnFamilyDescriptor for the
 // the family the column is part of.
-func (desc *ImmutableTableDescriptor) GetFamilyOfColumn(
+func (desc *Immutable) GetFamilyOfColumn(
 	colID descpb.ColumnID,
 ) (*descpb.ColumnFamilyDescriptor, error) {
 	for _, fam := range desc.Families {
@@ -3649,7 +3585,7 @@ func (desc *ImmutableTableDescriptor) GetFamilyOfColumn(
 
 // PartitionNames returns a slice containing the name of every partition and
 // subpartition in an arbitrary order.
-func (desc *ImmutableTableDescriptor) PartitionNames() []string {
+func (desc *Immutable) PartitionNames() []string {
 	var names []string
 	for _, index := range desc.AllNonDropIndexes() {
 		names = append(names, index.Partitioning.PartitionNames()...)
@@ -3658,7 +3594,7 @@ func (desc *ImmutableTableDescriptor) PartitionNames() []string {
 }
 
 // SetAuditMode configures the audit mode on the descriptor.
-func (desc *MutableTableDescriptor) SetAuditMode(mode tree.AuditMode) (bool, error) {
+func (desc *Mutable) SetAuditMode(mode tree.AuditMode) (bool, error) {
 	prev := desc.AuditMode
 	switch mode {
 	case tree.AuditModeDisable:
@@ -3673,7 +3609,7 @@ func (desc *MutableTableDescriptor) SetAuditMode(mode tree.AuditMode) (bool, err
 }
 
 // FindAllReferences returns all the references from a table.
-func (desc *ImmutableTableDescriptor) FindAllReferences() (map[descpb.ID]struct{}, error) {
+func (desc *Immutable) FindAllReferences() (map[descpb.ID]struct{}, error) {
 	refs := map[descpb.ID]struct{}{}
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
@@ -3714,49 +3650,49 @@ func (desc *ImmutableTableDescriptor) FindAllReferences() (map[descpb.ID]struct{
 // ActiveChecks returns a list of all check constraints that should be enforced
 // on writes (including constraints being added/validated). The columns
 // referenced by the returned checks are writable, but not necessarily public.
-func (desc *ImmutableTableDescriptor) ActiveChecks() []descpb.TableDescriptor_CheckConstraint {
+func (desc *Immutable) ActiveChecks() []descpb.TableDescriptor_CheckConstraint {
 	return desc.allChecks
 }
 
 // WritableColumns returns a list of public and write-only mutation columns.
-func (desc *ImmutableTableDescriptor) WritableColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) WritableColumns() []descpb.ColumnDescriptor {
 	return desc.publicAndNonPublicCols[:len(desc.Columns)+desc.writeOnlyColCount]
 }
 
 // DeletableColumns returns a list of public and non-public columns.
-func (desc *ImmutableTableDescriptor) DeletableColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) DeletableColumns() []descpb.ColumnDescriptor {
 	return desc.publicAndNonPublicCols
 }
 
 // MutationColumns returns a list of mutation columns.
-func (desc *ImmutableTableDescriptor) MutationColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) MutationColumns() []descpb.ColumnDescriptor {
 	return desc.publicAndNonPublicCols[len(desc.Columns):]
 }
 
 // WritableIndexes returns a list of public and write-only mutation indexes.
-func (desc *ImmutableTableDescriptor) WritableIndexes() []descpb.IndexDescriptor {
+func (desc *Immutable) WritableIndexes() []descpb.IndexDescriptor {
 	return desc.publicAndNonPublicIndexes[:len(desc.Indexes)+desc.writeOnlyIndexCount]
 }
 
 // DeletableIndexes returns a list of public and non-public indexes.
-func (desc *ImmutableTableDescriptor) DeletableIndexes() []descpb.IndexDescriptor {
+func (desc *Immutable) DeletableIndexes() []descpb.IndexDescriptor {
 	return desc.publicAndNonPublicIndexes
 }
 
 // DeleteOnlyIndexes returns a list of delete-only mutation indexes.
-func (desc *ImmutableTableDescriptor) DeleteOnlyIndexes() []descpb.IndexDescriptor {
+func (desc *Immutable) DeleteOnlyIndexes() []descpb.IndexDescriptor {
 	return desc.publicAndNonPublicIndexes[len(desc.Indexes)+desc.writeOnlyIndexCount:]
 }
 
 // PartialIndexOrds returns a set containing the ordinal of each partial index
 // defined on the table.
-func (desc *ImmutableTableDescriptor) PartialIndexOrds() util.FastIntSet {
+func (desc *Immutable) PartialIndexOrds() util.FastIntSet {
 	return desc.partialIndexOrds
 }
 
 // IsShardColumn returns true if col corresponds to a non-dropped hash sharded
 // index. This method assumes that col is currently a member of desc.
-func (desc *MutableTableDescriptor) IsShardColumn(col *descpb.ColumnDescriptor) bool {
+func (desc *Mutable) IsShardColumn(col *descpb.ColumnDescriptor) bool {
 	for _, idx := range desc.AllNonDropIndexes() {
 		if idx.Sharded.IsSharded && idx.Sharded.Name == col.Name {
 			return true
@@ -3766,7 +3702,7 @@ func (desc *MutableTableDescriptor) IsShardColumn(col *descpb.ColumnDescriptor) 
 }
 
 // TableDesc implements the TableDescriptor interface.
-func (desc *ImmutableTableDescriptor) TableDesc() *descpb.TableDescriptor {
+func (desc *Immutable) TableDesc() *descpb.TableDescriptor {
 	return &desc.TableDescriptor
 }
 
@@ -3783,18 +3719,18 @@ func GenerateUniqueConstraintName(prefix string, nameExistsFunc func(name string
 }
 
 // SetParentSchemaID sets the SchemaID of the table.
-func (desc *MutableTableDescriptor) SetParentSchemaID(schemaID descpb.ID) {
+func (desc *Mutable) SetParentSchemaID(schemaID descpb.ID) {
 	desc.UnexposedParentSchemaID = schemaID
 }
 
 // AddDrainingName adds a draining name to the TableDescriptor's slice of
 // draining names.
-func (desc *MutableTableDescriptor) AddDrainingName(name descpb.NameInfo) {
+func (desc *Mutable) AddDrainingName(name descpb.NameInfo) {
 	desc.DrainingNames = append(desc.DrainingNames, name)
 }
 
 // GetPostDeserializationChanges returns the set of changes which occurred to
 // this descriptor post deserialization.
-func (desc *ImmutableTableDescriptor) GetPostDeserializationChanges() PostDeserializationTableDescriptorChanges {
+func (desc *Immutable) GetPostDeserializationChanges() PostDeserializationTableDescriptorChanges {
 	return desc.postDeserializationChanges
 }

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -3400,7 +3400,7 @@ const IncludeConstraints = true
 func (desc *ImmutableTableDescriptor) MakeFirstMutationPublic(
 	includeConstraints bool,
 ) (*MutableTableDescriptor, error) {
-	// Clone the ImmutableTable descriptor because we want to create an Immutable one.
+	// Clone the ImmutableTable descriptor because we want to create an ImmutableCopy one.
 	table := NewMutableExistingTableDescriptor(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))
 	mutationID := desc.Mutations[0].MutationID
 	i := 0

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -1381,7 +1381,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 		t.Fatal(err)
 	}
 	lookup := func(_ descpb.ID) (catalog.TableDescriptor, error) {
-		return desc.Immutable().(catalog.TableDescriptor), nil
+		return desc.ImmutableCopy().(catalog.TableDescriptor), nil
 	}
 
 	before, err := desc.GetConstraintInfoWithLookup(lookup)

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -974,7 +974,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 
 	for i, test := range tests {
 		descs := catalog.MapDescGetter{}
-		descs[1] = dbdesc.NewImmutableDatabaseDescriptor(descpb.DatabaseDescriptor{ID: 1})
+		descs[1] = dbdesc.NewImmutable(descpb.DatabaseDescriptor{ID: 1})
 		for _, otherDesc := range test.otherDescs {
 			otherDesc.Privileges = descpb.NewDefaultPrivilegeDescriptor(security.AdminRole)
 			descs[otherDesc.ID] = NewImmutable(otherDesc)

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -53,7 +53,7 @@ func makeIndexDescriptor(name string, columnNames []string) descpb.IndexDescript
 func TestAllocateIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	desc := NewMutableCreatedTableDescriptor(descpb.TableDescriptor{
+	desc := NewCreatedMutable(descpb.TableDescriptor{
 		ParentID: keys.MinUserDescID,
 		ID:       keys.MinUserDescID + 1,
 		Name:     "foo",
@@ -79,7 +79,7 @@ func TestAllocateIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := NewMutableCreatedTableDescriptor(descpb.TableDescriptor{
+	expected := NewCreatedMutable(descpb.TableDescriptor{
 		ParentID: keys.MinUserDescID,
 		ID:       keys.MinUserDescID + 1,
 		Version:  1,
@@ -645,7 +645,7 @@ func TestValidateTableDesc(t *testing.T) {
 	}
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {
-			desc := NewImmutableTableDescriptor(d.desc)
+			desc := NewImmutable(d.desc)
 			if err := desc.ValidateTable(); err == nil {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
 			} else if d.err != err.Error() && "internal error: "+d.err != err.Error() {
@@ -977,9 +977,9 @@ func TestValidateCrossTableReferences(t *testing.T) {
 		descs[1] = dbdesc.NewImmutableDatabaseDescriptor(descpb.DatabaseDescriptor{ID: 1})
 		for _, otherDesc := range test.otherDescs {
 			otherDesc.Privileges = descpb.NewDefaultPrivilegeDescriptor(security.AdminRole)
-			descs[otherDesc.ID] = NewImmutableTableDescriptor(otherDesc)
+			descs[otherDesc.ID] = NewImmutable(otherDesc)
 		}
-		desc := NewImmutableTableDescriptor(test.desc)
+		desc := NewImmutable(test.desc)
 		if err := desc.ValidateCrossReferences(ctx, descs); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, test.err, test.desc)
 		} else if test.err != err.Error() && "internal error: "+test.err != err.Error() {
@@ -1188,7 +1188,7 @@ func TestValidatePartitioning(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			desc := NewImmutableTableDescriptor(test.desc)
+			desc := NewImmutable(test.desc)
 			err := desc.ValidatePartitioning()
 			if !testutils.IsError(err, test.err) {
 				t.Errorf(`%d: got "%v" expected "%v"`, i, err, test.err)
@@ -1232,7 +1232,7 @@ func TestColumnTypeSQLString(t *testing.T) {
 func TestFitColumnToFamily(t *testing.T) {
 	intEncodedSize := 10 // 1 byte tag + 9 bytes max varint encoded size
 
-	makeTestTableDescriptor := func(familyTypes [][]*types.T) *MutableTableDescriptor {
+	makeTestTableDescriptor := func(familyTypes [][]*types.T) *Mutable {
 		nextColumnID := descpb.ColumnID(8)
 		var desc descpb.TableDescriptor
 		for _, fTypes := range familyTypes {
@@ -1247,7 +1247,7 @@ func TestFitColumnToFamily(t *testing.T) {
 			}
 			desc.Families = append(desc.Families, family)
 		}
-		return NewMutableCreatedTableDescriptor(desc)
+		return NewCreatedMutable(desc)
 	}
 
 	emptyFamily := []*types.T{}
@@ -1315,7 +1315,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 	tests := []struct {
 		desc       descpb.TableDescriptor
 		expUpgrade bool
-		verify     func(int, *ImmutableTableDescriptor) // nil means no extra verification.
+		verify     func(int, *Immutable) // nil means no extra verification.
 	}{
 		{
 			desc: descpb.TableDescriptor{
@@ -1326,7 +1326,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 				Privileges: descpb.NewDefaultPrivilegeDescriptor("root"),
 			},
 			expUpgrade: true,
-			verify: func(i int, desc *ImmutableTableDescriptor) {
+			verify: func(i int, desc *Immutable) {
 				if len(desc.Families) == 0 {
 					t.Errorf("%d: expected families to be set, but it was empty", i)
 				}
@@ -1346,7 +1346,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		desc, err := NewFilledInImmutableTableDescriptor(context.Background(), nil, &test.desc)
+		desc, err := NewFilledInImmutable(context.Background(), nil, &test.desc)
 		require.NoError(t, err)
 		upgraded := desc.GetPostDeserializationChanges().UpgradedFormatVersion
 		if upgraded != test.expUpgrade {
@@ -1359,7 +1359,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 }
 
 func TestUnvalidateConstraints(t *testing.T) {
-	desc := NewMutableCreatedTableDescriptor(descpb.TableDescriptor{
+	desc := NewCreatedMutable(descpb.TableDescriptor{
 		Name:     "test",
 		ParentID: descpb.ID(1),
 		Columns: []descpb.ColumnDescriptor{

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -175,7 +175,7 @@ func GetShardColumnName(colNames []string, buckets int32) string {
 }
 
 // GetConstraintInfo returns a summary of all constraints on the table.
-func (desc *ImmutableTableDescriptor) GetConstraintInfo(
+func (desc *Immutable) GetConstraintInfo(
 	ctx context.Context, dg catalog.DescGetter,
 ) (map[string]descpb.ConstraintDetail, error) {
 	var tableLookup catalog.TableLookupFn
@@ -189,7 +189,7 @@ func (desc *ImmutableTableDescriptor) GetConstraintInfo(
 
 // GetConstraintInfoWithLookup returns a summary of all constraints on the
 // table using the provided function to fetch a TableDescriptor from an ID.
-func (desc *ImmutableTableDescriptor) GetConstraintInfoWithLookup(
+func (desc *Immutable) GetConstraintInfoWithLookup(
 	tableLookup catalog.TableLookupFn,
 ) (map[string]descpb.ConstraintDetail, error) {
 	return desc.collectConstraintInfo(tableLookup)
@@ -197,14 +197,14 @@ func (desc *ImmutableTableDescriptor) GetConstraintInfoWithLookup(
 
 // CheckUniqueConstraints returns a non-nil error if a descriptor contains two
 // constraints with the same name.
-func (desc *ImmutableTableDescriptor) CheckUniqueConstraints() error {
+func (desc *Immutable) CheckUniqueConstraints() error {
 	_, err := desc.collectConstraintInfo(nil)
 	return err
 }
 
 // if `tableLookup` is non-nil, provide a full summary of constraints, otherwise just
 // check that constraints have unique names.
-func (desc *ImmutableTableDescriptor) collectConstraintInfo(
+func (desc *Immutable) collectConstraintInfo(
 	tableLookup catalog.TableLookupFn,
 ) (map[string]descpb.ConstraintDetail, error) {
 	info := make(map[string]descpb.ConstraintDetail)
@@ -370,7 +370,7 @@ func FindFKOriginIndex(
 // It returns either an index that is active, or an index that was created
 // in the same transaction that is currently running.
 func FindFKOriginIndexInTxn(
-	originTable *MutableTableDescriptor, originColIDs descpb.ColumnIDs,
+	originTable *Mutable, originColIDs descpb.ColumnIDs,
 ) (*descpb.IndexDescriptor, error) {
 	// Search for an index on the origin table that matches our foreign
 	// key columns.
@@ -409,9 +409,9 @@ func InitTableDescriptor(
 	creationTime hlc.Timestamp,
 	privileges *descpb.PrivilegeDescriptor,
 	persistence tree.Persistence,
-) MutableTableDescriptor {
-	return MutableTableDescriptor{
-		ImmutableTableDescriptor: ImmutableTableDescriptor{
+) Mutable {
+	return Mutable{
+		Immutable: Immutable{
 			TableDescriptor: descpb.TableDescriptor{
 				ID:                      id,
 				Name:                    name,

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -20,6 +20,7 @@ import (
 
 var _ catalog.TableDescriptor = (*ImmutableTableDescriptor)(nil)
 var _ catalog.TableDescriptor = (*MutableTableDescriptor)(nil)
+var _ catalog.MutableDescriptor = (*MutableTableDescriptor)(nil)
 
 // ImmutableTableDescriptor is a custom type for TableDescriptors
 // It holds precomputed values and the underlying TableDescriptor
@@ -95,8 +96,8 @@ func (desc *ImmutableTableDescriptor) GetColumnAtIdx(idx int) *descpb.ColumnDesc
 	return &desc.Columns[idx]
 }
 
-// Immutable implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) Immutable() catalog.Descriptor {
+// ImmutableCopy implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableTableDescriptor(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -18,14 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
-var _ catalog.TableDescriptor = (*ImmutableTableDescriptor)(nil)
-var _ catalog.TableDescriptor = (*MutableTableDescriptor)(nil)
-var _ catalog.MutableDescriptor = (*MutableTableDescriptor)(nil)
+var _ catalog.TableDescriptor = (*Immutable)(nil)
+var _ catalog.TableDescriptor = (*Mutable)(nil)
+var _ catalog.MutableDescriptor = (*Mutable)(nil)
 
-// ImmutableTableDescriptor is a custom type for TableDescriptors
+// Immutable is a custom type for TableDescriptors
 // It holds precomputed values and the underlying TableDescriptor
 // should be const.
-type ImmutableTableDescriptor struct {
+type Immutable struct {
 	descpb.TableDescriptor
 
 	// publicAndNonPublicCols is a list of public and non-public columns.
@@ -62,48 +62,48 @@ type ImmutableTableDescriptor struct {
 }
 
 // NameResolutionResult implements the tree.NameResolutionResult interface.
-func (*ImmutableTableDescriptor) NameResolutionResult() {}
+func (*Immutable) NameResolutionResult() {}
 
 // DescriptorProto prepares desc for serialization.
-func (desc *ImmutableTableDescriptor) DescriptorProto() *descpb.Descriptor {
+func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
 		Union: &descpb.Descriptor_Table{Table: &desc.TableDescriptor},
 	}
 }
 
 // GetPrimaryIndexID returns the ID of the primary index.
-func (desc *ImmutableTableDescriptor) GetPrimaryIndexID() descpb.IndexID {
+func (desc *Immutable) GetPrimaryIndexID() descpb.IndexID {
 	return desc.PrimaryIndex.ID
 }
 
 // GetPublicNonPrimaryIndexes returns the public non-primary indexes of the descriptor.
-func (desc *ImmutableTableDescriptor) GetPublicNonPrimaryIndexes() []descpb.IndexDescriptor {
+func (desc *Immutable) GetPublicNonPrimaryIndexes() []descpb.IndexDescriptor {
 	return desc.GetIndexes()
 }
 
 // IsTemporary returns true if this is a temporary table.
-func (desc *ImmutableTableDescriptor) IsTemporary() bool {
+func (desc *Immutable) IsTemporary() bool {
 	return desc.GetTemporary()
 }
 
 // GetPublicColumns return the public columns in the descriptor.
-func (desc *ImmutableTableDescriptor) GetPublicColumns() []descpb.ColumnDescriptor {
+func (desc *Immutable) GetPublicColumns() []descpb.ColumnDescriptor {
 	return desc.Columns
 }
 
 // GetColumnAtIdx returns the column at the specified index.
-func (desc *ImmutableTableDescriptor) GetColumnAtIdx(idx int) *descpb.ColumnDescriptor {
+func (desc *Immutable) GetColumnAtIdx(idx int) *descpb.ColumnDescriptor {
 	return &desc.Columns[idx]
 }
 
 // ImmutableCopy implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) ImmutableCopy() catalog.Descriptor {
+func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutableTableDescriptor(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))
+	return NewImmutable(*protoutil.Clone(desc.TableDesc()).(*descpb.TableDescriptor))
 }
 
 // SetDrainingNames implements the MutableDescriptor interface.
-func (desc *MutableTableDescriptor) SetDrainingNames(names []descpb.NameInfo) {
+func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -35,6 +35,7 @@ import (
 
 var _ catalog.TypeDescriptor = (*ImmutableTypeDescriptor)(nil)
 var _ catalog.TypeDescriptor = (*MutableTypeDescriptor)(nil)
+var _ catalog.MutableDescriptor = (*MutableTypeDescriptor)(nil)
 
 // MakeSimpleAliasTypeDescriptor creates a type descriptor that is an alias
 // for the input type. It is intended to be used as an intermediate for name
@@ -227,8 +228,8 @@ func (desc *MutableTypeDescriptor) OriginalVersion() descpb.DescriptorVersion {
 	return desc.ClusterVersion.Version
 }
 
-// Immutable implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) Immutable() catalog.Descriptor {
+// ImmutableCopy implements the MutableDescriptor interface.
+func (desc *MutableTypeDescriptor) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableTypeDescriptor(*protoutil.Clone(desc.TypeDesc()).(*descpb.TypeDescriptor))

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -33,15 +33,15 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-var _ catalog.TypeDescriptor = (*ImmutableTypeDescriptor)(nil)
-var _ catalog.TypeDescriptor = (*MutableTypeDescriptor)(nil)
-var _ catalog.MutableDescriptor = (*MutableTypeDescriptor)(nil)
+var _ catalog.TypeDescriptor = (*Immutable)(nil)
+var _ catalog.TypeDescriptor = (*Mutable)(nil)
+var _ catalog.MutableDescriptor = (*Mutable)(nil)
 
-// MakeSimpleAliasTypeDescriptor creates a type descriptor that is an alias
-// for the input type. It is intended to be used as an intermediate for name
-// resolution, and should not be serialized and stored on disk.
-func MakeSimpleAliasTypeDescriptor(typ *types.T) *ImmutableTypeDescriptor {
-	return NewImmutableTypeDescriptor(descpb.TypeDescriptor{
+// MakeSimpleAlias creates a type descriptor that is an alias for the input
+// type. It is intended to be used as an intermediate for name resolution, and
+// should not be serialized and stored on disk.
+func MakeSimpleAlias(typ *types.T) *Immutable {
+	return NewImmutable(descpb.TypeDescriptor{
 		ParentID:       descpb.InvalidID,
 		ParentSchemaID: descpb.InvalidID,
 		Name:           typ.Name(),
@@ -52,27 +52,27 @@ func MakeSimpleAliasTypeDescriptor(typ *types.T) *ImmutableTypeDescriptor {
 }
 
 // NameResolutionResult implements the NameResolutionResult interface.
-func (desc *ImmutableTypeDescriptor) NameResolutionResult() {}
+func (desc *Immutable) NameResolutionResult() {}
 
-// MutableTypeDescriptor is a custom type for TypeDescriptors undergoing
+// Mutable is a custom type for TypeDescriptors undergoing
 // any types of modifications.
-type MutableTypeDescriptor struct {
+type Mutable struct {
 
 	// TODO(ajwerner): Decide whether we're okay embedding the
-	// ImmutableTypeDescriptor or whether we should be embedding some other base
+	// Immutable or whether we should be embedding some other base
 	// struct that implements the various methods. For now we have the trap that
 	// the code really wants direct field access and moving all access to
 	// getters on an interface is a bigger task.
-	ImmutableTypeDescriptor
+	Immutable
 
 	// ClusterVersion represents the version of the type descriptor read
 	// from the store.
-	ClusterVersion *ImmutableTypeDescriptor
+	ClusterVersion *Immutable
 }
 
-// ImmutableTypeDescriptor is a custom type for wrapping TypeDescriptors
+// Immutable is a custom type for wrapping TypeDescriptors
 // when used in a read only way.
-type ImmutableTypeDescriptor struct {
+type Immutable struct {
 	descpb.TypeDescriptor
 
 	// The fields below are used to fill user defined type metadata for ENUMs.
@@ -81,34 +81,33 @@ type ImmutableTypeDescriptor struct {
 	readOnlyMembers []bool
 }
 
-// NewMutableCreatedTypeDescriptor returns a MutableTypeDescriptor from the
-// given type descriptor with the cluster version being the zero type. This
-// is for a type that is created in the same transaction.
-func NewMutableCreatedTypeDescriptor(desc descpb.TypeDescriptor) *MutableTypeDescriptor {
-	return &MutableTypeDescriptor{
-		ImmutableTypeDescriptor: makeImmutableTypeDescriptor(desc),
+// NewCreatedMutable returns a Mutable from the given type descriptor with the
+// cluster version being the zero type. This is for a type that is created in
+// the same transaction.
+func NewCreatedMutable(desc descpb.TypeDescriptor) *Mutable {
+	return &Mutable{
+		Immutable: makeImmutable(desc),
 	}
 }
 
-// NewMutableExistingTypeDescriptor returns a MutableTypeDescriptor from the
-// given type descriptor with the cluster version also set to the descriptor.
-// This is for types that already exist.
-func NewMutableExistingTypeDescriptor(desc descpb.TypeDescriptor) *MutableTypeDescriptor {
-	return &MutableTypeDescriptor{
-		ImmutableTypeDescriptor: makeImmutableTypeDescriptor(*protoutil.Clone(&desc).(*descpb.TypeDescriptor)),
-		ClusterVersion:          NewImmutableTypeDescriptor(desc),
+// NewExistingMutable returns a Mutable from the given type descriptor with the
+// cluster version also set to the descriptor. This is for types that already
+// exist.
+func NewExistingMutable(desc descpb.TypeDescriptor) *Mutable {
+	return &Mutable{
+		Immutable:      makeImmutable(*protoutil.Clone(&desc).(*descpb.TypeDescriptor)),
+		ClusterVersion: NewImmutable(desc),
 	}
 }
 
-// NewImmutableTypeDescriptor returns an ImmutableTypeDescriptor from the
-// given TypeDescriptor.
-func NewImmutableTypeDescriptor(desc descpb.TypeDescriptor) *ImmutableTypeDescriptor {
-	m := makeImmutableTypeDescriptor(desc)
+// NewImmutable returns an Immutable from the given TypeDescriptor.
+func NewImmutable(desc descpb.TypeDescriptor) *Immutable {
+	m := makeImmutable(desc)
 	return &m
 }
 
-func makeImmutableTypeDescriptor(desc descpb.TypeDescriptor) ImmutableTypeDescriptor {
-	immutDesc := ImmutableTypeDescriptor{TypeDescriptor: desc}
+func makeImmutable(desc descpb.TypeDescriptor) Immutable {
+	immutDesc := Immutable{TypeDescriptor: desc}
 
 	// Initialize metadata specific to the TypeDescriptor kind.
 	switch immutDesc.Kind {
@@ -151,27 +150,27 @@ func GetArrayTypeDescID(t *types.T) descpb.ID {
 }
 
 // TypeDesc implements the Descriptor interface.
-func (desc *ImmutableTypeDescriptor) TypeDesc() *descpb.TypeDescriptor {
+func (desc *Immutable) TypeDesc() *descpb.TypeDescriptor {
 	return &desc.TypeDescriptor
 }
 
 // Adding implements the Descriptor interface.
-func (desc *ImmutableTypeDescriptor) Adding() bool {
+func (desc *Immutable) Adding() bool {
 	return false
 }
 
 // Offline implements the Descriptor interface.
-func (desc *ImmutableTypeDescriptor) Offline() bool {
+func (desc *Immutable) Offline() bool {
 	return false
 }
 
 // GetOfflineReason implements the Descriptor interface.
-func (desc *ImmutableTypeDescriptor) GetOfflineReason() string {
+func (desc *Immutable) GetOfflineReason() string {
 	return ""
 }
 
 // DescriptorProto returns a Descriptor for serialization.
-func (desc *ImmutableTypeDescriptor) DescriptorProto() *descpb.Descriptor {
+func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
 		Union: &descpb.Descriptor_Type{
 			Type: &desc.TypeDescriptor,
@@ -180,22 +179,22 @@ func (desc *ImmutableTypeDescriptor) DescriptorProto() *descpb.Descriptor {
 }
 
 // SetDrainingNames implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) SetDrainingNames(names []descpb.NameInfo) {
+func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names
 }
 
 // GetAuditMode implements the DescriptorProto interface.
-func (desc *ImmutableTypeDescriptor) GetAuditMode() descpb.TableDescriptor_AuditMode {
+func (desc *Immutable) GetAuditMode() descpb.TableDescriptor_AuditMode {
 	return descpb.TableDescriptor_DISABLED
 }
 
 // TypeName implements the DescriptorProto interface.
-func (desc *ImmutableTypeDescriptor) TypeName() string {
+func (desc *Immutable) TypeName() string {
 	return "type"
 }
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) MaybeIncrementVersion() {
+func (desc *Mutable) MaybeIncrementVersion() {
 	// Already incremented, no-op.
 	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
@@ -205,7 +204,7 @@ func (desc *MutableTypeDescriptor) MaybeIncrementVersion() {
 }
 
 // OriginalName implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) OriginalName() string {
+func (desc *Mutable) OriginalName() string {
 	if desc.ClusterVersion == nil {
 		return ""
 	}
@@ -213,7 +212,7 @@ func (desc *MutableTypeDescriptor) OriginalName() string {
 }
 
 // OriginalID implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) OriginalID() descpb.ID {
+func (desc *Mutable) OriginalID() descpb.ID {
 	if desc.ClusterVersion == nil {
 		return descpb.InvalidID
 	}
@@ -221,7 +220,7 @@ func (desc *MutableTypeDescriptor) OriginalID() descpb.ID {
 }
 
 // OriginalVersion implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) OriginalVersion() descpb.DescriptorVersion {
+func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 	if desc.ClusterVersion == nil {
 		return 0
 	}
@@ -229,21 +228,21 @@ func (desc *MutableTypeDescriptor) OriginalVersion() descpb.DescriptorVersion {
 }
 
 // ImmutableCopy implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) ImmutableCopy() catalog.Descriptor {
+func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutableTypeDescriptor(*protoutil.Clone(desc.TypeDesc()).(*descpb.TypeDescriptor))
+	return NewImmutable(*protoutil.Clone(desc.TypeDesc()).(*descpb.TypeDescriptor))
 }
 
 // IsNew implements the MutableDescriptor interface.
-func (desc *MutableTypeDescriptor) IsNew() bool {
+func (desc *Mutable) IsNew() bool {
 	return desc.ClusterVersion == nil
 }
 
 // AddEnumValue adds an enum member to the type.
 // AddEnumValue assumes that the type is an enum, and that the new value
 // doesn't exist already in the enum.
-func (desc *MutableTypeDescriptor) AddEnumValue(node *tree.AlterTypeAddValue) error {
+func (desc *Mutable) AddEnumValue(node *tree.AlterTypeAddValue) error {
 	getPhysicalRep := func(idx int) []byte {
 		if idx < 0 || idx >= len(desc.EnumMembers) {
 			return nil
@@ -306,7 +305,7 @@ func (desc *MutableTypeDescriptor) AddEnumValue(node *tree.AlterTypeAddValue) er
 
 // AddReferencingDescriptorID adds a new referencing descriptor ID to the
 // TypeDescriptor. It ensures that duplicates are not added.
-func (desc *MutableTypeDescriptor) AddReferencingDescriptorID(new descpb.ID) {
+func (desc *Mutable) AddReferencingDescriptorID(new descpb.ID) {
 	for _, id := range desc.ReferencingDescriptorIDs {
 		if new == id {
 			return
@@ -317,7 +316,7 @@ func (desc *MutableTypeDescriptor) AddReferencingDescriptorID(new descpb.ID) {
 
 // RemoveReferencingDescriptorID removes the desired referencing descriptor ID
 // from the TypeDescriptor. It has no effect if the requested ID is not present.
-func (desc *MutableTypeDescriptor) RemoveReferencingDescriptorID(remove descpb.ID) {
+func (desc *Mutable) RemoveReferencingDescriptorID(remove descpb.ID) {
 	for i, id := range desc.ReferencingDescriptorIDs {
 		if id == remove {
 			desc.ReferencingDescriptorIDs = append(desc.ReferencingDescriptorIDs[:i], desc.ReferencingDescriptorIDs[i+1:]...)
@@ -327,13 +326,13 @@ func (desc *MutableTypeDescriptor) RemoveReferencingDescriptorID(remove descpb.I
 }
 
 // SetParentSchemaID sets the SchemaID of the type.
-func (desc *MutableTypeDescriptor) SetParentSchemaID(schemaID descpb.ID) {
+func (desc *Mutable) SetParentSchemaID(schemaID descpb.ID) {
 	desc.ParentSchemaID = schemaID
 }
 
 // AddDrainingName adds a draining name to the TypeDescriptor's slice of
 // draining names.
-func (desc *MutableTypeDescriptor) AddDrainingName(name descpb.NameInfo) {
+func (desc *Mutable) AddDrainingName(name descpb.NameInfo) {
 	desc.DrainingNames = append(desc.DrainingNames, name)
 }
 
@@ -348,7 +347,7 @@ func (e EnumMembers) Less(i, j int) bool {
 func (e EnumMembers) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 
 // Validate performs validation on the TypeDescriptor.
-func (desc *ImmutableTypeDescriptor) Validate(ctx context.Context, dg catalog.DescGetter) error {
+func (desc *Immutable) Validate(ctx context.Context, dg catalog.DescGetter) error {
 	// Validate local properties of the descriptor.
 	if err := catalog.ValidateName(desc.Name, "type"); err != nil {
 		return err
@@ -480,7 +479,7 @@ func (t TypeLookupFunc) GetTypeDescriptor(
 }
 
 // MakeTypesT creates a types.T from the input type descriptor.
-func (desc *ImmutableTypeDescriptor) MakeTypesT(
+func (desc *Immutable) MakeTypesT(
 	ctx context.Context, name *tree.TypeName, res catalog.TypeDescriptorResolver,
 ) (*types.T, error) {
 	switch t := desc.Kind; t {
@@ -542,7 +541,7 @@ func HydrateTypesInTableDescriptor(
 // HydrateTypeInfoWithName fills in user defined type metadata for
 // a type and also sets the name in the metadata to the passed in name.
 // This is used when hydrating a type with a known qualified name.
-func (desc *ImmutableTypeDescriptor) HydrateTypeInfoWithName(
+func (desc *Immutable) HydrateTypeInfoWithName(
 	ctx context.Context, typ *types.T, name *tree.TypeName, res catalog.TypeDescriptorResolver,
 ) error {
 	typ.TypeMeta.Name = &types.UserDefinedTypeName{
@@ -590,7 +589,7 @@ func (desc *ImmutableTypeDescriptor) HydrateTypeInfoWithName(
 // IsCompatibleWith returns whether the type "desc" is compatible with "other".
 // As of now "compatibility" entails that disk encoded data of "desc" can be
 // interpreted and used by "other".
-func (desc *ImmutableTypeDescriptor) IsCompatibleWith(other *ImmutableTypeDescriptor) error {
+func (desc *Immutable) IsCompatibleWith(other *Immutable) error {
 	switch desc.Kind {
 	case descpb.TypeDescriptor_ENUM:
 		if other.Kind != descpb.TypeDescriptor_ENUM {
@@ -627,7 +626,7 @@ func (desc *ImmutableTypeDescriptor) IsCompatibleWith(other *ImmutableTypeDescri
 
 // HasPendingSchemaChanges returns whether or not this descriptor has schema
 // changes that need to be completed.
-func (desc *ImmutableTypeDescriptor) HasPendingSchemaChanges() bool {
+func (desc *Immutable) HasPendingSchemaChanges() bool {
 	switch desc.Kind {
 	case descpb.TypeDescriptor_ENUM:
 		// If there are any non-public enum members, then a type schema change is
@@ -645,7 +644,7 @@ func (desc *ImmutableTypeDescriptor) HasPendingSchemaChanges() bool {
 
 // GetIDClosure returns all type descriptor IDs that are referenced by this
 // type descriptor.
-func (desc *ImmutableTypeDescriptor) GetIDClosure() map[descpb.ID]struct{} {
+func (desc *Immutable) GetIDClosure() map[descpb.ID]struct{} {
 	ret := make(map[descpb.ID]struct{})
 	// Collect the descriptor's own ID.
 	ret[desc.ID] = struct{}{}

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -195,8 +195,8 @@ func TestTypeDescIsCompatibleWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		a := typedesc.NewImmutableTypeDescriptor(test.a)
-		b := typedesc.NewImmutableTypeDescriptor(test.b)
+		a := typedesc.NewImmutable(test.a)
+		b := typedesc.NewImmutable(test.b)
 		err := a.IsCompatibleWith(b)
 		if test.err == "" {
 			require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestValidateTypeDesc(t *testing.T) {
 		ID:   101,
 		Name: "schema",
 	})
-	descs[102] = typedesc.NewImmutableTypeDescriptor(descpb.TypeDescriptor{
+	descs[102] = typedesc.NewImmutable(descpb.TypeDescriptor{
 		ID:   102,
 		Name: "type",
 	})
@@ -388,7 +388,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	}
 
 	for _, test := range testData {
-		desc := typedesc.NewImmutableTypeDescriptor(test.desc)
+		desc := typedesc.NewImmutable(test.desc)
 		if err := desc.Validate(ctx, descs); err == nil {
 			t.Errorf("expected err: %s but found nil: %v", test.err, test.desc)
 		} else if test.err != err.Error() && "internal error: "+test.err != err.Error() {

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -217,7 +217,7 @@ func TestValidateTypeDesc(t *testing.T) {
 		Name: "db",
 		ID:   100,
 	})
-	descs[101] = schemadesc.NewImmutableSchemaDescriptor(descpb.SchemaDescriptor{
+	descs[101] = schemadesc.NewImmutable(descpb.SchemaDescriptor{
 		ID:   101,
 		Name: "schema",
 	})

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -213,7 +213,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	ctx := context.Background()
 
 	descs := catalog.MapDescGetter{}
-	descs[100] = dbdesc.NewImmutableDatabaseDescriptor(descpb.DatabaseDescriptor{
+	descs[100] = dbdesc.NewImmutable(descpb.DatabaseDescriptor{
 		Name: "db",
 		ID:   100,
 	})

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -40,7 +40,7 @@ func validateCheckExpr(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	exprStr string,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	ie *InternalExecutor,
 	txn *kv.Txn,
 ) error {
@@ -229,7 +229,7 @@ func nonMatchingRowQuery(
 // reuse an existing client.Txn safely.
 func validateForeignKey(
 	ctx context.Context,
-	srcTable *tabledesc.MutableTableDescriptor,
+	srcTable *tabledesc.Mutable,
 	fk *descpb.ForeignKeyConstraint,
 	ie *InternalExecutor,
 	txn *kv.Txn,
@@ -315,7 +315,7 @@ func formatValues(colNames []string, values tree.Datums) string {
 }
 
 // checkSet contains a subset of checks, as ordinals into
-// ImmutableTableDescriptor.ActiveChecks. These checks have boolean columns
+// Immutable.ActiveChecks. These checks have boolean columns
 // produced as input to mutations, indicating the result of evaluating the
 // check.
 //

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -133,11 +133,11 @@ func NewColBatchScan(
 	limitHint := execinfra.LimitHint(spec.LimitHint, post)
 
 	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
-	// TODO(ajwerner): The need to construct an ImmutableTableDescriptor here
+	// TODO(ajwerner): The need to construct an Immutable here
 	// indicates that we're probably doing this wrong. Instead we should be
 	// just seting the ID and Version in the spec or something like that and
-	// retrieving the hydrated ImmutableTableDescriptor from cache.
-	table := tabledesc.NewImmutableTableDescriptor(spec.Table)
+	// retrieving the hydrated Immutable from cache.
+	table := tabledesc.NewImmutable(spec.Table)
 	typs := table.ColumnTypesWithMutations(returnMutations)
 	columnIdxMap := table.ColumnIdxMapWithMutations(returnMutations)
 	// Add all requested system columns to the output.
@@ -219,7 +219,7 @@ func initCRowFetcher(
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	systemColumnDescs []descpb.ColumnDescriptor,
 ) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
-	immutDesc := tabledesc.NewImmutableTableDescriptor(*desc)
+	immutDesc := tabledesc.NewImmutable(*desc)
 	index, isSecondaryIndex, err = immutDesc.FindIndexByIndexIdx(indexIdx)
 	if err != nil {
 		return nil, false, err

--- a/pkg/sql/comment_on_database.go
+++ b/pkg/sql/comment_on_database.go
@@ -23,7 +23,7 @@ import (
 
 type commentOnDatabaseNode struct {
 	n      *tree.CommentOnDatabase
-	dbDesc *dbdesc.ImmutableDatabaseDescriptor
+	dbDesc *dbdesc.Immutable
 }
 
 // CommentOnDatabase add comment on a database.

--- a/pkg/sql/comment_on_index.go
+++ b/pkg/sql/comment_on_index.go
@@ -24,7 +24,7 @@ import (
 
 type commentOnIndexNode struct {
 	n         *tree.CommentOnIndex
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 	indexDesc *descpb.IndexDescriptor
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -310,7 +310,7 @@ CREATE TABLE crdb_internal.tables (
 			// Note: we do not use forEachTableDesc() here because we want to
 			// include added and dropped descriptors.
 			for _, desc := range descs {
-				table, ok := desc.(*tabledesc.ImmutableTableDescriptor)
+				table, ok := desc.(*tabledesc.Immutable)
 				if !ok || p.CheckAnyPrivilege(ctx, table) != nil {
 					continue
 				}
@@ -424,7 +424,7 @@ CREATE TABLE crdb_internal.schema_changes (
 		// Note: we do not use forEachTableDesc() here because we want to
 		// include added and dropped descriptors.
 		for _, desc := range descs {
-			table, ok := desc.(*tabledesc.ImmutableTableDescriptor)
+			table, ok := desc.(*tabledesc.Immutable)
 			if !ok || p.CheckAnyPrivilege(ctx, table) != nil {
 				continue
 			}
@@ -2279,7 +2279,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		for _, desc := range descs {
 			id := uint32(desc.GetID())
 			switch desc := desc.(type) {
-			case *tabledesc.ImmutableTableDescriptor:
+			case *tabledesc.Immutable:
 				parents[id] = uint32(desc.ParentID)
 				tableNames[id] = desc.GetName()
 				indexNames[id] = make(map[uint32]string)
@@ -2546,7 +2546,7 @@ CREATE TABLE crdb_internal.zones (
 				return err
 			}
 
-			var table *tabledesc.ImmutableTableDescriptor
+			var table *tabledesc.Immutable
 			if zs.Database != "" {
 				database, err := catalogkv.MustGetDatabaseDescByID(ctx, p.txn, p.ExecCfg().Codec, descpb.ID(id))
 				if err != nil {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1477,7 +1477,7 @@ CREATE TABLE crdb_internal.create_type_statements (
 )
 `,
 	populate: func(ctx context.Context, p *planner, db *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachTypeDesc(ctx, p, db, func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typeDesc *typedesc.ImmutableTypeDescriptor) error {
+		return forEachTypeDesc(ctx, p, db, func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typeDesc *typedesc.Immutable) error {
 			switch typeDesc.Kind {
 			case descpb.TypeDescriptor_ENUM:
 				var enumLabels []string

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -129,7 +129,7 @@ CREATE TABLE crdb_internal.node_build_info (
   field   STRING NOT NULL,
   value   STRING NOT NULL
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		execCfg := p.ExecCfg()
 		nodeID, _ := execCfg.NodeID.OptionalNodeID() // zero if not available
 
@@ -163,7 +163,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
   field     STRING NOT NULL,
   value     STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "access the node runtime information"); err != nil {
 			return err
 		}
@@ -220,9 +220,9 @@ CREATE TABLE crdb_internal.databases (
 	id INT NOT NULL,
 	name STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, nil /* all databases */, true, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				return addRow(
 					tree.NewDInt(tree.DInt(db.GetID())), // id
 					tree.NewDString(db.GetName()),       // name
@@ -251,7 +251,7 @@ CREATE TABLE crdb_internal.tables (
   audit_mode               STRING NOT NULL,
   schema_name              STRING NOT NULL
 )`,
-	generator: func(ctx context.Context, p *planner, dbDesc *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, dbDesc *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 14)
 		worker := func(pusher rowPusher) error {
 			descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
@@ -261,7 +261,7 @@ CREATE TABLE crdb_internal.tables (
 			dbNames := make(map[descpb.ID]string)
 			// Record database descriptors for name lookups.
 			for _, desc := range descs {
-				if dbDesc, ok := desc.(*dbdesc.ImmutableDatabaseDescriptor); ok {
+				if dbDesc, ok := desc.(*dbdesc.Immutable); ok {
 					dbNames[dbDesc.GetID()] = dbDesc.GetName()
 				}
 			}
@@ -354,7 +354,7 @@ CREATE TABLE crdb_internal.table_row_statistics (
   table_name                 STRING      NOT NULL,
   estimated_row_count        INT
 )`,
-	populate: func(ctx context.Context, p *planner, db *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, db *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Collect the latests statistics for all tables.
 		query := `
            SELECT s."tableID", max(s."rowCount")
@@ -382,7 +382,7 @@ CREATE TABLE crdb_internal.table_row_statistics (
 		// Walk over all available tables and show row count for each of them
 		// using collected statistics.
 		return forEachTableDescAll(ctx, p, db, virtualMany,
-			func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 				tableID := tree.DInt(table.GetID())
 				rowCount := tree.DNull
 				// For Virtual Tables report NULL row count.
@@ -416,7 +416,7 @@ CREATE TABLE crdb_internal.schema_changes (
   state         STRING NOT NULL,
   direction     STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
@@ -479,7 +479,7 @@ CREATE TABLE crdb_internal.leases (
   deleted     BOOL NOT NULL
 )`,
 	populate: func(
-		ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error,
+		ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error,
 	) (err error) {
 		nodeID := tree.NewDInt(tree.DInt(int64(p.execCfg.NodeID.Get())))
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, dropped bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
@@ -532,7 +532,7 @@ CREATE TABLE crdb_internal.jobs (
 	coordinator_id     		INT
 )`,
 	comment: `decoded job metadata from system.jobs (KV scan)`,
-	generator: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		currentUser := p.SessionData().User
 		isAdmin, err := p.HasAdminRole(ctx)
 		if err != nil {
@@ -747,7 +747,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   rows_read_var       FLOAT NOT NULL,
   implicit_txn        BOOL NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "access application statistics"); err != nil {
 			return err
 		}
@@ -858,7 +858,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
   committed_count    INT NOT NULL,
   implicit_count     INT NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "access application statistics"); err != nil {
 			return err
 		}
@@ -922,7 +922,7 @@ CREATE TABLE crdb_internal.session_trace (
   message     STRING NOT NULL,     -- The logged message.
   age         INTERVAL NOT NULL    -- The age of this message relative to the beginning of the trace.
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		rows, err := p.ExtendedEvalContext().Tracing.getSessionTrace()
 		if err != nil {
 			return err
@@ -950,7 +950,7 @@ CREATE TABLE crdb_internal.cluster_settings (
   public        BOOL NOT NULL, -- whether the setting is documented, which implies the user can expect support.
   description   STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.cluster_settings"); err != nil {
 			return err
 		}
@@ -982,7 +982,7 @@ CREATE TABLE crdb_internal.session_variables (
   value    STRING NOT NULL,
   hidden   BOOL   NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
 			value := gen.Get(&p.extendedEvalCtx)
@@ -1011,7 +1011,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalLocalTxnsTable = virtualSchemaTable{
 	comment: "running user transactions visible by the current user (RAM; local node only)",
 	schema:  fmt.Sprintf(txnsSchemaPattern, "node_transactions"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.node_transactions"); err != nil {
 			return err
 		}
@@ -1031,7 +1031,7 @@ var crdbInternalLocalTxnsTable = virtualSchemaTable{
 var crdbInternalClusterTxnsTable = virtualSchemaTable{
 	comment: "running user transactions visible by the current user (cluster RPC; expensive!)",
 	schema:  fmt.Sprintf(txnsSchemaPattern, "cluster_transactions"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.cluster_transactions"); err != nil {
 			return err
 		}
@@ -1144,7 +1144,7 @@ func getSessionID(session serverpb.Session) tree.Datum {
 var crdbInternalLocalQueriesTable = virtualSchemaTable{
 	comment: "running queries visible by current user (RAM; local node only)",
 	schema:  fmt.Sprintf(queriesSchemaPattern, "node_queries"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
 		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
 		if err != nil {
@@ -1163,7 +1163,7 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 var crdbInternalClusterQueriesTable = virtualSchemaTable{
 	comment: "running queries visible by current user (cluster RPC; expensive!)",
 	schema:  fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
 		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
 		if err != nil {
@@ -1275,7 +1275,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalLocalSessionsTable = virtualSchemaTable{
 	comment: "running sessions visible by current user (RAM; local node only)",
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
 		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
 		if err != nil {
@@ -1294,7 +1294,7 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 var crdbInternalClusterSessionsTable = virtualSchemaTable{
 	comment: "running sessions visible to current user (cluster RPC; expensive!)",
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
 		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
 		if err != nil {
@@ -1402,7 +1402,7 @@ var crdbInternalLocalMetricsTable = virtualSchemaTable{
   name               STRING NOT NULL,  -- name of the metric
   value							 FLOAT NOT NULL    -- value of the metric
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.node_metrics"); err != nil {
 			return err
 		}
@@ -1444,7 +1444,7 @@ CREATE TABLE crdb_internal.builtin_functions (
   category  STRING NOT NULL,
   details   STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, _ *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for _, name := range builtins.AllBuiltinNames {
 			props, overloads := builtins.GetBuiltinProperties(name)
 			for _, f := range overloads {
@@ -1476,8 +1476,8 @@ CREATE TABLE crdb_internal.create_type_statements (
 	INDEX (descriptor_id)
 )
 `,
-	populate: func(ctx context.Context, p *planner, db *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachTypeDesc(ctx, p, db, func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typeDesc *typedesc.Immutable) error {
+	populate: func(ctx context.Context, p *planner, db *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return forEachTypeDesc(ctx, p, db, func(db *dbdesc.Immutable, sc string, typeDesc *typedesc.Immutable) error {
 			switch typeDesc.Kind {
 			case descpb.TypeDescriptor_ENUM:
 				var enumLabels []string
@@ -1548,7 +1548,7 @@ CREATE TABLE crdb_internal.create_statements (
   INDEX(descriptor_id)
 )
 `, virtualOnce, false, /* includesIndexEntries */
-	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.ImmutableDatabaseDescriptor, scName string,
+	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable, scName string,
 		table catalog.TableDescriptor, lookup simpleSchemaResolver, addRow func(...tree.Datum) error) error {
 		contextName := ""
 		parentNameStr := tree.DNull
@@ -1760,11 +1760,11 @@ CREATE TABLE crdb_internal.table_columns (
   hidden           BOOL NOT NULL
 )
 `,
-	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 8)
 		worker := func(pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
-				func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+				func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 					tableID := tree.NewDInt(tree.DInt(table.GetID()))
 					tableName := tree.NewDString(table.GetName())
 					columns := table.GetPublicColumns()
@@ -1818,13 +1818,13 @@ CREATE TABLE crdb_internal.table_indexes (
   is_inverted      BOOL NOT NULL
 )
 `,
-	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		primary := tree.NewDString("primary")
 		secondary := tree.NewDString("secondary")
 		row := make(tree.Datums, 7)
 		worker := func(pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
-				func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+				func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 					tableID := tree.NewDInt(tree.DInt(table.GetID()))
 					tableName := tree.NewDString(table.GetName())
 					// We report the primary index of non-physical tables here. These
@@ -1873,7 +1873,7 @@ CREATE TABLE crdb_internal.index_columns (
   column_direction STRING
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		key := tree.NewDString("key")
 		storing := tree.NewDString("storing")
 		extra := tree.NewDString("extra")
@@ -1884,7 +1884,7 @@ CREATE TABLE crdb_internal.index_columns (
 		}
 
 		return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
-			func(parent *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+			func(parent *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 				tableID := tree.NewDInt(tree.DInt(table.GetID()))
 				parentName := parent.GetName()
 				tableName := tree.NewDString(table.GetName())
@@ -1985,14 +1985,14 @@ CREATE TABLE crdb_internal.backward_dependencies (
   dependson_details  STRING
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		fkDep := tree.NewDString("fk")
 		viewDep := tree.NewDString("view")
 		sequenceDep := tree.NewDString("sequence")
 		interleaveDep := tree.NewDString("interleave")
 		return forEachTableDescAllWithTableLookup(ctx, p, dbContext, hideVirtual,
 			/* virtual tables have no backward/forward dependencies*/
-			func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor, tableLookup tableLookupFn) error {
+			func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor, tableLookup tableLookupFn) error {
 				tableID := tree.NewDInt(tree.DInt(table.GetID()))
 				tableName := tree.NewDString(table.GetName())
 
@@ -2092,7 +2092,7 @@ CREATE TABLE crdb_internal.feature_usage (
   usage_count           INT NOT NULL
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for feature, count := range telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly) {
 			if count == 0 {
 				// Skip over empty counters to avoid polluting the output.
@@ -2127,13 +2127,13 @@ CREATE TABLE crdb_internal.forward_dependencies (
   dependedonby_details  STRING
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		fkDep := tree.NewDString("fk")
 		viewDep := tree.NewDString("view")
 		interleaveDep := tree.NewDString("interleave")
 		sequenceDep := tree.NewDString("sequence")
 		return forEachTableDescAll(ctx, p, dbContext, hideVirtual, /* virtual tables have no backward/forward dependencies*/
-			func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 				tableID := tree.NewDInt(tree.DInt(table.GetID()))
 				tableName := tree.NewDString(table.GetName())
 
@@ -2263,7 +2263,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 	split_enforced_until TIMESTAMP
 )
 `,
-	generator: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.ranges_no_leases"); err != nil {
 			return nil, nil, err
 		}
@@ -2286,7 +2286,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				for _, idx := range desc.Indexes {
 					indexNames[id][uint32(idx.ID)] = idx.Name
 				}
-			case *dbdesc.ImmutableDatabaseDescriptor:
+			case *dbdesc.Immutable:
 				dbNames[id] = desc.GetName()
 			}
 		}
@@ -2485,7 +2485,7 @@ CREATE TABLE crdb_internal.zones (
 	full_config_sql STRING
 )
 `,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if !p.ExecCfg().Codec.ForSystemTenant() {
 			// Don't try to populate crdb_internal.zones if running in a multitenant
 			// configuration.
@@ -2708,7 +2708,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
   leases                INT NOT NULL
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_nodes"); err != nil {
 			return err
 		}
@@ -2829,7 +2829,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
   updated_at       TIMESTAMP
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// ATTENTION: The contents of this table should only access gossip data
 		// which is highly available. DO NOT CALL functions which require the
 		// cluster to be healthy, such as StatusServer.Nodes().
@@ -2909,7 +2909,7 @@ CREATE TABLE crdb_internal.gossip_alerts (
   value           FLOAT NOT NULL   -- value of the alert (depends on subsystem, can be NaN)
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_alerts"); err != nil {
 			return err
 		}
@@ -2978,7 +2978,7 @@ CREATE TABLE crdb_internal.gossip_network (
   target_id       INT NOT NULL     -- target node of a gossip connection
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_network"); err != nil {
 			return err
 		}
@@ -3175,14 +3175,14 @@ CREATE TABLE crdb_internal.partitions (
 	subzone_id INT -- references a subzone id in the crdb_internal.zones table
 )
 	`,
-	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable) (virtualTableGenerator, cleanupFunc, error) {
 		dbName := ""
 		if dbContext != nil {
 			dbName = dbContext.GetName()
 		}
 		worker := func(pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual, /* virtual tables have no partitions*/
-				func(db *dbdesc.ImmutableDatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+				func(db *dbdesc.Immutable, _ string, table catalog.TableDescriptor) error {
 					return table.ForeachIndex(catalog.IndexOpts{
 						AddMutations: true,
 					}, func(index *descpb.IndexDescriptor, _ bool) error {
@@ -3226,7 +3226,7 @@ CREATE TABLE crdb_internal.kv_node_status (
   activity       JSON NOT NULL
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_node_status"); err != nil {
 			return err
 		}
@@ -3340,7 +3340,7 @@ CREATE TABLE crdb_internal.kv_store_status (
   metrics            JSON NOT NULL
 )
 	`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_store_status"); err != nil {
 			return err
 		}
@@ -3452,7 +3452,7 @@ CREATE TABLE crdb_internal.predefined_comments (
 	COMMENT   STRING
 )`,
 	populate: func(
-		ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error,
+		ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error,
 	) error {
 		tableCommentKey := tree.NewDInt(keys.TableCommentType)
 		vt := p.getVirtualTabler()

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -34,7 +34,7 @@ import (
 
 type createIndexNode struct {
 	n         *tree.CreateIndex
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 }
 
 type indexStorageParamObserver struct {
@@ -260,7 +260,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 // is hash sharded. Note that `tableDesc` will be modified when this method is called for
 // a hash sharded index.
 func MakeIndexDescriptor(
-	params runParams, n *tree.CreateIndex, tableDesc *tabledesc.MutableTableDescriptor,
+	params runParams, n *tree.CreateIndex, tableDesc *tabledesc.Mutable,
 ) (*descpb.IndexDescriptor, error) {
 	// Ensure that the columns we want to index exist before trying to create the
 	// index.
@@ -381,9 +381,7 @@ func MakeIndexDescriptor(
 
 // validateIndexColumnsExists validates that the columns for an index exist
 // in the table and are not being dropped prior to attempting to add the index.
-func validateIndexColumnsExist(
-	desc *tabledesc.MutableTableDescriptor, columns tree.IndexElemList,
-) error {
+func validateIndexColumnsExist(desc *tabledesc.Mutable, columns tree.IndexElemList) error {
 	for _, column := range columns {
 		_, dropping, err := desc.FindColumnByName(column.Column)
 		if err != nil {
@@ -414,7 +412,7 @@ func setupShardedIndex(
 	shardedIndexEnabled bool,
 	columns *tree.IndexElemList,
 	bucketsExpr tree.Expr,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	isNewTable bool,
 ) (shard *descpb.ColumnDescriptor, newColumn bool, err error) {
@@ -457,7 +455,7 @@ func setupShardedIndex(
 // `desc`, if one doesn't already exist for the given index column set and number of shard
 // buckets.
 func maybeCreateAndAddShardCol(
-	shardBuckets int, desc *tabledesc.MutableTableDescriptor, colNames []string, isNewTable bool,
+	shardBuckets int, desc *tabledesc.Mutable, colNames []string, isNewTable bool,
 ) (col *descpb.ColumnDescriptor, created bool, err error) {
 	shardCol, err := makeShardColumnDesc(colNames, shardBuckets)
 	if err != nil {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -177,7 +177,7 @@ func NewSequenceTableDesc(
 	privileges *descpb.PrivilegeDescriptor,
 	persistence tree.Persistence,
 	params *runParams,
-) (*tabledesc.MutableTableDescriptor, error) {
+) (*tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
 		id,
 		parentID,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -491,7 +491,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				params.ctx,
 				params.p.txn,
 				params.ExecCfg().Codec,
-				desc.Immutable().(*tabledesc.ImmutableTableDescriptor),
+				desc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
 				desc.Columns,
 				params.p.alloc)
 			if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -362,8 +362,8 @@ func (n *createTableNode) startExec(params runParams) error {
 	privs := createInheritedPrivilegesFromDBDesc(n.dbDesc, params.SessionData().User)
 
 	var asCols colinfo.ResultColumns
-	var desc *tabledesc.MutableTableDescriptor
-	var affected map[descpb.ID]*tabledesc.MutableTableDescriptor
+	var desc *tabledesc.Mutable
+	var affected map[descpb.ID]*tabledesc.Mutable
 	// creationTime is initialized to a zero value and populated at read time.
 	// See the comment in desc.MaybeIncrementVersion.
 	//
@@ -392,7 +392,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			desc.State = descpb.TableDescriptor_ADD
 		}
 	} else {
-		affected = make(map[descpb.ID]*tabledesc.MutableTableDescriptor)
+		affected = make(map[descpb.ID]*tabledesc.Mutable)
 		desc, err = newTableDesc(params, n.n, n.dbDesc.GetID(), schemaID, id, creationTime, privs, affected)
 		if err != nil {
 			return err
@@ -491,7 +491,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				params.ctx,
 				params.p.txn,
 				params.ExecCfg().Codec,
-				desc.ImmutableCopy().(*tabledesc.ImmutableTableDescriptor),
+				desc.ImmutableCopy().(*tabledesc.Immutable),
 				desc.Columns,
 				params.p.alloc)
 			if err != nil {
@@ -599,9 +599,9 @@ func (n *createTableNode) Close(ctx context.Context) {
 // descriptors without caching. See the comment on resolveFK().
 func (p *planner) resolveFK(
 	ctx context.Context,
-	tbl *tabledesc.MutableTableDescriptor,
+	tbl *tabledesc.Mutable,
 	d *tree.ForeignKeyConstraintTableDef,
-	backrefs map[descpb.ID]*tabledesc.MutableTableDescriptor,
+	backrefs map[descpb.ID]*tabledesc.Mutable,
 	ts FKTableState,
 	validationBehavior tree.ValidationBehavior,
 ) error {
@@ -609,11 +609,7 @@ func (p *planner) resolveFK(
 }
 
 func qualifyFKColErrorWithDB(
-	ctx context.Context,
-	txn *kv.Txn,
-	codec keys.SQLCodec,
-	tbl *tabledesc.MutableTableDescriptor,
-	col string,
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, tbl *tabledesc.Mutable, col string,
 ) string {
 	if txn == nil {
 		return tree.ErrString(tree.NewUnresolvedName(tbl.Name, col))
@@ -649,7 +645,7 @@ const (
 // to catch upgrade 19.1 version table descriptors that haven't been upgraded yet before an operation
 // like drop index which could cause them to lose FK information in the old representation.
 func (p *planner) MaybeUpgradeDependentOldForeignKeyVersionTables(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor,
+	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
 	// In order to avoid having old version foreign key descriptors that depend on this
 	// index lose information when this index is dropped, ensure that they get updated.
@@ -661,7 +657,7 @@ func (p *planner) MaybeUpgradeDependentOldForeignKeyVersionTables(
 		if err != nil {
 			return err
 		}
-		tbl := desc.(*tabledesc.MutableTableDescriptor)
+		tbl := desc.(*tabledesc.Mutable)
 		changes := tbl.GetPostDeserializationChanges()
 		if changes.UpgradedForeignKeyRepresentation {
 			err := p.writeSchemaChange(ctx, tbl, descpb.InvalidMutationID,
@@ -716,9 +712,9 @@ func ResolveFK(
 	ctx context.Context,
 	txn *kv.Txn,
 	sc resolver.SchemaResolver,
-	tbl *tabledesc.MutableTableDescriptor,
+	tbl *tabledesc.Mutable,
 	d *tree.ForeignKeyConstraintTableDef,
-	backrefs map[descpb.ID]*tabledesc.MutableTableDescriptor,
+	backrefs map[descpb.ID]*tabledesc.Mutable,
 	ts FKTableState,
 	validationBehavior tree.ValidationBehavior,
 	evalCtx *tree.EvalContext,
@@ -945,7 +941,7 @@ func ResolveFK(
 // Adds an index to a table descriptor (that is in the process of being created)
 // that will support using `srcCols` as the referencing (src) side of an FK.
 func addIndexForFK(
-	tbl *tabledesc.MutableTableDescriptor,
+	tbl *tabledesc.Mutable,
 	srcCols []*descpb.ColumnDescriptor,
 	constraintName string,
 	ts FKTableState,
@@ -994,7 +990,7 @@ func addIndexForFK(
 
 func (p *planner) addInterleave(
 	ctx context.Context,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	index *descpb.IndexDescriptor,
 	interleave *tree.InterleaveDef,
 ) error {
@@ -1007,7 +1003,7 @@ func addInterleave(
 	ctx context.Context,
 	txn *kv.Txn,
 	vt resolver.SchemaResolver,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	index *descpb.IndexDescriptor,
 	interleave *tree.InterleaveDef,
 ) error {
@@ -1097,7 +1093,7 @@ func addInterleave(
 // finalizeInterleave creates backreferences from an interleaving parent to the
 // child data being interleaved.
 func (p *planner) finalizeInterleave(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor, index *descpb.IndexDescriptor,
+	ctx context.Context, desc *tabledesc.Mutable, index *descpb.IndexDescriptor,
 ) error {
 	// TODO(dan): This is similar to finalizeFKs. Consolidate them
 	if len(index.Interleave.Ancestors) == 0 {
@@ -1105,7 +1101,7 @@ func (p *planner) finalizeInterleave(
 	}
 	// Only the last ancestor needs the backreference.
 	ancestor := index.Interleave.Ancestors[len(index.Interleave.Ancestors)-1]
-	var ancestorTable *tabledesc.MutableTableDescriptor
+	var ancestorTable *tabledesc.Mutable
 	if ancestor.TableID == desc.ID {
 		ancestorTable = desc
 	} else {
@@ -1152,7 +1148,7 @@ func CreatePartitioning(
 	ctx context.Context,
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
 ) (descpb.PartitioningDescriptor, error) {
@@ -1169,7 +1165,7 @@ var CreatePartitioningCCL = func(
 	ctx context.Context,
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
 ) (descpb.PartitioningDescriptor, error) {
@@ -1226,7 +1222,7 @@ func newTableDescIfAs(
 	resultColumns []colinfo.ResultColumn,
 	privileges *descpb.PrivilegeDescriptor,
 	evalContext *tree.EvalContext,
-) (desc *tabledesc.MutableTableDescriptor, err error) {
+) (desc *tabledesc.Mutable, err error) {
 	colResIndex := 0
 	// TableDefs for a CREATE TABLE ... AS AST node comprise of a ColumnTableDef
 	// for each column, and a ConstraintTableDef for any constraints on those
@@ -1304,12 +1300,12 @@ func NewTableDesc(
 	parentID, parentSchemaID, id descpb.ID,
 	creationTime hlc.Timestamp,
 	privileges *descpb.PrivilegeDescriptor,
-	affected map[descpb.ID]*tabledesc.MutableTableDescriptor,
+	affected map[descpb.ID]*tabledesc.Mutable,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	sessionData *sessiondata.SessionData,
 	persistence tree.Persistence,
-) (*tabledesc.MutableTableDescriptor, error) {
+) (*tabledesc.Mutable, error) {
 	// Used to delay establishing Column/Sequence dependency until ColumnIDs have
 	// been populated.
 	columnDefaultExprs := make([]tree.TypedExpr, len(n.Defs))
@@ -1887,8 +1883,8 @@ func newTableDesc(
 	parentID, parentSchemaID, id descpb.ID,
 	creationTime hlc.Timestamp,
 	privileges *descpb.PrivilegeDescriptor,
-	affected map[descpb.ID]*tabledesc.MutableTableDescriptor,
-) (ret *tabledesc.MutableTableDescriptor, err error) {
+	affected map[descpb.ID]*tabledesc.Mutable,
+) (ret *tabledesc.Mutable, err error) {
 	// Process any SERIAL columns to remove the SERIAL type,
 	// as required by NewTableDesc.
 	createStmt := n

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -154,7 +154,7 @@ func (p *planner) createArrayType(
 	params runParams,
 	n *tree.CreateType,
 	typ *tree.TypeName,
-	typDesc *typedesc.MutableTypeDescriptor,
+	typDesc *typedesc.Mutable,
 	db catalog.DatabaseDescriptor,
 	schemaID descpb.ID,
 ) (descpb.ID, error) {
@@ -190,7 +190,7 @@ func (p *planner) createArrayType(
 	// Construct the descriptor for the array type.
 	// TODO(ajwerner): This is getting fixed up in a later commit to deal with
 	// meta, just hold on.
-	arrayTypDesc := typedesc.NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{
+	arrayTypDesc := typedesc.NewCreatedMutable(descpb.TypeDescriptor{
 		Name:           arrayTypeName,
 		ID:             id,
 		ParentID:       db.GetID(),
@@ -286,7 +286,7 @@ func (p *planner) createEnum(params runParams, n *tree.CreateType) error {
 	//  a free list of descriptor ID's (#48438), we should allocate an ID from
 	//  there if id + oidext.CockroachPredefinedOIDMax overflows past the
 	//  maximum uint32 value.
-	typeDesc := typedesc.NewMutableCreatedTypeDescriptor(
+	typeDesc := typedesc.NewCreatedMutable(
 		descpb.TypeDescriptor{
 			Name:           typeName.Type(),
 			ID:             id,

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -43,7 +43,7 @@ type createViewNode struct {
 	replace      bool
 	persistence  tree.Persistence
 	materialized bool
-	dbDesc       *dbdesc.ImmutableDatabaseDescriptor
+	dbDesc       *dbdesc.Immutable
 	columns      colinfo.ResultColumns
 
 	// planDeps tracks which tables and views the view being created

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -66,11 +66,11 @@ func (n *createViewNode) startExec(params runParams) error {
 
 	// First check the backrefs and see if any of them are temporary.
 	// If so, promote this view to temporary.
-	backRefMutables := make(map[descpb.ID]*tabledesc.MutableTableDescriptor, len(n.planDeps))
+	backRefMutables := make(map[descpb.ID]*tabledesc.Mutable, len(n.planDeps))
 	for id, updated := range n.planDeps {
 		backRefMutable := params.p.Descriptors().GetUncommittedTableByID(id)
 		if backRefMutable == nil {
-			backRefMutable = tabledesc.NewMutableExistingTableDescriptor(*updated.desc.TableDesc())
+			backRefMutable = tabledesc.NewExistingMutable(*updated.desc.TableDesc())
 		}
 		if !persistence.IsTemporary() && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
@@ -83,7 +83,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		backRefMutables[id] = backRefMutable
 	}
 
-	var replacingDesc *tabledesc.MutableTableDescriptor
+	var replacingDesc *tabledesc.Mutable
 
 	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), persistence, n.viewName)
 	if err != nil {
@@ -121,7 +121,7 @@ func (n *createViewNode) startExec(params runParams) error {
 
 	privs := createInheritedPrivilegesFromDBDesc(n.dbDesc, params.SessionData().User)
 
-	var newDesc *tabledesc.MutableTableDescriptor
+	var newDesc *tabledesc.Mutable
 
 	// If replacingDesc != nil, we found an existing view while resolving
 	// the name for our view. So instead of creating a new view, replace
@@ -282,7 +282,7 @@ func makeViewTableDesc(
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	persistence tree.Persistence,
-) (tabledesc.MutableTableDescriptor, error) {
+) (tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
 		id,
 		parentID,
@@ -294,7 +294,7 @@ func makeViewTableDesc(
 	)
 	desc.ViewQuery = viewQuery
 	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
-		return tabledesc.MutableTableDescriptor{}, err
+		return tabledesc.Mutable{}, err
 	}
 
 	return desc, nil
@@ -308,9 +308,9 @@ func makeViewTableDesc(
 func (p *planner) replaceViewDesc(
 	ctx context.Context,
 	n *createViewNode,
-	toReplace *tabledesc.MutableTableDescriptor,
-	backRefMutables map[descpb.ID]*tabledesc.MutableTableDescriptor,
-) (*tabledesc.MutableTableDescriptor, error) {
+	toReplace *tabledesc.Mutable,
+	backRefMutables map[descpb.ID]*tabledesc.Mutable,
+) (*tabledesc.Mutable, error) {
 	// Set the query to the new query.
 	toReplace.ViewQuery = n.viewQuery
 	// Reset the columns to add the new result columns onto.
@@ -381,7 +381,7 @@ func addResultColumns(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	resultColumns colinfo.ResultColumns,
 ) error {
 	for _, colRes := range resultColumns {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -35,7 +35,7 @@ import (
 
 // renameDatabase implements the DatabaseDescEditor interface.
 func (p *planner) renameDatabase(
-	ctx context.Context, desc *dbdesc.MutableDatabaseDescriptor, newName string, stmt string,
+	ctx context.Context, desc *dbdesc.Mutable, newName string, stmt string,
 ) error {
 	oldName := desc.GetName()
 	desc.SetName(newName)
@@ -90,7 +90,7 @@ func (p *planner) renameDatabase(
 // only be called when database descriptor leasing is enabled. See
 // writeDatabaseChangeToBatch. Also queues a job to complete the schema change.
 func (p *planner) writeNonDropDatabaseChange(
-	ctx context.Context, desc *dbdesc.MutableDatabaseDescriptor, jobDesc string,
+	ctx context.Context, desc *dbdesc.Mutable, jobDesc string,
 ) error {
 	if err := p.createNonDropDatabaseChangeJob(ctx, desc.ID, jobDesc); err != nil {
 		return err
@@ -106,7 +106,7 @@ func (p *planner) writeNonDropDatabaseChange(
 // can only be called when database descriptor leasing is enabled. Does not
 // queue a job to complete the schema change.
 func (p *planner) writeDatabaseChangeToBatch(
-	ctx context.Context, desc *dbdesc.MutableDatabaseDescriptor, b *kv.Batch,
+	ctx context.Context, desc *dbdesc.Mutable, b *kv.Batch,
 ) error {
 	if p.Descriptors().DatabaseLeasingUnsupported() {
 		log.Fatal(ctx, "invalid attempted write of database descriptor")

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -68,8 +68,8 @@ CREATE SCHEMA sc;
 		t.Fatal(err)
 	}
 
-	getDB := func() *dbdesc.ImmutableDatabaseDescriptor {
-		var db *dbdesc.ImmutableDatabaseDescriptor
+	getDB := func() *dbdesc.Immutable {
+		var db *dbdesc.Immutable
 		if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			dbID, err := catalogkv.GetDatabaseID(ctx, txn, keys.SystemSQLCodec, "d", true /* required */)
 			if err != nil {

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -40,10 +40,10 @@ type deleteRangeNode struct {
 	// spans are the spans to delete.
 	spans roachpb.Spans
 	// desc is the table descriptor the delete is operating on.
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 	// interleavedDesc are the table descriptors of any child interleaved tables
 	// the delete is operating on.
-	interleavedDesc []*tabledesc.ImmutableTableDescriptor
+	interleavedDesc []*tabledesc.Immutable
 	// fetcher is around to decode the returned keys from the DeleteRange, so that
 	// we can count the number of rows deleted.
 	fetcher row.Fetcher

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -152,7 +152,7 @@ func (p *planner) createDescriptorWithID(
 	}
 	isTable := false
 	switch desc := mutDesc.(type) {
-	case *typedesc.MutableTypeDescriptor:
+	case *typedesc.Mutable:
 		dg := catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.ExecCfg().Codec)
 		if err := desc.Validate(ctx, dg); err != nil {
 			return err

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -179,7 +179,7 @@ func (p *planner) createDescriptorWithID(
 				return err
 			}
 		}
-	case *schemadesc.MutableSchemaDescriptor:
+	case *schemadesc.Mutable:
 		// TODO (lucy): Call AddUncommittedDescriptor when we're ready.
 	default:
 		log.Fatalf(ctx, "unexpected type %T when creating descriptor", mutDesc)

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -160,7 +160,7 @@ func (p *planner) createDescriptorWithID(
 		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {
 			return err
 		}
-	case *tabledesc.MutableTableDescriptor:
+	case *tabledesc.Mutable:
 		isTable = true
 		if err := desc.ValidateTable(); err != nil {
 			return err
@@ -192,7 +192,7 @@ func (p *planner) createDescriptorWithID(
 		// Queue a schema change job to eventually make the table public.
 		if err := p.createOrUpdateSchemaChangeJob(
 			ctx,
-			mutDesc.(*tabledesc.MutableTableDescriptor),
+			mutDesc.(*tabledesc.Mutable),
 			jobDesc,
 			descpb.InvalidMutationID); err != nil {
 			return err

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -59,7 +59,7 @@ var (
 // createDatabase implements the DatabaseDescEditor interface.
 func (p *planner) createDatabase(
 	ctx context.Context, database *tree.CreateDatabase, jobDesc string,
-) (*dbdesc.MutableDatabaseDescriptor, bool, error) {
+) (*dbdesc.Mutable, bool, error) {
 
 	dbName := string(database.Name)
 	shouldCreatePublicSchema := true
@@ -86,7 +86,7 @@ func (p *planner) createDatabase(
 		return nil, false, err
 	}
 
-	desc := dbdesc.NewInitialDatabaseDescriptor(id, string(database.Name), p.SessionData().User)
+	desc := dbdesc.NewInitial(id, string(database.Name), p.SessionData().User)
 	if err := p.createDescriptorWithID(ctx, dKey.Key(p.ExecCfg().Codec), id, desc, nil, jobDesc); err != nil {
 		return nil, true, err
 	}
@@ -168,7 +168,7 @@ func (p *planner) createDescriptorWithID(
 		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {
 			return err
 		}
-	case *dbdesc.MutableDatabaseDescriptor:
+	case *dbdesc.Mutable:
 		if err := desc.Validate(); err != nil {
 			return err
 		}

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -40,11 +40,11 @@ type mutationTest struct {
 	testing.TB
 	*sqlutils.SQLRunner
 	kvDB      *kv.DB
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 }
 
 func makeMutationTest(
-	t *testing.T, kvDB *kv.DB, db *gosql.DB, tableDesc *tabledesc.MutableTableDescriptor,
+	t *testing.T, kvDB *kv.DB, db *gosql.DB, tableDesc *tabledesc.Mutable,
 ) mutationTest {
 	return mutationTest{
 		TB:        t,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -921,9 +921,7 @@ func (dsp *DistSQLPlanner) nodeVersionIsCompatible(nodeID roachpb.NodeID) bool {
 	return distsql.FlowVerIsCompatible(dsp.planVersion, v.MinAcceptedVersion, v.Version)
 }
 
-func getIndexIdx(
-	index *descpb.IndexDescriptor, desc *tabledesc.ImmutableTableDescriptor,
-) (uint32, error) {
+func getIndexIdx(index *descpb.IndexDescriptor, desc *tabledesc.Immutable) (uint32, error) {
 	if index.ID == desc.PrimaryIndex.ID {
 		return 0, nil
 	}
@@ -978,9 +976,7 @@ func initTableReaderSpec(
 
 // scanNodeOrdinal returns the index of a column with the given ID.
 func tableOrdinal(
-	desc *tabledesc.ImmutableTableDescriptor,
-	colID descpb.ColumnID,
-	visibility execinfrapb.ScanVisibility,
+	desc *tabledesc.Immutable, colID descpb.ColumnID, visibility execinfrapb.ScanVisibility,
 ) int {
 	for i := range desc.Columns {
 		if desc.Columns[i].ID == colID {
@@ -1008,9 +1004,7 @@ func tableOrdinal(
 // toTableOrdinals returns a mapping from column ordinals in cols to table
 // reader column ordinals.
 func toTableOrdinals(
-	cols []*descpb.ColumnDescriptor,
-	desc *tabledesc.ImmutableTableDescriptor,
-	visibility execinfrapb.ScanVisibility,
+	cols []*descpb.ColumnDescriptor, desc *tabledesc.Immutable, visibility execinfrapb.ScanVisibility,
 ) []int {
 	res := make([]int, len(cols))
 	for i := range res {
@@ -1168,7 +1162,7 @@ func (dsp *DistSQLPlanner) createTableReaders(
 type tableReaderPlanningInfo struct {
 	spec                  *execinfrapb.TableReaderSpec
 	post                  execinfrapb.PostProcessSpec
-	desc                  *tabledesc.ImmutableTableDescriptor
+	desc                  *tabledesc.Immutable
 	spans                 []roachpb.Span
 	reverse               bool
 	scanVisibility        execinfrapb.ScanVisibility

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -64,10 +64,7 @@ import (
 // TODO(radu): we should verify that the queries in tests using SplitTable
 // are indeed distributed as intended.
 func SplitTable(
-	t *testing.T,
-	tc serverutils.TestClusterInterface,
-	desc *tabledesc.ImmutableTableDescriptor,
-	sps []SplitPoint,
+	t *testing.T, tc serverutils.TestClusterInterface, desc *tabledesc.Immutable, sps []SplitPoint,
 ) {
 	if tc.ReplicationMode() != base.ReplicationManual {
 		t.Fatal("SplitTable called on a test cluster that was not in manual replication mode")
@@ -163,7 +160,7 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 				return
 			default:
 				// Split the table at a random row.
-				var tableDesc *tabledesc.ImmutableTableDescriptor
+				var tableDesc *tabledesc.Immutable
 				require.NoError(t, cdb.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 					desc, err := catalogkv.UncachedPhysicalAccessor{}.GetObjectDesc(ctx,
 						txn, tc.Server(0).ClusterSettings(), keys.SystemSQLCodec,
@@ -172,7 +169,7 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					tableDesc = desc.(*tabledesc.ImmutableTableDescriptor)
+					tableDesc = desc.(*tabledesc.Immutable)
 					return nil
 				}))
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -156,7 +156,7 @@ func presplitTableBoundaries(
 	expirationTime := cfg.DB.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
 	for _, tbl := range tables {
 		// TODO(ajwerner): Consider passing in the wrapped descriptors.
-		tblDesc := tabledesc.MakeImmutableTableDescriptor(*tbl.Desc)
+		tblDesc := tabledesc.MakeImmutable(*tbl.Desc)
 		for _, span := range tblDesc.AllIndexSpans(cfg.Codec) {
 			if err := cfg.DB.AdminSplit(ctx, span.Key, expirationTime); err != nil {
 				return err

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -54,10 +54,7 @@ var maxTimestampAge = settings.RegisterDurationSetting(
 )
 
 func (dsp *DistSQLPlanner) createStatsPlan(
-	planCtx *PlanningCtx,
-	desc *tabledesc.ImmutableTableDescriptor,
-	reqStats []requestedStat,
-	job *jobs.Job,
+	planCtx *PlanningCtx, desc *tabledesc.Immutable, reqStats []requestedStat, job *jobs.Job,
 ) (*PhysicalPlan, error) {
 	if len(reqStats) == 0 {
 		return nil, errors.New("no stats requested")
@@ -254,7 +251,7 @@ func (dsp *DistSQLPlanner) createPlanForCreateStats(
 		}
 	}
 
-	tableDesc := tabledesc.NewImmutableTableDescriptor(details.Table)
+	tableDesc := tabledesc.NewImmutable(details.Table)
 	return dsp.createStatsPlan(planCtx, tableDesc, reqStats, job)
 }
 

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -32,7 +32,7 @@ type dropCascadeState struct {
 
 	td                      []toDelete
 	allTableObjectsToDelete []*tabledesc.Mutable
-	typesToDelete           []*typedesc.MutableTypeDescriptor
+	typesToDelete           []*typedesc.Mutable
 
 	droppedNames []string
 }
@@ -132,10 +132,10 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			if !found {
 				continue
 			}
-			typDesc, ok := desc.(*typedesc.MutableTypeDescriptor)
+			typDesc, ok := desc.(*typedesc.Mutable)
 			if !ok {
 				return errors.AssertionFailedf(
-					"descriptor for %q is not MutableTypeDescriptor",
+					"descriptor for %q is not Mutable",
 					objName.Object(),
 				)
 			}

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -31,7 +31,7 @@ type dropCascadeState struct {
 	objectNamesToDelete []tree.ObjectName
 
 	td                      []toDelete
-	allTableObjectsToDelete []*tabledesc.MutableTableDescriptor
+	allTableObjectsToDelete []*tabledesc.Mutable
 	typesToDelete           []*typedesc.MutableTypeDescriptor
 
 	droppedNames []string
@@ -86,10 +86,10 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			return err
 		}
 		if found {
-			tbDesc, ok := desc.(*tabledesc.MutableTableDescriptor)
+			tbDesc, ok := desc.(*tabledesc.Mutable)
 			if !ok {
 				return errors.AssertionFailedf(
-					"descriptor for %q is not MutableTableDescriptor",
+					"descriptor for %q is not Mutable",
 					objName.Object(),
 				)
 			}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -282,7 +282,7 @@ func (p *planner) accumulateAllObjectsToDelete(
 func (p *planner) accumulateOwnedSequences(
 	ctx context.Context,
 	dependentObjects map[descpb.ID]*MutableTableDescriptor,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 ) error {
 	for colID := range desc.GetColumns() {
 		for _, seqID := range desc.GetColumns()[colID].OwnsSequenceIds {
@@ -311,7 +311,7 @@ func (p *planner) accumulateOwnedSequences(
 func (p *planner) accumulateCascadingViews(
 	ctx context.Context,
 	dependentObjects map[descpb.ID]*MutableTableDescriptor,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 ) error {
 	for _, ref := range desc.DependedOnBy {
 		dependentDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ID, p.txn)

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -37,7 +37,7 @@ import (
 
 type dropDatabaseNode struct {
 	n      *tree.DropDatabase
-	dbDesc *dbdesc.MutableDatabaseDescriptor
+	dbDesc *dbdesc.Mutable
 	d      *dropCascadeState
 }
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -135,9 +135,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 // dropShardColumnAndConstraint drops the given shard column and its associated check
 // constraint.
 func (n *dropIndexNode) dropShardColumnAndConstraint(
-	params runParams,
-	tableDesc *tabledesc.MutableTableDescriptor,
-	shardColDesc *descpb.ColumnDescriptor,
+	params runParams, tableDesc *tabledesc.Mutable, shardColDesc *descpb.ColumnDescriptor,
 ) error {
 	validChecks := tableDesc.Checks[:0]
 	for _, check := range tableDesc.AllActiveAndInactiveChecks() {
@@ -189,7 +187,7 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 //
 // Assumes that the given index is sharded.
 func (n *dropIndexNode) maybeDropShardColumn(
-	params runParams, tableDesc *tabledesc.MutableTableDescriptor, shardColName string,
+	params runParams, tableDesc *tabledesc.Mutable, shardColName string,
 ) error {
 	shardColDesc, dropped, err := tableDesc.FindColumnByName(tree.Name(shardColName))
 	if err != nil {
@@ -236,7 +234,7 @@ func (p *planner) dropIndexByName(
 	ctx context.Context,
 	tn *tree.TableName,
 	idxName tree.UnrestrictedName,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	ifExists bool,
 	behavior tree.DropBehavior,
 	constraintBehavior dropIndexConstraintBehavior,

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -117,7 +117,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 
 	// First check all the databases.
 	if err := forEachDatabaseDesc(params.ctx, params.p, nil /*nil prefix = all databases*/, true, /* requiresPrivileges */
-		func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+		func(db *dbdesc.Immutable) error {
 			if _, ok := userNames[db.GetPrivileges().Owner]; ok {
 				userNames[db.GetPrivileges().Owner] = append(
 					userNames[db.GetPrivileges().Owner],

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -31,7 +31,7 @@ import (
 
 type dropSchemaNode struct {
 	n  *tree.DropSchema
-	db *dbdesc.MutableDatabaseDescriptor
+	db *dbdesc.Mutable
 	d  *dropCascadeState
 }
 

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -163,7 +163,7 @@ func (n *dropSchemaNode) startExec(params runParams) error {
 func (p *planner) createDropSchemaJob(
 	schemas []descpb.ID,
 	tableDropDetails []jobspb.DroppedTableDetails,
-	typesToDrop []*typedesc.MutableTypeDescriptor,
+	typesToDrop []*typedesc.Mutable,
 	jobDesc string,
 ) error {
 	typeIDs := make([]descpb.ID, 0, len(typesToDrop))

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -105,7 +105,7 @@ func (*dropSequenceNode) Close(context.Context)        {}
 
 func (p *planner) dropSequenceImpl(
 	ctx context.Context,
-	seqDesc *tabledesc.MutableTableDescriptor,
+	seqDesc *tabledesc.Mutable,
 	queueJob bool,
 	jobDesc string,
 	behavior tree.DropBehavior,
@@ -120,7 +120,7 @@ func (p *planner) dropSequenceImpl(
 // a table uses it in a DEFAULT expression on one of its columns, or nil if there is no
 // such dependency.
 func (p *planner) sequenceDependencyError(
-	ctx context.Context, droppedDesc *tabledesc.MutableTableDescriptor,
+	ctx context.Context, droppedDesc *tabledesc.Mutable,
 ) error {
 	if len(droppedDesc.DependedOnBy) > 0 {
 		return pgerror.Newf(
@@ -133,7 +133,7 @@ func (p *planner) sequenceDependencyError(
 }
 
 func (p *planner) canRemoveAllTableOwnedSequences(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor, behavior tree.DropBehavior,
+	ctx context.Context, desc *tabledesc.Mutable, behavior tree.DropBehavior,
 ) error {
 	for _, col := range desc.Columns {
 		err := p.canRemoveOwnedSequencesImpl(ctx, desc, &col, behavior, false /* isColumnDrop */)
@@ -146,7 +146,7 @@ func (p *planner) canRemoveAllTableOwnedSequences(
 
 func (p *planner) canRemoveAllColumnOwnedSequences(
 	ctx context.Context,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	behavior tree.DropBehavior,
 ) error {
@@ -155,7 +155,7 @@ func (p *planner) canRemoveAllColumnOwnedSequences(
 
 func (p *planner) canRemoveOwnedSequencesImpl(
 	ctx context.Context,
-	desc *tabledesc.MutableTableDescriptor,
+	desc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	behavior tree.DropBehavior,
 	isColumnDrop bool,

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -119,7 +119,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	tbDesc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
-	var dbDesc *dbdesc.ImmutableDatabaseDescriptor
+	var dbDesc *dbdesc.Immutable
 	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		dbDesc, err = catalogkv.GetDatabaseDescByID(ctx, txn, keys.SystemSQLCodec, tbDesc.GetParentID())
 		return err
@@ -284,7 +284,7 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 
 	tbDesc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
 	tb2Desc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv2")
-	var dbDesc *dbdesc.ImmutableDatabaseDescriptor
+	var dbDesc *dbdesc.Immutable
 	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		dbDesc, err = catalogkv.GetDatabaseDescByID(ctx, txn, keys.SystemSQLCodec, tbDesc.GetParentID())
 		return err

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -709,7 +709,7 @@ func TestDropTableDeleteData(t *testing.T) {
 	const numRows = 2*row.TableTruncateChunkSize + 1
 	const numKeys = 3 * numRows
 	const numTables = 5
-	var descs []*tabledesc.ImmutableTableDescriptor
+	var descs []*tabledesc.Immutable
 	for i := 0; i < numTables; i++ {
 		tableName := fmt.Sprintf("test%d", i)
 		if err := tests.CreateKVTable(sqlDB, tableName, numRows); err != nil {
@@ -827,9 +827,7 @@ func TestDropTableDeleteData(t *testing.T) {
 	}
 }
 
-func writeTableDesc(
-	ctx context.Context, db *kv.DB, tableDesc *tabledesc.MutableTableDescriptor,
-) error {
+func writeTableDesc(ctx context.Context, db *kv.DB, tableDesc *tabledesc.Mutable) error {
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		if err := txn.SetSystemConfigTrigger(true /* forSystemTenant */); err != nil {
 			return err
@@ -891,7 +889,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		tableDesc = desc.(*tabledesc.MutableTableDescriptor)
+		tableDesc = desc.(*tabledesc.Mutable)
 		return nil
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -170,7 +170,7 @@ func (p *planner) removeTypeBackReference(
 }
 
 func (p *planner) addBackRefsFromAllTypesInTable(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor,
+	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
 	typeIDs, err := desc.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
 		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)
@@ -192,7 +192,7 @@ func (p *planner) addBackRefsFromAllTypesInTable(
 }
 
 func (p *planner) removeBackRefsFromAllTypesInTable(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor,
+	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
 	typeIDs, err := desc.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
 		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -28,7 +28,7 @@ import (
 
 type dropTypeNode struct {
 	n  *tree.DropType
-	td map[descpb.ID]*typedesc.MutableTypeDescriptor
+	td map[descpb.ID]*typedesc.Mutable
 }
 
 // Use to satisfy the linter.
@@ -37,7 +37,7 @@ var _ planNode = &dropTypeNode{n: nil}
 func (p *planner) DropType(ctx context.Context, n *tree.DropType) (planNode, error) {
 	node := &dropTypeNode{
 		n:  n,
-		td: make(map[descpb.ID]*typedesc.MutableTypeDescriptor),
+		td: make(map[descpb.ID]*typedesc.Mutable),
 	}
 	if n.DropBehavior == tree.DropCascade {
 		return nil, unimplemented.NewWithIssue(51480, "DROP TYPE CASCADE is not yet supported")
@@ -87,7 +87,7 @@ func (p *planner) DropType(ctx context.Context, n *tree.DropType) (planNode, err
 }
 
 func (p *planner) canDropTypeDesc(
-	ctx context.Context, desc *typedesc.MutableTypeDescriptor, behavior tree.DropBehavior,
+	ctx context.Context, desc *typedesc.Mutable, behavior tree.DropBehavior,
 ) error {
 	if err := p.canModifyType(ctx, desc); err != nil {
 		return err
@@ -215,7 +215,7 @@ func (p *planner) removeBackRefsFromAllTypesInTable(
 
 // dropTypeImpl does the work of dropping a type and everything that depends on it.
 func (p *planner) dropTypeImpl(
-	ctx context.Context, typeDesc *typedesc.MutableTypeDescriptor, jobDesc string, queueJob bool,
+	ctx context.Context, typeDesc *typedesc.Mutable, jobDesc string, queueJob bool,
 ) error {
 	if typeDesc.Dropped() {
 		return errors.Errorf("type %q is already being dropped", typeDesc.Name)

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -134,7 +134,7 @@ func descInSlice(descID descpb.ID, td []toDelete) bool {
 
 func (p *planner) canRemoveDependentView(
 	ctx context.Context,
-	from *tabledesc.MutableTableDescriptor,
+	from *tabledesc.Mutable,
 	ref descpb.TableDescriptor_Reference,
 	behavior tree.DropBehavior,
 ) error {
@@ -169,7 +169,7 @@ func (p *planner) canRemoveDependentViewGeneric(
 // Returns the names of any additional views that were also dropped
 // due to `cascade` behavior.
 func (p *planner) removeDependentView(
-	ctx context.Context, tableDesc, viewDesc *tabledesc.MutableTableDescriptor, jobDesc string,
+	ctx context.Context, tableDesc, viewDesc *tabledesc.Mutable, jobDesc string,
 ) ([]string, error) {
 	// In the table whose index is being removed, filter out all back-references
 	// that refer to the view that's being removed.
@@ -183,7 +183,7 @@ func (p *planner) removeDependentView(
 // were also dropped due to `cascade` behavior.
 func (p *planner) dropViewImpl(
 	ctx context.Context,
-	viewDesc *tabledesc.MutableTableDescriptor,
+	viewDesc *tabledesc.Mutable,
 	queueJob bool,
 	jobDesc string,
 	behavior tree.DropBehavior,
@@ -248,7 +248,7 @@ func (p *planner) getViewDescForCascade(
 	objName string,
 	parentID, viewID descpb.ID,
 	behavior tree.DropBehavior,
-) (*tabledesc.MutableTableDescriptor, error) {
+) (*tabledesc.Mutable, error) {
 	viewDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, viewID, p.txn)
 	if err != nil {
 		log.Warningf(ctx, "unable to retrieve descriptor for view %d: %v", viewID, err)

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -131,7 +131,7 @@ func (tr *TableReaderSpec) summary() (string, []string) {
 	details := []string{indexDetail(&tr.Table, tr.IndexIdx)}
 
 	if len(tr.Spans) > 0 {
-		tbl := tabledesc.NewImmutableTableDescriptor(tr.Table)
+		tbl := tabledesc.NewImmutable(tr.Table)
 		// only show the first span
 		idx, _, _ := tbl.FindIndexByIndexIdx(int(tr.IndexIdx))
 		valDirs := catalogkeys.IndexKeyValDirs(idx)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -71,7 +71,7 @@ func emitExplain(
 	ob.AddField("distribution", distribution.String())
 	ob.AddField("vectorized", fmt.Sprintf("%t", vectorized))
 	spanFormatFn := func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string {
-		var tabDesc *tabledesc.ImmutableTableDescriptor
+		var tabDesc *tabledesc.Immutable
 		var idxDesc *descpb.IndexDescriptor
 		if table.IsVirtualTable() {
 			tabDesc = table.(*optVirtualTable).desc

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -27,13 +27,13 @@ import (
 func updateDescriptorGCMutations(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
-	table *tabledesc.ImmutableTableDescriptor,
+	table *tabledesc.Immutable,
 	garbageCollectedIndexID descpb.IndexID,
 ) error {
 	log.Infof(ctx, "updating GCMutations for table %d after removing index %d", table.ID, garbageCollectedIndexID)
 	// Remove the mutation from the table descriptor.
 	updateTableMutations := func(desc catalog.MutableDescriptor) error {
-		tbl := desc.(*tabledesc.MutableTableDescriptor)
+		tbl := desc.(*tabledesc.Mutable)
 		for i := 0; i < len(tbl.GCMutations); i++ {
 			other := tbl.GCMutations[i]
 			if other.IndexID == garbageCollectedIndexID {
@@ -59,10 +59,7 @@ func updateDescriptorGCMutations(
 
 // dropTableDesc removes a descriptor from the KV database.
 func dropTableDesc(
-	ctx context.Context,
-	db *kv.DB,
-	codec keys.SQLCodec,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, db *kv.DB, codec keys.SQLCodec, tableDesc *tabledesc.Immutable,
 ) error {
 	log.Infof(ctx, "removing table descriptor for table %d", tableDesc.ID)
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -109,7 +109,7 @@ func (r schemaChangeGCResumer) Resume(
 		if err := sql.TruncateInterleavedIndexes(
 			ctx,
 			execCfg,
-			tabledesc.NewImmutableTableDescriptor(*details.InterleavedTable),
+			tabledesc.NewImmutable(*details.InterleavedTable),
 			details.InterleavedIndexes,
 		); err != nil {
 			return err

--- a/pkg/sql/gcjob/index_garbage_collection.go
+++ b/pkg/sql/gcjob/index_garbage_collection.go
@@ -46,7 +46,7 @@ func gcIndexes(
 		return false, err
 	}
 
-	var parentTable *tabledesc.ImmutableTableDescriptor
+	var parentTable *tabledesc.Immutable
 	if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		parentTable, err = catalogkv.MustGetTableDescByID(ctx, txn, execCfg.Codec, parentID)
 		return err
@@ -86,7 +86,7 @@ func gcIndexes(
 func clearIndex(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	index descpb.IndexDescriptor,
 ) error {
 	log.Infof(ctx, "clearing index %d from table %d", index.ID, tableDesc.ID)
@@ -113,7 +113,7 @@ func clearIndex(
 func completeDroppedIndex(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
-	table *tabledesc.ImmutableTableDescriptor,
+	table *tabledesc.Immutable,
 	indexID descpb.IndexID,
 	progress *jobspb.SchemaChangeGCProgress,
 ) error {

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -146,7 +146,7 @@ func updateTableStatus(
 	execCfg *sql.ExecutorConfig,
 	ttlSeconds int64,
 	protectedtsCache protectedts.Cache,
-	table *tabledesc.ImmutableTableDescriptor,
+	table *tabledesc.Immutable,
 	tableDropTimes map[descpb.ID]int64,
 	progress *jobspb.SchemaChangeGCProgress,
 ) time.Time {
@@ -191,7 +191,7 @@ func updateIndexesStatus(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	tableTTL int32,
-	table *tabledesc.ImmutableTableDescriptor,
+	table *tabledesc.Immutable,
 	protectedtsCache protectedts.Cache,
 	zoneCfg *zonepb.ZoneConfig,
 	indexDropTimes map[descpb.IndexID]int64,

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -44,7 +44,7 @@ func gcTables(
 			continue
 		}
 
-		var table *tabledesc.ImmutableTableDescriptor
+		var table *tabledesc.Immutable
 		if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			var err error
 			table, err = catalogkv.MustGetTableDescByID(ctx, txn, execCfg.Codec, droppedTable.ID)
@@ -90,7 +90,7 @@ func ClearTableData(
 	db *kv.DB,
 	distSender *kvcoord.DistSender,
 	codec keys.SQLCodec,
-	table *tabledesc.ImmutableTableDescriptor,
+	table *tabledesc.Immutable,
 ) error {
 	// If DropTime isn't set, assume this drop request is from a version
 	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -82,21 +82,21 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			myTableID := descpb.ID(keys.MinUserDescID + 3)
 			myOtherTableID := descpb.ID(keys.MinUserDescID + 4)
 
-			var myTableDesc *tabledesc.MutableTableDescriptor
-			var myOtherTableDesc *tabledesc.MutableTableDescriptor
+			var myTableDesc *tabledesc.Mutable
+			var myOtherTableDesc *tabledesc.Mutable
 			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				myDesc, err := catalogkv.GetDescriptorByID(ctx, txn, keys.SystemSQLCodec, myTableID,
 					catalogkv.Mutable, catalogkv.TableDescriptorKind, true /* required */)
 				if err != nil {
 					return err
 				}
-				myTableDesc = myDesc.(*tabledesc.MutableTableDescriptor)
+				myTableDesc = myDesc.(*tabledesc.Mutable)
 				myOtherDesc, err := catalogkv.GetDescriptorByID(ctx, txn, keys.SystemSQLCodec, myOtherTableID,
 					catalogkv.Mutable, catalogkv.TableDescriptorKind, true /* required */)
 				if err != nil {
 					return err
 				}
-				myOtherTableDesc = myOtherDesc.(*tabledesc.MutableTableDescriptor)
+				myOtherTableDesc = myOtherDesc.(*tabledesc.Mutable)
 				return nil
 			}); err != nil {
 				t.Fatal(err)
@@ -216,7 +216,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				myTableDesc = myDesc.(*tabledesc.MutableTableDescriptor)
+				myTableDesc = myDesc.(*tabledesc.Mutable)
 				myOtherDesc, err := catalogkv.GetDescriptorByID(ctx, txn, keys.SystemSQLCodec, myOtherTableID,
 					catalogkv.Mutable, catalogkv.TableDescriptorKind, true /* required */)
 				if ttlTime != FUTURE && dropItem == DATABASE {
@@ -227,7 +227,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				myOtherTableDesc = myOtherDesc.(*tabledesc.MutableTableDescriptor)
+				myOtherTableDesc = myOtherDesc.(*tabledesc.Mutable)
 				return nil
 			}); err != nil {
 				t.Fatal(err)

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -198,7 +198,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 				}
 			}
 
-		case *tabledesc.MutableTableDescriptor:
+		case *tabledesc.Mutable:
 			// TODO (lucy): This should probably have a single consolidated job like
 			// DROP DATABASE.
 			if err := p.createOrUpdateSchemaChangeJob(

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -171,7 +171,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 		}
 
 		switch d := descriptor.(type) {
-		case *dbdesc.MutableDatabaseDescriptor:
+		case *dbdesc.Mutable:
 			if p.Descriptors().DatabaseLeasingUnsupported() {
 				if err := d.Validate(); err != nil {
 					return err

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -213,7 +213,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 					return err
 				}
 			}
-		case *typedesc.MutableTypeDescriptor:
+		case *typedesc.Mutable:
 			err := p.writeTypeSchemaChange(ctx, d, fmt.Sprintf("updating privileges for type %d", d.ID))
 			if err != nil {
 				return err

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1579,7 +1579,7 @@ func forEachTypeDesc(
 	ctx context.Context,
 	p *planner,
 	dbContext *dbdesc.ImmutableDatabaseDescriptor,
-	fn func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typ *typedesc.ImmutableTypeDescriptor) error,
+	fn func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typ *typedesc.Immutable) error,
 ) error {
 	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -629,7 +629,7 @@ CREATE TABLE information_schema.constraint_column_usage (
 					// For foreign key constraint, constraint_column_usage
 					// identifies the table/columns that the foreign key
 					// references.
-					conTable = tabledesc.NewImmutableTableDescriptor(*con.ReferencedTable)
+					conTable = tabledesc.NewImmutable(*con.ReferencedTable)
 					conCols, err = conTable.NamesForColumnIDs(con.FK.ReferencedColumnIDs)
 					if err != nil {
 						return err

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -205,7 +205,7 @@ var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#administrable_role_authorizations") + `
 https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations.html`,
 	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
 		if err != nil {
@@ -237,7 +237,7 @@ var informationSchemaApplicableRoles = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#applicable_roles") + `
 https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 	schema: vtable.InformationSchemaApplicableRoles,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
 		if err != nil {
@@ -265,10 +265,10 @@ var informationSchemaCheckConstraints = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#check_constraints") + `
 https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 	schema: vtable.InformationSchemaCheckConstraints,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -334,9 +334,9 @@ var informationSchemaColumnPrivileges = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#column_privileges") + `
 https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 	schema: vtable.InformationSchemaColumnPrivileges,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(
-			db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor,
+			db *dbdesc.Immutable, scName string, table catalog.TableDescriptor,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
@@ -373,9 +373,9 @@ var informationSchemaColumnsTable = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#columns") + `
 https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 	schema: vtable.InformationSchemaColumns,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(
-			db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor,
+			db *dbdesc.Immutable, scName string, table catalog.TableDescriptor,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
@@ -468,7 +468,7 @@ https://www.postgresql.org/docs/9.5/infoschema-enabled-roles.html`,
 CREATE TABLE information_schema.enabled_roles (
 	ROLE_NAME STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
 		if err != nil {
@@ -607,9 +607,9 @@ CREATE TABLE information_schema.constraint_column_usage (
 	CONSTRAINT_SCHEMA  STRING NOT NULL,
 	CONSTRAINT_NAME    STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -672,9 +672,9 @@ CREATE TABLE information_schema.key_column_usage (
 	ORDINAL_POSITION   INT NOT NULL,
 	POSITION_IN_UNIQUE_CONSTRAINT INT
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -764,7 +764,7 @@ CREATE TABLE information_schema.parameters (
 	DTD_IDENTIFIER STRING,
 	PARAMETER_DEFAULT STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -822,9 +822,9 @@ CREATE TABLE information_schema.referential_constraints (
 	TABLE_NAME                STRING NOT NULL,
 	REFERENCED_TABLE_NAME     STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -974,7 +974,7 @@ CREATE TABLE information_schema.routines (
 	RESULT_CAST_MAXIMUM_CARDINALITY INT,
 	RESULT_CAST_DTD_IDENTIFIER STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -985,9 +985,9 @@ var informationSchemaSchemataTable = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#schemata") + `
 https://www.postgresql.org/docs/9.5/infoschema-schemata.html`,
 	schema: vtable.InformationSchemaSchemata,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				return forEachSchemaName(ctx, p, db, func(sc string, userDefined bool) error {
 					return addRow(
 						tree.NewDString(db.GetName()), // catalog_name
@@ -1013,9 +1013,9 @@ CREATE TABLE information_schema.schema_privileges (
 	PRIVILEGE_TYPE  STRING NOT NULL,
 	IS_GRANTABLE    STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				return forEachSchemaName(ctx, p, db, func(scName string, _ bool) error {
 					privs := db.Privileges.Show(privilege.Schema)
 					dbNameStr := tree.NewDString(db.GetName())
@@ -1077,9 +1077,9 @@ CREATE TABLE information_schema.sequences (
     INCREMENT                STRING NOT NULL,
     CYCLE_OPTION             STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* no sequences in virtual schemas */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				if !table.IsSequence() {
 					return nil
 				}
@@ -1122,9 +1122,9 @@ CREATE TABLE information_schema.statistics (
 	STORING       STRING NOT NULL,
 	IMPLICIT      STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables have no indexes */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				dbNameStr := tree.NewDString(db.GetName())
 				scNameStr := tree.NewDString(scName)
 				tbNameStr := tree.NewDString(table.GetName())
@@ -1219,11 +1219,11 @@ CREATE TABLE information_schema.table_constraints (
 	IS_DEFERRABLE      STRING NOT NULL,
 	INITIALLY_DEFERRED STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual, /* virtual tables have no constraints */
 			func(
-				db *dbdesc.ImmutableDatabaseDescriptor,
+				db *dbdesc.Immutable,
 				scName string,
 				table catalog.TableDescriptor,
 				tableLookup tableLookupFn,
@@ -1297,9 +1297,9 @@ CREATE TABLE information_schema.user_privileges (
 	PRIVILEGE_TYPE STRING NOT NULL,
 	IS_GRANTABLE   STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
-			func(dbDesc *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(dbDesc *dbdesc.Immutable) error {
 				dbNameStr := tree.NewDString(dbDesc.GetName())
 				for _, u := range []string{security.RootUser, security.AdminRole} {
 					grantee := tree.NewDString(u)
@@ -1340,13 +1340,10 @@ CREATE TABLE information_schema.table_privileges (
 
 // populateTablePrivileges is used to populate both table_privileges and role_table_grants.
 func populateTablePrivileges(
-	ctx context.Context,
-	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
-	addRow func(...tree.Datum) error,
+	ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error,
 ) error {
 	return forEachTableDesc(ctx, p, dbContext, virtualMany,
-		func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+		func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
 			tbNameStr := tree.NewDString(table.GetName())
@@ -1384,12 +1381,12 @@ var informationSchemaTablesTable = virtualSchemaTable{
 ` + base.DocsURL("information-schema.html#tables") + `
 https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 	schema: vtable.InformationSchemaTables,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, addTablesTableRow(addRow))
 	},
 	indexes: []virtualIndex{
 		{
-			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.ImmutableDatabaseDescriptor,
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.Immutable,
 				addRow func(...tree.Datum) error) (bool, error) {
 				// This index is on the TABLE_NAME column.
 				name := tree.MustBeDString(constraint)
@@ -1412,11 +1409,11 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 func addTablesTableRow(
 	addRow func(...tree.Datum) error,
 ) func(
-	db *dbdesc.ImmutableDatabaseDescriptor,
+	db *dbdesc.Immutable,
 	scName string,
 	table catalog.TableDescriptor,
 ) error {
-	return func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+	return func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 		if table.IsSequence() {
 			return nil
 		}
@@ -1464,9 +1461,9 @@ CREATE TABLE information_schema.views (
     IS_TRIGGER_DELETABLE       STRING NOT NULL,
     IS_TRIGGER_INSERTABLE_INTO STRING NOT NULL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas have no views */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				if !table.IsView() {
 					return nil
 				}
@@ -1498,7 +1495,7 @@ CREATE TABLE information_schema.views (
 func forEachSchemaName(
 	ctx context.Context,
 	p *planner,
-	db *dbdesc.ImmutableDatabaseDescriptor,
+	db *dbdesc.Immutable,
 	fn func(scName string, userDefined bool) error,
 ) error {
 	userDefinedSchemas := make(map[string]struct{})
@@ -1536,11 +1533,11 @@ func forEachSchemaName(
 func forEachDatabaseDesc(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	requiresPrivileges bool,
-	fn func(*dbdesc.ImmutableDatabaseDescriptor) error,
+	fn func(*dbdesc.Immutable) error,
 ) error {
-	var dbDescs []*dbdesc.ImmutableDatabaseDescriptor
+	var dbDescs []*dbdesc.Immutable
 	if dbContext == nil {
 		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
 		if err != nil {
@@ -1578,8 +1575,8 @@ func forEachDatabaseDesc(
 func forEachTypeDesc(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
-	fn func(db *dbdesc.ImmutableDatabaseDescriptor, sc string, typ *typedesc.Immutable) error,
+	dbContext *dbdesc.Immutable,
+	fn func(db *dbdesc.Immutable, sc string, typ *typedesc.Immutable) error,
 ) error {
 	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
@@ -1622,13 +1619,13 @@ func forEachTypeDesc(
 func forEachTableDesc(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
 	// TODO(ajwerner): Introduce TableDescriptor.
-	fn func(*dbdesc.ImmutableDatabaseDescriptor, string, catalog.TableDescriptor) error,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
 	return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts, func(
-		db *dbdesc.ImmutableDatabaseDescriptor,
+		db *dbdesc.Immutable,
 		scName string,
 		table catalog.TableDescriptor,
 		_ tableLookupFn,
@@ -1653,14 +1650,14 @@ const (
 func forEachTableDescAll(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	fn func(*dbdesc.ImmutableDatabaseDescriptor, string, catalog.TableDescriptor) error,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
 	return forEachTableDescAllWithTableLookup(ctx,
 		p, dbContext, virtualOpts,
 		func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			_ tableLookupFn,
@@ -1674,9 +1671,9 @@ func forEachTableDescAll(
 func forEachTableDescAllWithTableLookup(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	fn func(*dbdesc.ImmutableDatabaseDescriptor, string, catalog.TableDescriptor, tableLookupFn) error,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(ctx,
 		p, dbContext, virtualOpts, true /* allowAdding */, fn)
@@ -1694,15 +1691,15 @@ func forEachTableDescAllWithTableLookup(
 func forEachTableDescWithTableLookup(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	fn func(*dbdesc.ImmutableDatabaseDescriptor, string, catalog.TableDescriptor, tableLookupFn) error,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(ctx, p, dbContext, virtualOpts, false /* allowAdding */, fn)
 }
 
 func getSchemaNames(
-	ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	ctx context.Context, p *planner, dbContext *dbdesc.Immutable,
 ) (map[descpb.ID]string, error) {
 	if dbContext != nil {
 		return p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbContext.GetID())
@@ -1732,10 +1729,10 @@ func getSchemaNames(
 func forEachTableDescWithTableLookupInternal(
 	ctx context.Context,
 	p *planner,
-	dbContext *dbdesc.ImmutableDatabaseDescriptor,
+	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
 	allowAdding bool,
-	fn func(*dbdesc.ImmutableDatabaseDescriptor, string, catalog.TableDescriptor, tableLookupFn) error,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
 	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
@@ -1748,7 +1745,7 @@ func forEachTableDescWithTableLookupInternal(
 		vt := p.getVirtualTabler()
 		vEntries := vt.getEntries()
 		vSchemaNames := vt.getSchemaNames()
-		iterate := func(dbDesc *dbdesc.ImmutableDatabaseDescriptor) error {
+		iterate := func(dbDesc *dbdesc.Immutable) error {
 			for _, virtSchemaName := range vSchemaNames {
 				e := vEntries[virtSchemaName]
 				for _, tName := range e.orderedDefNames {
@@ -1881,9 +1878,7 @@ func forEachRoleMembership(
 	return nil
 }
 
-func userCanSeeDatabase(
-	ctx context.Context, p *planner, db *dbdesc.ImmutableDatabaseDescriptor,
-) bool {
+func userCanSeeDatabase(ctx context.Context, p *planner, db *dbdesc.Immutable) bool {
 	return p.CheckAnyPrivilege(ctx, db) == nil
 }
 

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -95,7 +95,7 @@ type insertFastPathFKSpanInfo struct {
 type insertFastPathFKCheck struct {
 	exec.InsertFastPathFKCheck
 
-	tabDesc     *tabledesc.ImmutableTableDescriptor
+	tabDesc     *tabledesc.Immutable
 	idxDesc     *descpb.IndexDescriptor
 	keyPrefix   []byte
 	colMap      map[descpb.ColumnID]int

--- a/pkg/sql/old_foreign_key_desc_test.go
+++ b/pkg/sql/old_foreign_key_desc_test.go
@@ -56,7 +56,7 @@ CREATE INDEX ON t.t1 (x);
 	// downgradeForeignKey downgrades a table descriptor's foreign key representation
 	// to the pre-19.2 table descriptor format where foreign key information
 	// is stored on the index.
-	downgradeForeignKey := func(tbl *tabledesc.ImmutableTableDescriptor) *tabledesc.ImmutableTableDescriptor {
+	downgradeForeignKey := func(tbl *tabledesc.Immutable) *tabledesc.Immutable {
 		// Downgrade the outbound foreign keys.
 		for i := range tbl.OutboundFKs {
 			fk := &tbl.OutboundFKs[i]
@@ -64,7 +64,7 @@ CREATE INDEX ON t.t1 (x);
 			if err != nil {
 				t.Fatal(err)
 			}
-			var referencedTbl *tabledesc.ImmutableTableDescriptor
+			var referencedTbl *tabledesc.Immutable
 			err = kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 				referencedTbl, err = catalogkv.MustGetTableDescByID(ctx, txn, keys.SystemSQLCodec, fk.ReferencedTableID)
 				return err
@@ -95,7 +95,7 @@ CREATE INDEX ON t.t1 (x);
 			if err != nil {
 				t.Fatal(err)
 			}
-			var originTbl *tabledesc.ImmutableTableDescriptor
+			var originTbl *tabledesc.Immutable
 			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 				originTbl, err = catalogkv.MustGetTableDescByID(ctx, txn, keys.SystemSQLCodec, fk.OriginTableID)
 				return err

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -58,7 +58,7 @@ type optCatalog struct {
 	// repeated calls for the same data source.
 	// Note that the data source object might still need to be recreated if
 	// something outside of the descriptor has changed (e.g. table stats).
-	dataSources map[*tabledesc.ImmutableTableDescriptor]cat.DataSource
+	dataSources map[*tabledesc.Immutable]cat.DataSource
 
 	// tn is a temporary name used during resolution to avoid heap allocation.
 	tn tree.TableName
@@ -71,7 +71,7 @@ var _ cat.Catalog = &optCatalog{}
 // called for each query.
 func (oc *optCatalog) init(planner *planner) {
 	oc.planner = planner
-	oc.dataSources = make(map[*tabledesc.ImmutableTableDescriptor]cat.DataSource)
+	oc.dataSources = make(map[*tabledesc.Immutable]cat.DataSource)
 }
 
 // reset prepares the optCatalog to be used for a new query.
@@ -80,7 +80,7 @@ func (oc *optCatalog) reset() {
 	// This deals with possible edge cases where we do a lot of DDL in a
 	// long-lived session.
 	if len(oc.dataSources) > 100 {
-		oc.dataSources = make(map[*tabledesc.ImmutableTableDescriptor]cat.DataSource)
+		oc.dataSources = make(map[*tabledesc.Immutable]cat.DataSource)
 	}
 
 	oc.cfg = oc.planner.execCfg.SystemConfig.GetSystemConfig()
@@ -262,7 +262,7 @@ func getDescFromCatalogObjectForPermissions(o cat.Object) (catalog.Descriptor, e
 	}
 }
 
-func getDescForDataSource(o cat.DataSource) (*tabledesc.ImmutableTableDescriptor, error) {
+func getDescForDataSource(o cat.DataSource) (*tabledesc.Immutable, error) {
 	switch t := o.(type) {
 	case *optTable:
 		return t.desc, nil
@@ -337,10 +337,7 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 // dataSourceForDesc returns a data source wrapper for the given descriptor.
 // The wrapper might come from the cache, or it may be created now.
 func (oc *optCatalog) dataSourceForDesc(
-	ctx context.Context,
-	flags cat.Flags,
-	desc *tabledesc.ImmutableTableDescriptor,
-	name *cat.DataSourceName,
+	ctx context.Context, flags cat.Flags, desc *tabledesc.Immutable, name *cat.DataSourceName,
 ) (cat.DataSource, error) {
 	// Because they are backed by physical data, we treat materialized views
 	// as tables for the purposes of planning.
@@ -372,10 +369,7 @@ func (oc *optCatalog) dataSourceForDesc(
 // dataSourceForTable returns a table data source wrapper for the given descriptor.
 // The wrapper might come from the cache, or it may be created now.
 func (oc *optCatalog) dataSourceForTable(
-	ctx context.Context,
-	flags cat.Flags,
-	desc *tabledesc.ImmutableTableDescriptor,
-	name *cat.DataSourceName,
+	ctx context.Context, flags cat.Flags, desc *tabledesc.Immutable, name *cat.DataSourceName,
 ) (cat.DataSource, error) {
 	if desc.IsVirtualTable() {
 		// Virtual tables can have multiple effective instances that utilize the
@@ -423,9 +417,7 @@ var emptyZoneConfig = &zonepb.ZoneConfig{}
 // ZoneConfigs are stored in protobuf binary format in the SystemConfig, which
 // is gossiped around the cluster. Note that the returned ZoneConfig might be
 // somewhat stale, since it's taken from the gossiped SystemConfig.
-func (oc *optCatalog) getZoneConfig(
-	desc *tabledesc.ImmutableTableDescriptor,
-) (*zonepb.ZoneConfig, error) {
+func (oc *optCatalog) getZoneConfig(desc *tabledesc.Immutable) (*zonepb.ZoneConfig, error) {
 	// Lookup table's zone if system config is available (it may not be as node
 	// is starting up and before it's received the gossiped config). If it is
 	// not available, use an empty config that has no zone constraints.
@@ -447,15 +439,15 @@ func (oc *optCatalog) codec() keys.SQLCodec {
 	return oc.planner.ExecCfg().Codec
 }
 
-// optView is a wrapper around sqlbase.ImmutableTableDescriptor that implements
+// optView is a wrapper around sqlbase.Immutable that implements
 // the cat.Object, cat.DataSource, and cat.View interfaces.
 type optView struct {
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 }
 
 var _ cat.View = &optView{}
 
-func newOptView(desc *tabledesc.ImmutableTableDescriptor) *optView {
+func newOptView(desc *tabledesc.Immutable) *optView {
 	return &optView{desc: desc}
 }
 
@@ -503,16 +495,16 @@ func (ov *optView) ColumnName(i int) tree.Name {
 	return tree.Name(ov.desc.Columns[i].Name)
 }
 
-// optSequence is a wrapper around sqlbase.ImmutableTableDescriptor that
+// optSequence is a wrapper around sqlbase.Immutable that
 // implements the cat.Object and cat.DataSource interfaces.
 type optSequence struct {
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 }
 
 var _ cat.DataSource = &optSequence{}
 var _ cat.Sequence = &optSequence{}
 
-func newOptSequence(desc *tabledesc.ImmutableTableDescriptor) *optSequence {
+func newOptSequence(desc *tabledesc.Immutable) *optSequence {
 	return &optSequence{desc: desc}
 }
 
@@ -543,10 +535,10 @@ func (os *optSequence) Name() tree.Name {
 // SequenceMarker is part of the cat.Sequence interface.
 func (os *optSequence) SequenceMarker() {}
 
-// optTable is a wrapper around sqlbase.ImmutableTableDescriptor that caches
+// optTable is a wrapper around sqlbase.Immutable that caches
 // index wrappers and maintains a ColumnID => Column mapping for fast lookup.
 type optTable struct {
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 
 	// columns contains all the columns presented to the catalog. This includes:
 	//  - ordinary table columns (those in the table descriptor)
@@ -598,7 +590,7 @@ type optTable struct {
 var _ cat.Table = &optTable{}
 
 func newOptTable(
-	desc *tabledesc.ImmutableTableDescriptor,
+	desc *tabledesc.Immutable,
 	codec keys.SQLCodec,
 	stats []*stats.TableStatistic,
 	tblZone *zonepb.ZoneConfig,
@@ -838,9 +830,7 @@ func (ot *optTable) PostgresDescriptorID() cat.StableID {
 // isStale checks if the optTable object needs to be refreshed because the stats,
 // zone config, or used types have changed. False positives are ok.
 func (ot *optTable) isStale(
-	rawDesc *tabledesc.ImmutableTableDescriptor,
-	tableStats []*stats.TableStatistic,
-	zone *zonepb.ZoneConfig,
+	rawDesc *tabledesc.Immutable, tableStats []*stats.TableStatistic, zone *zonepb.ZoneConfig,
 ) bool {
 	// Fast check to verify that the statistics haven't changed: we check the
 	// length and the address of the underlying array. This is not a perfect
@@ -1479,7 +1469,7 @@ func (fk *optForeignKeyConstraint) UpdateReferenceAction() tree.ReferenceAction 
 
 // optVirtualTable is similar to optTable but is used with virtual tables.
 type optVirtualTable struct {
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 
 	// columns contains all the columns presented to the catalog. This includes
 	// the dummy PK column and the columns in the table descriptor.
@@ -1518,10 +1508,7 @@ type optVirtualTable struct {
 var _ cat.Table = &optVirtualTable{}
 
 func newOptVirtualTable(
-	ctx context.Context,
-	oc *optCatalog,
-	desc *tabledesc.ImmutableTableDescriptor,
-	name *cat.DataSourceName,
+	ctx context.Context, oc *optCatalog, desc *tabledesc.Immutable, name *cat.DataSourceName,
 ) (*optVirtualTable, error) {
 	// Calculate the stable ID (see the comment for optVirtualTable.id).
 	id := cat.StableID(desc.ID)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -91,7 +91,7 @@ func (oc *optCatalog) reset() {
 type optSchema struct {
 	planner *planner
 
-	database *dbdesc.ImmutableDatabaseDescriptor
+	database *dbdesc.Immutable
 	schema   catalog.ResolvedSchema
 
 	name cat.SchemaName
@@ -184,7 +184,7 @@ func (oc *optCatalog) ResolveSchema(
 	prefix := prefixI.(*catalog.ResolvedObjectPrefix)
 	return &optSchema{
 		planner:  oc.planner,
-		database: prefix.Database.(*dbdesc.ImmutableDatabaseDescriptor),
+		database: prefix.Database.(*dbdesc.Immutable),
 		schema:   prefix.Schema,
 		name:     oc.tn.ObjectNamePrefix,
 	}, oc.tn.ObjectNamePrefix, nil

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -129,7 +129,7 @@ func (ef *execFactory) ConstructScan(
 
 func generateScanSpans(
 	codec keys.SQLCodec,
-	tabDesc *tabledesc.ImmutableTableDescriptor,
+	tabDesc *tabledesc.Immutable,
 	indexDesc *descpb.IndexDescriptor,
 	params exec.ScanParams,
 ) (roachpb.Spans, error) {
@@ -781,7 +781,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 // and requested cols.
 func (ef *execFactory) constructScanForZigzag(
 	indexDesc *descpb.IndexDescriptor,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	cols exec.TableColumnOrdinalSet,
 ) (*scanNode, error) {
 
@@ -1646,7 +1646,7 @@ func (ef *execFactory) ConstructDeleteRange(
 
 	if len(interleavedTables) > 0 {
 		dr.interleavedFastPath = true
-		dr.interleavedDesc = make([]*tabledesc.ImmutableTableDescriptor, len(interleavedTables))
+		dr.interleavedDesc = make([]*tabledesc.Immutable, len(interleavedTables))
 		for i := range dr.interleavedDesc {
 			dr.interleavedDesc[i] = interleavedTables[i].(*optTable).desc
 		}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -307,7 +307,7 @@ CREATE TABLE pg_catalog.pg_am (
 	amhandler OID,
 	amtype CHAR
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// add row for forward indexes
 		if err := addRow(
 			forwardIndexOid,                      // oid - all versions
@@ -402,7 +402,7 @@ CREATE TABLE pg_catalog.pg_attrdef (
   INDEX(adrelid)
 )`,
 	virtualMany, false, /* includesIndexEntries */
-	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.ImmutableDatabaseDescriptor, scName string,
+	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable, scName string,
 		table catalog.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error) error {
@@ -470,7 +470,7 @@ CREATE TABLE pg_catalog.pg_attribute (
   INDEX(attrelid)
 )`,
 	virtualMany, true, /* includesIndexEntries */
-	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.ImmutableDatabaseDescriptor, scName string,
+	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable, scName string,
 		table catalog.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error) error {
@@ -546,7 +546,7 @@ CREATE TABLE pg_catalog.pg_cast (
 	castcontext CHAR,
 	castmethod CHAR
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// TODO(someone): to populate this, we should split up the big PerformCast
 		// method in tree/eval.go into entries in a list. Then, this virtual table
 		// can simply range over the list. This would probably be better for
@@ -574,7 +574,7 @@ CREATE TABLE pg_catalog.pg_authid (
   rolpassword TEXT, 
   rolvaliduntil TIMESTAMPTZ
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRole(ctx, p, func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
 			isRoot := tree.DBool(username == security.RootUser || username == security.AdminRole)
@@ -617,7 +617,7 @@ CREATE TABLE pg_catalog.pg_auth_members (
 	grantor OID,
 	admin_option BOOL
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRoleMembership(ctx, p,
 			func(roleName, memberName string, isAdmin bool) error {
@@ -641,7 +641,7 @@ CREATE TABLE pg_catalog.pg_available_extensions (
 	installed_version TEXT,
 	comment TEXT
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// We support no extensions.
 		return nil
 	},
@@ -693,7 +693,7 @@ CREATE TABLE pg_catalog.pg_class (
   INDEX (oid)
 )`,
 	virtualMany, true, /* includesIndexEntries */
-	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.ImmutableDatabaseDescriptor, scName string,
+	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable, scName string,
 		table catalog.TableDescriptor, _ simpleSchemaResolver, addRow func(...tree.Datum) error) error {
 		// The only difference between tables, views and sequences are the relkind and relam columns.
 		relKind := relKindTable
@@ -801,9 +801,9 @@ CREATE TABLE pg_catalog.pg_collation (
   collcollate STRING,
   collctype STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, false /* requiresPrivileges */, func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+		return forEachDatabaseDesc(ctx, p, dbContext, false /* requiresPrivileges */, func(db *dbdesc.Immutable) error {
 			namespaceOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 			for _, tag := range collate.Supported() {
 				collName := tag.String()
@@ -867,7 +867,7 @@ func populateTableConstraints(
 	ctx context.Context,
 	p *planner,
 	h oidHasher,
-	db *dbdesc.ImmutableDatabaseDescriptor,
+	db *dbdesc.Immutable,
 	scName string,
 	table catalog.TableDescriptor,
 	tableLookup simpleSchemaResolver,
@@ -1013,9 +1013,7 @@ type oneAtATimeSchemaResolver struct {
 	p   *planner
 }
 
-func (r oneAtATimeSchemaResolver) getDatabaseByID(
-	id descpb.ID,
-) (*dbdesc.ImmutableDatabaseDescriptor, error) {
+func (r oneAtATimeSchemaResolver) getDatabaseByID(id descpb.ID) (*dbdesc.Immutable, error) {
 	return r.p.Descriptors().GetDatabaseVersionByID(r.ctx, r.p.txn, id, tree.DatabaseLookupFlags{})
 }
 
@@ -1052,15 +1050,15 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 	schemaDef string,
 	virtualOpts virtualOpts,
 	includesIndexEntries bool,
-	populateFromTable func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.ImmutableDatabaseDescriptor,
+	populateFromTable func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable,
 		scName string, table catalog.TableDescriptor, lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error,
 	) error,
 ) virtualSchemaTable {
-	populateAll := func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populateAll := func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts,
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor, lookup tableLookupFn) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor, lookup tableLookupFn) error {
 				return populateFromTable(ctx, p, h, db, scName, table, lookup, addRow)
 			})
 	}
@@ -1070,7 +1068,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 		indexes: []virtualIndex{
 			{
 				partial: includesIndexEntries,
-				populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.ImmutableDatabaseDescriptor,
+				populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.Immutable,
 					addRow func(...tree.Datum) error) (bool, error) {
 					var id descpb.ID
 					d := tree.UnwrapDatum(p.EvalContext(), constraint)
@@ -1203,7 +1201,7 @@ CREATE TABLE pg_catalog.pg_conversion (
 	conproc OID,
   condefault BOOL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -1228,9 +1226,9 @@ CREATE TABLE pg_catalog.pg_database (
 	dattablespace OID,
 	datacl STRING[]
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, false, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				return addRow(
 					dbOid(db.GetID()),           // oid
 					tree.NewDName(db.GetName()), // datname
@@ -1264,7 +1262,7 @@ CREATE TABLE pg_catalog.pg_default_acl (
 	defaclobjtype CHAR,
 	defaclacl STRING[]
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -1309,7 +1307,7 @@ CREATE TABLE pg_catalog.pg_depend (
   refobjsubid INT4,
   deptype CHAR
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		vt := p.getVirtualTabler()
 		pgConstraintsDesc, err := vt.getVirtualTableDesc(&pgConstraintsTableName)
 		if err != nil {
@@ -1321,7 +1319,7 @@ CREATE TABLE pg_catalog.pg_depend (
 		}
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*virtual tables have no constraints*/, func(
-			db *dbdesc.ImmutableDatabaseDescriptor,
+			db *dbdesc.Immutable,
 			scName string,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -1414,7 +1412,7 @@ CREATE TABLE pg_catalog.pg_description (
 	populate: func(
 		ctx context.Context,
 		p *planner,
-		dbContext *dbdesc.ImmutableDatabaseDescriptor,
+		dbContext *dbdesc.Immutable,
 		addRow func(...tree.Datum) error) error {
 
 		// This is less efficient than it has to be - if we see performance problems
@@ -1467,7 +1465,7 @@ CREATE TABLE pg_catalog.pg_shdescription (
 	classoid OID,
 	description STRING
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// See comment above - could make this more efficient if necessary.
 		comments, err := getComments(ctx, p)
 		if err != nil {
@@ -1502,10 +1500,10 @@ CREATE TABLE pg_catalog.pg_enum (
   enumsortorder FLOAT4,
   enumlabel STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 
-		return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.Immutable) error {
+		return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.Immutable, _ string, typDesc *typedesc.Immutable) error {
 			// We only want to iterate over ENUM types.
 			if typDesc.Kind != descpb.TypeDescriptor_ENUM {
 				return nil
@@ -1541,7 +1539,7 @@ CREATE TABLE pg_catalog.pg_event_trigger (
 	evtenabled CHAR,
 	evttags TEXT[]
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Event triggers are not currently supported.
 		return nil
 	},
@@ -1561,7 +1559,7 @@ CREATE TABLE pg_catalog.pg_extension (
   extconfig STRING,
   extcondition STRING
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Extensions are not supported.
 		return nil
 	},
@@ -1580,7 +1578,7 @@ CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
   fdwacl STRING[],
   fdwoptions STRING[]
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Foreign data wrappers are not supported.
 		return nil
 	},
@@ -1600,7 +1598,7 @@ CREATE TABLE pg_catalog.pg_foreign_server (
   srvacl STRING[],
   srvoptions STRING[]
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Foreign servers are not supported.
 		return nil
 	},
@@ -1615,7 +1613,7 @@ CREATE TABLE pg_catalog.pg_foreign_table (
   ftserver OID,
   ftoptions STRING[]
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Foreign tables are not supported.
 		return nil
 	},
@@ -1656,10 +1654,10 @@ CREATE TABLE pg_catalog.pg_index (
     indexprs STRING,
     indpred STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				tableOid := tableOid(table.GetID())
 				return table.ForeachIndex(catalog.IndexOpts{}, func(index *descpb.IndexDescriptor, isPrimary bool) error {
 					isMutation, isWriteOnly :=
@@ -1743,10 +1741,10 @@ CREATE TABLE pg_catalog.pg_indexes (
 	tablespace NAME,
 	indexdef STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor, tableLookup tableLookupFn) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor, tableLookup tableLookupFn) error {
 				scNameName := tree.NewDName(scName)
 				tblName := tree.NewDName(table.GetName())
 				return table.ForeachIndex(catalog.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
@@ -1773,7 +1771,7 @@ CREATE TABLE pg_catalog.pg_indexes (
 func indexDefFromDescriptor(
 	ctx context.Context,
 	p *planner,
-	db *dbdesc.ImmutableDatabaseDescriptor,
+	db *dbdesc.Immutable,
 	table catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
 	tableLookup tableLookupFn,
@@ -1838,7 +1836,7 @@ CREATE TABLE pg_catalog.pg_inherits (
 	inhparent OID,
 	inhseqno INT4
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Table inheritance is not supported.
 		return nil
 	},
@@ -1859,7 +1857,7 @@ CREATE TABLE pg_catalog.pg_language (
 	lanvalidator OID,
 	lanacl STRING[]
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Languages to write functions and stored procedures are not supported.
 		return nil
 	},
@@ -1886,7 +1884,7 @@ CREATE TABLE pg_catalog.pg_locks (
   granted BOOLEAN,
   fastpath BOOLEAN
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -1904,7 +1902,7 @@ CREATE TABLE pg_catalog.pg_matviews (
   ispopulated BOOL,
   definition TEXT
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -1919,10 +1917,10 @@ CREATE TABLE pg_catalog.pg_namespace (
 	nspowner OID,
 	nspacl STRING[]
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				return forEachSchemaName(ctx, p, db, func(s string, _ bool) error {
 					return addRow(
 						h.NamespaceOid(db.GetID(), s), // oid
@@ -1965,7 +1963,7 @@ CREATE TABLE pg_catalog.pg_operator (
 	oprrest OID,
 	oprjoin OID
 )`,
-	populate: func(ctx context.Context, p *planner, db *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, db *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 		addOp := func(opName string, kind tree.Datum, params tree.TypeList, returnTyper tree.ReturnTyper) error {
@@ -2070,7 +2068,7 @@ CREATE TABLE pg_catalog.pg_prepared_xacts (
   owner NAME,
   database NAME
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -2091,7 +2089,7 @@ CREATE TABLE pg_catalog.pg_prepared_statements (
 	parameter_types REGTYPE[],
 	from_sql boolean
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for name, stmt := range p.preparedStatements.List() {
 			placeholderTypes := stmt.PrepareMetadata.PlaceholderTypesInfo.Types
 			paramTypes := tree.NewDArray(types.RegType)
@@ -2172,10 +2170,10 @@ CREATE TABLE pg_catalog.pg_proc (
 	proconfig STRING[],
 	proacl STRING[]
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 				for _, name := range builtins.AllBuiltinNames {
 					// parser.Builtins contains duplicate uppercase and lowercase keys.
@@ -2309,7 +2307,7 @@ CREATE TABLE pg_catalog.pg_range (
 	rngcanonical OID,
 	rngsubdiff OID
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
 		// oidToDatum (and therefore pg_type).
@@ -2331,7 +2329,7 @@ CREATE TABLE pg_catalog.pg_rewrite (
 	ev_qual TEXT,
 	ev_action TEXT
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Rewrite rules are not supported.
 		return nil
 	},
@@ -2357,7 +2355,7 @@ CREATE TABLE pg_catalog.pg_roles (
 	rolbypassrls BOOL,
 	rolconfig STRING[]
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// We intentionally do not check if the user has access to system.user.
 		// Because Postgres allows access to pg_roles by non-privileged users, we
 		// need to do the same. This shouldn't be an issue, because pg_roles doesn't
@@ -2411,7 +2409,7 @@ CREATE TABLE pg_catalog.pg_seclabels (
 	provider TEXT,
 	label TEXT
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -2430,9 +2428,9 @@ CREATE TABLE pg_catalog.pg_sequence (
 	seqcache INT8,
 	seqcycle BOOL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas do not have indexes */
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				if !table.IsSequence() {
 					return nil
 				}
@@ -2479,7 +2477,7 @@ CREATE TABLE pg_catalog.pg_settings (
     sourceline INT4,
     pending_restart BOOL
 )`,
-	populate: func(_ context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
 			if gen.Hidden {
@@ -2542,7 +2540,7 @@ CREATE TABLE pg_catalog.pg_shdepend (
 	refobjid OID,
 	deptype CHAR
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -2561,12 +2559,12 @@ CREATE TABLE pg_catalog.pg_tables (
 	hastriggers BOOL,
 	rowsecurity BOOL
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Note: pg_catalog.pg_tables is not well-defined if the dbContext is
 		// empty -- listing tables across databases can yield duplicate
 		// schema/table names.
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				if !table.IsTable() {
 					return nil
 				}
@@ -2596,7 +2594,7 @@ CREATE TABLE pg_catalog.pg_tablespace (
 	spcacl TEXT[],
 	spcoptions TEXT[]
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return addRow(
 			oidZero,                       // oid
 			tree.NewDString("pg_default"), // spcname
@@ -2632,7 +2630,7 @@ CREATE TABLE pg_catalog.pg_trigger (
 	tgoldtable NAME,
 	tgnewtable NAME
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Triggers are unsupported.
 		return nil
 	},
@@ -2794,10 +2792,10 @@ CREATE TABLE pg_catalog.pg_type (
 	typacl STRING[],
   INDEX(oid)
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 
 				// Generate rows for all predefined types.
@@ -2808,7 +2806,7 @@ CREATE TABLE pg_catalog.pg_type (
 				}
 
 				// Now generate rows for user defined types in this database.
-				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.Immutable) error {
+				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.Immutable, _ string, typDesc *typedesc.Immutable) error {
 					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, typDesc.ParentSchemaID)
 					if err != nil {
 						return err
@@ -2825,7 +2823,7 @@ CREATE TABLE pg_catalog.pg_type (
 	indexes: []virtualIndex{
 		{
 			partial: false,
-			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.ImmutableDatabaseDescriptor,
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *dbdesc.Immutable,
 				addRow func(...tree.Datum) error) (bool, error) {
 
 				h := makeOidHasher()
@@ -2889,7 +2887,7 @@ CREATE TABLE pg_catalog.pg_user (
 	valuntil TIMESTAMP,
 	useconfig TEXT[]
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
 			func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
@@ -2922,7 +2920,7 @@ CREATE TABLE pg_catalog.pg_user_mapping (
 	umserver OID,
 	umoptions TEXT[]
 )`,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// This table stores the mapping to foreign server users.
 		// Foreign servers are not supported.
 		return nil
@@ -2955,7 +2953,7 @@ CREATE TABLE pg_catalog.pg_stat_activity (
 	query TEXT
 )
 `,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -2972,7 +2970,7 @@ CREATE TABLE pg_catalog.pg_seclabel (
 	label TEXT
 )
 `,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -2988,7 +2986,7 @@ CREATE TABLE pg_catalog.pg_shseclabel (
 	label TEXT
 )
 `,
-	populate: func(ctx context.Context, p *planner, _ *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }
@@ -3078,11 +3076,11 @@ CREATE TABLE pg_catalog.pg_views (
 	viewowner STRING,
 	definition STRING
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		// Note: pg_views is not well defined if the dbContext is empty,
 		// because it does not distinguish views in separate databases.
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /*virtual schemas do not have views*/
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, desc catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, desc catalog.TableDescriptor) error {
 				if !desc.IsView() {
 					return nil
 				}
@@ -3131,10 +3129,10 @@ CREATE TABLE pg_catalog.pg_aggregate (
 	aggminitval TEXT
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
-			func(db *dbdesc.ImmutableDatabaseDescriptor) error {
+			func(db *dbdesc.Immutable) error {
 				for _, name := range builtins.AllAggregateBuiltinNames {
 					if name == builtins.AnyNotNull {
 						// any_not_null is treated as a special case.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1027,15 +1027,13 @@ func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (catalog.TableDescr
 	return table, nil
 }
 
-func (r oneAtATimeSchemaResolver) getSchemaByID(
-	id descpb.ID,
-) (*schemadesc.ImmutableSchemaDescriptor, error) {
+func (r oneAtATimeSchemaResolver) getSchemaByID(id descpb.ID) (*schemadesc.Immutable, error) {
 	// TODO (rohany): This should use the descs.Collection.
 	desc, err := catalogkv.GetAnyDescriptorByID(r.ctx, r.p.txn, r.p.ExecCfg().Codec, id, catalogkv.Immutable)
 	if err != nil {
 		return nil, err
 	}
-	sc, ok := desc.(*schemadesc.ImmutableSchemaDescriptor)
+	sc, ok := desc.(*schemadesc.Immutable)
 	if !ok {
 		return nil, sqlerrors.NewUndefinedSchemaError(fmt.Sprintf("[%d]", id))
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1505,7 +1505,7 @@ CREATE TABLE pg_catalog.pg_enum (
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 
-		return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.ImmutableTypeDescriptor) error {
+		return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.Immutable) error {
 			// We only want to iterate over ENUM types.
 			if typDesc.Kind != descpb.TypeDescriptor_ENUM {
 				return nil
@@ -2808,7 +2808,7 @@ CREATE TABLE pg_catalog.pg_type (
 				}
 
 				// Now generate rows for user defined types in this database.
-				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.ImmutableTypeDescriptor) error {
+				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.ImmutableDatabaseDescriptor, _ string, typDesc *typedesc.Immutable) error {
 					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, typDesc.ParentSchemaID)
 					if err != nil {
 						return err

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -41,14 +41,14 @@ var pgExtension = virtualSchema{
 
 func postgisColumnsTablePopulator(
 	matchingFamily types.Family,
-) func(context.Context, *planner, *dbdesc.ImmutableDatabaseDescriptor, func(...tree.Datum) error) error {
-	return func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+) func(context.Context, *planner, *dbdesc.Immutable, func(...tree.Datum) error) error {
+	return func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(
 			ctx,
 			p,
 			dbContext,
 			hideVirtual,
-			func(db *dbdesc.ImmutableDatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
+			func(db *dbdesc.Immutable, scName string, table catalog.TableDescriptor) error {
 				if !table.IsPhysicalTable() {
 					return nil
 				}
@@ -140,7 +140,7 @@ CREATE TABLE pg_extension.spatial_ref_sys (
 	srtext varchar(2048),
 	proj4text varchar(2048)
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		for _, projection := range geoprojbase.Projections {
 			if err := addRow(
 				tree.NewDInt(tree.DInt(projection.SRID)),

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":522,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":520,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -117,7 +117,7 @@ func checkDistAggregationInfo(
 	ctx context.Context,
 	t *testing.T,
 	srv serverutils.TestServerInterface,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	colIdx int,
 	numRows int,
 	fn execinfrapb.AggregatorSpec_Func,

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -167,7 +167,7 @@ func populateCache(db *gosql.DB, expectedNumRows int) error {
 // `CREATE TABLE test (k INT PRIMARY KEY)` at row with value pk (the row will be
 // the first on the right of the split).
 func splitRangeAtVal(
-	ts *server.TestServer, tableDesc *tabledesc.ImmutableTableDescriptor, pk int,
+	ts *server.TestServer, tableDesc *tabledesc.Immutable, pk int,
 ) (roachpb.RangeDescriptor, roachpb.RangeDescriptor, error) {
 	if len(tableDesc.Indexes) != 0 {
 		return roachpb.RangeDescriptor{}, roachpb.RangeDescriptor{},
@@ -321,7 +321,7 @@ func TestMixedDirections(t *testing.T) {
 
 func setupRanges(
 	db *gosql.DB, s *server.TestServer, cdb *kv.DB, t *testing.T,
-) ([]roachpb.RangeDescriptor, *tabledesc.ImmutableTableDescriptor) {
+) ([]roachpb.RangeDescriptor, *tabledesc.Immutable) {
 	if _, err := db.Exec(`CREATE DATABASE t`); err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func expectResolved(actual [][]rngInfo, expected ...[]rngInfo) error {
 	return nil
 }
 
-func makeSpan(tableDesc *tabledesc.ImmutableTableDescriptor, i, j int) roachpb.Span {
+func makeSpan(tableDesc *tabledesc.Immutable, i, j int) roachpb.Span {
 	makeKey := func(val int) roachpb.Key {
 		key, err := rowenc.TestingMakePrimaryIndexKey(tableDesc, val)
 		if err != nil {

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -97,7 +97,7 @@ type PlanHookState interface {
 		ctx context.Context, tn *TableName, required bool, requiredType tree.RequiredTableKind,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
-		ctx context.Context, dbPrefix string, allDescs []descpb.Descriptor, desc *tabledesc.ImmutableTableDescriptor, displayOptions ShowCreateDisplayOptions,
+		ctx context.Context, dbPrefix string, allDescs []descpb.Descriptor, desc *tabledesc.Immutable, displayOptions ShowCreateDisplayOptions,
 	) (string, error)
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -487,7 +487,7 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tre
 //  of having its own logic for lookups.
 func (p *planner) LookupTableByID(
 	ctx context.Context, tableID descpb.ID,
-) (*tabledesc.ImmutableTableDescriptor, error) {
+) (*tabledesc.Immutable, error) {
 	if entry, err := p.getVirtualTabler().getVirtualTableEntryByID(tableID); err == nil {
 		return entry.desc, nil
 	}

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -24,7 +24,7 @@ import (
 
 type refreshMaterializedViewNode struct {
 	n    *tree.RefreshMaterializedView
-	desc *tabledesc.MutableTableDescriptor
+	desc *tabledesc.Mutable
 }
 
 func (p *planner) RefreshMaterializedView(

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -30,7 +30,7 @@ type relocateNode struct {
 	optColumnsSlot
 
 	relocateLease bool
-	tableDesc     *tabledesc.ImmutableTableDescriptor
+	tableDesc     *tabledesc.Immutable
 	index         *descpb.IndexDescriptor
 	rows          planNode
 

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -29,7 +29,7 @@ var errEmptyColumnName = pgerror.New(pgcode.Syntax, "empty column name")
 
 type renameColumnNode struct {
 	n         *tree.RenameColumn
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 }
 
 // RenameColumn renames the column.
@@ -89,7 +89,7 @@ func (n *renameColumnNode) startExec(params runParams) error {
 // the column being renamed is a generated column for a hash sharded index.
 func (p *planner) renameColumn(
 	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	oldName, newName *tree.Name,
 	allowRenameOfShardColumn bool,
 ) (changed bool, err error) {

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -32,7 +32,7 @@ import (
 
 type renameDatabaseNode struct {
 	n       *tree.RenameDatabase
-	dbDesc  *dbdesc.MutableDatabaseDescriptor
+	dbDesc  *dbdesc.Mutable
 	newName string
 }
 

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -240,7 +240,7 @@ func isAllowedDependentDescInRenameDatabase(
 	ctx context.Context,
 	dependedOn *descpb.TableDescriptor_Reference,
 	tbDesc catalog.TableDescriptor,
-	dependentDesc *tabledesc.ImmutableTableDescriptor,
+	dependentDesc *tabledesc.Immutable,
 	dbName string,
 ) (bool, string, error) {
 	// If it is a sequence, and it does not contain the database name, then we have

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -27,7 +27,7 @@ var errEmptyIndexName = pgerror.New(pgcode.Syntax, "empty index name")
 
 type renameIndexNode struct {
 	n         *tree.RenameIndex
-	tableDesc *tabledesc.MutableTableDescriptor
+	tableDesc *tabledesc.Mutable
 	idx       *descpb.IndexDescriptor
 }
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -32,7 +32,7 @@ import (
 type renameTableNode struct {
 	n            *tree.RenameTable
 	oldTn, newTn *tree.TableName
-	tableDesc    *tabledesc.MutableTableDescriptor
+	tableDesc    *tabledesc.Mutable
 }
 
 // RenameTable renames the table, view or sequence.

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -33,8 +33,8 @@ import (
 
 type reparentDatabaseNode struct {
 	n         *tree.ReparentDatabase
-	db        *dbdesc.MutableDatabaseDescriptor
-	newParent *dbdesc.MutableDatabaseDescriptor
+	db        *dbdesc.Mutable
+	newParent *dbdesc.Mutable
 }
 
 func (p *planner) ReparentDatabase(

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -159,9 +159,9 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 		}
 		if found {
 			// Remap the ID's on the table.
-			tbl, ok := desc.(*tabledesc.MutableTableDescriptor)
+			tbl, ok := desc.(*tabledesc.Mutable)
 			if !ok {
-				return errors.AssertionFailedf("%q was not a MutableTableDescriptor", objName.Object())
+				return errors.AssertionFailedf("%q was not a Mutable", objName.Object())
 			}
 
 			// If this table has any dependents, then we can't proceed (similar to the

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -226,9 +226,9 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 				continue
 			}
 			// Remap the ID's on the type.
-			typ, ok := desc.(*typedesc.MutableTypeDescriptor)
+			typ, ok := desc.(*typedesc.Mutable)
 			if !ok {
-				return errors.AssertionFailedf("%q was not a MutableTypeDescriptor", objName.Object())
+				return errors.AssertionFailedf("%q was not a Mutable", objName.Object())
 			}
 			typ.AddDrainingName(descpb.NameInfo{
 				ParentID:       typ.ParentID,

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -497,7 +497,7 @@ func (p *planner) getTableAndIndex(
 		return nil, nil, err
 	}
 	optIdx := idx.(*optIndex)
-	return tabledesc.NewMutableExistingTableDescriptor(optIdx.tab.desc.TableDescriptor), optIdx.desc, nil
+	return tabledesc.NewExistingMutable(optIdx.tab.desc.TableDescriptor), optIdx.desc, nil
 }
 
 // expandTableGlob expands pattern into a list of objects represented
@@ -520,7 +520,7 @@ func expandTableGlob(
 type fkSelfResolver struct {
 	resolver.SchemaResolver
 	newTableName *tree.TableName
-	newTableDesc *tabledesc.MutableTableDescriptor
+	newTableDesc *tabledesc.Mutable
 }
 
 var _ resolver.SchemaResolver = &fkSelfResolver{}
@@ -536,7 +536,7 @@ func (r *fkSelfResolver) LookupObject(
 		if lookupFlags.RequireMutable {
 			return true, table, nil
 		}
-		return true, &table.ImmutableTableDescriptor, nil
+		return true, &table.Immutable, nil
 	}
 	lookupFlags.IncludeOffline = false
 	return r.SchemaResolver.LookupObject(ctx, lookupFlags, dbName, scName, tbName)
@@ -578,7 +578,7 @@ func newInternalLookupCtxFromDescriptors(
 		case *descpb.Descriptor_Database:
 			descs[i] = dbdesc.NewImmutableDatabaseDescriptor(*t.Database)
 		case *descpb.Descriptor_Table:
-			descs[i] = tabledesc.NewImmutableTableDescriptor(*t.Table)
+			descs[i] = tabledesc.NewImmutable(*t.Table)
 		case *descpb.Descriptor_Type:
 			descs[i] = typedesc.NewImmutableTypeDescriptor(*t.Type)
 		case *descpb.Descriptor_Schema:
@@ -606,7 +606,7 @@ func newInternalLookupCtx(
 			if prefix == nil || prefix.GetID() == desc.GetID() {
 				dbIDs = append(dbIDs, desc.GetID())
 			}
-		case *tabledesc.ImmutableTableDescriptor:
+		case *tabledesc.Immutable:
 			tbDescs[desc.GetID()] = desc
 			if prefix == nil || prefix.GetID() == desc.ParentID {
 				// Only make the table visible for iteration if the prefix was included.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -205,7 +205,7 @@ func (p *planner) ResolveType(
 		return nil, err
 	}
 	tn := tree.MakeNewQualifiedTypeName(prefix.Catalog(), prefix.Schema(), name.Object())
-	tdesc := desc.(*typedesc.ImmutableTypeDescriptor)
+	tdesc := desc.(*typedesc.Immutable)
 
 	// Disllow cross-database type resolution. Note that we check
 	// p.contextDatabaseID != descpb.InvalidID when we have been restricted to
@@ -557,7 +557,7 @@ type internalLookupCtx struct {
 	schemaDescs map[descpb.ID]*schemadesc.Immutable
 	tbDescs     map[descpb.ID]*ImmutableTableDescriptor
 	tbIDs       []descpb.ID
-	typDescs    map[descpb.ID]*typedesc.ImmutableTypeDescriptor
+	typDescs    map[descpb.ID]*typedesc.Immutable
 	typIDs      []descpb.ID
 }
 
@@ -580,7 +580,7 @@ func newInternalLookupCtxFromDescriptors(
 		case *descpb.Descriptor_Table:
 			descs[i] = tabledesc.NewImmutable(*t.Table)
 		case *descpb.Descriptor_Type:
-			descs[i] = typedesc.NewImmutableTypeDescriptor(*t.Type)
+			descs[i] = typedesc.NewImmutable(*t.Type)
 		case *descpb.Descriptor_Schema:
 			descs[i] = schemadesc.NewImmutable(*t.Schema)
 		}
@@ -595,7 +595,7 @@ func newInternalLookupCtx(
 	dbDescs := make(map[descpb.ID]*dbdesc.ImmutableDatabaseDescriptor)
 	schemaDescs := make(map[descpb.ID]*schemadesc.Immutable)
 	tbDescs := make(map[descpb.ID]*ImmutableTableDescriptor)
-	typDescs := make(map[descpb.ID]*typedesc.ImmutableTypeDescriptor)
+	typDescs := make(map[descpb.ID]*typedesc.Immutable)
 	var tbIDs, typIDs, dbIDs []descpb.ID
 	// Record database descriptors for name lookups.
 	for i := range descs {
@@ -612,7 +612,7 @@ func newInternalLookupCtx(
 				// Only make the table visible for iteration if the prefix was included.
 				tbIDs = append(tbIDs, desc.ID)
 			}
-		case *typedesc.ImmutableTypeDescriptor:
+		case *typedesc.Immutable:
 			typDescs[desc.GetID()] = desc
 			if prefix == nil || prefix.GetID() == desc.ParentID {
 				// Only make the type visible for iteration if the prefix was included.
@@ -733,7 +733,7 @@ func getTableNameFromTableDescriptor(
 // ResolveMutableTypeDescriptor resolves a type descriptor for mutable access.
 func (p *planner) ResolveMutableTypeDescriptor(
 	ctx context.Context, name *tree.UnresolvedObjectName, required bool,
-) (*typedesc.MutableTypeDescriptor, error) {
+) (*typedesc.Mutable, error) {
 	tn, desc, err := resolver.ResolveMutableType(ctx, p, name, required)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -554,7 +554,7 @@ type internalLookupCtx struct {
 	dbNames     map[descpb.ID]string
 	dbIDs       []descpb.ID
 	dbDescs     map[descpb.ID]*dbdesc.ImmutableDatabaseDescriptor
-	schemaDescs map[descpb.ID]*schemadesc.ImmutableSchemaDescriptor
+	schemaDescs map[descpb.ID]*schemadesc.Immutable
 	tbDescs     map[descpb.ID]*ImmutableTableDescriptor
 	tbIDs       []descpb.ID
 	typDescs    map[descpb.ID]*typedesc.ImmutableTypeDescriptor
@@ -582,7 +582,7 @@ func newInternalLookupCtxFromDescriptors(
 		case *descpb.Descriptor_Type:
 			descs[i] = typedesc.NewImmutableTypeDescriptor(*t.Type)
 		case *descpb.Descriptor_Schema:
-			descs[i] = schemadesc.NewImmutableSchemaDescriptor(*t.Schema)
+			descs[i] = schemadesc.NewImmutable(*t.Schema)
 		}
 	}
 	return newInternalLookupCtx(descs, prefix)
@@ -593,7 +593,7 @@ func newInternalLookupCtx(
 ) *internalLookupCtx {
 	dbNames := make(map[descpb.ID]string)
 	dbDescs := make(map[descpb.ID]*dbdesc.ImmutableDatabaseDescriptor)
-	schemaDescs := make(map[descpb.ID]*schemadesc.ImmutableSchemaDescriptor)
+	schemaDescs := make(map[descpb.ID]*schemadesc.Immutable)
 	tbDescs := make(map[descpb.ID]*ImmutableTableDescriptor)
 	typDescs := make(map[descpb.ID]*typedesc.ImmutableTypeDescriptor)
 	var tbIDs, typIDs, dbIDs []descpb.ID
@@ -618,7 +618,7 @@ func newInternalLookupCtx(
 				// Only make the type visible for iteration if the prefix was included.
 				typIDs = append(typIDs, desc.GetID())
 			}
-		case *schemadesc.ImmutableSchemaDescriptor:
+		case *schemadesc.Immutable:
 			schemaDescs[desc.GetID()] = desc
 		}
 	}
@@ -653,9 +653,7 @@ func (l *internalLookupCtx) getTableByID(id descpb.ID) (catalog.TableDescriptor,
 	return tb, nil
 }
 
-func (l *internalLookupCtx) getSchemaByID(
-	id descpb.ID,
-) (*schemadesc.ImmutableSchemaDescriptor, error) {
+func (l *internalLookupCtx) getSchemaByID(id descpb.ID) (*schemadesc.Immutable, error) {
 	sc, ok := l.schemaDescs[id]
 	if !ok {
 		return nil, sqlerrors.NewUndefinedSchemaError(fmt.Sprintf("[%d]", id))
@@ -829,6 +827,6 @@ func (p *planner) ResolvedName(u *tree.UnresolvedObjectName) tree.ObjectName {
 
 type simpleSchemaResolver interface {
 	getDatabaseByID(id descpb.ID) (*dbdesc.ImmutableDatabaseDescriptor, error)
-	getSchemaByID(id descpb.ID) (*schemadesc.ImmutableSchemaDescriptor, error)
+	getSchemaByID(id descpb.ID) (*schemadesc.Immutable, error)
 	getTableByID(id descpb.ID) (catalog.TableDescriptor, error)
 }

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -33,7 +33,7 @@ func RevertTables(
 	ctx context.Context,
 	db *kv.DB,
 	execCfg *ExecutorConfig,
-	tables []*tabledesc.ImmutableTableDescriptor,
+	tables []*tabledesc.Immutable,
 	targetTime hlc.Timestamp,
 	batchSize int64,
 ) error {

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -80,7 +80,7 @@ func TestRevertTable(t *testing.T) {
 		// Revert the table to ts.
 		desc := catalogkv.TestingGetTableDescriptor(kv, keys.SystemSQLCodec, "test", "test")
 		desc.State = descpb.TableDescriptor_OFFLINE // bypass the offline check.
-		require.NoError(t, sql.RevertTables(context.Background(), kv, &execCfg, []*tabledesc.ImmutableTableDescriptor{desc}, targetTime, 10))
+		require.NoError(t, sql.RevertTables(context.Background(), kv, &execCfg, []*tabledesc.Immutable{desc}, targetTime, 10))
 
 		var reverted int
 		db.QueryRow(t, `SELECT xor_agg(k # rev) FROM test`).Scan(&reverted)
@@ -109,14 +109,14 @@ func TestRevertTable(t *testing.T) {
 		child := catalogkv.TestingGetTableDescriptor(kv, keys.SystemSQLCodec, "test", "child")
 		child.State = descpb.TableDescriptor_OFFLINE
 		t.Run("reject only parent", func(t *testing.T) {
-			require.Error(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.ImmutableTableDescriptor{desc}, targetTime, 10))
+			require.Error(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.Immutable{desc}, targetTime, 10))
 		})
 		t.Run("reject only child", func(t *testing.T) {
-			require.Error(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.ImmutableTableDescriptor{child}, targetTime, 10))
+			require.Error(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.Immutable{child}, targetTime, 10))
 		})
 
 		t.Run("rollback parent and child", func(t *testing.T) {
-			require.NoError(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.ImmutableTableDescriptor{desc, child}, targetTime, sql.RevertTableDefaultBatchSize))
+			require.NoError(t, sql.RevertTables(ctx, kv, &execCfg, []*tabledesc.Immutable{desc, child}, targetTime, sql.RevertTableDefaultBatchSize))
 
 			var reverted, revertedChild int
 			db.QueryRow(t, `SELECT xor_agg(k # rev) FROM test`).Scan(&reverted)

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -38,9 +38,7 @@ type Deleter struct {
 // expectation of which values are passed as values to DeleteRow. Any column
 // passed in requestedCols will be included in FetchCols.
 func MakeDeleter(
-	codec keys.SQLCodec,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
-	requestedCols []descpb.ColumnDescriptor,
+	codec keys.SQLCodec, tableDesc *tabledesc.Immutable, requestedCols []descpb.ColumnDescriptor,
 ) Deleter {
 	indexes := tableDesc.DeletableIndexes()
 

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -89,7 +89,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	parentDesc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `parent`)
 	childDesc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `child`)
 	var args []row.FetcherTableArgs
-	for _, desc := range []*tabledesc.ImmutableTableDescriptor{parentDesc, childDesc} {
+	for _, desc := range []*tabledesc.Immutable{parentDesc, childDesc} {
 		colIdxMap := make(map[descpb.ColumnID]int)
 		var valNeededForCol util.FastIntSet
 		for colIdx := range desc.Columns {

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 type initFetcherArgs struct {
-	tableDesc       *tabledesc.ImmutableTableDescriptor
+	tableDesc       *tabledesc.Immutable
 	indexIdx        int
 	valNeededForCol util.FastIntSet
 	spans           roachpb.Spans

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -45,7 +45,7 @@ func MakeInserter(
 	ctx context.Context,
 	txn *kv.Txn,
 	codec keys.SQLCodec,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	insertCols []descpb.ColumnDescriptor,
 	alloc *rowenc.DatumAlloc,
 ) (Inserter, error) {

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -89,7 +89,7 @@ func GenerateInsertRow(
 	insertCols []descpb.ColumnDescriptor,
 	computedColsLookup []descpb.ColumnDescriptor,
 	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	rowVals tree.Datums,
 	rowContainerForComputedVals *schemaexpr.RowIndexedVarContainer,
 ) (tree.Datums, error) {
@@ -201,7 +201,7 @@ type DatumRowConverter struct {
 	KvBatch  KVBatch
 	BatchCap int
 
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 
 	// Tracks which column indices in the set of visible columns are part of the
 	// user specified target columns. This can be used before populating Datums
@@ -237,7 +237,7 @@ func TestingSetDatumRowConverterBatchSize(newSize int) func() {
 // NewDatumRowConverter returns an instance of a DatumRowConverter.
 func NewDatumRowConverter(
 	ctx context.Context,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	targetColNames tree.NameList,
 	evalCtx *tree.EvalContext,
 	kvCh chan<- KVBatch,

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -82,7 +82,7 @@ func MakeUpdater(
 	ctx context.Context,
 	txn *kv.Txn,
 	codec keys.SQLCodec,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	updateCols []descpb.ColumnDescriptor,
 	requestedCols []descpb.ColumnDescriptor,
 	updateType rowUpdaterType,

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -49,9 +49,7 @@ type indexKeyTest struct {
 	secondaryValues      []tree.Datum // len must be at least secondaryInterleaveComponents+1
 }
 
-func makeTableDescForTest(
-	test indexKeyTest,
-) (*tabledesc.ImmutableTableDescriptor, map[descpb.ColumnID]int) {
+func makeTableDescForTest(test indexKeyTest) (*tabledesc.Immutable, map[descpb.ColumnID]int) {
 	primaryColumnIDs := make([]descpb.ColumnID, len(test.primaryValues))
 	secondaryColumnIDs := make([]descpb.ColumnID, len(test.secondaryValues))
 	columns := make([]descpb.ColumnDescriptor, len(test.primaryValues)+len(test.secondaryValues))
@@ -101,14 +99,11 @@ func makeTableDescForTest(
 			Interleave:       makeInterleave(2, test.secondaryInterleaves),
 		}},
 	}
-	return tabledesc.NewImmutableTableDescriptor(tableDesc), colMap
+	return tabledesc.NewImmutable(tableDesc), colMap
 }
 
 func decodeIndex(
-	codec keys.SQLCodec,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
-	index *descpb.IndexDescriptor,
-	key []byte,
+	codec keys.SQLCodec, tableDesc *tabledesc.Immutable, index *descpb.IndexDescriptor, key []byte,
 ) ([]tree.Datum, error) {
 	types, err := colinfo.GetColumnTypes(tableDesc, index.ColumnIDs)
 	if err != nil {

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -38,7 +38,7 @@ type bulkRowWriter struct {
 	flowCtx        *execinfra.FlowCtx
 	processorID    int32
 	batchIdxAtomic int64
-	tableDesc      tabledesc.ImmutableTableDescriptor
+	tableDesc      tabledesc.Immutable
 	spec           execinfrapb.BulkRowWriterSpec
 	input          execinfra.RowSource
 	output         execinfra.RowReceiver
@@ -59,7 +59,7 @@ func newBulkRowWriterProcessor(
 		flowCtx:        flowCtx,
 		processorID:    processorID,
 		batchIdxAtomic: 0,
-		tableDesc:      tabledesc.MakeImmutableTableDescriptor(spec.Table),
+		tableDesc:      tabledesc.MakeImmutable(spec.Table),
 		spec:           spec,
 		input:          input,
 		output:         output,

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -29,7 +29,7 @@ type columnBackfiller struct {
 
 	backfill.ColumnBackfiller
 
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 }
 
 var _ execinfra.Processor = &columnBackfiller{}
@@ -44,7 +44,7 @@ func newColumnBackfiller(
 	output execinfra.RowReceiver,
 ) (*columnBackfiller, error) {
 	cb := &columnBackfiller{
-		desc: tabledesc.NewImmutableTableDescriptor(spec.Table),
+		desc: tabledesc.NewImmutable(spec.Table),
 		backfiller: backfiller{
 			name:        "Column",
 			filter:      backfill.ColumnMutationFilter,

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -39,7 +39,7 @@ type indexBackfiller struct {
 
 	adder kvserverbase.BulkAdder
 
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 }
 
 var _ execinfra.Processor = &indexBackfiller{}
@@ -70,7 +70,7 @@ func newIndexBackfiller(
 	output execinfra.RowReceiver,
 ) (*indexBackfiller, error) {
 	ib := &indexBackfiller{
-		desc: tabledesc.NewImmutableTableDescriptor(spec.Table),
+		desc: tabledesc.NewImmutable(spec.Table),
 		backfiller: backfiller{
 			name:        "Index",
 			filter:      backfill.IndexMutationFilter,
@@ -131,7 +131,7 @@ func (ib *indexBackfiller) wrapDupError(ctx context.Context, orig error) error {
 	}
 
 	desc, err := ib.desc.MakeFirstMutationPublic(tabledesc.IncludeConstraints)
-	immutable := tabledesc.NewImmutableTableDescriptor(*desc.TableDesc())
+	immutable := tabledesc.NewImmutable(*desc.TableDesc())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -308,9 +308,9 @@ func newInterleavedReaderJoiner(
 			}
 		}
 	}
-	tableDescs := make([]*tabledesc.ImmutableTableDescriptor, len(spec.Tables))
+	tableDescs := make([]*tabledesc.Immutable, len(spec.Tables))
 	for i, raw := range spec.Tables {
-		tableDescs[i] = tabledesc.NewImmutableTableDescriptor(raw.Desc)
+		tableDescs[i] = tabledesc.NewImmutable(raw.Desc)
 	}
 	tables := make([]tableInfo, len(spec.Tables))
 	// We need to take spans from all tables and merge them together
@@ -429,7 +429,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	args := make([]row.FetcherTableArgs, len(tables))
 
 	for i, table := range tables {
-		desc := tabledesc.NewImmutableTableDescriptor(table.Desc)
+		desc := tabledesc.NewImmutable(table.Desc)
 		var err error
 		args[i].Index, args[i].IsSecondaryIndex, err = desc.FindIndexByIndexIdx(int(table.IndexIdx))
 		if err != nil {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -62,7 +62,7 @@ type invertedJoiner struct {
 
 	runningState invertedJoinerState
 	diskMonitor  *mon.BytesMonitor
-	desc         tabledesc.ImmutableTableDescriptor
+	desc         tabledesc.Immutable
 	// The map from ColumnIDs in the table to the column position.
 	colIdxMap map[descpb.ColumnID]int
 	index     *descpb.IndexDescriptor
@@ -161,7 +161,7 @@ func newInvertedJoiner(
 	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
 	ij := &invertedJoiner{
-		desc:                 tabledesc.MakeImmutableTableDescriptor(spec.Table),
+		desc:                 tabledesc.MakeImmutable(spec.Table),
 		input:                input,
 		inputTypes:           input.OutputTypes(),
 		datumsToInvertedExpr: datumsToInvertedExpr,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -71,7 +71,7 @@ type joinReader struct {
 
 	diskMonitor *mon.BytesMonitor
 
-	desc      tabledesc.ImmutableTableDescriptor
+	desc      tabledesc.Immutable
 	index     *descpb.IndexDescriptor
 	colIdxMap map[descpb.ColumnID]int
 
@@ -136,7 +136,7 @@ func newJoinReader(
 		return nil, errors.Errorf("unsupported joinReaderType")
 	}
 	jr := &joinReader{
-		desc:       tabledesc.MakeImmutableTableDescriptor(spec.Table),
+		desc:       tabledesc.MakeImmutable(spec.Table),
 		input:      input,
 		inputTypes: input.OutputTypes(),
 		lookupCols: lookupCols,

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -409,7 +409,7 @@ func TestJoinReader(t *testing.T) {
 	)
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
-	for i, td := range []*tabledesc.ImmutableTableDescriptor{tdSecondary, tdFamily, tdInterleaved} {
+	for i, td := range []*tabledesc.Immutable{tdSecondary, tdFamily, tdInterleaved} {
 		for _, c := range testCases {
 			for _, reqOrdering := range []bool{true, false} {
 				t.Run(fmt.Sprintf("%d/reqOrdering=%t/%s", i, reqOrdering, c.description), func(t *testing.T) {

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -58,7 +58,7 @@ type rowFetcher interface {
 func initRowFetcher(
 	flowCtx *execinfra.FlowCtx,
 	fetcher *row.Fetcher,
-	desc *tabledesc.ImmutableTableDescriptor,
+	desc *tabledesc.Immutable,
 	indexIdx int,
 	colIdxMap map[descpb.ColumnID]int,
 	reverseScan bool,

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -47,7 +47,7 @@ var ScrubTypes = []*types.T{
 
 type scrubTableReader struct {
 	tableReader
-	tableDesc tabledesc.ImmutableTableDescriptor
+	tableDesc tabledesc.Immutable
 	// fetcherResultToColIdx maps Fetcher results to the column index in
 	// the TableDescriptor. This is only initialized and used during scrub
 	// physical checks.
@@ -78,7 +78,7 @@ func newScrubTableReader(
 		indexIdx: int(spec.IndexIdx),
 	}
 
-	tr.tableDesc = tabledesc.MakeImmutableTableDescriptor(spec.Table)
+	tr.tableDesc = tabledesc.MakeImmutable(spec.Table)
 	tr.limitHint = execinfra.LimitHint(spec.LimitHint, post)
 
 	if err := tr.Init(

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -90,7 +90,7 @@ func newTableReader(
 	tr.parallelize = spec.Parallelize && tr.limitHint == 0
 	tr.maxTimestampAge = time.Duration(spec.MaxTimestampAgeNanos)
 
-	tableDesc := tabledesc.NewImmutableTableDescriptor(spec.Table)
+	tableDesc := tabledesc.NewImmutable(spec.Table)
 	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	resultTypes := tableDesc.ColumnTypesWithMutations(returnMutations)
 	columnIdxMap := tableDesc.ColumnIdxMapWithMutations(returnMutations)

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -280,9 +280,9 @@ func newZigzagJoiner(
 	z := &zigzagJoiner{}
 
 	// TODO(ajwerner): Utilize a cached copy of these tables.
-	tables := make([]tabledesc.ImmutableTableDescriptor, len(spec.Tables))
+	tables := make([]tabledesc.Immutable, len(spec.Tables))
 	for i := range spec.Tables {
-		tables[i] = tabledesc.MakeImmutableTableDescriptor(spec.Tables[i])
+		tables[i] = tabledesc.MakeImmutable(spec.Tables[i])
 	}
 	leftColumnTypes := tables[0].ColumnTypes()
 	rightColumnTypes := tables[1].ColumnTypes()
@@ -368,7 +368,7 @@ func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
 type zigzagJoinerInfo struct {
 	fetcher    row.Fetcher
 	alloc      *rowenc.DatumAlloc
-	table      *tabledesc.ImmutableTableDescriptor
+	table      *tabledesc.Immutable
 	index      *descpb.IndexDescriptor
 	indexTypes []*types.T
 	indexDirs  []descpb.IndexDescriptor_Direction
@@ -405,7 +405,7 @@ func (z *zigzagJoiner) setupInfo(
 	spec *execinfrapb.ZigzagJoinerSpec,
 	side int,
 	colOffset int,
-	tables []tabledesc.ImmutableTableDescriptor,
+	tables []tabledesc.Immutable,
 ) error {
 	z.side = side
 	info := z.infos[side]

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -44,7 +44,7 @@ type scanNode struct {
 	// Enforce this using NoCopy.
 	_ util.NoCopy
 
-	desc  *tabledesc.ImmutableTableDescriptor
+	desc  *tabledesc.Immutable
 	index *descpb.IndexDescriptor
 
 	// Set if an index was explicitly specified.
@@ -194,7 +194,7 @@ func (n *scanNode) limitHint() int64 {
 func (n *scanNode) initTable(
 	ctx context.Context,
 	p *planner,
-	desc *tabledesc.ImmutableTableDescriptor,
+	desc *tabledesc.Immutable,
 	indexFlags *tree.IndexFlags,
 	colCfg scanColumnsConfig,
 ) error {
@@ -257,7 +257,7 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 
 // initColsForScan initializes cols according to desc and colCfg.
 func initColsForScan(
-	desc *tabledesc.ImmutableTableDescriptor, colCfg scanColumnsConfig,
+	desc *tabledesc.Immutable, colCfg scanColumnsConfig,
 ) (cols []*descpb.ColumnDescriptor, err error) {
 	if colCfg.wantedColumns == nil {
 		return nil, errors.AssertionFailedf("unexpectedly wantedColumns is nil")

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -43,9 +43,7 @@ func (p *planner) schemaExists(
 	return exists, nil
 }
 
-func (p *planner) writeSchemaDesc(
-	ctx context.Context, desc *schemadesc.MutableSchemaDescriptor,
-) error {
+func (p *planner) writeSchemaDesc(ctx context.Context, desc *schemadesc.Mutable) error {
 	desc.MaybeIncrementVersion()
 	p.Descriptors().ResetSchemaCache()
 	if err := p.Descriptors().AddUncommittedDescriptor(desc); err != nil {
@@ -67,7 +65,7 @@ func (p *planner) writeSchemaDesc(
 }
 
 func (p *planner) writeSchemaDescChange(
-	ctx context.Context, desc *schemadesc.MutableSchemaDescriptor, jobDesc string,
+	ctx context.Context, desc *schemadesc.Mutable, jobDesc string,
 ) error {
 	job, jobExists := p.extendedEvalCtx.SchemaChangeJobCache[desc.ID]
 	if jobExists {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -50,10 +50,10 @@ type (
 	ImmutableDatabaseDescriptor = dbdesc.ImmutableDatabaseDescriptor
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	MutableTableDescriptor = tabledesc.MutableTableDescriptor
+	MutableTableDescriptor = tabledesc.Mutable
 	// ImmutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	ImmutableTableDescriptor = tabledesc.ImmutableTableDescriptor
+	ImmutableTableDescriptor = tabledesc.Immutable
 	// TableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TableDescriptor = descpb.TableDescriptor

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -74,5 +74,5 @@ type (
 	TableNames = tree.TableNames
 	// MutableSchemaDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	MutableSchemaDescriptor = schemadesc.MutableSchemaDescriptor
+	MutableSchemaDescriptor = schemadesc.Mutable
 )

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -44,10 +44,10 @@ type (
 	DatabaseDescriptor = descpb.DatabaseDescriptor
 	// MutableDatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	MutableDatabaseDescriptor = dbdesc.MutableDatabaseDescriptor
+	MutableDatabaseDescriptor = dbdesc.Mutable
 	// ImmutableDatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	ImmutableDatabaseDescriptor = dbdesc.ImmutableDatabaseDescriptor
+	ImmutableDatabaseDescriptor = dbdesc.Immutable
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	MutableTableDescriptor = tabledesc.Mutable

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -62,7 +62,7 @@ type (
 	TypeDescriptor = descpb.TypeDescriptor
 	// MutableTypeDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	MutableTypeDescriptor = typedesc.MutableTypeDescriptor
+	MutableTypeDescriptor = typedesc.Mutable
 	// ViewDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	ViewDescriptor = descpb.TableDescriptor

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -201,9 +201,7 @@ func (e errTableVersionMismatch) Error() string {
 
 // refreshMaterializedView updates the physical data for a materialized view.
 func (sc *SchemaChanger) refreshMaterializedView(
-	ctx context.Context,
-	table *tabledesc.MutableTableDescriptor,
-	refresh *descpb.MaterializedViewRefresh,
+	ctx context.Context, table *tabledesc.Mutable, refresh *descpb.MaterializedViewRefresh,
 ) error {
 	// The data for the materialized view is stored under the current set of
 	// indexes in table. We want to keep all of that data untouched, and write
@@ -333,7 +331,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 // this writing) this code path is only used for standalone CREATE
 // TABLE AS statements, which cannot be traced.
 func (sc *SchemaChanger) maybeBackfillCreateTableAs(
-	ctx context.Context, table *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, table *tabledesc.Immutable,
 ) error {
 	if !(table.Adding() && table.IsAs()) {
 		return nil
@@ -344,7 +342,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 }
 
 func (sc *SchemaChanger) maybeBackfillMaterializedView(
-	ctx context.Context, table *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, table *tabledesc.Immutable,
 ) error {
 	if !(table.Adding() && table.MaterializedView()) {
 		return nil
@@ -356,7 +354,7 @@ func (sc *SchemaChanger) maybeBackfillMaterializedView(
 
 // maybe make a table PUBLIC if it's in the ADD state.
 func (sc *SchemaChanger) maybeMakeAddTablePublic(
-	ctx context.Context, table *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, table *tabledesc.Immutable,
 ) error {
 	if table.Adding() {
 		log.Info(ctx, "making table public")
@@ -591,7 +589,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 		return nil
 	}
 
-	tableDesc, ok := desc.(*tabledesc.ImmutableTableDescriptor)
+	tableDesc, ok := desc.(*tabledesc.Immutable)
 	if !ok {
 		// If our descriptor is not a table, then just drain leases.
 		if err := waitToUpdateLeases(false /* refreshStats */); err != nil {
@@ -1301,7 +1299,7 @@ func maybeUpdateZoneConfigsForPKChange(
 	ctx context.Context,
 	txn *kv.Txn,
 	execCfg *ExecutorConfig,
-	table *tabledesc.MutableTableDescriptor,
+	table *tabledesc.Mutable,
 	swapInfo *descpb.PrimaryKeySwap,
 ) error {
 	if !execCfg.Codec.ForSystemTenant() {
@@ -1555,7 +1553,7 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 
 // updateJobForRollback updates the schema change job in the case of a rollback.
 func (sc *SchemaChanger) updateJobForRollback(
-	ctx context.Context, txn *kv.Txn, tableDesc *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, txn *kv.Txn, tableDesc *tabledesc.Immutable,
 ) error {
 	// Initialize refresh spans to scan the entire table.
 	span := tableDesc.PrimaryIndexSpan(sc.execCfg.Codec)
@@ -1636,7 +1634,7 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 // references one of the reversed columns. Execute this as a breadth
 // first search graph traversal.
 func (sc *SchemaChanger) deleteIndexMutationsWithReversedColumns(
-	ctx context.Context, desc *tabledesc.MutableTableDescriptor, columns map[string]struct{},
+	ctx context.Context, desc *tabledesc.Mutable, columns map[string]struct{},
 ) (map[descpb.MutationID]struct{}, error) {
 	dropMutations := make(map[descpb.MutationID]struct{})
 	// Run breadth first search traversal that reverses mutations

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -430,7 +430,7 @@ func drainNamesForDescriptor(
 			// If the descriptor to drain is a schema, then we need to delete the
 			// draining names from the parent database's schema mapping.
 			if isSchema {
-				db := descs[desc.GetParentID()].(*dbdesc.MutableDatabaseDescriptor)
+				db := descs[desc.GetParentID()].(*dbdesc.Mutable)
 				for _, name := range namesToReclaim {
 					delete(db.Schemas, name.Name)
 				}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1230,7 +1230,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		// don't install any backreferences.
 		if !scTable.Dropped() {
 			newReferencedTypeIDs, err := scTable.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
-				return descs[id].(*typedesc.MutableTypeDescriptor), nil
+				return descs[id].(*typedesc.Mutable), nil
 			})
 			if err != nil {
 				return err
@@ -1238,10 +1238,10 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 			// Update the set of back references.
 			for _, id := range referencedTypeIDs {
-				descs[id].(*typedesc.MutableTypeDescriptor).RemoveReferencingDescriptorID(scTable.ID)
+				descs[id].(*typedesc.Mutable).RemoveReferencingDescriptorID(scTable.ID)
 			}
 			for _, id := range newReferencedTypeIDs {
-				descs[id].(*typedesc.MutableTypeDescriptor).AddReferencingDescriptorID(scTable.ID)
+				descs[id].(*typedesc.Mutable).AddReferencingDescriptorID(scTable.ID)
 			}
 		}
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1390,7 +1390,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		leaseMgr := s.LeaseManager().(*lease.Manager)
 		var version descpb.DescriptorVersion
 		if _, err := leaseMgr.Publish(ctx, id, func(desc catalog.MutableDescriptor) error {
-			table := desc.(*tabledesc.MutableTableDescriptor)
+			table := desc.(*tabledesc.Mutable)
 			// Publish nothing; only update the version.
 			version = table.Version
 			return nil
@@ -5031,7 +5031,7 @@ func TestIndexBackfillValidation(t *testing.T) {
 	const maxValue = 1000
 	backfillCount := int64(0)
 	var db *kv.DB
-	var tableDesc *tabledesc.ImmutableTableDescriptor
+	var tableDesc *tabledesc.Immutable
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			BackfillChunkSize: maxValue / 5,
@@ -5101,7 +5101,7 @@ func TestInvertedIndexBackfillValidation(t *testing.T) {
 	const maxValue = 1000
 	backfillCount := int64(0)
 	var db *kv.DB
-	var tableDesc *tabledesc.ImmutableTableDescriptor
+	var tableDesc *tabledesc.Immutable
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			BackfillChunkSize: maxValue / 5,

--- a/pkg/sql/schemaexpr/testutils_test.go
+++ b/pkg/sql/schemaexpr/testutils_test.go
@@ -52,7 +52,7 @@ func testTableDesc(
 			Direction: descpb.DescriptorMutation_ADD,
 		}
 	}
-	return tabledesc.NewImmutableTableDescriptor(descpb.TableDescriptor{
+	return tabledesc.NewImmutable(descpb.TableDescriptor{
 		Name:      name,
 		ID:        1,
 		Columns:   cols,

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -192,7 +192,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		if err != nil {
 			return err
 		}
-		tableDesc := objDesc.(*tabledesc.ImmutableTableDescriptor)
+		tableDesc := objDesc.(*tabledesc.Immutable)
 		// Skip non-tables and don't throw an error if we encounter one.
 		if !tableDesc.IsTable() {
 			continue
@@ -205,10 +205,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 }
 
 func (n *scrubNode) startScrubTable(
-	ctx context.Context,
-	p *planner,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
-	tableName *tree.TableName,
+	ctx context.Context, p *planner, tableDesc *tabledesc.Immutable, tableName *tree.TableName,
 ) error {
 	ts, hasTS, err := p.getTimestamp(ctx, n.n.AsOf)
 	if err != nil {
@@ -286,7 +283,7 @@ func (n *scrubNode) startScrubTable(
 // getPrimaryColIdxs returns a list of the primary index columns and
 // their corresponding index in the columns list.
 func getPrimaryColIdxs(
-	tableDesc *tabledesc.ImmutableTableDescriptor, columns []*descpb.ColumnDescriptor,
+	tableDesc *tabledesc.Immutable, columns []*descpb.ColumnDescriptor,
 ) (primaryColIdxs []int, err error) {
 	for i, colID := range tableDesc.PrimaryIndex.ColumnIDs {
 		rowIdx := -1
@@ -345,7 +342,7 @@ func pairwiseOp(left []string, right []string, op string) []string {
 // createPhysicalCheckOperations will return the physicalCheckOperation
 // for all indexes on a table.
 func createPhysicalCheckOperations(
-	tableDesc *tabledesc.ImmutableTableDescriptor, tableName *tree.TableName,
+	tableDesc *tabledesc.Immutable, tableName *tree.TableName,
 ) (checks []checkOperation) {
 	checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, &tableDesc.PrimaryIndex))
 	for i := range tableDesc.Indexes {
@@ -362,7 +359,7 @@ func createPhysicalCheckOperations(
 // first invalid index.
 func createIndexCheckOperations(
 	indexNames tree.NameList,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	tableName *tree.TableName,
 	asOf hlc.Timestamp,
 ) (results []checkOperation, err error) {
@@ -420,7 +417,7 @@ func createConstraintCheckOperations(
 	ctx context.Context,
 	p *planner,
 	constraintNames tree.NameList,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	tableName *tree.TableName,
 	asOf hlc.Timestamp,
 ) (results []checkOperation, err error) {

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -27,7 +27,7 @@ import (
 // CHECK constraint on a table.
 type sqlCheckConstraintCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 	checkDesc *descpb.TableDescriptor_CheckConstraint
 	asOf      hlc.Timestamp
 
@@ -51,7 +51,7 @@ type sqlCheckConstraintCheckRun struct {
 
 func newSQLCheckConstraintCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	checkDesc *descpb.TableDescriptor_CheckConstraint,
 	asOf hlc.Timestamp,
 ) *sqlCheckConstraintCheckOperation {

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -24,8 +24,8 @@ import (
 // sqlForeignKeyCheckOperation is a check on an indexes physical data.
 type sqlForeignKeyCheckOperation struct {
 	tableName           *tree.TableName
-	tableDesc           *tabledesc.ImmutableTableDescriptor
-	referencedTableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc           *tabledesc.Immutable
+	referencedTableDesc *tabledesc.Immutable
 	constraint          *descpb.ConstraintDetail
 	asOf                hlc.Timestamp
 
@@ -44,7 +44,7 @@ type sqlForeignKeyConstraintCheckRun struct {
 
 func newSQLForeignKeyCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	constraint descpb.ConstraintDetail,
 	asOf hlc.Timestamp,
 ) *sqlForeignKeyCheckOperation {
@@ -52,7 +52,7 @@ func newSQLForeignKeyCheckOperation(
 		tableName:           tableName,
 		tableDesc:           tableDesc,
 		constraint:          &constraint,
-		referencedTableDesc: tabledesc.NewImmutableTableDescriptor(*constraint.ReferencedTable),
+		referencedTableDesc: tabledesc.NewImmutable(*constraint.ReferencedTable),
 		asOf:                asOf,
 	}
 }

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -32,7 +32,7 @@ import (
 //    that refers to a primary index key that cannot be found.
 type indexCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 	indexDesc *descpb.IndexDescriptor
 	asOf      hlc.Timestamp
 
@@ -57,7 +57,7 @@ type indexCheckRun struct {
 
 func newIndexCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
+	tableDesc *tabledesc.Immutable,
 	indexDesc *descpb.IndexDescriptor,
 	asOf hlc.Timestamp,
 ) *indexCheckOperation {

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -28,7 +28,7 @@ var _ checkOperation = &physicalCheckOperation{}
 // physicalCheckOperation is a check on an indexes physical data.
 type physicalCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 	indexDesc *descpb.IndexDescriptor
 
 	// columns is a list of the columns returned in the query result
@@ -50,9 +50,7 @@ type physicalCheckRun struct {
 }
 
 func newPhysicalCheckOperation(
-	tableName *tree.TableName,
-	tableDesc *tabledesc.ImmutableTableDescriptor,
-	indexDesc *descpb.IndexDescriptor,
+	tableName *tree.TableName, tableDesc *tabledesc.Immutable, indexDesc *descpb.IndexDescriptor,
 ) *physicalCheckOperation {
 	return &physicalCheckOperation{
 		tableName: tableName,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -300,7 +300,7 @@ var builtins = map[string]builtinDefinition{
 			// In Postgres concat can take any arguments, converting them to
 			// their text representation. Since the text representation can
 			// depend on the context (e.g. timezone), the function is Stable. In
-			// our case, we only take String inputs so our version is Immutable.
+			// our case, we only take String inputs so our version is ImmutableCopy.
 			IgnoreVolatilityCheck: true,
 		},
 	),
@@ -346,7 +346,7 @@ var builtins = map[string]builtinDefinition{
 			// In Postgres concat_ws can take any arguments, converting them to
 			// their text representation. Since the text representation can
 			// depend on the context (e.g. timezone), the function is Stable. In
-			// our case, we only take String inputs so our version is Immutable.
+			// our case, we only take String inputs so our version is ImmutableCopy.
 			IgnoreVolatilityCheck: true,
 		},
 	),

--- a/pkg/sql/sem/tree/volatility.go
+++ b/pkg/sql/sem/tree/volatility.go
@@ -46,7 +46,7 @@ const (
 	// VolatilityImmutable means that the operator cannot modify the database, the
 	// transaction state, or any other state. It cannot depend on configuration
 	// settings and is guaranteed to return the same results given the same
-	// arguments in any context. Immutable operators can be constant folded.
+	// arguments in any context. ImmutableCopy operators can be constant folded.
 	// Examples: log, from_json.
 	VolatilityImmutable
 	// VolatilityStable means that the operator cannot modify the database or the

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -111,7 +111,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 	return val, nil
 }
 
-func boundsExceededError(descriptor *tabledesc.ImmutableTableDescriptor) error {
+func boundsExceededError(descriptor *tabledesc.Immutable) error {
 	seqOpts := descriptor.SequenceOpts
 	isAscending := seqOpts.Increment > 0
 
@@ -211,7 +211,7 @@ func MakeSequenceKeyVal(
 
 // GetSequenceValue returns the current value of the sequence.
 func (p *planner) GetSequenceValue(
-	ctx context.Context, codec keys.SQLCodec, desc *tabledesc.ImmutableTableDescriptor,
+	ctx context.Context, codec keys.SQLCodec, desc *tabledesc.Immutable,
 ) (int64, error) {
 	if desc.SequenceOpts == nil {
 		return 0, errors.New("descriptor is not a sequence")
@@ -463,10 +463,10 @@ func addSequenceOwner(
 func maybeAddSequenceDependencies(
 	ctx context.Context,
 	sc resolver.SchemaResolver,
-	tableDesc *tabledesc.MutableTableDescriptor,
+	tableDesc *tabledesc.Mutable,
 	col *descpb.ColumnDescriptor,
 	expr tree.TypedExpr,
-	backrefs map[descpb.ID]*tabledesc.MutableTableDescriptor,
+	backrefs map[descpb.ID]*tabledesc.Mutable,
 ) ([]*MutableTableDescriptor, error) {
 	seqNames, err := sequence.GetUsedSequenceNames(expr)
 	if err != nil {
@@ -558,7 +558,7 @@ func (p *planner) dropSequencesOwnedByCol(
 //   - writes the sequence descriptor and notifies a schema change.
 // The column descriptor is mutated but not saved to persistent storage; the caller must save it.
 func (p *planner) removeSequenceDependencies(
-	ctx context.Context, tableDesc *tabledesc.MutableTableDescriptor, col *descpb.ColumnDescriptor,
+	ctx context.Context, tableDesc *tabledesc.Mutable, col *descpb.ColumnDescriptor,
 ) error {
 	for _, sequenceID := range col.UsesSequenceIds {
 		// Get the sequence descriptor so we can remove the reference from it.

--- a/pkg/sql/sequence_select.go
+++ b/pkg/sql/sequence_select.go
@@ -21,7 +21,7 @@ import (
 type sequenceSelectNode struct {
 	optColumnsSlot
 
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 
 	val  int64
 	done bool
@@ -29,7 +29,7 @@ type sequenceSelectNode struct {
 
 var _ planNode = &sequenceSelectNode{}
 
-func (p *planner) SequenceSelectNode(desc *tabledesc.ImmutableTableDescriptor) (planNode, error) {
+func (p *planner) SequenceSelectNode(desc *tabledesc.Immutable) (planNode, error) {
 	if desc.SequenceOpts == nil {
 		return nil, errors.New("descriptor is not a sequence")
 	}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -231,7 +231,7 @@ func (p *planner) ShowCreate(
 	ctx context.Context,
 	dbPrefix string,
 	allDescs []descpb.Descriptor,
-	desc *tabledesc.ImmutableTableDescriptor,
+	desc *tabledesc.Immutable,
 	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
 	var stmt string

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -28,7 +28,7 @@ import (
 type showFingerprintsNode struct {
 	optColumnsSlot
 
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 	indexes   []*descpb.IndexDescriptor
 
 	run showFingerprintsRun

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -28,7 +28,7 @@ import (
 // Builder is a single struct for generating key spans from Constraints, Datums and encDatums.
 type Builder struct {
 	codec         keys.SQLCodec
-	table         *tabledesc.ImmutableTableDescriptor
+	table         *tabledesc.Immutable
 	index         *descpb.IndexDescriptor
 	indexColTypes []*types.T
 	indexColDirs  []descpb.IndexDescriptor_Direction
@@ -52,7 +52,7 @@ var _ = (*Builder).UnsetNeededFamilies
 
 // MakeBuilder creates a Builder for a table and index.
 func MakeBuilder(
-	codec keys.SQLCodec, table *tabledesc.ImmutableTableDescriptor, index *descpb.IndexDescriptor,
+	codec keys.SQLCodec, table *tabledesc.Immutable, index *descpb.IndexDescriptor,
 ) *Builder {
 	s := &Builder{
 		codec:          codec,

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -26,7 +26,7 @@ import (
 type splitNode struct {
 	optColumnsSlot
 
-	tableDesc      *tabledesc.ImmutableTableDescriptor
+	tableDesc      *tabledesc.Immutable
 	index          *descpb.IndexDescriptor
 	rows           planNode
 	run            splitRun

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -37,7 +37,7 @@ func (p *planner) createDropDatabaseJob(
 	ctx context.Context,
 	databaseID descpb.ID,
 	tableDropDetails []jobspb.DroppedTableDetails,
-	typesToDrop []*typedesc.MutableTypeDescriptor,
+	typesToDrop []*typedesc.Mutable,
 	jobDesc string,
 ) error {
 	// TODO (lucy): This should probably be deleting the queued jobs for all the

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -106,10 +106,7 @@ func (p *planner) createNonDropDatabaseChangeJob(
 // is no existing schema change job for the table, or updates the existing job
 // if there is one.
 func (p *planner) createOrUpdateSchemaChangeJob(
-	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
-	jobDesc string,
-	mutationID descpb.MutationID,
+	ctx context.Context, tableDesc *tabledesc.Mutable, jobDesc string, mutationID descpb.MutationID,
 ) error {
 	var job *jobs.Job
 	if cachedJob, ok := p.extendedEvalCtx.SchemaChangeJobCache[tableDesc.ID]; ok {
@@ -223,10 +220,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 // table descriptor during a schema change to another table, or from a step in a
 // larger schema change to the same table.
 func (p *planner) writeSchemaChange(
-	ctx context.Context,
-	tableDesc *tabledesc.MutableTableDescriptor,
-	mutationID descpb.MutationID,
-	jobDesc string,
+	ctx context.Context, tableDesc *tabledesc.Mutable, mutationID descpb.MutationID, jobDesc string,
 ) error {
 	if !p.EvalContext().TxnImplicit {
 		telemetry.Inc(sqltelemetry.SchemaChangeInExplicitTxnCounter)
@@ -243,7 +237,7 @@ func (p *planner) writeSchemaChange(
 }
 
 func (p *planner) writeSchemaChangeToBatch(
-	ctx context.Context, tableDesc *tabledesc.MutableTableDescriptor, b *kv.Batch,
+	ctx context.Context, tableDesc *tabledesc.Mutable, b *kv.Batch,
 ) error {
 	if !p.EvalContext().TxnImplicit {
 		telemetry.Inc(sqltelemetry.SchemaChangeInExplicitTxnCounter)
@@ -257,7 +251,7 @@ func (p *planner) writeSchemaChangeToBatch(
 }
 
 func (p *planner) writeDropTable(
-	ctx context.Context, tableDesc *tabledesc.MutableTableDescriptor, queueJob bool, jobDesc string,
+	ctx context.Context, tableDesc *tabledesc.Mutable, queueJob bool, jobDesc string,
 ) error {
 	if queueJob {
 		if err := p.createOrUpdateSchemaChangeJob(ctx, tableDesc, jobDesc, descpb.InvalidMutationID); err != nil {
@@ -267,9 +261,7 @@ func (p *planner) writeDropTable(
 	return p.writeTableDesc(ctx, tableDesc)
 }
 
-func (p *planner) writeTableDesc(
-	ctx context.Context, tableDesc *tabledesc.MutableTableDescriptor,
-) error {
+func (p *planner) writeTableDesc(ctx context.Context, tableDesc *tabledesc.Mutable) error {
 	b := p.txn.NewBatch()
 	if err := p.writeTableDescToBatch(ctx, tableDesc, b); err != nil {
 		return err
@@ -278,7 +270,7 @@ func (p *planner) writeTableDesc(
 }
 
 func (p *planner) writeTableDescToBatch(
-	ctx context.Context, tableDesc *tabledesc.MutableTableDescriptor, b *kv.Batch,
+	ctx context.Context, tableDesc *tabledesc.Mutable, b *kv.Batch,
 ) error {
 	if tableDesc.IsVirtualTable() {
 		return errors.AssertionFailedf("virtual descriptors cannot be stored, found: %v", tableDesc)

--- a/pkg/sql/tests/hash_sharded_test.go
+++ b/pkg/sql/tests/hash_sharded_test.go
@@ -28,7 +28,7 @@ import (
 // getShardColumnID fetches the id of the shard column associated with the given sharded
 // index.
 func getShardColumnID(
-	t *testing.T, tableDesc *tabledesc.ImmutableTableDescriptor, shardedIndexName string,
+	t *testing.T, tableDesc *tabledesc.Immutable, shardedIndexName string,
 ) descpb.ColumnID {
 	idx, _, err := tableDesc.FindIndexByName(shardedIndexName)
 	if err != nil {
@@ -47,7 +47,7 @@ func getShardColumnID(
 // 2. A hidden check constraint was created on the aforementioned shard column.
 // 3. The first column in the index set is the aforementioned shard column.
 func verifyTableDescriptorState(
-	t *testing.T, tableDesc *tabledesc.ImmutableTableDescriptor, shardedIndexName string,
+	t *testing.T, tableDesc *tabledesc.Immutable, shardedIndexName string,
 ) {
 	idx, _, err := tableDesc.FindIndexByName(shardedIndexName)
 	if err != nil {

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -162,7 +162,7 @@ func TestSystemTableLiterals(t *testing.T) {
 	type testcase struct {
 		id     descpb.ID
 		schema string
-		pkg    *tabledesc.ImmutableTableDescriptor
+		pkg    *tabledesc.Immutable
 	}
 
 	for _, test := range []testcase{

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -32,7 +32,7 @@ func CreateTestTableDescriptor(
 	parentID, id descpb.ID,
 	schema string,
 	privileges *descpb.PrivilegeDescriptor,
-) (*tabledesc.MutableTableDescriptor, error) {
+) (*tabledesc.Mutable, error) {
 	st := cluster.MakeTestingClusterSettings()
 	stmt, err := parser.ParseOne(schema)
 	if err != nil {

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -26,7 +26,7 @@ import (
 type unsplitNode struct {
 	optColumnsSlot
 
-	tableDesc *tabledesc.ImmutableTableDescriptor
+	tableDesc *tabledesc.Immutable
 	index     *descpb.IndexDescriptor
 	run       unsplitRun
 	rows      planNode

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -28,7 +28,7 @@ import (
 type planDependencyInfo struct {
 	// desc is a reference to the descriptor for the table being
 	// depended on.
-	desc *tabledesc.ImmutableTableDescriptor
+	desc *tabledesc.Immutable
 	// deps is the list of ways in which the current plan depends on
 	// that table. There can be more than one entries when the same
 	// table is used in different places. The entries can also be

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -328,7 +328,7 @@ func (v virtualSchemaEntry) GetObjectByName(
 		if def, ok := v.defs[name]; ok {
 			if flags.RequireMutable {
 				return mutableVirtualDefEntry{
-					desc: tabledesc.NewMutableExistingTableDescriptor(*def.desc.TableDesc()),
+					desc: tabledesc.NewExistingMutable(*def.desc.TableDesc()),
 				}, nil
 			}
 			return &def, nil
@@ -372,7 +372,7 @@ func (v virtualSchemaEntry) GetObjectByName(
 
 type virtualDefEntry struct {
 	virtualDef                 virtualSchemaDef
-	desc                       *tabledesc.ImmutableTableDescriptor
+	desc                       *tabledesc.Immutable
 	comment                    string
 	validWithNoDatabaseContext bool
 }
@@ -382,7 +382,7 @@ func (e virtualDefEntry) Desc() catalog.Descriptor {
 }
 
 type mutableVirtualDefEntry struct {
-	desc *tabledesc.MutableTableDescriptor
+	desc *tabledesc.Mutable
 }
 
 func (e mutableVirtualDefEntry) Desc() catalog.Descriptor {
@@ -641,7 +641,7 @@ func NewVirtualSchemaHolder(
 
 			entry := virtualDefEntry{
 				virtualDef:                 def,
-				desc:                       tabledesc.NewImmutableTableDescriptor(tableDesc),
+				desc:                       tabledesc.NewImmutable(tableDesc),
 				validWithNoDatabaseContext: schema.validWithNoDatabaseContext,
 				comment:                    def.getComment(),
 			}
@@ -731,7 +731,7 @@ func (vs *VirtualSchemaHolder) getVirtualTableEntryByID(id descpb.ID) (virtualDe
 
 // VirtualTabler is used to fetch descriptors for virtual tables and databases.
 type VirtualTabler interface {
-	getVirtualTableDesc(tn *tree.TableName) (*tabledesc.ImmutableTableDescriptor, error)
+	getVirtualTableDesc(tn *tree.TableName) (*tabledesc.Immutable, error)
 	getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool)
 	getVirtualTableEntry(tn *tree.TableName) (virtualDefEntry, error)
 	getVirtualTableEntryByID(id descpb.ID) (virtualDefEntry, error)
@@ -744,7 +744,7 @@ type VirtualTabler interface {
 // getVirtualTableDesc is part of the VirtualTabler interface.
 func (vs *VirtualSchemaHolder) getVirtualTableDesc(
 	tn *tree.TableName,
-) (*tabledesc.ImmutableTableDescriptor, error) {
+) (*tabledesc.Immutable, error) {
 	t, err := vs.getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -362,7 +362,7 @@ func (v virtualSchemaEntry) GetObjectByName(
 		}
 
 		return virtualTypeEntry{
-			desc:    typedesc.MakeSimpleAliasTypeDescriptor(typ),
+			desc:    typedesc.MakeSimpleAlias(typ),
 			mutable: flags.RequireMutable,
 		}, nil
 	default:
@@ -390,7 +390,7 @@ func (e mutableVirtualDefEntry) Desc() catalog.Descriptor {
 }
 
 type virtualTypeEntry struct {
-	desc    *typedesc.ImmutableTypeDescriptor
+	desc    *typedesc.Immutable
 	mutable bool
 }
 

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -195,7 +195,7 @@ type vTableLookupJoinNode struct {
 	input planNode
 
 	dbName string
-	db     *dbdesc.ImmutableDatabaseDescriptor
+	db     *dbdesc.Immutable
 	table  *tabledesc.Immutable
 	index  *descpb.IndexDescriptor
 	// eqCol is the single equality column ordinal into the lookup table. Virtual
@@ -261,7 +261,7 @@ func (v *vTableLookupJoinNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
-	v.db = db.(*dbdesc.ImmutableDatabaseDescriptor)
+	v.db = db.(*dbdesc.Immutable)
 	return err
 }
 

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -196,7 +196,7 @@ type vTableLookupJoinNode struct {
 
 	dbName string
 	db     *dbdesc.ImmutableDatabaseDescriptor
-	table  *tabledesc.ImmutableTableDescriptor
+	table  *tabledesc.Immutable
 	index  *descpb.IndexDescriptor
 	// eqCol is the single equality column ordinal into the lookup table. Virtual
 	// indexes only support a single indexed column currently.

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -545,7 +545,7 @@ func TestCreateSystemTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	table := tabledesc.NewMutableExistingTableDescriptor(systemschema.NamespaceTable.TableDescriptor)
+	table := tabledesc.NewExistingMutable(systemschema.NamespaceTable.TableDescriptor)
 	table.ID = keys.MaxReservedDescID
 
 	prevPrivileges, ok := descpb.SystemAllowedPrivileges[table.ID]
@@ -856,7 +856,7 @@ CREATE TABLE system.jobs (
 	require.Equal(t, oldPrimaryFamilyColumns, oldJobsTable.Families[0].ColumnNames)
 
 	jobsTable := systemschema.JobsTable
-	systemschema.JobsTable = tabledesc.NewImmutableTableDescriptor(*oldJobsTable.TableDesc())
+	systemschema.JobsTable = tabledesc.NewImmutable(*oldJobsTable.TableDesc())
 	defer func() {
 		systemschema.JobsTable = jobsTable
 	}()
@@ -937,7 +937,7 @@ func TestVersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable
 	require.Equal(t, oldPrimaryFamilyColumns, oldJobsTable.Families[0].ColumnNames)
 
 	jobsTable := systemschema.JobsTable
-	systemschema.JobsTable = tabledesc.NewImmutableTableDescriptor(*oldJobsTable.TableDesc())
+	systemschema.JobsTable = tabledesc.NewImmutable(*oldJobsTable.TableDesc())
 	defer func() {
 		systemschema.JobsTable = jobsTable
 	}()


### PR DESCRIPTION
This PR implements the renames outlined in https://github.com/cockroachdb/cockroach/pull/52519#issuecomment-678598468 with the additional change of renaming the `dbdesc` package to `databasedesc` for symmetry. 

It's a big change but it's completely mechanical. Take it or leave it.
