### PR TITLE
cli: add the postgres \dT alias for listing enums

### DIFF
--- a/docs/generated/sql/bnf/show_var.bnf
+++ b/docs/generated/sql/bnf/show_var.bnf
@@ -6,6 +6,7 @@ show_stmt ::=
 	| show_csettings_stmt
 	| show_databases_stmt
 	| show_enums_stmt
+	| show_types_stmt
 	| show_grants_stmt
 	| show_indexes_stmt
 	| show_partitions_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -195,6 +195,7 @@ show_stmt ::=
 	| show_csettings_stmt
 	| show_databases_stmt
 	| show_enums_stmt
+	| show_types_stmt
 	| show_grants_stmt
 	| show_indexes_stmt
 	| show_partitions_stmt
@@ -571,6 +572,9 @@ show_databases_stmt ::=
 
 show_enums_stmt ::=
 	'SHOW' 'ENUMS'
+
+show_types_stmt ::=
+	'SHOW' 'TYPES'
 
 show_grants_stmt ::=
 	'SHOW' 'GRANTS' opt_on_targets_roles for_grantee_clause
@@ -982,6 +986,7 @@ unreserved_keyword ::=
 	| 'TRUNCATE'
 	| 'TRUSTED'
 	| 'TYPE'
+	| 'TYPES'
 	| 'THROTTLING'
 	| 'UNBOUNDED'
 	| 'UNCOMMITTED'

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -63,6 +63,7 @@ Type:
   \hf [NAME]        help on SQL built-in functions.
   \l                list all databases in the CockroachDB cluster.
   \dt               show the tables of the current schema in the current database.
+  \dT               show the user defined types of the current database.
   \du               list the users for all databases.
   \d [TABLE]        show details about columns in the specified table, or alias for '\dt' if no table is specified.
 %s
@@ -1040,6 +1041,10 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 
 	case `\dt`:
 		c.concatLines = `SHOW TABLES`
+		return cliRunStatement
+
+	case `\dT`:
+		c.concatLines = `SHOW TYPES`
 		return cliRunStatement
 
 	case `\du`:

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -201,6 +201,7 @@ func TestHandleCliCmdSqlAlias(t *testing.T) {
 	}{
 		{`\l`, `SHOW DATABASES`},
 		{`\dt`, `SHOW TABLES`},
+		{`\dT`, `SHOW TYPES`},
 		{`\du`, `SHOW USERS`},
 		{`\d mytable`, `SHOW COLUMNS FROM mytable`},
 		{`\d`, `SHOW TABLES`},

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -46,6 +46,9 @@ func TryDelegate(
 	case *tree.ShowEnums:
 		return d.delegateShowEnums()
 
+	case *tree.ShowTypes:
+		return d.delegateShowTypes()
+
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)
 

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package delegate
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+func (d *delegator) delegateShowTypes() (tree.Statement, error) {
+	// TODO (SQL Features, SQL Exec): Once more user defined types are added
+	//  they should be added here.
+	return parse(`
+SELECT
+  schema, name, value AS description
+FROM
+  [SHOW ENUMS]
+ORDER BY
+  (schema, name)`)
+}

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1119,6 +1119,17 @@ public greeting2  hello
 public int        Z|S of int
 public notbad     dup|DUP
 
+query TTT
+SHOW TYPES
+----
+public as_bytes   bytes
+public dbs        postgres|mysql|spanner|cockroach
+public farewell   bye|seeya
+public greeting   hello|howdy|hi
+public greeting2  hello
+public int        Z|S of int
+public notbad     dup|DUP
+
 statement ok
 SET experimental_enable_user_defined_schemas = true;
 CREATE SCHEMA uds;

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -308,6 +308,7 @@ func TestContextualHelp(t *testing.T) {
 		{`SHOW DATABASES ??`, `SHOW DATABASES`},
 
 		{`SHOW ENUMS ??`, `SHOW ENUMS`},
+		{`SHOW TYPES ??`, `SHOW TYPES`},
 
 		{`SHOW GRANTS ON ??`, `SHOW GRANTS`},
 		{`SHOW GRANTS ON foo FOR ??`, `SHOW GRANTS`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -510,6 +510,8 @@ func TestParse(t *testing.T) {
 		{`EXPLAIN SHOW DATABASES`},
 		{`SHOW ENUMS`},
 		{`EXPLAIN SHOW ENUMS`},
+		{`SHOW TYPES`},
+		{`EXPLAIN SHOW TYPES`},
 		{`SHOW SCHEMAS`},
 		{`EXPLAIN SHOW SCHEMAS`},
 		{`SHOW SCHEMAS FROM a`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -648,7 +648,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 
 %token <str> TABLE TABLES TEMP TEMPLATE TEMPORARY TENANT TESTING_RELOCATE EXPERIMENTAL_RELOCATE TEXT THEN
 %token <str> TIES TIME TIMETZ TIMESTAMP TIMESTAMPTZ TO THROTTLING TRAILING TRACE TRANSACTION TREAT TRIGGER TRIM TRUE
-%token <str> TRUNCATE TRUSTED TYPE
+%token <str> TRUNCATE TRUSTED TYPE TYPES
 %token <str> TRACING
 
 %token <str> UNBOUNDED UNCOMMITTED UNION UNIQUE UNKNOWN UNLOGGED UNSPLIT
@@ -857,6 +857,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %type <tree.Statement> show_tables_stmt
 %type <tree.Statement> show_trace_stmt
 %type <tree.Statement> show_transaction_stmt
+%type <tree.Statement> show_types_stmt
 %type <tree.Statement> show_users_stmt
 %type <tree.Statement> show_zone_stmt
 %type <tree.Statement> show_schedules_stmt
@@ -4126,8 +4127,8 @@ zone_value:
 // SHOW CREATE, SHOW DATABASES, SHOW ENUMS, SHOW HISTOGRAM, SHOW INDEXES, SHOW
 // PARTITIONS, SHOW JOBS, SHOW QUERIES, SHOW RANGE, SHOW RANGES,
 // SHOW ROLES, SHOW SCHEMAS, SHOW SEQUENCES, SHOW SESSION, SHOW SESSIONS,
-// SHOW STATISTICS, SHOW SYNTAX, SHOW TABLES, SHOW TRACE SHOW TRANSACTION, SHOW USERS,
-// SHOW LAST QUERY STATISTICS, SHOW SCHEDULES
+// SHOW STATISTICS, SHOW SYNTAX, SHOW TABLES, SHOW TRACE, SHOW TRANSACTION, SHOW TYPES,
+// SHOW USERS, SHOW LAST QUERY STATISTICS, SHOW SCHEDULES
 show_stmt:
   show_backup_stmt          // EXTEND WITH HELP: SHOW BACKUP
 | show_columns_stmt         // EXTEND WITH HELP: SHOW COLUMNS
@@ -4136,6 +4137,7 @@ show_stmt:
 | show_csettings_stmt       // EXTEND WITH HELP: SHOW CLUSTER SETTING
 | show_databases_stmt       // EXTEND WITH HELP: SHOW DATABASES
 | show_enums_stmt           // EXTEND WITH HELP: SHOW ENUMS
+| show_types_stmt           // EXTEND WITH HELP: SHOW TYPES
 | show_fingerprints_stmt
 | show_grants_stmt          // EXTEND WITH HELP: SHOW GRANTS
 | show_histogram_stmt       // EXTEND WITH HELP: SHOW HISTOGRAM
@@ -4391,7 +4393,7 @@ show_databases_stmt:
   }
 | SHOW DATABASES error // SHOW HELP: SHOW DATABASES
 
-// %Help: SHOW ENUMS - list defined enums
+// %Help: SHOW ENUMS - list enums
 // %Category: Misc
 // %Text: SHOW ENUMS
 show_enums_stmt:
@@ -4400,6 +4402,16 @@ show_enums_stmt:
     $$.val = &tree.ShowEnums{}
   }
 | SHOW ENUMS error // SHOW HELP: SHOW ENUMS
+
+// %Help: SHOW TYPES - list user defined types
+// %Category: Misc
+// %Text: SHOW TYPES
+show_types_stmt:
+  SHOW TYPES
+  {
+    $$.val = &tree.ShowTypes{}
+  }
+| SHOW TYPES error // SHOW HELP: SHOW TYPES
 
 // %Help: SHOW GRANTS - list grants
 // %Category: Priv
@@ -11476,6 +11488,7 @@ unreserved_keyword:
 | TRUNCATE
 | TRUSTED
 | TYPE
+| TYPES
 | THROTTLING
 | UNBOUNDED
 | UNCOMMITTED

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -155,6 +155,14 @@ func (node *ShowEnums) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ENUMS")
 }
 
+// ShowTypes represents a SHOW TYPES statement.
+type ShowTypes struct{}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowTypes) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW TYPES")
+}
+
 // ShowTraceType is an enum of SHOW TRACE variants.
 type ShowTraceType string
 

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -788,6 +788,12 @@ func (*ShowEnums) StatementType() StatementType { return Rows }
 func (*ShowEnums) StatementTag() string { return "SHOW ENUMS" }
 
 // StatementType implements the Statement interface.
+func (*ShowTypes) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowTypes) StatementTag() string { return "SHOW TYPES" }
+
+// StatementType implements the Statement interface.
 func (*ShowTraceForSession) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -1105,6 +1111,7 @@ func (n *ShowSessions) String() string                   { return AsString(n) }
 func (n *ShowSyntax) String() string                     { return AsString(n) }
 func (n *ShowTableStats) String() string                 { return AsString(n) }
 func (n *ShowTables) String() string                     { return AsString(n) }
+func (n *ShowTypes) String() string                      { return AsString(n) }
 func (n *ShowTraceForSession) String() string            { return AsString(n) }
 func (n *ShowTransactionStatus) String() string          { return AsString(n) }
 func (n *ShowLastQueryStatistics) String() string        { return AsString(n) }


### PR DESCRIPTION
Teach the cli to translate \dT into a call to `SHOW ENUMS`.

Release note (cli change): Recognize the \dT alias for listing user
defined types.

Release note (sql change): Add the `SHOW TYPES` command to list all user
defined types.