### PR TITLE
backupccl: remove enterprise check in SHOW

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -42,12 +41,6 @@ func showBackupPlanHook(
 	backup, ok := stmt.(*tree.ShowBackup)
 	if !ok {
 		return nil, nil, nil, false, nil
-	}
-
-	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "SHOW BACKUP",
-	); err != nil {
-		return nil, nil, nil, false, err
 	}
 
 	if err := p.RequireAdminRole(ctx, "SHOW BACKUP"); err != nil {


### PR DESCRIPTION
Release note (enterprise change): As part of making basic BACKUP and RESTORE free to use without an enterpris license, SHOW BACKUP and SHOW BACKUPS IN no longer require a license.