### PR TITLE
pgwire: teach pgwire decoding about user defined types

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -364,10 +364,12 @@ func (c *copyMachine) readBinaryTuple(ctx context.Context) error {
 			return errors.Newf("partial copy data row")
 		}
 		d, err := pgwirebase.DecodeOidDatum(
+			ctx,
 			c.parsingEvalCtx,
 			c.resultColumns[i].Typ.Oid(),
 			pgwirebase.FormatBinary,
 			data,
+			&c.p,
 		)
 		if err != nil {
 			return pgerror.Wrapf(err, pgcode.BadCopyFileFormat,

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -782,6 +782,12 @@ func (c *conn) handleParse(
 			if t == 0 {
 				continue
 			}
+			// If the OID is user defined, then write nil into the type hints and let
+			// the consumer of the PrepareStmt resolve the types.
+			if types.IsOIDUserDefinedType(t) {
+				sqlTypeHints[i] = nil
+				continue
+			}
 			v, ok := types.OidToType[t]
 			if !ok {
 				err := pgwirebase.NewProtocolViolationErrorf("unknown oid type: %v", t)

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -183,7 +183,7 @@ func TestEncodings(t *testing.T) {
 				pgwirebase.FormatText:   tc.TextAsBinary,
 				pgwirebase.FormatBinary: tc.Binary,
 			} {
-				d, err := pgwirebase.DecodeOidDatum(nil, tc.Oid, code, value)
+				d, err := pgwirebase.DecodeOidDatum(context.Background(), nil, tc.Oid, code, value, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -241,7 +241,7 @@ func TestExoticNumericEncodings(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(nil)
 	for i, c := range testCases {
 		t.Run(fmt.Sprintf("%d_%s", i, c.Value), func(t *testing.T) {
-			d, err := pgwirebase.DecodeOidDatum(nil, oid.T_numeric, pgwirebase.FormatBinary, c.Encoding)
+			d, err := pgwirebase.DecodeOidDatum(context.Background(), nil, oid.T_numeric, pgwirebase.FormatBinary, c.Encoding, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/pgwire/pgwirebase/fuzz.go
+++ b/pkg/sql/pgwire/pgwirebase/fuzz.go
@@ -13,6 +13,8 @@
 package pgwirebase
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -40,7 +42,7 @@ func FuzzDecodeOidDatum(data []byte) int {
 	code := FormatCode(data[0]) % (FormatBinary + 1)
 	b := data[2:]
 
-	_, err := DecodeOidDatum(timeCtx, id, code, b)
+	_, err := DecodeOidDatum(context.Background(), timeCtx, id, code, b, nil)
 	if err != nil {
 		return 0
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -11,6 +11,16 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"DROP TYPE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+send
+Query {"String": "DROP TABLE IF EXISTS tb"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 send crdb_only
 Query {"String": "SET experimental_enable_enums=true;"}
 ----
@@ -46,10 +56,10 @@ RowDescription
 # DataTypeSize for an enum is 4, as floats are used to represent enums
 # internally (4 bytes). Since our encodings are variable size, we report
 # the DataTypeSize to be -1, which is the variable length size.
-until ignore_type_oids crdb_only
+until crdb_only
 RowDescription
 ----
-{"Type":"RowDescription","Fields":[{"Name":"te","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"te","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 
 until
 ReadyForQuery
@@ -57,3 +67,53 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"hi"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression for #53413. This test ensures that the wire protocol can handle
+# user defined type OIDs.
+
+send
+Query {"String": "CREATE TABLE tb (x te)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Prepare a query and type hint a user defined type. Then bind this prepared
+# statement with a user defined type argument ([104, 105] = 'hi').
+send
+Parse {"Name": "s1", "Query": "INSERT INTO tb VALUES ($1)", "ParameterOIDs": [100052]}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [[104, 105]]}
+Execute {"Portal": "p"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Ensure that our value was successfully inserted.
+send
+Query {"String": "SELECT * FROM tb"}
+----
+
+until ignore_table_oids ignore_type_oids noncrdb_only
+RowDescription
+----
+{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":0,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+
+until crdb_only
+RowDescription
+----
+{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+
+until
+DataRow
+----
+{"Type":"DataRow","Values":[{"text":"hi"}]}

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -136,7 +136,7 @@ func TestIntArrayRoundTrip(t *testing.T) {
 
 	b := buf.wrapped.Bytes()
 
-	got, err := pgwirebase.DecodeOidDatum(nil, oid.T__int8, pgwirebase.FormatText, b[4:])
+	got, err := pgwirebase.DecodeOidDatum(context.Background(), nil, oid.T__int8, pgwirebase.FormatText, b[4:], nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestByteArrayRoundTrip(t *testing.T) {
 					b := buf.wrapped.Bytes()
 					t.Logf("encoded: %v (%q)", b, b)
 
-					got, err := pgwirebase.DecodeOidDatum(nil, oid.T_bytea, pgwirebase.FormatText, b[4:])
+					got, err := pgwirebase.DecodeOidDatum(context.Background(), nil, oid.T_bytea, pgwirebase.FormatText, b[4:], nil)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -486,7 +486,7 @@ func BenchmarkDecodeBinaryDecimal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		got, err := pgwirebase.DecodeOidDatum(nil, oid.T_numeric, pgwirebase.FormatBinary, bytes)
+		got, err := pgwirebase.DecodeOidDatum(context.Background(), nil, oid.T_numeric, pgwirebase.FormatBinary, bytes, nil)
 		b.StopTimer()
 		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1219,8 +1219,14 @@ func RemapUserDefinedTypeOIDs(t *T, newOID, newArrayOID oid.Oid) {
 
 // UserDefined returns whether or not t is a user defined type.
 func (t *T) UserDefined() bool {
+	return IsOIDUserDefinedType(t.Oid())
+}
+
+// IsOIDUserDefinedType returns whether or not o corresponds to a user
+// defined type.
+func IsOIDUserDefinedType(o oid.Oid) bool {
 	// Types with OIDs larger than the predefined max are user defined.
-	return t.Oid() > oidext.CockroachPredefinedOIDMax
+	return o > oidext.CockroachPredefinedOIDMax
 }
 
 var familyNames = map[Family]string{


### PR DESCRIPTION
Fixes #53413.

This commit teaches the pgwire decoder about user defined types.

Release note (bug fix): Fix a bug where user defined types could not be
used with some ORMs due to an assertion failure within Cockroach.

Release justification: bug fix for new functionality