### PR TITLE
sql/catalog/hydratedtables: add a cache for hydrated table descriptors and adopt

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -828,7 +828,7 @@ func createImportingDescriptors(
 				mutableDatabases = append(mutableDatabases, mut)
 			}
 		case catalog.SchemaDescriptor:
-			schemas = append(schemas, schemadesc.NewMutableCreatedSchemaDescriptor(*desc.SchemaDesc()))
+			schemas = append(schemas, schemadesc.NewCreatedMutable(*desc.SchemaDesc()))
 		case catalog.TypeDescriptor:
 			types = append(types, typedesc.NewCreatedMutable(*desc.TypeDesc()))
 		}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -580,7 +580,7 @@ func (sc *SchemaChanger) validateConstraints(
 				evalCtx.Txn = txn
 				// Use the DistSQLTypeResolver because we need to resolve types by ID.
 				semaCtx := tree.MakeSemaContext()
-				collection := descs.NewCollection(ctx, sc.settings, sc.leaseMgr)
+				collection := descs.NewCollection(ctx, sc.settings, sc.leaseMgr, nil /* hydratedTables */)
 				semaCtx.TypeResolver = descs.NewDistSQLTypeResolver(collection, txn)
 				// TODO (rohany): When to release this? As of now this is only going to get released
 				//  after the check is validated.
@@ -723,7 +723,7 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				// Retrieve a lease for this table inside the current txn.
-				tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr)
+				tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr, nil /* hydratedTables */)
 				defer tc.ReleaseAll(ctx)
 				tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
 				if err != nil {
@@ -907,7 +907,7 @@ func (sc *SchemaChanger) distBackfill(
 				}
 			}
 
-			tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr)
+			tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr, nil /* hydratedTables */)
 			// Use a leased table descriptor for the backfill.
 			defer tc.ReleaseAll(ctx)
 			tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
@@ -1265,7 +1265,7 @@ func (sc *SchemaChanger) validateForwardIndexes(
 			if err != nil {
 				return err
 			}
-			tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr)
+			tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr, nil /* hydratedTables */)
 			// pretend that the schema has been modified.
 			if err := tc.AddUncommittedDescriptor(desc); err != nil {
 				return err
@@ -1341,7 +1341,7 @@ func (sc *SchemaChanger) validateForwardIndexes(
 			return err
 		}
 
-		tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr)
+		tc := descs.NewCollection(ctx, sc.settings, sc.leaseMgr, nil /* hydratedTables */)
 		if err := tc.AddUncommittedDescriptor(desc); err != nil {
 			return err
 		}
@@ -1729,7 +1729,7 @@ func validateCheckInTxn(
 ) error {
 	ie := evalCtx.InternalExecutor.(*InternalExecutor)
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
-		newTc := descs.NewCollection(ctx, evalCtx.Settings, leaseMgr)
+		newTc := descs.NewCollection(ctx, evalCtx.Settings, leaseMgr, nil /* hydratedTables */)
 		// pretend that the schema has been modified.
 		if err := newTc.AddUncommittedDescriptor(tableDesc); err != nil {
 			return err
@@ -1770,7 +1770,7 @@ func validateFkInTxn(
 ) error {
 	ie := evalCtx.InternalExecutor.(*InternalExecutor)
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
-		newTc := descs.NewCollection(ctx, evalCtx.Settings, leaseMgr)
+		newTc := descs.NewCollection(ctx, evalCtx.Settings, leaseMgr, nil /* hydratedTables */)
 		// pretend that the schema has been modified.
 		if err := newTc.AddUncommittedDescriptor(tableDesc); err != nil {
 			return err

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -43,6 +43,13 @@ type Descriptor interface {
 	GetParentID() descpb.ID
 	GetParentSchemaID() descpb.ID
 
+	// IsUncommittedVersion returns true if this descriptor represent a version
+	// which is not the currently committed version. Implementations may return
+	// false negatives here in cases where a descriptor may have crossed a
+	// serialization boundary. In particular, this can occur during execution on
+	// remote nodes as well as during some scenarios in schema changes.
+	IsUncommittedVersion() bool
+
 	// Metadata for descriptor leasing.
 	GetVersion() descpb.DescriptorVersion
 	GetModificationTime() hlc.Timestamp

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/database"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
@@ -141,6 +142,7 @@ func MakeCollection(
 	dbCache *database.Cache,
 	dbCacheSubscriber DatabaseCacheSubscriber,
 	sessionData *sessiondata.SessionData,
+	hydratedTables *hydratedtables.Cache,
 ) Collection {
 	// For testing.
 	databaseLeasingUnsupported := false
@@ -154,14 +156,26 @@ func MakeCollection(
 		dbCacheSubscriber:          dbCacheSubscriber,
 		databaseLeasingUnsupported: databaseLeasingUnsupported,
 		sessionData:                sessionData,
+		hydratedTables:             hydratedTables,
 	}
 }
 
 // NewCollection constructs a new *Collection.
 func NewCollection(
-	ctx context.Context, settings *cluster.Settings, leaseMgr *lease.Manager,
+	ctx context.Context,
+	settings *cluster.Settings,
+	leaseMgr *lease.Manager,
+	hydratedTables *hydratedtables.Cache,
 ) *Collection {
-	tc := MakeCollection(ctx, leaseMgr, settings, nil, nil, nil)
+	tc := MakeCollection(
+		ctx,
+		leaseMgr,
+		settings,
+		nil, /* dbCache */
+		nil, /* dbCache */
+		nil, /* sessionData */
+		hydratedTables,
+	)
 	return &tc
 }
 
@@ -236,6 +250,10 @@ type Collection struct {
 	// true in mixed-version 20.1/20.2 clusters, but it remains constant for the
 	// duration of each use of the Collection.
 	databaseLeasingUnsupported bool
+
+	// hydratedTables is node-level cache of table descriptors which utlize
+	// user-defined types.
+	hydratedTables *hydratedtables.Cache
 }
 
 // getLeasedDescriptorByName return a leased descriptor valid for the
@@ -1057,12 +1075,9 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			return desc, nil
 		}
 
-		// TODO (rohany, ajwerner): Here we would look into the cached set of
-		//  hydrated table descriptors and potentially return without having to
-		//  make a copy. However, we could avoid hitting the cache if any of the
-		//  user defined types have been modified in this transaction.
-
-		getType := func(ctx context.Context, id descpb.ID) (tree.TypeName, catalog.TypeDescriptor, error) {
+		getType := typedesc.TypeLookupFunc(func(
+			ctx context.Context, id descpb.ID,
+		) (tree.TypeName, catalog.TypeDescriptor, error) {
 			desc, err := tc.GetTypeVersionByID(ctx, txn, id, tree.ObjectLookupFlagsWithRequired())
 			if err != nil {
 				return tree.TypeName{}, nil, err
@@ -1078,11 +1093,27 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			}
 			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, sc.Name, desc.Name)
 			return name, desc, nil
+		})
+
+		// Utilize the cache of hydrated tables if we have one.
+		if tc.hydratedTables != nil {
+			hydrated, err := tc.hydratedTables.GetHydratedTableDescriptor(ctx, t, getType)
+			if err != nil {
+				return nil, err
+			}
+			if hydrated != nil {
+				return hydrated, nil
+			}
+			// The cache decided not to give back a hydrated descriptor, likely
+			// because either we've modified the table or one of the types or because
+			// this transaction has a stale view of one of the relevant descriptors.
+			// Proceed to hydrating a fresh copy.
 		}
 
+		// TODO(ajwerner): Propagate the IsModified status here.
 		// Make a copy of the underlying descriptor before hydration.
 		descBase := protoutil.Clone(t.TableDesc()).(*descpb.TableDescriptor)
-		if err := typedesc.HydrateTypesInTableDescriptor(ctx, descBase, typedesc.TypeLookupFunc(getType)); err != nil {
+		if err := typedesc.HydrateTypesInTableDescriptor(ctx, descBase, getType); err != nil {
 			return nil, err
 		}
 		return tabledesc.NewImmutable(*descBase), nil

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1110,13 +1110,12 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			// Proceed to hydrating a fresh copy.
 		}
 
-		// TODO(ajwerner): Propagate the IsModified status here.
 		// Make a copy of the underlying descriptor before hydration.
 		descBase := protoutil.Clone(t.TableDesc()).(*descpb.TableDescriptor)
 		if err := typedesc.HydrateTypesInTableDescriptor(ctx, descBase, getType); err != nil {
 			return nil, err
 		}
-		return tabledesc.NewImmutable(*descBase), nil
+		return tabledesc.NewImmutableWithIsUncommittedVersion(*descBase, t.IsUncommittedVersion()), nil
 	default:
 		return desc, nil
 	}

--- a/pkg/sql/catalog/hydratedtables/hydratedcache.go
+++ b/pkg/sql/catalog/hydratedtables/hydratedcache.go
@@ -1,0 +1,387 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package hydratedtables contains logic to cache table descriptors with user
+// defined types hydrated.
+package hydratedtables
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/biogo/store/llrb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+// TODO(ajwerner): Consider adding a mechanism to remove entries which have not
+// been used in a long time.
+
+// Cache caches table descriptors which have their user-defined types hydrated.
+// The cache's contract is a bit tricky. In order to use a hydrated type, the
+// caller needs to have a lease on the relevant type descriptor. The way that
+// this is made to work is that the user provides a handle to a leased
+// ImmutableCopy and then the cache will call through to type resolver for each
+// of the referenced types which ensures that user always uses properly leased
+// descriptors. While all of the types will need to be resolved, they should
+// already be cached so, in this way, this cache prevents the need to copy
+// and re-construct the tabledesc.Immutable in most cases.
+type Cache struct {
+	settings *cluster.Settings
+	g        singleflight.Group
+	metrics  Metrics
+	mu       struct {
+		syncutil.Mutex
+		cache *cache.OrderedCache
+	}
+}
+
+// Metrics returns the cache's metrics.
+func (c *Cache) Metrics() *Metrics {
+	return &c.metrics
+}
+
+var _ metric.Struct = (*Metrics)(nil)
+
+// Metrics exposes cache metrics.
+type Metrics struct {
+	Hits   *metric.Counter
+	Misses *metric.Counter
+}
+
+func makeMetrics() Metrics {
+	return Metrics{
+		Hits:   metric.NewCounter(metaHits),
+		Misses: metric.NewCounter(metaMisses),
+	}
+}
+
+// MetricStruct makes Metrics a metric.Struct.
+func (m *Metrics) MetricStruct() {}
+
+var (
+	metaHits = metric.Metadata{
+		Name:        "sql.hydrated_table_cache.hits",
+		Help:        "counter on the number of cache hits",
+		Measurement: "reads",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	metaMisses = metric.Metadata{
+		Name:        "sql.hydrated_table_cache.misses",
+		Help:        "counter on the number of cache misses",
+		Measurement: "reads",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+)
+
+// CacheSize controls the size of the LRU cache.
+var CacheSize = settings.RegisterNonNegativeIntSetting(
+	"sql.catalog.hydrated_tables.cache_size",
+	"number of table descriptor versions retained in the hydratedtables LRU cache",
+	128)
+
+// NewCache constructs a new Cache.
+func NewCache(settings *cluster.Settings) *Cache {
+	c := &Cache{
+		settings: settings,
+		metrics:  makeMetrics(),
+	}
+	c.mu.cache = cache.NewOrderedCache(cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > int(CacheSize.Get(&settings.SV))
+		},
+		OnEvicted: func(key, value interface{}) {
+			putCacheKey(key.(*cacheKey))
+		},
+	})
+	return c
+}
+
+type hydratedTableDescriptor struct {
+	tableDesc *tabledesc.Immutable
+	typeDescs []*cachedType
+}
+
+type cachedType struct {
+	name    tree.TypeName
+	typDesc catalog.TypeDescriptor
+}
+
+// GetHydratedTableDescriptor returns an ImmutableCopy with the types
+// hydrated. It may use a cached copy but all of the relevant type descriptors
+// will be retrieved via the TypeDescriptorResolver. Note that if the table
+// descriptor is modified, nil will be returned. If any of the types used by
+// the table or have uncommitted versions, then nil may be returned. If a nil
+// descriptor is returned, it up to the caller to clone and hydrate the table
+// descriptor on their own. If the table descriptor does not contain any
+// user-defined types, it will be returned unchanged.
+func (c *Cache) GetHydratedTableDescriptor(
+	ctx context.Context, table *tabledesc.Immutable, res catalog.TypeDescriptorResolver,
+) (hydrated *tabledesc.Immutable, err error) {
+
+	// If the table has an uncommitted version, it cannot be cached. Return nil
+	// forcing the caller to hydrate.
+	if table.IsUncommittedVersion() {
+		return nil, nil
+	}
+
+	// If the table has no user defined types, it is already effectively hydrated,
+	// so just return it.
+	if !table.ContainsUserDefinedTypes() {
+		return table, nil
+	}
+
+	// TODO(ajwerner): This cache may thrash a bit right when a version of a type
+	// changes as different callers oscillate evicting the old and new versions of
+	// that type. It should converge rapidly but nevertheless, a finer-granularity
+	// cache which stored descriptors by not just the table version but also by
+	// the set of type-versions could mitigate the problem. The idea would be to
+	// cache all tuples of table and type versions and then check if what we get
+	// from the resolver matches any of them. Only long-running transactions
+	// should still resolve older versions. Furthermore, the cache has a policy to
+	// not evict never versions of types for older ones. The downside is that
+	// long-running transactions may end up re-hydrating for every statement.
+	//
+	// Probably a better solution would be to cache the hydrated descriptor in the
+	// descs.Collection and invalidate that cache whenever an uncommitted
+	// descriptor that is relevant is added. That way any given transaction will
+	// only ever hydrate a table at most once per modification of a descriptor.
+	// and the cache will converge on new versions rapidly.
+	var groupKey string // used as a proxy for cache hit
+	defer func() {
+		if hydrated != nil {
+			c.recordMetrics(groupKey == "" /* hitCache */)
+		}
+	}()
+	key := newCacheKey(table)
+	defer func() {
+		if key != nil {
+			putCacheKey(key)
+		}
+	}()
+
+	// A loop is required in cases where concurrent operations enter this method,
+	// concurrently determine that they cannot use the cached value but for
+	// different reasons, then serialize on the singleflight group. The goroutine
+	// which does not win the singleflight race will need to verify that the
+	// newly added value can be used before it can use it.
+	for {
+		if cached, ok := c.getFromCache(key); ok {
+			canUse, skipCache, err := canUseCachedDescriptor(ctx, cached, res)
+			if err != nil || skipCache {
+				return nil, err
+			}
+			if canUse {
+				return cached.tableDesc, nil
+			}
+		}
+
+		// Now we want to lock this key and populate the descriptors.
+		// Using a singleflight prevent concurrent attempts to update the cache for
+		// a given descriptor version.
+		if groupKey == "" {
+			groupKey = fmt.Sprintf("%d@%d", key.ID, key.Version)
+		}
+
+		// Only the calling goroutine can actually use the result directly.
+		// Furthermore, if an error is encountered, only the calling goroutine
+		// should return it. Other goroutines will have to go back around and
+		// attempt to read from the cache.
+		var called bool
+		res, _, err := c.g.Do(groupKey, func() (interface{}, error) {
+			called = true
+			cachedRes := cachedTypeDescriptorResolver{
+				underlying: res,
+				cache:      map[descpb.ID]*cachedType{},
+			}
+			descBase := protoutil.Clone(table.TableDesc()).(*descpb.TableDescriptor)
+			if err := typedesc.HydrateTypesInTableDescriptor(ctx, descBase, &cachedRes); err != nil {
+				return nil, err
+			}
+			hydrated := tabledesc.NewImmutable(*descBase)
+
+			// If any of the types resolved as part of hydration are modified, skip
+			// writing this descriptor to the cache.
+			if !cachedRes.haveUncommitted {
+				c.addToCache(key, &hydratedTableDescriptor{
+					tableDesc: hydrated,
+					typeDescs: cachedRes.types,
+				})
+
+				// Prevent the key from being put back in the pool as it is now a member
+				// of the cache's data structure. It will be released when the entry is
+				// evicted.
+				key = nil
+			}
+
+			return hydrated, nil
+		})
+
+		// Another goroutine populated the cache or failed to due to having a
+		// modified descriptor, go back around and see if the	new cache entry can be
+		// used, or if another round of re-population is in order.
+		if !called {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return res.(*tabledesc.Immutable), nil
+	}
+}
+
+// canUseCachedDescriptor returns whether the types stored in the cached
+// descriptor are the same types which are resolved through res.
+//
+// The skipCache return value indicates that either one of the types returned
+// from res contain uncommitted versions or that a resolved types descriptor is
+// from an older version than the currently cached value. We don't want to wind
+// up evicting a newer version with an older version.
+func canUseCachedDescriptor(
+	ctx context.Context, cached *hydratedTableDescriptor, res catalog.TypeDescriptorResolver,
+) (canUse, skipCache bool, _ error) {
+	for _, typ := range cached.typeDescs {
+		name, typDesc, err := res.GetTypeDescriptor(ctx, typ.typDesc.GetID())
+		if err != nil {
+			return false, false, err
+		}
+		// Ensure that the type is not an uncommitted version.
+		if isUncommittedVersion := typDesc.IsUncommittedVersion(); isUncommittedVersion ||
+			// Ensure that the type version matches.
+			typ.typDesc.GetVersion() != typDesc.GetVersion() ||
+			// Only match on the name if the retrieved type has a qualified name.
+			// Note that this behavior is important and ensures that when this
+			// function is passed a resolved which looks up qualified names, it always
+			// get a hydrated descriptor with qualified names in its types.
+			// This is important as we share this cache between distsql which does
+			// not resolve type names and the local planner which does. It'd be a real
+			// bummer if mixes of distributed and local flows lead to thrashing of the
+			// cache.
+			(name.ObjectNamePrefix != (tree.ObjectNamePrefix{}) && typ.name != name) {
+
+			// TODO(ajwerner): Make the TypeDescriptorResolver return a
+			// ResolvedObjectPrefix instead of a tree.TypeName so that we can
+			// determine whether the mismatched name is too old or too new.
+			skipCache = isUncommittedVersion || typ.typDesc.GetVersion() > typDesc.GetVersion()
+			return false, skipCache, nil
+		}
+	}
+	return true, false, nil
+}
+
+// getFromCache locks the cache and retrieves the descriptor with the given key.
+func (c *Cache) getFromCache(key *cacheKey) (*hydratedTableDescriptor, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	got, ok := c.mu.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+	return got.(*hydratedTableDescriptor), true
+}
+
+// getFromCache locks the cache and stores the descriptor with the given key.
+func (c *Cache) addToCache(key *cacheKey, toCache *hydratedTableDescriptor) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.cache.Add(key, toCache)
+}
+
+func (c *Cache) recordMetrics(hitCache bool) {
+	if hitCache {
+		c.metrics.Hits.Inc(1)
+	} else {
+		c.metrics.Misses.Inc(1)
+	}
+}
+
+type cachedTypeDescriptorResolver struct {
+	underlying      catalog.TypeDescriptorResolver
+	cache           map[descpb.ID]*cachedType
+	types           []*cachedType
+	haveUncommitted bool
+}
+
+func (c *cachedTypeDescriptorResolver) GetTypeDescriptor(
+	ctx context.Context, id descpb.ID,
+) (tree.TypeName, catalog.TypeDescriptor, error) {
+	if typ, exists := c.cache[id]; exists {
+		return typ.name, typ.typDesc, nil
+	}
+	name, typDesc, err := c.underlying.GetTypeDescriptor(ctx, id)
+	if err != nil {
+		return tree.TypeName{}, nil, err
+	}
+	typ := &cachedType{
+		name:    name,
+		typDesc: typDesc,
+	}
+	c.cache[id] = typ
+	c.types = append(c.types, typ)
+	c.haveUncommitted = c.haveUncommitted || typDesc.IsUncommittedVersion()
+	return name, typDesc, nil
+}
+
+type cacheKey lease.IDVersion
+
+func (c cacheKey) Compare(comparable llrb.Comparable) int {
+	o := comparable.(*cacheKey)
+	switch {
+	case c.ID < o.ID:
+		return -1
+	case c.ID > o.ID:
+		return 1
+	default:
+		switch {
+		case c.Version < o.Version:
+			return -1
+		case c.Version > o.Version:
+			return 1
+		default:
+			return 0
+		}
+	}
+}
+
+var _ llrb.Comparable = (*cacheKey)(nil)
+
+var cacheKeySyncPool = sync.Pool{
+	New: func() interface{} { return new(cacheKey) },
+}
+
+func newCacheKey(table catalog.TableDescriptor) *cacheKey {
+	k := cacheKeySyncPool.Get().(*cacheKey)
+	*k = cacheKey{
+		ID:      table.GetID(),
+		Version: table.GetVersion(),
+	}
+	return k
+}
+
+func putCacheKey(k *cacheKey) {
+	*k = cacheKey{}
+	cacheKeySyncPool.Put(k)
+}

--- a/pkg/sql/catalog/hydratedtables/hydratedcache_test.go
+++ b/pkg/sql/catalog/hydratedtables/hydratedcache_test.go
@@ -1,0 +1,415 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package hydratedtables
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHydratedCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	t.Run("basic caching", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 1)
+
+		// Observe that the cache's lookup functionality only gets each type
+		// one time. The table in question uses one type two times.
+		require.Equal(t, res.calls, 2)
+
+		// Show that the cache returned a new pointer and hydrated the UDT
+		// (user-defined type).
+		require.NotEqual(t, tableDescUDT, hydrated)
+		require.EqualValues(t, hydrated.Columns[0].Type, typ1T)
+
+		// Try again and ensure we get pointer-for-pointer the same descriptor.
+		res.calls = 0
+		cached, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		require.Equal(t, hydrated, cached)
+		assertMetrics(t, m, 1, 1)
+
+		// Observe that the cache's cache checking functionality only gets each
+		// type one time.
+		require.Equal(t, res.calls, 2)
+	})
+	t.Run("no UDT, no metrics", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		td := tableDescNoUDT.ImmutableCopy().(*tabledesc.Immutable)
+		_, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 0)
+	})
+	t.Run("name change causes eviction", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 1)
+
+		// Change the database name.
+		dbDesc := dbdesc.NewExistingMutable(*dg[dbID].(*dbdesc.Immutable).DatabaseDesc())
+		dbDesc.SetName("new_name")
+		dbDesc.Version++
+		dg[dbID] = dbDesc.ImmutableCopy()
+
+		// Ensure that we observe a new descriptor get created due to
+		// the name change.
+		retrieved, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 2)
+
+		require.NotEqual(t, hydrated, retrieved)
+	})
+	t.Run("unqualified resolution after qualified does not cause eviction", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 1)
+
+		// Attempt to retrieve retrieve the same hydrated descriptor
+		// using a resolver that does not create a qualified name and
+		// see that the same descriptor with the qualified name gets
+		// returned.
+		res.unqualifiedName = true
+		retrieved, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 1, 1)
+
+		require.Equal(t, hydrated, retrieved)
+	})
+	t.Run("qualified resolution after unqualified causes eviction", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		res.unqualifiedName = true
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 1)
+
+		// Attempt to retrieve retrieve the same hydrated descriptor
+		// using a resolver that does create a qualified name and
+		// see that the old descriptor with an unqualified name gets
+		// evicted.
+		res.unqualifiedName = false
+		retrieved, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 2)
+
+		require.NotEqual(t, hydrated, retrieved)
+	})
+	t.Run("version change causes eviction", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		res.unqualifiedName = true
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 1)
+
+		// Change the type descriptor.
+		typDesc := typedesc.NewExistingMutable(*dg[typ1ID].(*typedesc.Immutable).TypeDesc())
+		typDesc.Version++
+		dg[typ1ID] = typedesc.NewImmutable(*typDesc.TypeDesc())
+
+		// Ensure that a new descriptor is returned.
+		retrieved, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		assertMetrics(t, m, 0, 2)
+
+		require.NotEqual(t, hydrated, retrieved)
+	})
+	// If one cache retrieval hits an error during a lookup, it should not
+	// propagate back to a concurrent retrieval as it could be due to something
+	// like cancellation.
+	t.Run("errors do not propagate to concurrent calls", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		calledCh := make(chan chan error, 1)
+		res.called = func(ctx context.Context, id descpb.ID) error {
+			errCh := make(chan error, 1)
+			calledCh <- errCh
+			return <-errCh
+		}
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+
+		callOneErrCh := make(chan error, 1)
+		go func() {
+			_, err := c.GetHydratedTableDescriptor(ctx, td, res)
+			callOneErrCh <- err
+		}()
+
+		call2Res := &descGetterTypeDescriptorResolver{dg: &dg}
+		unblockCallOne := <-calledCh
+		callTwoErrCh := make(chan error, 1)
+		go func() {
+			_, err := c.GetHydratedTableDescriptor(ctx, td, call2Res)
+			callTwoErrCh <- err
+		}()
+		unblockCallOne <- context.Canceled
+		require.Equal(t, context.Canceled, <-callOneErrCh)
+		require.NoError(t, <-callTwoErrCh)
+		assertMetrics(t, c.Metrics(), 0, 1)
+	})
+	t.Run("modified table gets rejected", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+		mut := tabledesc.NewExistingMutable(*dg[tableUDTID].(catalog.TableDescriptor).TableDesc())
+		mut.MaybeIncrementVersion()
+		td := mut.ImmutableCopy().(*tabledesc.Immutable)
+		hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+		require.NoError(t, err)
+		require.Nil(t, hydrated)
+	})
+	t.Run("modified type does not get cached", func(t *testing.T) {
+		c := NewCache(cluster.MakeTestingClusterSettings())
+		m := c.Metrics()
+
+		dg := mkDescGetter(descs...)
+		res := &descGetterTypeDescriptorResolver{dg: &dg}
+
+		mut := typedesc.NewExistingMutable(*dg[typ1ID].(catalog.TypeDescriptor).TypeDesc())
+		mut.MaybeIncrementVersion()
+		dgWithMut := mkDescGetter(append(descs, mut)...)
+		resWithMut := &descGetterTypeDescriptorResolver{dg: &dgWithMut}
+
+		// Given that there is no cached value for this version, we will not find
+		// check for a cached type and will construct the hydrated type underneath
+		// the cache. We can use this descriptor, however, it will not be stored.
+		//
+		// This behavior is a bit bizarre but exists to not waste the work of
+		// hydrating the descriptor if we've already started to do it.
+		// This case should not meaningfully arise in practice.
+		td := tableDescUDT.ImmutableCopy().(*tabledesc.Immutable)
+		{
+			hydrated, err := c.GetHydratedTableDescriptor(ctx, td, resWithMut)
+			require.NoError(t, err)
+			require.NotNil(t, hydrated)
+			assertMetrics(t, m, 0, 1)
+		}
+		{
+			hydrated, err := c.GetHydratedTableDescriptor(ctx, td, resWithMut)
+			require.NoError(t, err)
+			require.NotNil(t, hydrated)
+			assertMetrics(t, m, 0, 2)
+		}
+
+		// Now cache the old version.
+		{
+			hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+			require.NoError(t, err)
+			require.NotNil(t, hydrated)
+			assertMetrics(t, m, 0, 3)
+		}
+		{
+			hydrated, err := c.GetHydratedTableDescriptor(ctx, td, res)
+			require.NoError(t, err)
+			require.NotNil(t, hydrated)
+			assertMetrics(t, m, 1, 3)
+		}
+
+		// Show that now we won't use the cache for the mutated type.
+		{
+			hydrated, err := c.GetHydratedTableDescriptor(ctx, td, resWithMut)
+			require.NoError(t, err)
+			require.Nil(t, hydrated)
+			assertMetrics(t, m, 1, 3)
+		}
+
+	})
+}
+
+func mkTypeT(desc catalog.TypeDescriptor, name *tree.TypeName) *types.T {
+	typT, err := desc.MakeTypesT(context.Background(), name, nil)
+	if err != nil {
+		panic(err)
+	}
+	return typT
+}
+
+const (
+	dbID         = 1
+	scID         = 2
+	typ1ID       = 3
+	typ2ID       = 4
+	tableUDTID   = 5
+	tableNoUDTID = 6
+)
+
+// This block contains definitions for a mocked schema.
+//
+// TODO(ajwerner): This is horrible to both read and write. Build tools to make
+// constructing descriptors for testing less terrible without running a whole
+// server.
+var (
+	dbDesc     = dbdesc.NewInitial(dbID, "db", "root")
+	schemaDesc = schemadesc.NewCreatedMutable(descpb.SchemaDescriptor{
+		Name:     "schema",
+		ID:       scID,
+		ParentID: dbID,
+	})
+	enumMembers = []descpb.TypeDescriptor_EnumMember{
+		{
+			LogicalRepresentation:  "hello",
+			PhysicalRepresentation: []byte{128},
+		},
+		{
+			LogicalRepresentation:  "hi",
+			PhysicalRepresentation: []byte{200},
+		},
+	}
+
+	typ1Desc = typedesc.NewExistingMutable(descpb.TypeDescriptor{
+		Name:                     "enum",
+		ID:                       typ1ID,
+		Version:                  1,
+		ParentID:                 dbID,
+		ParentSchemaID:           scID,
+		State:                    descpb.DescriptorState_PUBLIC,
+		Kind:                     descpb.TypeDescriptor_ENUM,
+		ReferencingDescriptorIDs: []descpb.ID{tableUDTID},
+		EnumMembers:              enumMembers,
+	})
+	typ1Name        = tree.MakeNewQualifiedTypeName(dbDesc.Name, schemaDesc.Name, typ1Desc.Name)
+	typ1T           = mkTypeT(typ1Desc, &typ1Name)
+	typ1TSerialized = &types.T{InternalType: typ1T.InternalType}
+
+	typ2Desc = typedesc.NewExistingMutable(descpb.TypeDescriptor{
+		Name:                     "other_enum",
+		ID:                       typ2ID,
+		Version:                  1,
+		ParentID:                 dbID,
+		ParentSchemaID:           scID,
+		State:                    descpb.DescriptorState_PUBLIC,
+		Kind:                     descpb.TypeDescriptor_ENUM,
+		ReferencingDescriptorIDs: []descpb.ID{tableUDTID},
+		EnumMembers:              enumMembers,
+	})
+	typ2Name        = tree.MakeNewQualifiedTypeName(dbDesc.Name, schemaDesc.Name, typ2Desc.Name)
+	typ2T           = mkTypeT(typ2Desc, &typ2Name)
+	typ2TSerialized = &types.T{InternalType: typ2T.InternalType}
+	tableDescUDT    = tabledesc.NewExistingMutable(descpb.TableDescriptor{
+		Name:                    "foo",
+		ID:                      tableUDTID,
+		Version:                 1,
+		ParentID:                dbID,
+		UnexposedParentSchemaID: scID,
+		Columns: []descpb.ColumnDescriptor{
+			{Name: "a", ID: 1, Type: typ1TSerialized},
+			{Name: "b", ID: 1, Type: typ2TSerialized},
+			{Name: "c", ID: 1, Type: typ1TSerialized},
+		},
+	})
+	tableDescNoUDT = tabledesc.NewExistingMutable(descpb.TableDescriptor{
+		Name:                    "bar",
+		ID:                      tableNoUDTID,
+		Version:                 1,
+		ParentID:                dbID,
+		UnexposedParentSchemaID: scID,
+		Columns: []descpb.ColumnDescriptor{
+			{Name: "a", ID: 1, Type: types.Int},
+		},
+	})
+	descs = []catalog.MutableDescriptor{
+		dbDesc, schemaDesc, typ1Desc, typ2Desc, tableDescUDT, tableDescNoUDT,
+	}
+)
+
+func mkDescGetter(descs ...catalog.MutableDescriptor) catalog.MapDescGetter {
+	ret := make(catalog.MapDescGetter, len(descs))
+	for _, desc := range descs {
+		ret[desc.GetID()] = desc.ImmutableCopy()
+	}
+	return ret
+}
+
+type descGetterTypeDescriptorResolver struct {
+	dg              catalog.DescGetter
+	called          func(ctx context.Context, id descpb.ID) error
+	unqualifiedName bool
+	calls           int
+}
+
+func (d *descGetterTypeDescriptorResolver) GetTypeDescriptor(
+	ctx context.Context, id descpb.ID,
+) (tree.TypeName, catalog.TypeDescriptor, error) {
+	d.calls++
+	if d.called != nil {
+		if err := d.called(ctx, id); err != nil {
+			return tree.TypeName{}, nil, err
+		}
+	}
+	desc, err := d.dg.GetDesc(ctx, id)
+	if err != nil {
+		return tree.TypeName{}, nil, err
+	}
+	if d.unqualifiedName {
+		return tree.MakeUnqualifiedTypeName(tree.Name(desc.GetName())),
+			desc.(catalog.TypeDescriptor), nil
+	}
+	dbDesc, err := d.dg.GetDesc(ctx, desc.GetParentID())
+	if err != nil {
+		return tree.TypeName{}, nil, err
+	}
+	// Assume we've got a user-defined schema.
+	// TODO(ajwerner): Unify this with some other resolution logic.
+	scDesc, err := d.dg.GetDesc(ctx, desc.GetParentSchemaID())
+	if err != nil {
+		return tree.TypeName{}, nil, err
+	}
+	name := tree.MakeNewQualifiedTypeName(dbDesc.GetName(), scDesc.GetName(), desc.GetName())
+	return name, desc.(catalog.TypeDescriptor), nil
+}
+
+func assertMetrics(t *testing.T, m *Metrics, hits, misses int64) {
+	t.Helper()
+	require.Equal(t, hits, m.Hits.Count())
+	require.Equal(t, misses, m.Misses.Count())
+}
+
+var _ catalog.TypeDescriptorResolver = (*descGetterTypeDescriptorResolver)(nil)

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -72,10 +72,10 @@ var (
 	_ = NewImmutable
 )
 
-// NewMutableCreatedSchemaDescriptor returns a Mutable from the
+// NewCreatedMutable returns a Mutable from the
 // given SchemaDescriptor with the cluster version being the zero schema. This
 // is for a schema that is created within the current transaction.
-func NewMutableCreatedSchemaDescriptor(desc descpb.SchemaDescriptor) *Mutable {
+func NewCreatedMutable(desc descpb.SchemaDescriptor) *Mutable {
 	return &Mutable{
 		Immutable: makeImmutable(desc),
 	}

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -31,6 +31,10 @@ var _ catalog.MutableDescriptor = (*Mutable)(nil)
 // Immutable wraps a Schema descriptor and provides methods on it.
 type Immutable struct {
 	descpb.SchemaDescriptor
+
+	// isUncommittedVersion is set to true if this descriptor was created from
+	// a copy of a Mutable with an uncommitted version.
+	isUncommittedVersion bool
 }
 
 // Mutable is a mutable reference to a SchemaDescriptor.
@@ -89,6 +93,11 @@ func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 // GetParentSchemaID implements the Descriptor interface.
 func (desc *Immutable) GetParentSchemaID() descpb.ID {
 	return keys.RootNamespaceID
+}
+
+// IsUncommittedVersion implements the Descriptor interface.
+func (desc *Immutable) IsUncommittedVersion() bool {
+	return desc.isUncommittedVersion
 }
 
 // GetAuditMode implements the DescriptorProto interface.
@@ -171,7 +180,9 @@ func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutable(*protoutil.Clone(desc.SchemaDesc()).(*descpb.SchemaDescriptor))
+	imm := NewImmutable(*protoutil.Clone(desc.SchemaDesc()).(*descpb.SchemaDescriptor))
+	imm.isUncommittedVersion = desc.IsUncommittedVersion()
+	return imm
 }
 
 // IsNew implements the MutableDescriptor interface.
@@ -188,6 +199,11 @@ func (desc *Mutable) SetName(name string) {
 		Name:           desc.Name,
 	})
 	desc.Name = name
+}
+
+// IsUncommittedVersion implements the Descriptor interface.
+func (desc *Mutable) IsUncommittedVersion() bool {
+	return desc.IsNew() || desc.GetVersion() != desc.ClusterVersion.GetVersion()
 }
 
 // IsSchemaNameValid returns whether the input name is valid for a user defined

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -187,8 +187,21 @@ func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 }
 
 // NewImmutable returns a Immutable from the given TableDescriptor.
+// This function assumes that this descriptor has not been modified from the
+// version stored in the key-value store.
 func NewImmutable(tbl descpb.TableDescriptor) *Immutable {
+	return NewImmutableWithIsUncommittedVersion(tbl, false /* isUncommittedVersion */)
+}
+
+// NewImmutableWithIsUncommittedVersion returns a Immutable from the given
+// TableDescriptor and allows the caller to mark the table as corresponding to
+// an uncommitted version. This should be used when constructing a new copy of
+// an Immutable from an existing descriptor which may have a new version.
+func NewImmutableWithIsUncommittedVersion(
+	tbl descpb.TableDescriptor, isUncommittedVersion bool,
+) *Immutable {
 	desc := MakeImmutable(tbl)
+	desc.isUncommittedVersion = isUncommittedVersion
 	return &desc
 }
 

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -70,6 +70,11 @@ type Mutable struct {
 	ClusterVersion *Immutable
 }
 
+// IsUncommittedVersion implements the Descriptor interface.
+func (desc *Mutable) IsUncommittedVersion() bool {
+	return desc.IsNew() || desc.ClusterVersion.GetVersion() != desc.GetVersion()
+}
+
 // Immutable is a custom type for wrapping TypeDescriptors
 // when used in a read only way.
 type Immutable struct {
@@ -79,6 +84,10 @@ type Immutable struct {
 	logicalReps     []string
 	physicalReps    [][]byte
 	readOnlyMembers []bool
+
+	// isUncommittedVersion is set to true if this descriptor was created from
+	// a copy of a Mutable with an uncommitted version.
+	isUncommittedVersion bool
 }
 
 // NewCreatedMutable returns a Mutable from the given type descriptor with the
@@ -169,6 +178,11 @@ func (desc *Immutable) GetOfflineReason() string {
 	return ""
 }
 
+// IsUncommittedVersion implements the Descriptor interface.
+func (desc *Immutable) IsUncommittedVersion() bool {
+	return desc.isUncommittedVersion
+}
+
 // DescriptorProto returns a Descriptor for serialization.
 func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
@@ -231,7 +245,9 @@ func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 func (desc *Mutable) ImmutableCopy() catalog.Descriptor {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
-	return NewImmutable(*protoutil.Clone(desc.TypeDesc()).(*descpb.TypeDescriptor))
+	imm := NewImmutable(*protoutil.Clone(desc.TypeDesc()).(*descpb.TypeDescriptor))
+	imm.isUncommittedVersion = desc.IsUncommittedVersion()
+	return imm
 }
 
 // IsNew implements the MutableDescriptor interface.

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -513,9 +513,7 @@ func HydrateTypesInTableDescriptor(
 			if err != nil {
 				return err
 			}
-			// TODO (rohany): This should be a noop if the hydrated type
-			//  information present in the descriptor has the same version as
-			//  the resolved type descriptor we found here.
+			// Note that this will no-op if the type is already hydrated.
 			if err := typDesc.HydrateTypeInfoWithName(ctx, col.Type, &name, res); err != nil {
 				return err
 			}
@@ -541,9 +539,15 @@ func HydrateTypesInTableDescriptor(
 // HydrateTypeInfoWithName fills in user defined type metadata for
 // a type and also sets the name in the metadata to the passed in name.
 // This is used when hydrating a type with a known qualified name.
+//
+// Note that if the passed type is already hydrated, regardless of the version
+// with which it has been hydrated, this is a no-op.
 func (desc *Immutable) HydrateTypeInfoWithName(
 	ctx context.Context, typ *types.T, name *tree.TypeName, res catalog.TypeDescriptorResolver,
 ) error {
+	if typ.IsHydrated() {
+		return nil
+	}
 	typ.TypeMeta.Name = &types.UserDefinedTypeName{
 		Catalog:        name.Catalog(),
 		ExplicitSchema: name.ExplicitSchema,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -656,7 +656,7 @@ func (s *Server) newConnExecutor(
 	}
 	ex.extraTxnState.prepStmtsNamespaceMemAcc = ex.sessionMon.MakeBoundAccount()
 	ex.extraTxnState.descCollection = descs.MakeCollection(ctx, s.cfg.LeaseManager,
-		s.cfg.Settings, s.dbCache.getDatabaseCache(), s.dbCache, sd)
+		s.cfg.Settings, s.dbCache.getDatabaseCache(), s.dbCache, sd, s.cfg.HydratedTables)
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobsCache = make(map[descpb.ID]*jobs.Job)
 	ex.mu.ActiveQueries = make(map[ClusterWideID]*queryMeta)

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -92,7 +92,7 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	privs.SetOwner(params.SessionData().User)
 
 	// Create the SchemaDescriptor.
-	desc := schemadesc.NewMutableCreatedSchemaDescriptor(descpb.SchemaDescriptor{
+	desc := schemadesc.NewCreatedMutable(descpb.SchemaDescriptor{
 		ParentID:   db.ID,
 		Name:       n.Schema,
 		ID:         id,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -439,7 +439,9 @@ func (ds *ServerImpl) NewFlowContext(
 		// If we weren't passed a descs.Collection, then make a new one. We are
 		// responsible for cleaning it up and releasing any accessed descriptors
 		// on flow cleanup.
-		collection := descs.NewCollection(ctx, ds.ServerConfig.Settings, ds.ServerConfig.LeaseManager.(*lease.Manager))
+		collection := descs.NewCollection(ctx, ds.ServerConfig.Settings,
+			ds.ServerConfig.LeaseManager.(*lease.Manager),
+			ds.ServerConfig.HydratedTables)
 		flowCtx.TypeResolverFactory = &descs.DistSQLTypeResolverFactory{
 			Descriptors: collection,
 			CleanupFunc: func(ctx context.Context) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/database"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
@@ -701,6 +702,10 @@ type ExecutorConfig struct {
 	StmtDiagnosticsRecorder *stmtdiagnostics.Registry
 
 	ExternalIODirConfig base.ExternalIODirConfig
+
+	// HydratedTables is a node-level cache of table descriptors which utilize
+	// user-defined types.
+	HydratedTables *hydratedtables.Cache
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -170,6 +171,10 @@ type ServerConfig struct {
 	// processors query the cache to see if they should communicate updates to the
 	// gateway.
 	RangeCache *kvcoord.RangeDescriptorCache
+
+	// HydratedTables is a node-level cache of table descriptors which utilize
+	// user-defined types.
+	HydratedTables *hydratedtables.Cache
 }
 
 // RuntimeStats is an interface through which the rowexec layer can get

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -269,7 +269,10 @@ func newInternalPlanner(
 	// The table collection used by the internal planner does not rely on the
 	// deprecatedDatabaseCache and there are no subscribers to the
 	// deprecatedDatabaseCache, so we can leave it uninitialized.
-	tables := descs.NewCollection(ctx, execCfg.Settings, execCfg.LeaseManager)
+	// Furthermore, we're not concerned about the efficiency of querying tables
+	// with user-defined types, hence the nil hydratedTables.
+	tables := descs.NewCollection(ctx, execCfg.Settings, execCfg.LeaseManager,
+		nil /* hydratedTables */)
 	dataMutator := &sessionDataMutator{
 		data: sd,
 		defaults: SessionDefaults(map[string]string{

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -102,7 +102,7 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
-	schema := schemadesc.NewMutableCreatedSchemaDescriptor(descpb.SchemaDescriptor{
+	schema := schemadesc.NewCreatedMutable(descpb.SchemaDescriptor{
 		ParentID:   n.newParent.ID,
 		Name:       n.db.Name,
 		ID:         id,

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -423,7 +423,8 @@ func (sc *TableStatisticsCache) parseStats(
 			// will need to start writing a timestamp on the stats objects and request
 			// TypeDescriptor's with the timestamp that the stats were recorded with.
 			err := sc.ClientDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				collection := descs.NewCollection(ctx, sc.Settings, sc.LeaseMgr)
+				collection := descs.NewCollection(ctx, sc.Settings, sc.LeaseMgr,
+					nil /* hydratedTables */)
 				defer collection.ReleaseAll(ctx)
 				resolver := descs.NewDistSQLTypeResolver(collection, txn)
 				var err error

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2478,6 +2478,12 @@ func (t *T) stringTypeSQL() string {
 	return typName
 }
 
+// IsHydrated returns true if this is a user-defined type and the TypeMeta
+// is hydrated.
+func (t *T) IsHydrated() bool {
+	return t.UserDefined() && t.TypeMeta != (UserDefinedTypeMetadata{})
+}
+
 var typNameLiterals map[string]*T
 
 func init() {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1488,7 +1488,19 @@ var charts = []sectionDescription{
 		},
 	},
 	{
-		Organization: [][]string{{SQLLayer, "SQL Livness"}},
+		Organization: [][]string{{SQLLayer, "SQL Catalog", "Hydrated Descriptor Cache"}},
+		Charts: []chartDescription{
+			{
+				Title: "Cache Hits and Misses",
+				Metrics: []string{
+					"sql.hydrated_table_cache.hits",
+					"sql.hydrated_table_cache.misses",
+				},
+			},
+		},
+	},
+	{
+		Organization: [][]string{{SQLLayer, "SQL Liveness"}},
 		Charts: []chartDescription{
 			{
 				Title: "Session Writes",


### PR DESCRIPTION
See individual commits.

Fixes #51385.

Release note: None