### PR TITLE
security: fix the support for separate client CAs

### DIFF
--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -80,7 +80,7 @@ func NewNetwork(
 		Settings:   cluster.MakeTestingClusterSettings(),
 	})
 	var err error
-	n.tlsConfig, err = n.RPCContext.GetServerTLSConfig()
+	n.tlsConfig, err = n.RPCContext.GetNodeToNodeServerTLSConfig()
 	if err != nil {
 		log.Fatalf(context.TODO(), "%v", err)
 	}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -169,7 +169,7 @@ func NewServer(ctx *Context, opts ...ServerOption) *grpc.Server {
 		grpc.StatsHandler(&ctx.stats),
 	}
 	if !ctx.Config.Insecure {
-		tlsConfig, err := ctx.GetServerTLSConfig()
+		tlsConfig, err := ctx.GetNodeToNodeServerTLSConfig()
 		if err != nil {
 			panic(err)
 		}
@@ -699,7 +699,7 @@ func (ctx *Context) grpcDialOptions(
 		var tlsConfig *tls.Config
 		var err error
 		if ctx.tenID == roachpb.SystemTenantID {
-			tlsConfig, err = ctx.GetClientTLSConfig()
+			tlsConfig, err = ctx.GetNodeToNodeClientTLSConfig()
 		} else {
 			tlsConfig, err = ctx.GetTenantClientTLSConfig()
 		}

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -78,7 +78,7 @@ func (ctx *Context) AddTestingDialOpts(opts ...grpc.DialOption) {
 }
 
 func newTestServer(t testing.TB, ctx *Context, extraOpts ...grpc.ServerOption) *grpc.Server {
-	tlsConfig, err := ctx.GetServerTLSConfig()
+	tlsConfig, err := ctx.GetNodeToNodeServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +495,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
 	// newTestServer with a custom listener.
-	tlsConfig, err := serverCtx.GetServerTLSConfig()
+	tlsConfig, err := serverCtx.GetNodeToNodeServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1040,7 +1040,7 @@ func grpcRunKeepaliveTestCase(testCtx context.Context, c grpcKeepaliveTestCase) 
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
-	tlsConfig, err := serverCtx.GetServerTLSConfig()
+	tlsConfig, err := serverCtx.GetNodeToNodeServerTLSConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/rpc/tls_test.go
+++ b/pkg/rpc/tls_test.go
@@ -43,10 +43,8 @@ func TestClientSSLSettings(t *testing.T) {
 	}{
 		{true, false, security.NodeUser, "http", "", true, false},
 		{true, true, "not-a-user", "http", "", true, false},
-		{false, true, "not-a-user", "https", clientCertNotFound, true, false},
 		{false, false, security.NodeUser, "https", certDirNotFound, false, true},
 		{false, true, security.NodeUser, "https", "", false, false},
-		{false, true, "bad-user", "https", clientCertNotFound, false, false},
 	}
 
 	for _, tc := range testCases {
@@ -72,7 +70,7 @@ func TestClientSSLSettings(t *testing.T) {
 			if cfg.HTTPRequestScheme() != tc.requestScheme {
 				t.Fatalf("expected HTTPRequestScheme=%s, got: %s", tc.requestScheme, cfg.HTTPRequestScheme())
 			}
-			tlsConfig, err := rpcContext.GetClientTLSConfig()
+			tlsConfig, err := rpcContext.GetNodeToNodeClientTLSConfig()
 			if !testutils.IsError(err, tc.configErr) {
 				t.Fatalf("expected err=%s, got err=%v", tc.configErr, err)
 			}
@@ -128,7 +126,7 @@ func TestServerSSLSettings(t *testing.T) {
 			if cfg.HTTPRequestScheme() != tc.requestScheme {
 				t.Fatalf("#%d: expected HTTPRequestScheme=%s, got: %s", tcNum, tc.requestScheme, cfg.HTTPRequestScheme())
 			}
-			tlsConfig, err := rpcContext.GetServerTLSConfig()
+			tlsConfig, err := rpcContext.GetNodeToNodeServerTLSConfig()
 			if (err == nil) != tc.configSuccess {
 				t.Fatalf("#%d: expected GetServerTLSConfig success=%t, got err=%v", tcNum, tc.configSuccess, err)
 			}

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -123,6 +123,8 @@ func (p PemUsage) String() string {
 		return "UI"
 	case ClientPem:
 		return "Client"
+	case TenantClientPem:
+		return "Tenant Client"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -49,7 +49,7 @@ func TestManagerWithEmbedded(t *testing.T) {
 	}
 
 	// Verify that we can build tls.Config objects.
-	if _, err := cm.GetServerTLSConfig(); err != nil {
+	if _, err := cm.GetNodeToNodeServerTLSConfig(); err != nil {
 		t.Error(err)
 	}
 	if _, err := cm.GetClientTLSConfig(security.NodeUser); err != nil {

--- a/pkg/security/certs_tenant_test.go
+++ b/pkg/security/certs_tenant_test.go
@@ -102,7 +102,7 @@ func testTenantCertificatesInner(t *testing.T, embedded bool) {
 
 	cm, err := security.NewCertificateManager(certsDir)
 	require.NoError(t, err)
-	serverTLSConfig, err := cm.GetServerTLSConfig()
+	serverTLSConfig, err := cm.GetNodeToNodeServerTLSConfig()
 	require.NoError(t, err)
 
 	// Make a new CertificateManager for the tenant. We could've used this one

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -63,7 +63,14 @@ func newServerTLSConfig(
 	cfg.ClientAuth = tls.VerifyClientCertIfGiven
 
 	if len(caClientPEMs) != 0 {
-		certPool := x509.NewCertPool()
+		// cfg.ClientCAs is hopefully already populated with a cert pool
+		// containing the main caPEM, if caPEM is not nil. If already there,
+		// we reuse it.
+		certPool := cfg.ClientCAs
+		if certPool == nil {
+			// Otherwise we create a new one.
+			certPool = x509.NewCertPool()
+		}
 		for _, pem := range caClientPEMs {
 			if !certPool.AppendCertsFromPEM(pem) {
 				return nil, errors.Errorf("failed to parse client CA PEM data to pool")

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -24,7 +24,7 @@ func TestLoadTLSConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cm, err := security.NewCertificateManager(security.EmbeddedCertsDir)
 	require.NoError(t, err)
-	config, err := cm.GetServerTLSConfig()
+	config, err := cm.GetNodeToNodeServerTLSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, config.GetConfigForClient)
 	config, err = config.GetConfigForClient(&tls.ClientHelloInfo{})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -301,13 +301,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if !cfg.Insecure {
 		// TODO(peter): Call methods on CertificateManager directly. Need to call
 		// base.wrapError or similar on the resulting error.
-		if _, err := rpcContext.GetServerTLSConfig(); err != nil {
+		if _, err := rpcContext.GetNodeToNodeServerTLSConfig(); err != nil {
 			return nil, err
 		}
 		if _, err := rpcContext.GetUIServerTLSConfig(); err != nil {
 			return nil, err
 		}
-		if _, err := rpcContext.GetClientTLSConfig(); err != nil {
+		if _, err := rpcContext.GetNodeToNodeClientTLSConfig(); err != nil {
 			return nil, err
 		}
 		cm, err := rpcContext.GetCertificateManager()

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -719,7 +719,14 @@ func (s *Server) maybeUpgradeToSecureConn(
 	// connection to use TLS/SSL.
 
 	// Do we have a TLS configuration?
-	tlsConfig, serverErr := s.execCfg.RPCContext.GetServerTLSConfig()
+	//
+	// TODO(knz): The node-to-node TLS config accepts certs signed by
+	// the node-to-node CA, in addition to the client CA. Since it
+	// supports both, using it keeps things flexible. However we may
+	// want to restrict this and prevent certs signed by the
+	// node-to-node CA from using SQL.
+	// See: https://github.com/cockroachdb/cockroach/issues/53316
+	tlsConfig, serverErr := s.execCfg.RPCContext.GetNodeToNodeServerTLSConfig()
 	if serverErr != nil {
 		return
 	}


### PR DESCRIPTION
Fixes #47603

Since about forever, there was already code internally to support separate CAs to validate node certs and client certs. That code was triggered if the file `ca-client.crt` was present in the cert directory.

However, this feature was never advertised in docs!
This is because it was broken: when `ca-client.crt` was present, then `ca.crt` was not available any more for node-node connections and cluster connectivity was broken. This was a small implementation bug, which this PR now fixes.


Release note (cli change): CockroachDB now properly supports a
separate CA to validate certificates from incoming connections from
SQL clients. The file `ca-client.crt`, if present, is used in addition
to `ca.crt` to validate clients. This file can be generated with the
command `cockroach cert create-client-ca`. Note: this command had been
present since an earlier version of CockroachDB but the client CA cert
was not working as intended. This has now been fixed.

Epic: CRDB-6663
