### PR TITLE
colexec: add buffering stage to hash aggregator

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -69,6 +69,9 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 		return
 	}
 	batchLength := batch.Length()
+	if batchLength == 0 {
+		return
+	}
 	// Ensure that convertedVecs are of sufficient length.
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < batchLength {
 		for _, vecIdx := range c.vecIdxsToConvert {
@@ -108,17 +111,22 @@ func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
 // being the fact that it takes in a "disassembled" batch and not coldata.Batch.
 // Consider whether you should be using ConvertBatch instead.
 func (c *VecToDatumConverter) ConvertVecs(vecs []coldata.Vec, inputLen int, sel []int) {
-	if len(c.vecIdxsToConvert) == 0 {
-		// No vectors were selected for conversion, so there is nothing to do.
+	if len(c.vecIdxsToConvert) == 0 || inputLen == 0 {
+		// No vectors were selected for conversion or there are no tuples to
+		// convert, so there is nothing to do.
 		return
 	}
 	// Ensure that convertedVecs are of sufficient length.
 	requiredLength := inputLen
 	if sel != nil {
 		// When sel is non-nil, it might be something like sel = [1023], so we
-		// need to allocate up to the full coldata.BatchSize(), regardless of
-		// the length of the batch.
-		requiredLength = coldata.BatchSize()
+		// need to allocate up to the largest index mentioned in sel.
+		requiredLength = 0
+		for _, idx := range sel[:inputLen] {
+			if idx+1 > requiredLength {
+				requiredLength = idx + 1
+			}
+		}
 	}
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < requiredLength {
 		for _, vecIdx := range c.vecIdxsToConvert {

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -29,11 +29,17 @@ import (
 type hashAggregatorState int
 
 const (
+	// hashAggregatorBuffering is the state in which the hashAggregator reads
+	// the batches from the input and buffers them up. Once the number of
+	// buffered tuples reaches maxBuffered or the input has been fully exhausted,
+	// the hashAggregator transitions to hashAggregatorAggregating state.
+	hashAggregatorBuffering hashAggregatorState = iota
+
 	// hashAggregatorAggregating is the state in which the hashAggregator is
-	// reading the batches from the input and performing aggregation on them,
-	// one at a time. After the input has been fully exhausted, hashAggregator
-	// transitions to hashAggregatorOutputting state.
-	hashAggregatorAggregating hashAggregatorState = iota
+	// performing the aggregation on the buffered tuples. If the input has been
+	// fully exhausted and the buffer is empty, the hashAggregator transitions
+	// to hashAggregatorOutputting state.
+	hashAggregatorAggregating
 
 	// hashAggregatorOutputting is the state in which the hashAggregator is
 	// writing its aggregation results to the output buffer.
@@ -63,6 +69,21 @@ type hashAggregator struct {
 	inputTypes         []*types.T
 	outputTypes        []*types.T
 	inputArgsConverter *colconv.VecToDatumConverter
+
+	// maxBuffered determines the maximum number of tuples that are buffered up
+	// for aggregation at once.
+	maxBuffered    int
+	bufferingState struct {
+		// tuples contains the tuples that we have buffered up for aggregation.
+		// Its length will not exceed maxBuffered.
+		tuples *appendOnlyBufferedBatch
+		// pendingBatch stores the last read batch from the input that hasn't
+		// been fully processed yet.
+		pendingBatch coldata.Batch
+		// unprocessedIdx is the index of the first tuple in pendingBatch that
+		// hasn't been processed yet.
+		unprocessedIdx int
+	}
 
 	// buckets contains all aggregation groups that we have so far. There is
 	// 1-to-1 mapping between buckets[i] and ht.vals[i]. Once the output from
@@ -125,20 +146,32 @@ func NewHashAggregator(
 		allocator, inputTypes, spec, evalCtx, constructors, constArguments,
 		outputTypes, hashAggregatorAllocSize, true, /* isHashAgg */
 	)
+	// We want this number to be coldata.MaxBatchSize, but then we would lose
+	// some test coverage due to disabling of the randomization of the batch
+	// size, so we, instead, use 4 x coldata.BatchSize() (which ends up being
+	// coldata.MaxBatchSize in non-test environment).
+	maxBuffered := 4 * coldata.BatchSize()
+	if maxBuffered > coldata.MaxBatchSize {
+		// When randomizing coldata.BatchSize() in tests we might exceed
+		// coldata.MaxBatchSize, so we need to shrink it.
+		maxBuffered = coldata.MaxBatchSize
+	}
 	hashAgg := &hashAggregator{
 		OneInputNode:       NewOneInputNode(input),
 		allocator:          allocator,
 		spec:               spec,
-		state:              hashAggregatorAggregating,
+		state:              hashAggregatorBuffering,
 		inputTypes:         inputTypes,
 		outputTypes:        outputTypes,
 		inputArgsConverter: inputArgsConverter,
+		maxBuffered:        maxBuffered,
 		toClose:            toClose,
 		aggFnsAlloc:        aggFnsAlloc,
 		hashAlloc:          aggBucketAlloc{allocator: allocator},
 	}
+	hashAgg.bufferingState.tuples = newAppendOnlyBufferedBatch(allocator, inputTypes, nil /* colsToStore */)
 	hashAgg.datumAlloc.AllocSize = hashAggregatorAllocSize
-	hashAgg.aggHelper = newAggregatorHelper(allocator, memAccount, inputTypes, spec, &hashAgg.datumAlloc, true /* isHashAgg */)
+	hashAgg.aggHelper = newAggregatorHelper(allocator, memAccount, inputTypes, spec, &hashAgg.datumAlloc, true /* isHashAgg */, hashAgg.maxBuffered)
 	return hashAgg, err
 }
 
@@ -150,9 +183,9 @@ func (op *hashAggregator) Init() {
 	// TODO(yuzefovich): consider changing aggregateFunc interface to allow for
 	// updating the output vector.
 	op.output = op.allocator.NewMemBatchWithFixedCapacity(op.outputTypes, coldata.BatchSize())
-	op.scratch.eqChains = make([][]int, coldata.BatchSize())
-	op.scratch.intSlice = make([]int, coldata.BatchSize())
-	op.scratch.anotherIntSlice = make([]int, coldata.BatchSize())
+	op.scratch.eqChains = make([][]int, op.maxBuffered)
+	op.scratch.intSlice = make([]int, op.maxBuffered)
+	op.scratch.anotherIntSlice = make([]int, op.maxBuffered)
 	// The hash table only needs to store the grouping columns to be able to
 	// perform the equality check.
 	colsToStore := make([]int, len(op.spec.GroupCols))
@@ -177,19 +210,44 @@ func (op *hashAggregator) Init() {
 func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch op.state {
+		case hashAggregatorBuffering:
+			if op.bufferingState.pendingBatch != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+				op.bufferingState.tuples.append(
+					op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, op.bufferingState.pendingBatch.Length(),
+				)
+			}
+			op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx = op.input.Next(ctx), 0
+			n := op.bufferingState.pendingBatch.Length()
+			if n == 0 {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+			toBuffer := n
+			if op.bufferingState.tuples.Length()+toBuffer > op.maxBuffered {
+				toBuffer = op.maxBuffered - op.bufferingState.tuples.Length()
+			}
+			if toBuffer > 0 {
+				op.bufferingState.tuples.append(op.bufferingState.pendingBatch, 0 /* startIdx */, toBuffer)
+				op.bufferingState.unprocessedIdx = toBuffer
+			}
+			if op.bufferingState.tuples.Length() == op.maxBuffered {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+
 		case hashAggregatorAggregating:
-			b := op.input.Next(ctx)
-			if b.Length() == 0 {
+			op.inputArgsConverter.ConvertBatch(op.bufferingState.tuples)
+			op.onlineAgg(ctx, op.bufferingState.tuples)
+			if op.bufferingState.pendingBatch.Length() == 0 {
 				// TODO(yuzefovich): we no longer need the hash table, so we
 				// could be releasing its memory here.
 				op.state = hashAggregatorOutputting
 				continue
 			}
-			// TODO(yuzefovich): benchmark whether it is beneficial to buffer
-			// up several batches from the input before proceeding to online
-			// aggregation.
-			op.inputArgsConverter.ConvertBatch(b)
-			op.onlineAgg(ctx, b)
+			op.bufferingState.tuples.ResetInternalBatch()
+			op.bufferingState.tuples.SetLength(0)
+			op.state = hashAggregatorBuffering
+
 		case hashAggregatorOutputting:
 			op.output.ResetInternalBatch()
 			curOutputIdx := 0
@@ -206,8 +264,10 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 			}
 			op.output.SetLength(curOutputIdx)
 			return op.output
+
 		case hashAggregatorDone:
 			return coldata.ZeroBatch
+
 		default:
 			colexecerror.InternalError("hash aggregator in unhandled state")
 			// This code is unreachable, but the compiler cannot infer that.
@@ -369,11 +429,12 @@ func (op *hashAggregator) reset(ctx context.Context) {
 	if r, ok := op.input.(resetter); ok {
 		r.reset(ctx)
 	}
+	op.bufferingState.tuples.ResetInternalBatch()
+	op.bufferingState.tuples.SetLength(0)
+	op.bufferingState.pendingBatch = nil
 	op.buckets = op.buckets[:0]
-	op.state = hashAggregatorAggregating
+	op.state = hashAggregatorBuffering
 	op.ht.reset(ctx)
-	op.output.ResetInternalBatch()
-	op.output.SetLength(0)
 }
 
 func (op *hashAggregator) Close(ctx context.Context) error {

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -163,7 +163,7 @@ func NewOrderedAggregator(
 		inputArgsConverter: inputArgsConverter,
 		toClose:            toClose,
 	}
-	a.aggHelper = newAggregatorHelper(allocator, memAccount, inputTypes, spec, &a.datumAlloc, false /* isHashAgg */)
+	a.aggHelper = newAggregatorHelper(allocator, memAccount, inputTypes, spec, &a.datumAlloc, false /* isHashAgg */, coldata.BatchSize())
 	return a, nil
 }
 

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -162,6 +162,10 @@ type appendOnlyBufferedBatch struct {
 	length      int
 	colVecs     []coldata.Vec
 	colsToStore []int
+	// sel is the selection vector on this batch. Note that it is stored
+	// separately from embedded coldata.Batch because we need to be able to
+	// support a vector of an arbitrary length.
+	sel []int
 }
 
 var _ coldata.Batch = &appendOnlyBufferedBatch{}
@@ -180,6 +184,25 @@ func (b *appendOnlyBufferedBatch) ColVec(i int) coldata.Vec {
 
 func (b *appendOnlyBufferedBatch) ColVecs() []coldata.Vec {
 	return b.colVecs
+}
+
+func (b *appendOnlyBufferedBatch) Selection() []int {
+	if b.Batch.Selection() != nil {
+		return b.sel
+	}
+	return nil
+}
+
+func (b *appendOnlyBufferedBatch) SetSelection(useSel bool) {
+	b.Batch.SetSelection(useSel)
+	if useSel {
+		// Make sure that selection vector is of the appropriate length.
+		if cap(b.sel) < b.length {
+			b.sel = make([]int, b.length)
+		} else {
+			b.sel = b.sel[:b.length]
+		}
+	}
 }
 
 func (b *appendOnlyBufferedBatch) AppendCol(coldata.Vec) {


### PR DESCRIPTION
This commit adds a buffering stage to the hash aggregator in which we
accumulate tuples from the input until we get `coldata.MaxBatchSize` of
them and only then we proceed to the online aggregation. This shows nice
performance improvements in most of the cases due to the fact that with
more tuples in the online aggregation we're more likely to have more
tuples that belong to the same group, so we end up processing all of
them at once rather that in separate batches.

One thing worth calling out is that `appendOnlyBufferedBatch` has been
extended to support a selection vector of an arbitrary length. This is
necessary because online aggregation updates the selection vector on the
buffered tuples several times.

Release justification: low risk, high benefit change.

Release note: None