### PR TITLE
builtins: Implement ST_FlipCoordinates on arguments {geometry}

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1223,6 +1223,8 @@ Bottom Left.</p>
 </span></td></tr>
 <tr><td><a name="st_exteriorring"></a><code>st_exteriorring(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the exterior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon.</p>
 </span></td></tr>
+<tr><td><a name="st_flipcoordinates"></a><code>st_flipcoordinates(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new geometry with the X and Y axes flipped.</p>
+</span></td></tr>
 <tr><td><a name="st_force2d"></a><code>st_force2d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry which only contains X and Y coordinates.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>

--- a/pkg/geo/geomfn/flip_coordinates.go
+++ b/pkg/geo/geomfn/flip_coordinates.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/twpayne/go-geom"
+)
+
+// FlipCoordinates returns a modified Geometry whose X, Y coordinates are flipped.
+func FlipCoordinates(geometry *geo.Geometry) (*geo.Geometry, error) {
+	if geometry.Empty() {
+		return geometry, nil
+	}
+
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	g, err = flipCoordinates(g)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+func flipCoordinates(g geom.T) (geom.T, error) {
+	if geomCollection, ok := g.(*geom.GeometryCollection); ok {
+		return flipCollection(geomCollection)
+	}
+
+	newCoords, err := flipCoords(g)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := g.(type) {
+	case *geom.Point:
+		g = geom.NewPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.LineString:
+		g = geom.NewLineStringFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.Polygon:
+		g = geom.NewPolygonFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPoint:
+		g = geom.NewMultiPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.MultiLineString:
+		g = geom.NewMultiLineStringFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPolygon:
+		g = geom.NewMultiPolygonFlat(t.Layout(), newCoords, t.Endss()).SetSRID(g.SRID())
+	default:
+		return nil, geom.ErrUnsupportedType{Value: g}
+	}
+
+	return g, nil
+}
+
+// flipCoords swaps X,Y coordinates.
+// M and Z coordinates are maintained
+func flipCoords(g geom.T) ([]float64, error) {
+	stride := g.Stride()
+	coords := g.FlatCoords()
+
+	for i := 0; i < len(coords); i += stride {
+		coords[i], coords[i+1] = coords[i+1], coords[i]
+	}
+
+	return coords, nil
+}
+
+// flipCollection iterates through a GeometryCollection and calls flipCoordinates() on each item.
+func flipCollection(geomCollection *geom.GeometryCollection) (*geom.GeometryCollection, error) {
+	res := geom.NewGeometryCollection()
+
+	for _, subG := range geomCollection.Geoms() {
+		subGeom, err := flipCoordinates(subG)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := res.Push(subGeom); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/geo/geomfn/flip_coordinates_test.go
+++ b/pkg/geo/geomfn/flip_coordinates_test.go
@@ -1,0 +1,137 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestFlipCoordinates(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    geom.T
+		expected geom.T
+	}{
+		{
+			desc:     "flip coordinates of a 2D point with same X Y values",
+			input:    geom.NewPointFlat(geom.XY, []float64{10.1, 10.1}),
+			expected: geom.NewPointFlat(geom.XY, []float64{10.1, 10.1}),
+		},
+		{
+			desc:     "flip coordinates of a 2D point with different coordinates",
+			input:    geom.NewPointFlat(geom.XY, []float64{1, 2}),
+			expected: geom.NewPointFlat(geom.XY, []float64{2, 1}),
+		},
+		{
+			desc:     "flip coordinates of a line string",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1, 2, 3, 4}),
+			expected: geom.NewLineStringFlat(geom.XY, []float64{2, 1, 4, 3}),
+		},
+		{
+			desc:     "flip coordinates of a line string with same X Y values",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1.1, 1.1, 2.2, 2.2}),
+			expected: geom.NewLineStringFlat(geom.XY, []float64{1.1, 1.1, 2.2, 2.2}),
+		},
+		{
+			desc:     "flip coordinates of a polygon",
+			input:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 0, 10, 0, 0}, []int{8}),
+			expected: geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 10, 0, 0, 0}, []int{8}),
+		},
+		{
+			desc:     "flip coordinates of a multi polygon",
+			input:    geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 5, 0, 4, 4, 0, 4, 0, 0, 1, 1, 2, 3, 2, 2, 1, 2, 1, 1}, [][]int{{10}, {20}}),
+			expected: geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 0, 5, 4, 4, 4, 0, 0, 0, 1, 1, 3, 2, 2, 2, 2, 1, 1, 1}, [][]int{{10}, {20}}),
+		},
+		{
+			desc:     "flip coordinates of multiple 2D points",
+			input:    geom.NewMultiPointFlat(geom.XY, []float64{5, 10, -30.5, 40.2, 1, 1}),
+			expected: geom.NewMultiPointFlat(geom.XY, []float64{10, 5, 40.2, -30.5, 1, 1}),
+		},
+		{
+			desc:     "flip coordinates of multiple line strings",
+			input:    geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2.2, 2.2, 3, 3, 4, 4}, []int{4, 8}),
+			expected: geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2.2, 2.2, 3, 3, 4, 4}, []int{4, 8}),
+		},
+		{
+			desc:     "flip coordinates of an empty line string",
+			input:    geom.NewLineString(geom.XY),
+			expected: geom.NewLineString(geom.XY),
+		},
+		{
+			desc:     "flip coordinates of an empty polygon",
+			input:    geom.NewPolygon(geom.XY),
+			expected: geom.NewPolygon(geom.XY),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+			got, err := FlipCoordinates(geometry)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.input.SRID(), got.SRID())
+		})
+	}
+}
+
+func TestCollectionFlipCoordinates(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    *geom.GeometryCollection
+		expected *geom.GeometryCollection
+	}{
+		{
+			desc: "flip coordinates of a non-empty collection",
+			input: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 2}),
+				geom.NewPointFlat(geom.XY, []float64{3.33, 4}),
+				geom.NewPolygonFlat(geom.XY, []float64{150, 85, -30, 85, -20, 85, 160, 85, 150, 85}, []int{10}),
+			),
+			expected: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{2, 1.1}),
+				geom.NewPointFlat(geom.XY, []float64{4, 3.33}),
+				geom.NewPolygonFlat(geom.XY, []float64{85, 150, 85, -30, 85, -20, 85, 160, 85, 150}, []int{10})),
+		},
+		{
+			desc:     "flip coordinates of an empty collection",
+			input:    geom.NewGeometryCollection(),
+			expected: geom.NewGeometryCollection(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			geometry, err = FlipCoordinates(geometry)
+			require.NoError(t, err)
+
+			g, err := geometry.AsGeomT()
+			require.NoError(t, err)
+
+			gotCollection, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+
+			require.Equal(t, tc.expected, gotCollection)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4285,3 +4285,23 @@ POINT (10.5 20.25)
 
 statement error unknown function: public.log\(\), but log\(\) exists
 SELECT public.log(10)
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_FlipCoordinates(a.geom))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (0.5 -0.5, 0.5 0.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (0.5 -0.5)
+POINT (0.5 0.5)                                        POINT (0.5 0.5)
+POINT (5 5)                                            POINT (5 5)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0 -0.1, 0 1, 1 1, 1 -0.1, 0 -0.1))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((0 -1, 0 0, 1 0, 1 -1, 0 -1))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3708,6 +3708,29 @@ Bottom Left.`,
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_flipcoordinates": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DGeometry)
+
+				ret, err := geomfn.FlipCoordinates(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: "Returns a new geometry with the X and Y axes flipped.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
 	//
 	// BoundingBox


### PR DESCRIPTION
Should adopt PostGIS behavior. 

Release note (sql change): Implemented geometry builtin `ST_FlipCoordinates`
Closes #48932 