### PR TITLE
server: make the `/_admin/v1/location` endpoint usable by non-admins

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1492,7 +1492,7 @@ func (s *adminServer) Locations(
 ) (*serverpb.LocationsResponse, error) {
 	ctx = s.server.AnnotateCtx(ctx)
 
-	userName, err := userFromContext(ctx)
+	_, err := userFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1501,7 +1501,7 @@ func (s *adminServer) Locations(
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
 	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-locations", nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: userName},
+		sessiondata.InternalExecutorOverride{User: security.RootUser},
 		q.String(),
 	)
 	if err != nil {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1512,7 +1512,7 @@ func TestAdminAPILocations(t *testing.T) {
 		)
 	}
 	var res serverpb.LocationsResponse
-	if err := getAdminJSONProto(s, "locations", &res); err != nil {
+	if err := getAdminJSONProtoWithAdminOption(s, "locations", &res, false /* isAdmin */); err != nil {
 		t.Fatal(err)
 	}
 	for i, loc := range testLocations {


### PR DESCRIPTION
Fixes  #45089

This unlocks the cluster node map and the localities view for non-admin users.

Release justification: low risk, high benefit changes to existing functionality

Release note (bug fix): The cluster node map (enterprise feature) and
the debug page to list cluster localities are now available to
non-admin users.