### PR TITLE
sql: support the `USAGE` privilege on schemas

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -319,5 +319,3 @@ ALTER SCHEMA privs RENAME TO denied
 
 statement error pq: permission denied to drop schema "privs"
 DROP SCHEMA privs
-
-# TODO (rohany): Test the usage privilege here.

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -319,3 +319,36 @@ ALTER SCHEMA privs RENAME TO denied
 
 statement error pq: permission denied to drop schema "privs"
 DROP SCHEMA privs
+
+# Test the usage privilege.
+user root
+
+# Create some objects in privs (testuser doesn't have USAGE yet).
+statement ok
+CREATE TABLE privs.usage_tbl (x INT);
+CREATE TYPE privs.usage_typ AS ENUM ('usage');
+
+user testuser
+
+# Both mutable and immutable access should fail with this error.
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+SELECT * FROM privs.usage_tbl
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+SELECT 'usage'::privs.usage_typ
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+ALTER TABLE privs.usage_tbl ADD COLUMN y INT DEFAULT NULL
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+CREATE INDEX ON privs.usage_tbl (x)
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+COMMENT ON TABLE privs.usage_tbl IS 'foo'
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+COMMENT ON COLUMN privs.usage_tbl.x IS 'foo'
+
+statement error pq: user testuser does not have USAGE privilege on schema privs
+ALTER TYPE privs.usage_typ ADD VALUE 'denied'

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -207,6 +207,12 @@ func (oc *optCatalog) ResolveDataSource(
 	if err != nil {
 		return nil, cat.DataSourceName{}, err
 	}
+
+	// Ensure that the current user can access the target schema.
+	if err := oc.planner.canResolveDescUnderSchema(ctx, desc.GetParentSchemaID(), desc); err != nil {
+		return nil, cat.DataSourceName{}, err
+	}
+
 	ds, err := oc.dataSourceForDesc(ctx, flags, desc, &oc.tn)
 	if err != nil {
 		return nil, cat.DataSourceName{}, err


### PR DESCRIPTION
Fixes #53342.

This commit adds the `USAGE` privilege to schemas. The `USAGE` privilege
allows a user to resolve objects under a schema.

Release note (sql change): Support the `USAGE` privelege on schemas.