### PR TITLE
roachtest,colexec: misc cleanups

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -84,7 +84,7 @@ var (
 	slownessThresholdByVersion = map[crdbVersion]float64{
 		tpchVecVersion19_2: 1.5,
 		tpchVecVersion20_1: 1.2,
-		tpchVecVersion20_2: 1.2,
+		tpchVecVersion20_2: 1.15,
 	}
 )
 
@@ -278,16 +278,6 @@ func (p tpchVecPerfTest) preTestRunHook(
 	p.tpchVecTestCaseBase.preTestRunHook(ctx, t, c, conn, version, clusterSetup)
 	if !p.disableStatsCreation {
 		createStatsFromTables(t, conn, tpchTables)
-	}
-	// TODO(yuzefovich): remove this once we figure out the issue with random
-	// performance hits on query 7.
-	for node := 1; node <= c.spec.NodeCount; node++ {
-		nodeConn := c.Conn(ctx, node)
-		if _, err := nodeConn.Exec(
-			"SELECT crdb_internal.set_vmodule('vectorized_flow=1,spilling_queue=1,row_container=2,hash_row_container=2');",
-		); err != nil {
-			t.Fatal(err)
-		}
 	}
 }
 

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -163,7 +163,8 @@ func BenchmarkDefaultAggregateFunction(b *testing.B) {
 		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize() / 2, coldata.BatchSize()} {
 			for _, nullProb := range []float64{0.0, nullProbability} {
 				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize, nullProb, numInputBatches,
+					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize,
+					0 /* distinctProb */, nullProb, numInputBatches,
 				)
 			}
 		}


### PR DESCRIPTION
**roachtest: cleanup tpchvec/perf a bit**

The logging was added in order to help with tracking down some
performance hits on query 7 when vectorize was `on`, but it turned out
to be not helpful, so let's remove it. I still want to keep EXPLAIN
ANALYZE (DEBUG) that would get triggered when the slowness threshold is
exceeded just in case (at least for now). Additionally, this commit
reduces the slowness threshold itself from 1.2 to 1.15 to 20.2 branch.

Release justification: non-production code changes.

Release note: None

**colexec: cleanup benchmark of distinct aggregation**

This commit adds the support for distinct aggregation to
`benchmarkAggregateFunction` which allows us to cleanup the benchmark of
distinct aggregation.

Release justification: non-production code changes.

Release note: None