### PR TITLE
geo: return 3D+ dimensions from GEOS

### DIFF
--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -240,6 +240,22 @@ func TestParseEWKT(t *testing.T) {
 			require.Equal(t, tc.expected, ret)
 		})
 	}
+
+	errorTestCases := []struct {
+		wkt         geopb.EWKT
+		expectedErr string
+	}{
+		{"POINT Z (1 2 3)", "only 2D objects are currently supported"},
+		{"POINT M (1 2 3)", "only 2D objects are currently supported"},
+		{"POINT ZM (1 2 3)", "only 2D objects are currently supported"},
+	}
+	for _, tc := range errorTestCases {
+		t.Run(string(tc.wkt), func(t *testing.T) {
+			_, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.wkt, 0, false)
+			require.Error(t, err)
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
 }
 
 func TestParseGeometry(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4026,16 +4026,6 @@ SELECT ST_Summary('SRID=4326;POINT(0 0)'::geometry)
 Point[BS]
 
 query T
-SELECT ST_Summary('POINT(0 0 0)'::geometry)
-----
-Point[B]
-
-query T
-SELECT ST_Summary('POINT(0 0 0 0)'::geometry)
-----
-Point[B]
-
-query T
 SELECT ST_Summary('MULTIPOINT(0 0)'::geometry)
 ----
 MultiPoint[B] with 1 element
@@ -4075,16 +4065,6 @@ Point[BGS]
 
 query T
 SELECT ST_Summary('SRID=4326;POINT(0 0)'::geography)
-----
-Point[BGS]
-
-query T
-SELECT ST_Summary('POINT(0 0 0)'::geography)
-----
-Point[BGS]
-
-query T
-SELECT ST_Summary('POINT(0 0 0 0)'::geography)
 ----
 Point[BGS]
 


### PR DESCRIPTION
Currently any dimension about 2 was omitted with GEOS returned. Fix this
by telling the EWKB reader to return 3 if there is a Z coordinate.

Note this does not work for EMPTY geometries -- but this should be fine
since we don't store 3D/4D objects at this time.

Release note: None