### PR TITLE
roachtest: unskip kv/splits

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -463,22 +463,20 @@ func registerKVSplits(r *testRegistry) {
 		quiesce bool
 		splits  int
 		timeout time.Duration
-		skip    string
 	}{
 		// NB: with 500000 splits, this test sometimes fails since it's pushing
 		// far past the number of replicas per node we support, at least if the
 		// ranges start to unquiesce (which can set off a cascade due to resource
 		// exhaustion).
-		{true, 300000, 2 * time.Hour, "https://github.com/cockroachdb/cockroach/issues/50865"},
+		{true, 300000, 2 * time.Hour},
 		// This version of the test prevents range quiescence to trigger the
 		// badness described above more reliably for when we wish to improve
 		// the performance. For now, just verify that 30k unquiesced ranges
 		// is tenable.
-		{false, 30000, 2 * time.Hour, "https://github.com/cockroachdb/cockroach/issues/51034"},
+		{false, 30000, 2 * time.Hour},
 	} {
 		item := item // for use in closure below
 		r.Add(testSpec{
-			Skip:    item.skip,
 			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t", item.quiesce),
 			Owner:   OwnerKV,
 			Timeout: item.timeout,


### PR DESCRIPTION
See #50865 for details regarding the `quiesce=true` version. The
`quiesce=false` version (tracked in #51034) should've been fixed by
#52348.

Fixes #51034.

Release note: None