### PR TITLE
sql: fix memory leak caused by duplicate type in set

### DIFF
--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -368,13 +368,18 @@ func (expr *NumVal) ResolveAsType(
 	}
 }
 
+// intersectTypeSlices returns a slice of all the types that are in both of the
+// input slices that have the same OID.
 func intersectTypeSlices(xs, ys []*types.T) (out []*types.T) {
+	seen := make(map[oid.Oid]struct{})
 	for _, x := range xs {
 		for _, y := range ys {
-			if x == y {
+			_, ok := seen[x.Oid()]
+			if x.Oid() == y.Oid() && !ok {
 				out = append(out, x)
 			}
 		}
+		seen[x.Oid()] = struct{}{}
 	}
 	return out
 }
@@ -458,7 +463,6 @@ var (
 		types.String,
 		types.Bytes,
 		types.Bool,
-		types.Box2D,
 		types.Int,
 		types.Float,
 		types.Decimal,


### PR DESCRIPTION
The StrValAvailAllParsable slice is supposed to be a set, but it had a
duplicate in it.

This was causing a memory leak in intersectTypeSlices, especially when
type checking a large case expression, which calls this function once for each
case. The "intersection" slice would grow in size exponentially.

fixes #53213
fixes https://github.com/cockroachdb/cockroach/issues/52762

Release note: None