### PR TITLE
roachtest/indexes: support multi-region aws and tune for latency

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -2759,8 +2760,10 @@ func (m *monitor) wait(args ...string) error {
 	return err
 }
 
+// TODO(nvanbenschoten): this function should take a context and be responsive
+// to context cancellation.
 func waitForFullReplication(t *test, db *gosql.DB) {
-	t.l.Printf("waiting for up-replication...\n")
+	t.l.Printf("waiting for up-replication...")
 	tStart := timeutil.Now()
 	for ok := false; !ok; time.Sleep(time.Second) {
 		if err := db.QueryRow(
@@ -2770,6 +2773,45 @@ func waitForFullReplication(t *test, db *gosql.DB) {
 		}
 		if timeutil.Since(tStart) > 30*time.Second {
 			t.l.Printf("still waiting for full replication")
+		}
+	}
+}
+
+func waitForUpdatedReplicationReport(ctx context.Context, t *test, db *gosql.DB) {
+	t.l.Printf("waiting for updated replication report...")
+
+	// Temporarily drop the replication report interval down.
+	if _, err := db.ExecContext(
+		ctx, `SET CLUSTER setting kv.replication_reports.interval = '2s'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if _, err := db.ExecContext(
+			ctx, `RESET CLUSTER setting kv.replication_reports.interval`,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Wait for a new report with a timestamp after tStart to ensure
+	// that the report picks up any new tables or zones.
+	tStart := timeutil.Now()
+	for r := retry.StartWithCtx(ctx, retry.Options{}); r.Next(); {
+		var gen time.Time
+		if err := db.QueryRowContext(
+			ctx, `SELECT generated FROM system.reports_meta ORDER BY 1 DESC LIMIT 1`,
+		).Scan(&gen); err != nil {
+			if !errors.Is(err, gosql.ErrNoRows) {
+				t.Fatal(err)
+			}
+			// No report generated yet.
+		} else if tStart.Before(gen) {
+			// New report generated.
+			return
+		}
+		if timeutil.Since(tStart) > 30*time.Second {
+			t.l.Printf("still waiting for updated replication report")
 		}
 	}
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -885,16 +885,9 @@ func (s *clusterSpec) args() []string {
 
 	switch cloud {
 	case aws:
-		if s.Zones != "" {
-			fmt.Fprintf(os.Stderr, "zones spec not yet supported on AWS: %s\n", s.Zones)
-			os.Exit(1)
-		}
-		if s.Geo {
-			fmt.Fprintf(os.Stderr, "geo-distributed clusters not yet supported on AWS\n")
-			os.Exit(1)
-		}
-
 		args = append(args, "--clouds=aws")
+	case gce:
+		args = append(args, "--clouds=gce")
 	case azure:
 		args = append(args, "--clouds=azure")
 	}

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -72,7 +72,7 @@ func registerIndexes(r *testRegistry) {
 }
 
 func registerIndexesBench(r *testRegistry) {
-	for i := 0; i <= 10; i++ {
+	for i := 0; i <= 100; i++ {
 		registerNIndexes(r, i)
 	}
 }

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -15,11 +15,17 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
 func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 	const nodes = 6
-	geoZones := []string{"us-west1-b", "us-east1-b", "us-central1-a"}
+	geoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
+	if cloud == aws {
+		geoZones = []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
+	}
 	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
@@ -36,6 +42,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 			c.Put(ctx, cockroach, "./cockroach", roachNodes)
 			c.Put(ctx, workload, "./workload", loadNode)
 			c.Start(ctx, t, roachNodes)
+			conn := c.Conn(ctx, 1)
 
 			t.Status("running workload")
 			m := newMonitor(ctx, c, roachNodes)
@@ -47,15 +54,55 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 				// Set lease preferences so that all leases for the table are
 				// located in the availability zone with the load generator.
 				if !local {
-					leasePrefs := fmt.Sprintf(`ALTER TABLE indexes.indexes
-						                       CONFIGURE ZONE USING
-						                       constraints = COPY FROM PARENT,
-						                       lease_preferences = '[[+zone=%s]]'`, firstAZ)
-					c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "`+leasePrefs+`"`)
+					t.l.Printf("setting lease preferences")
+					if _, err := conn.ExecContext(ctx, fmt.Sprintf(`
+						ALTER TABLE indexes.indexes
+						CONFIGURE ZONE USING
+						constraints = COPY FROM PARENT,
+						lease_preferences = '[[+zone=%s]]'`,
+						firstAZ,
+					)); err != nil {
+						return err
+					}
+
+					// Add a small delay to allow ranges to rebalance.
+					t.l.Printf("waiting for rebalancing")
+					time.Sleep(time.Duration(5*secondaryIndexes) * time.Second)
+
+					// Wait for leases to adhere to preferences, if they aren't
+					// already.
+					for r := retry.StartWithCtx(ctx, retry.Options{}); r.Next(); {
+						t.l.Printf("checking lease preferences")
+						var ok bool
+						if err := conn.QueryRowContext(ctx, `
+							SELECT lease_holder <= $1
+							FROM crdb_internal.ranges
+							WHERE table_name = 'indexes'`,
+							nodes/3,
+						).Scan(&ok); err != nil {
+							return err
+						} else if ok {
+							break
+						}
+
+						t.l.Printf("leases still rebalancing...")
+					}
 				}
 
-				payload := " --payload=256"
-				concurrency := ifLocal("", " --concurrency="+strconv.Itoa(nodes*32))
+				// Set the DistSender concurrency setting high enough so that no
+				// requests get throttled. Add 2x headroom on top of this.
+				conc := 16 * len(gatewayNodes)
+				parallelWrites := (secondaryIndexes + 1) * conc
+				distSenderConc := 2 * parallelWrites
+				if _, err := conn.ExecContext(ctx, `
+					SET CLUSTER SETTING kv.dist_sender.concurrency_limit = $1`,
+					distSenderConc,
+				); err != nil {
+					return err
+				}
+
+				payload := " --payload=64"
+				concurrency := ifLocal("", " --concurrency="+strconv.Itoa(conc))
 				duration := " --duration=" + ifLocal("10s", "10m")
 				runCmd := fmt.Sprintf("./workload run indexes --histograms="+perfArtifactsDir+"/stats.json"+
 					payload+concurrency+duration+" {pgurl%s}", gatewayNodes)

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -134,7 +134,7 @@ var CanSendToFollower = func(
 
 const (
 	// The default limit for asynchronous senders.
-	defaultSenderConcurrency = 500
+	defaultSenderConcurrency = 1024
 	// The maximum number of range descriptors to prefetch during range lookups.
 	rangeLookupPrefetchCount = 8
 	// The maximum number of times a replica is retried when it repeatedly returns
@@ -151,7 +151,7 @@ var rangeDescriptorCacheSize = settings.RegisterIntSetting(
 var senderConcurrencyLimit = settings.RegisterNonNegativeIntSetting(
 	"kv.dist_sender.concurrency_limit",
 	"maximum number of asynchronous send requests",
-	max(defaultSenderConcurrency, int64(32*runtime.NumCPU())),
+	max(defaultSenderConcurrency, int64(64*runtime.NumCPU())),
 )
 
 func max(a, b int64) int64 {

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -86,8 +86,8 @@ func (w *indexes) Flags() workload.Flags { return w.flags }
 func (w *indexes) Hooks() workload.Hooks {
 	return workload.Hooks{
 		Validate: func() error {
-			if w.idxs < 0 || w.idxs > 10 {
-				return errors.Errorf(`--secondary-indexes must be in range [0, 10]`)
+			if w.idxs < 0 || w.idxs > 99 {
+				return errors.Errorf(`--secondary-indexes must be in range [0, 99]`)
 			}
 			if w.payload < 1 {
 				return errors.Errorf(`--payload size must be equal to or greater than 1`)
@@ -133,7 +133,12 @@ func (w *indexes) Tables() []workload.Table {
 	var b strings.Builder
 	b.WriteString(schemaBase)
 	for i := 0; i < w.idxs; i++ {
-		fmt.Fprintf(&b, ",\n\t\t%sINDEX idx%d (col%d)", unique, i, i)
+		col1, col2 := i/10, i%10
+		if col1 == col2 {
+			fmt.Fprintf(&b, ",\n\t\t%sINDEX idx%d (col%d)", unique, i, col1)
+		} else {
+			fmt.Fprintf(&b, ",\n\t\t%sINDEX idx%d (col%d, col%d)", unique, i, col1, col2)
+		}
 	}
 	b.WriteString("\n)")
 


### PR DESCRIPTION
This PR updates the `indexes` suite of roachtests to support a multi-region AWS deployment alongside its multi-region GCE deployment.

The commit then tunes the workload to optimize for a stable p50 and p99 latency all the way up to 50 secondary indexes. The concurrency is fairly low with low numbers of indexes, but that's not what the test is trying to stress.

This roachtest with these changes is being used in a POC to demonstrate single-round trip, multi-range transactions.