### PR TITLE
backupccl: support SHOW BACKUP options on tenant backups

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -304,7 +304,7 @@ func backupShowerDefault(
 					}
 				}
 				for _, t := range manifest.Tenants {
-					rows = append(rows, tree.Datums{
+					row := tree.Datums{
 						tree.NewDString("TENANT"),
 						tree.NewDString(roachpb.MakeTenantID(t.ID).String()),
 						start,
@@ -312,7 +312,14 @@ func backupShowerDefault(
 						tree.DNull,
 						tree.DNull,
 						tree.DNull,
-					})
+					}
+					if showSchemas {
+						row = append(row, tree.DNull)
+					}
+					if _, shouldShowPrivileges := opts[backupOptWithPrivileges]; shouldShowPrivileges {
+						row = append(row, tree.DNull)
+					}
+					rows = append(rows, row)
 				}
 			}
 			return rows, nil


### PR DESCRIPTION
This commit ensures that SHOW BACKUP can be used with all of the options
it supports on tenant backups.

Release note: None