### PR TITLE
backupccl: update SHOW BACKUP to show all descriptors

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -561,7 +561,7 @@ INSERT INTO t1 values (-1), (10), (-100);
 			latest, err := ioutil.ReadFile(path.Join(th.iodir, "backup", tc.name, latestFileName))
 			require.NoError(t, err)
 			backedUp := th.sqlDB.QueryStr(t,
-				`SELECT database_name, table_name FROM [SHOW BACKUP $1] ORDER BY database_name, table_name`,
+				`SELECT database_name, object_name FROM [SHOW BACKUP $1] WHERE object_type='table' ORDER BY database_name, object_name`,
 				fmt.Sprintf("%s/%s", destination, string(latest)))
 			require.Equal(t, tc.verifyTables, backedUp)
 		})


### PR DESCRIPTION
This change updates the SHOW BACKUP command to show all descriptors.
This means that there will be rows explicitly for databases, as well as
rows for schemas and types.

Release note (sql change): SHOW BACKUP now shows all schemas in a backup
(database, types and schemas were not shown before). Note: This
introduces a BREAKING CHANGE in that it changes the schema of SHOW
BACKUP and furthermore, the column `table_name` will no longer be
returned. This column is replaced by the more general `object_name`.

Release justification: low risk, high benefit change to existing
functionality