### PR TITLE
importccl: disallow IMPORT into table with partial indexes

### DIFF
--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -844,6 +844,30 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 	assert.Zero(t, importSummary.Rows)
 }
 
+func TestImportWithPartialIndexesErrs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t,
+		base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				RegistryLiveness: jobs.NewFakeNodeLiveness(1),
+				DistSQL: &execinfra.TestingKnobs{
+					BulkAdderFlushesEveryBatch: true,
+				},
+			},
+		})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, "CREATE TABLE t (id INT, data STRING, INDEX (data) WHERE id > 0)")
+	defer sqlDB.Exec(t, `DROP TABLE t`)
+
+	sqlDB.ExpectErr(t, "cannot import into table with partial indexes", `IMPORT INTO t (id, data) CSV DATA ('https://foo.bar')`)
+}
+
 func (ses *generatedStorage) externalStorageFactory() cloud.ExternalStorageFactory {
 	return func(_ context.Context, es roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		uri, err := url.Parse(es.HttpPath.BaseUri)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1003,6 +1003,15 @@ END;
 				return sb.String()
 			}(),
 		},
+		{
+			name: "partial index",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE t (a INT8, b INT8);
+CREATE INDEX i ON t USING btree (a) WHERE (b > 10);
+			`,
+			err: "cannot import a table with partial indexes",
+		},
 
 		// Error
 		{

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -337,6 +337,9 @@ func readPostgresStmt(
 			createTbl[name] = stmt
 		}
 	case *tree.CreateIndex:
+		if stmt.Predicate != nil {
+			return unimplemented.NewWithIssue(50225, "cannot import a table with partial indexes")
+		}
 		name, err := getTableName(&stmt.Table)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit disallows users from `IMPORT`ing into a table that has one
or more partial indexes. Additionally, importing a full database pgdump
with that has partial indexes will error. This functionallity is not
currently supported, so an error is returned.

Note that similar logic is not needed for MySQL or Avro imports because
MySQL does not support partial indexes and Avro does not encode partial
indexes.

The workaround for users is to drop any partial indexes defined on the
destination table, run the `IMPORT`, and finally re-create the partial
indexes. In the case of pgdump files, the partial indexes should be
dropped before the pgdump is created.

Fixes #52024

Release note: None