### PR TITLE
roachtest: skip jobs/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -307,6 +307,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		// is to to test the state transitions of jobs from paused to resumed and
 		// vice versa in order to detect regressions in the work done for 20.1.
 		MinVersion: "v20.1.0",
+		Skip:       "https://github.com/cockroachdb/cockroach/issues/51699",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)


### PR DESCRIPTION
Re-enabling this roachtest is high priority at this point, but due to
the many failures we're seeing, let's skip it for now to reduce noise
until we know that this test is stable.

Release note: None