### PR TITLE
cloudimpl: allows userfile import using relative file paths

### DIFF
--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -301,6 +301,9 @@ func testListFiles(t *testing.T, storeURI, user string, ie *sql.InternalExecutor
 		out := make([]string, len(in))
 		for i := range in {
 			u := *uri
+			if u.Scheme == "userfile" && u.Host == "" {
+				u.Host = cloudimpl.DefaultQualifiedNamePrefix + user
+			}
 			u.Path = u.Path + "/" + in[i]
 			out[i] = u.String()
 		}

--- a/pkg/storage/cloudimpl/cloudimpltests/file_table_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/file_table_storage_test.go
@@ -49,6 +49,16 @@ func TestPutUserFileTable(t *testing.T) {
 	testListFiles(t, "userfile://defaultdb.public.file_list_table/listing-test/basepath",
 		security.RootUser, ie, kvDB)
 
+	t.Run("empty-qualified-table-name", func(t *testing.T) {
+		dest := cloudimpl.MakeUserFileStorageURI("", filename)
+
+		ie := s.InternalExecutor().(*sql.InternalExecutor)
+		testExportStore(t, dest, false, security.RootUser, ie, kvDB)
+
+		testListFiles(t, "userfile:///listing-test/basepath",
+			security.RootUser, ie, kvDB)
+	})
+
 	t.Run("reject-normalized-basename", func(t *testing.T) {
 		testfile := "listing-test/../basepath"
 		userfileURL := url.URL{Scheme: "userfile", Host: qualifiedTableName, Path: ""}

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -197,12 +197,14 @@ func ExternalStorageConfFromURI(path, user string) (roachpb.ExternalStorage, err
 		}
 	case "userfile":
 		qualifiedTableName := uri.Host
-		if qualifiedTableName == "" {
-			return conf, errors.Errorf("host component of userfile URI must be a qualified table name")
-		}
-
 		if user == "" {
 			return conf, errors.Errorf("user creating the FileTable ExternalStorage must be specified")
+		}
+
+		// If the import statement does not specify a qualified table name then use
+		// the default to attempt to locate the file(s).
+		if qualifiedTableName == "" {
+			qualifiedTableName = DefaultQualifiedNamePrefix + user
 		}
 
 		conf.Provider = roachpb.ExternalStorageProvider_FileTable

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -29,7 +29,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const defaultUserfileScheme = "userfile"
+const (
+	// DefaultUserfileScheme is the default scheme used in a userfile URI.
+	DefaultUserfileScheme = "userfile"
+	// DefaultQualifiedNamePrefix is the default FQN prefix used when referencing
+	// tables in userfile.
+	DefaultQualifiedNamePrefix = "defaultdb.public.userfiles_"
+)
 
 type fileTableStorage struct {
 	fs       *filetable.FileToTableSystem
@@ -117,7 +123,7 @@ func MakeUserFileStorageURI(qualifiedTableName, filename string) string {
 
 func makeUserFileURIWithQualifiedName(qualifiedTableName, path string) string {
 	userfileURL := url.URL{
-		Scheme: defaultUserfileScheme,
+		Scheme: DefaultUserfileScheme,
 		Host:   qualifiedTableName,
 		Path:   path,
 	}

--- a/pkg/storage/cloudimpl/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/storage/cloudimpl/filetable/filetabletest/file_table_read_writer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl/filetable"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -269,6 +270,14 @@ func TestReadWriteFile(t *testing.T) {
 			expectedNumChunks, sqlDB)
 
 		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+	})
+
+	// Tests that a FQN without a db and/or schema prefix is rejected during
+	// FileTable creation.
+	t.Run("no-db-or-schema-qualified-table-name", func(t *testing.T) {
+		_, err := filetable.NewFileToTableSystem(ctx, "foo",
+			executor, security.RootUser)
+		testutils.IsError(err, "could not resolve db or schema name")
 	})
 }
 


### PR DESCRIPTION
Previously, we enforced that the user had to specify the host component of the
userfile URI, which contained the `db.schema.table_name_prefix` to search
for the file to IMPORT. Now, if the userfile host is left empty, we
default to searching in: `defaultdb.public.userfile_username` which is
what we do in upload, list, and delete CLI commands.

Also added a few error checks around FQN parsing.

Fixes: #53223

Release note: None