### PR TITLE
backupccl: checksum backup manifest

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1392,7 +1392,7 @@ func TestBackupRestoreResume(t *testing.T) {
 		}
 		fileType := http.DetectContentType(backupManifestBytes)
 		if fileType == ZipType {
-			backupManifestBytes, err = DecompressData(backupManifestBytes)
+			backupManifestBytes, err = decompressData(backupManifestBytes)
 			require.NoError(t, err)
 		}
 		var backupManifest BackupManifest
@@ -3569,7 +3569,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		}
 		fileType := http.DetectContentType(backupManifestBytes)
 		if fileType == ZipType {
-			backupManifestBytes, err = DecompressData(backupManifestBytes)
+			backupManifestBytes, err = decompressData(backupManifestBytes)
 			require.NoError(t, err)
 		}
 		if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {
@@ -5800,4 +5800,54 @@ func TestBackupDoesNotHangOnIntent(t *testing.T) {
 
 	// observe that the backup aborted our txn.
 	require.Error(t, tx.Commit())
+}
+
+// TestManifestBitFlip tests that we can detect a corrupt manifest when a bit
+// was flipped on disk for both an unencrypted and an encrypted manifest.
+func TestManifestBitFlip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	_, _, sqlDB, rawDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, 1, InitNone)
+	defer cleanupFn()
+	sqlDB.Exec(t, `CREATE DATABASE r1; CREATE DATABASE r2; CREATE DATABASE r3;`)
+	const checksumError = "checksum mismatch"
+	t.Run("unencrypted", func(t *testing.T) {
+		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://0/bit_flip_unencrypted'`)
+		flipBitInManifests(t, rawDir)
+		sqlDB.ExpectErr(t, checksumError,
+			`RESTORE data.* FROM 'nodelocal://0/bit_flip_unencrypted' WITH into_db='r1'`)
+	})
+
+	t.Run("encrypted", func(t *testing.T) {
+		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://0/bit_flip_encrypted' WITH encryption_passphrase='abc'`)
+		flipBitInManifests(t, rawDir)
+		sqlDB.ExpectErr(t, checksumError,
+			`RESTORE data.* FROM 'nodelocal://0/bit_flip_encrypted' WITH encryption_passphrase='abc', into_db='r3'`)
+	})
+}
+
+// flipBitInManifests flips a bit in every backup manifest it sees. If
+// afterDecompression is set to true, then the bit is contents are decompressed,
+// a bit is flipped, and the corrupt data is re-compressed. This simulates a
+// corruption in the data that will not be caught during the decompression
+// layer.
+func flipBitInManifests(t *testing.T, rawDir string) {
+	foundManifest := false
+	err := filepath.Walk(rawDir, func(path string, info os.FileInfo, err error) error {
+		log.Infof(context.Background(), "visiting %s", path)
+		if filepath.Base(path) == BackupManifestName {
+			foundManifest = true
+			data, err := ioutil.ReadFile(path)
+			require.NoError(t, err)
+			data[20] ^= 1
+			if err := ioutil.WriteFile(path, data, 0644 /* perm */); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	if !foundManifest {
+		t.Fatal("found no manifest")
+	}
 }

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -12,6 +12,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -44,6 +46,10 @@ const (
 	// BackupNewManifestName is a future name for the serialized BackupManifest
 	// proto.
 	BackupNewManifestName = "BACKUP_MANIFEST"
+	// BackupManifestChecksumSuffix indicates where the checksum for the manifest
+	// is stored if present. It can be found in the name of the backup manifest +
+	// this suffix.
+	BackupManifestChecksumSuffix = "-CHECKSUM"
 
 	// BackupPartitionDescriptorPrefix is the file name prefix for serialized
 	// BackupPartitionDescriptor protos.
@@ -151,9 +157,9 @@ func compressData(descBuf []byte) ([]byte, error) {
 	return gzipBuf.Bytes(), nil
 }
 
-// DecompressData decompresses gzip data buffer and
+// decompressData decompresses gzip data buffer and
 // returns decompressed bytes.
-func DecompressData(descBytes []byte) ([]byte, error) {
+func decompressData(descBytes []byte) ([]byte, error) {
 	r, err := gzip.NewReader(bytes.NewBuffer(descBytes))
 	if err != nil {
 		return nil, err
@@ -179,8 +185,33 @@ func readBackupManifest(
 	if err != nil {
 		return BackupManifest{}, err
 	}
+
+	checksumFile, err := exportStore.ReadFile(ctx, filename+BackupManifestChecksumSuffix)
+	if err == nil {
+		// If there is a checksum file present, check that it matches.
+		defer checksumFile.Close()
+		checksumFileData, err := ioutil.ReadAll(checksumFile)
+		if err != nil {
+			return BackupManifest{}, errors.Wrap(err, "reading checksum file")
+		}
+		checksum, err := getChecksum(descBytes)
+		if err != nil {
+			return BackupManifest{}, errors.Wrap(err, "calculating checksum of manifest")
+		}
+		if !bytes.Equal(checksumFileData, checksum) {
+			return BackupManifest{}, errors.Newf("checksum mismatch; expected %s, got %s",
+				hex.EncodeToString(checksumFileData), hex.EncodeToString(checksum))
+		}
+	} else {
+		// If we don't have a checksum file, carry on. This might be an old version.
+		if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+			return BackupManifest{}, err
+		}
+	}
+
+	var encryptionKey []byte
 	if encryption != nil {
-		encryptionKey, err := getEncryptionKey(ctx, encryption, exportStore.Settings(),
+		encryptionKey, err = getEncryptionKey(ctx, encryption, exportStore.Settings(),
 			exportStore.ExternalIOConf())
 		if err != nil {
 			return BackupManifest{}, err
@@ -193,12 +224,13 @@ func readBackupManifest(
 
 	fileType := http.DetectContentType(descBytes)
 	if fileType == ZipType {
-		descBytes, err = DecompressData(descBytes)
+		descBytes, err = decompressData(descBytes)
 		if err != nil {
 			return BackupManifest{}, errors.Wrap(
 				err, "decompressing backup manifest")
 		}
 	}
+
 	var backupManifest BackupManifest
 	if err := protoutil.Unmarshal(descBytes, &backupManifest); err != nil {
 		if encryption == nil && storageccl.AppearsEncrypted(descBytes) {
@@ -225,7 +257,7 @@ func readBackupManifest(
 			t.ModificationTime = hlc.Timestamp{WallTime: 1}
 		}
 	}
-	return backupManifest, err
+	return backupManifest, nil
 }
 
 func readBackupPartitionDescriptor(
@@ -257,7 +289,7 @@ func readBackupPartitionDescriptor(
 
 	fileType := http.DetectContentType(descBytes)
 	if fileType == ZipType {
-		descBytes, err = DecompressData(descBytes)
+		descBytes, err = decompressData(descBytes)
 		if err != nil {
 			return BackupPartitionDescriptor{}, errors.Wrap(
 				err, "decompressing backup partition descriptor")
@@ -319,6 +351,7 @@ func writeBackupManifest(
 	if err != nil {
 		return err
 	}
+
 	descBuf, err = compressData(descBuf)
 	if err != nil {
 		return errors.Wrap(err, "compressing backup manifest")
@@ -335,7 +368,31 @@ func writeBackupManifest(
 		}
 	}
 
-	return exportStore.WriteFile(ctx, filename, bytes.NewReader(descBuf))
+	if err := exportStore.WriteFile(ctx, filename, bytes.NewReader(descBuf)); err != nil {
+		return err
+	}
+
+	// Write the checksum file after we've successfully wrote the manifest.
+	checksum, err := getChecksum(descBuf)
+	if err != nil {
+		return errors.Wrap(err, "calculating checksum")
+	}
+	if err := exportStore.WriteFile(ctx, filename+BackupManifestChecksumSuffix, bytes.NewReader(checksum)); err != nil {
+		return errors.Wrap(err, "writing manifest checksum")
+	}
+
+	return nil
+}
+
+// getChecksum returns a 32 bit keyed-checksum for the given data.
+func getChecksum(data []byte) ([]byte, error) {
+	const checksumSizeBytes = 4
+	hash := sha256.New()
+	if _, err := hash.Write(data); err != nil {
+		return nil, errors.Wrap(err,
+			`"It never returns an error." -- https://golang.org/pkg/hash`)
+	}
+	return hash.Sum(nil)[:checksumSizeBytes], nil
 }
 
 func getEncryptionKey(


### PR DESCRIPTION
This commit checksums that backup manifest when it is written. This
helps detect issues such as random bitflips of the manifest file.

When writing a backup manifest, it will also write the checksum of that
file to a file with a "-CHECKSUM" suffix appended to the manifest file
name. When reading manifests, we check for the '...-CHECKSUM' file,
and if one is present, we compare the checksums. If there isn't one
present, we will continue as we did before. This allows backwards
compatibility with old backups.

Fixes #52061.

Release note: None