### PR TITLE
backupccl: add schedule lock file to collections

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -859,6 +859,12 @@ func backupPlanHook(
 		if err := verifyWriteableDestination(ctx, p.User(), makeCloudStorage, baseURI); err != nil {
 			return err
 		}
+		if !backupStmt.Options.IgnoreExistingSchedule && backupStmt.CreatedByInfo != nil {
+			if err := checkLockForSchedule(ctx, p.User(), makeCloudStorage, collectionURI,
+				backupStmt.CreatedByInfo.ID); err != nil {
+				return err
+			}
+		}
 
 		backupDetails := jobspb.BackupDetails{
 			StartTime:        startTime,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2207,6 +2207,10 @@ backup_options:
 	{
     $$.val = &tree.BackupOptions{EncryptionKMSURI: $3.stringOrPlaceholderOptList()}
 	}
+| IGNORE_EXISTING_SCHEDULE
+  {
+    $$.val = &tree.BackupOptions{IgnoreExistingSchedule: true}
+  }
 // %Help: CREATE SCHEDULE FOR BACKUP - backup data periodically
 // %Category: CCL
 // %Text:


### PR DESCRIPTION
Opening as a WIP for an alternative implementation of #53272.

My initial thought is that I prefer the flag on the CREATE STATEMENT.

This commit makes backups to collections that are run from schedules
lock the collection with a file that writes the schedule ID. This ensure
that no new schedules can interfere with a schedule that's already
running unless the backup is run with the ignore_existing_schedule flag.

Release note (enterprise change): Lock backup collections on a
per-schedule basis.