### PR TITLE
release-19.2: server: make the `/_admin/v1/location` endpoint usable by non-admins

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1388,7 +1388,7 @@ func (s *adminServer) Locations(
 ) (*serverpb.LocationsResponse, error) {
 	ctx = s.server.AnnotateCtx(ctx)
 
-	userName, err := userFromContext(ctx)
+	_, err := userFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1396,7 +1396,7 @@ func (s *adminServer) Locations(
 	q := makeSQLQuery()
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
 	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-locations", nil /* txn */, userName, q.String(),
+		ctx, "admin-locations", nil /* txn */, security.RootUser, q.String(),
 	)
 	if err != nil {
 		return nil, s.serverError(err)

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1443,7 +1443,7 @@ func TestAdminAPILocations(t *testing.T) {
 		)
 	}
 	var res serverpb.LocationsResponse
-	if err := getAdminJSONProto(s, "locations", &res); err != nil {
+	if err := getAdminJSONProtoWithAdminOption(s, "locations", &res, false /* isAdmin */); err != nil {
 		t.Fatal(err)
 	}
 	for i, loc := range testLocations {


### PR DESCRIPTION
Backport 1/1 commits from #53329.

/cc @cockroachdb/release

---
