### PR TITLE
release-20.1: colexec: fix hash join in some cases

### DIFF
--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -625,6 +625,11 @@ func makeHashJoinerSpec(
 		// conditions just yet. When we do, we'll have a separate case for that.
 		rightDistinct = true
 	case sqlbase.JoinType_LEFT_ANTI:
+		// LEFT ANTI joins currently rely on the fact that
+		// ht.probeScratch.headID is populated in order to perform the
+		// matching. However, headID is only populated when the right side is
+		// considered to be non-distinct, so we override that information here.
+		rightDistinct = false
 	default:
 		return spec, errors.AssertionFailedf("hash join of type %s not supported", joinType)
 	}

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1478,6 +1478,20 @@ var mjTestCases = []joinTestCase{
 		onExpr:       execinfrapb.Expression{Expr: "@2 + @3 < 50"},
 		expected:     tuples{{1, 10}, {4, 40}},
 	},
+	{
+		description:       "LEFT ANTI join when right eq cols are key",
+		joinType:          sqlbase.LeftAntiJoin,
+		leftTypes:         []coltypes.T{coltypes.Int64},
+		rightTypes:        []coltypes.T{coltypes.Int64},
+		leftTuples:        tuples{{0}, {0}, {1}, {2}},
+		rightTuples:       tuples{{0}, {2}},
+		leftEqCols:        []uint32{0},
+		rightEqCols:       []uint32{0},
+		leftOutCols:       []uint32{0},
+		rightOutCols:      []uint32{},
+		rightEqColsAreKey: true,
+		expected:          tuples{{1}},
+	},
 }
 
 func TestMergeJoiner(t *testing.T) {


### PR DESCRIPTION
Backport 1/3 commits from #53226.

/cc @cockroachdb/release

---

**colexec: fix LEFT ANTI hash join when right eq cols are key**

Release note (bug fix): Previously, CockroachDB could return incorrect
results when performing LEFT ANTI hash join when right equality columns
form a key when it was executed via the vectorized engine, and now this
has been fixed.