### PR TITLE
tpcc/roachtest: adjust tpcc workload to optionally include deprecated FKs

### DIFF
--- a/pkg/workload/cli/cli.go
+++ b/pkg/workload/cli/cli.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +74,11 @@ func HandleErrs(
 	return func(cmd *cobra.Command, args []string) {
 		err := f(cmd, args)
 		if err != nil {
+			hint := errors.FlattenHints(err)
 			cmd.Println("Error:", err.Error())
+			if hint != "" {
+				cmd.Println("Hint:", hint)
+			}
 			os.Exit(1)
 		}
 	}

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -90,8 +90,10 @@ const (
 		h_date   timestamp,
 		h_amount decimal(6,2),
 		h_data   varchar(24),
-		primary key (h_w_id, rowid)
-  )`
+		primary key (h_w_id, rowid)`
+	deprecatedTpccHistorySchemaFkSuffix = `
+		index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
+		index history_district_fk_idx (h_w_id, h_d_id)`
 
 	// ORDER table.
 	tpccOrderSchemaBase = `(
@@ -169,8 +171,9 @@ const (
 		ol_quantity     integer,
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
-		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)
-  )`
+		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`
+	deprecatedTpccOrderLineSchemaFkSuffix = `
+		index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id)`
 	tpccOrderLineSchemaInterleaveSuffix = `
 		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 )


### PR DESCRIPTION
Fixes #53136.
Fixes #53122.

Updates the TPCC workload to create no longer needed FK indexes based on
a flag, and use that flag when running tpcc on versions below 20.2.

Release note: None