### PR TITLE
cli flags clean-up

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -390,6 +391,8 @@ func init() {
 		// Use a separate variable to store the value of ServerInsecure.
 		// We share the default with the ClientInsecure flag.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
+		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
+			"For details, see: "+unimplemented.MakeURL(53404))
 
 		// Enable/disable various external storage endpoints.
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
@@ -555,6 +558,8 @@ func init() {
 		_ = f.MarkHidden(cliflags.ClientPort.Name)
 
 		boolFlag(f, &baseCfg.Insecure, cliflags.ClientInsecure)
+		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
+			"For details, see: "+unimplemented.MakeURL(53404))
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir)
@@ -735,6 +740,8 @@ func init() {
 		varFlag(f, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 		varFlag(f, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
 		boolFlag(f, &demoCtx.insecure, cliflags.ClientInsecure)
+		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
+			"For details, see: "+unimplemented.MakeURL(53404))
 		boolFlag(f, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense)
 		// Mark the --global flag as hidden until we investigate it more.
 		boolFlag(f, &demoCtx.simulateLatency, cliflags.Global)
@@ -799,6 +806,9 @@ func init() {
 		// (which is a PreRun for this command):
 		_ = extraServerFlagInit // guru assignment
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
+		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
+			"For details, see: "+unimplemented.MakeURL(53404))
+
 		stringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir)
 		// NB: this also gets PreRun treatment via extraServerFlagInit to populate BaseCfg.SQLAddr.
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -346,10 +346,6 @@ func init() {
 		varFlag(f, addrSetter{&serverSQLAdvertiseAddr, &serverSQLAdvertisePort}, cliflags.SQLAdvertiseAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
 		stringFlag(f, &serverSocketDir, cliflags.SocketDir)
-		// --socket is deprecated as of 20.1.
-		// TODO(knz): remove in 20.2.
-		stringFlag(f, &serverCfg.SocketFile, cliflags.Socket)
-		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
 		boolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP)
 
 		// Backward-compatibility flags.
@@ -924,14 +920,12 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	// Construct the socket name, if requested. The flags may not be defined for
 	// `cmd` so be cognizant of that.
 	//
-	// If --socket (DEPRECATED) was set, then serverCfg.SocketFile is
-	// already set and we don't want to change it.
-	// However, if --socket-dir is set, then we'll use that.
+	// If --socket-dir is set, then we'll use that.
 	// There are two cases:
 	// 1. --socket-dir is set and is empty; in this case the user is telling us
 	//    "disable the socket".
 	// 2. is set and non-empty. Then it should be used as specified.
-	if !changed(fs, cliflags.Socket.Name) && changed(fs, cliflags.SocketDir.Name) {
+	if changed(fs, cliflags.SocketDir.Name) {
 		if serverSocketDir == "" {
 			serverCfg.SocketFile = ""
 		} else {

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -751,9 +751,6 @@ func TestServerSocketSettings(t *testing.T) {
 		// Empty socket dir disables the socket.
 		{[]string{"start", "--socket-dir="}, ""},
 		{[]string{"start", "--socket-dir=", "--listen-addr=:12345"}, ""},
-		// Deprecated behavior (remove in 20.2):
-		{[]string{"start", "--socket=/blah/xxxx"}, "/blah/xxxx"},
-		{[]string{"start", "--socket-dir=/foo", "--socket=/blah/xxxx"}, "/blah/xxxx"},
 	}
 
 	for i, td := range testData {

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -28,7 +28,14 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 
 	lastWords := func(s string) []string {
 		var result []string
-		for _, line := range strings.Split(s, "\n") {
+		lines := strings.Split(s, "\n")
+		// v20.1 introduces a deprecation notice for --insecure. Skip over it.
+		// TODO(knz): Remove this when --insecure is dropped.
+		// See: https://github.com/cockroachdb/cockroach/issues/53404
+		if len(lines) > 0 && strings.HasPrefix(lines[0], "Flag --insecure has been deprecated") {
+			lines = lines[2:]
+		}
+		for _, line := range lines {
 			words := strings.Fields(line)
 			if n := len(words); n > 0 {
 				result = append(result, words[n-2]+" "+words[n-1])


### PR DESCRIPTION
Informs #53404
Informs #49918

Release note (cli change): The command-line flag `--socket` has been
removed. It was deprecated since v20.1. Use `--socket-dir` in
replacement.

Release note (cli change): The command-line `--insecure` has been
marked as deprecated. See #53404 for details.
The flag will be removed in a later version in a staged fashion:
first, additional security mechanisms will be added to enable more
flexible deployments which were previously done using `--insecure`;
then the flaf will be removed from server commands, then finally in a
later version also from client commands.