### PR TITLE
encoding: avoid heap allocation when encoding/decoding SpatialObject

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -268,6 +268,12 @@ func (g *Geometry) SpatialObject() geopb.SpatialObject {
 	return g.spatialObject
 }
 
+// SpatialObjectRef return a pointer to the SpatialObject representation of the
+// Geometry.
+func (g *Geometry) SpatialObjectRef() *geopb.SpatialObject {
+	return &g.spatialObject
+}
+
 // EWKBHex returns the EWKBHex representation of the Geometry.
 func (g *Geometry) EWKBHex() string {
 	return g.spatialObject.EWKBHex()
@@ -502,6 +508,12 @@ func (g *Geography) EWKB() geopb.EWKB {
 // SpatialObject returns the SpatialObject representation of the Geography.
 func (g *Geography) SpatialObject() geopb.SpatialObject {
 	return g.spatialObject
+}
+
+// SpatialObjectRef returns a pointer to the SpatialObject representation of the
+// Geography.
+func (g *Geography) SpatialObjectRef() *geopb.SpatialObject {
+	return &g.spatialObject
 }
 
 // EWKBHex returns the EWKBHex representation of the Geography.

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -345,7 +345,7 @@ func (g *Geometry) Compare(o *Geometry) int {
 	if lhs < rhs {
 		return -1
 	}
-	return compareSpatialObjectBytes(g.SpatialObject(), o.SpatialObject())
+	return compareSpatialObjectBytes(g.SpatialObjectRef(), o.SpatialObjectRef())
 }
 
 //
@@ -589,7 +589,7 @@ func (g *Geography) Compare(o *Geography) int {
 	if lhs < rhs {
 		return -1
 	}
-	return compareSpatialObjectBytes(g.SpatialObject(), o.SpatialObject())
+	return compareSpatialObjectBytes(g.SpatialObjectRef(), o.SpatialObjectRef())
 }
 
 //
@@ -895,12 +895,12 @@ func GeomTContainsEmpty(g geom.T) bool {
 // compareSpatialObjectBytes compares the SpatialObject if they were serialized.
 // This is used for comparison operations, and must be kept consistent with the indexing
 // encoding.
-func compareSpatialObjectBytes(lhs geopb.SpatialObject, rhs geopb.SpatialObject) int {
-	marshalledLHS, err := protoutil.Marshal(&lhs)
+func compareSpatialObjectBytes(lhs *geopb.SpatialObject, rhs *geopb.SpatialObject) int {
+	marshalledLHS, err := protoutil.Marshal(lhs)
 	if err != nil {
 		panic(err)
 	}
-	marshalledRHS, err := protoutil.Marshal(&rhs)
+	marshalledRHS, err := protoutil.Marshal(rhs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1234,12 +1234,12 @@ func TestEncodeDecodeGeometry(t *testing.T) {
 						if dir == Ascending {
 							b, err = EncodeGeoAscending(b, parsed.SpaceCurveIndex(), &spatialObject)
 							require.NoError(t, err)
-							_, decoded, err = DecodeGeoAscending(b)
+							_, err = DecodeGeoAscending(b, &decoded)
 							require.NoError(t, err)
 						} else {
 							b, err = EncodeGeoDescending(b, parsed.SpaceCurveIndex(), &spatialObject)
 							require.NoError(t, err)
-							_, decoded, err = DecodeGeoDescending(b)
+							_, err = DecodeGeoDescending(b, &decoded)
 							require.NoError(t, err)
 						}
 						require.Equal(t, spatialObject, decoded)
@@ -1290,12 +1290,12 @@ func TestEncodeDecodeGeography(t *testing.T) {
 						if dir == Ascending {
 							b, err = EncodeGeoAscending(b, parsed.SpaceCurveIndex(), &spatialObject)
 							require.NoError(t, err)
-							_, decoded, err = DecodeGeoAscending(b)
+							_, err = DecodeGeoAscending(b, &decoded)
 							require.NoError(t, err)
 						} else {
 							b, err = EncodeGeoDescending(b, parsed.SpaceCurveIndex(), &spatialObject)
 							require.NoError(t, err)
-							_, decoded, err = DecodeGeoDescending(b)
+							_, err = DecodeGeoDescending(b, &decoded)
 							require.NoError(t, err)
 						}
 						require.Equal(t, spatialObject, decoded)


### PR DESCRIPTION
This commit shaves off a heap allocation in each of the following functions:
- `EncodeTableKey`
- `EncodeGeoAscending`
- `EncodeGeoDescending`
- `DecodeGeoAscending`
- `DecodeGeoDescending`
- `EncodeGeoValue`
- `EncodeUntaggedGeoValue`
- `DecodeUntaggedGeoValue`

In each of these, we were letting a local SpatialObject variable escape
to the heap when passed through `protoutil.Marshal` or `protoutil.Unmarshal`.
This was unnecessary, as we already have a Datum on the heap nearby any
of the callers of these functions, so with a bit of restructuring, we
can avoid the allocations entirely.

The callers of the decode functions are a little more awkward than
strictly necessary right now. They are written the way that they are so
that we don't accidentally regress on this improvement when we remove
the double-boxing being discussed in #53252.

I don't have any benchmarks set up, so I wasn't able to measure the
exact effect of this change.