### PR TITLE
bors: only check Essential CI before merging

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,7 +2,7 @@
 
 # List of commit statuses that must pass on the merge commit before it is
 # pushed to master.
-status = ["GitHub CI (Cockroach)"]
+status = ["Essential CI (Cockroach)"]
 
 # List of commit statuses that must not be failing on the PR commit when it is
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will


### PR DESCRIPTION
We don't need testrace in bors, so avoid that check. This should improve
bors speeds when many packages have changed.

Release note: None

Release justification: non-production code change