### PR TITLE
release-20.1: server: make the `/_admin/v1/location` endpoint usable by non-admins

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1486,7 +1486,7 @@ func (s *adminServer) Locations(
 ) (*serverpb.LocationsResponse, error) {
 	ctx = s.server.AnnotateCtx(ctx)
 
-	userName, err := userFromContext(ctx)
+	_, err := userFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1495,7 +1495,7 @@ func (s *adminServer) Locations(
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
 	rows, cols, err := s.server.internalExecutor.QueryWithCols(
 		ctx, "admin-locations", nil, /* txn */
-		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		q.String(),
 	)
 	if err != nil {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1461,7 +1461,7 @@ func TestAdminAPILocations(t *testing.T) {
 		)
 	}
 	var res serverpb.LocationsResponse
-	if err := getAdminJSONProto(s, "locations", &res); err != nil {
+	if err := getAdminJSONProtoWithAdminOption(s, "locations", &res, false /* isAdmin */); err != nil {
 		t.Fatal(err)
 	}
 	for i, loc := range testLocations {


### PR DESCRIPTION
Backport 1/1 commits from #53329.

/cc @cockroachdb/release

---

