### PR TITLE
roachtest/cdc: add shell retry instead of curl retry

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -637,7 +637,7 @@ func (k kafkaManager) install(ctx context.Context) {
 		ctx,
 		k.nodes,
 		fmt.Sprintf(
-			`curl --retry 10 --retry-delay 5 -o /tmp/confluent.tar.gz https://storage.googleapis.com/cockroach-fixtures/tools/confluent-oss-4.0.0-2.11.tar.gz && tar xvf /tmp/confluent.tar.gz -C %s`,
+			`for i in $(seq 1 5); do curl --retry 3 --retry-delay 1 -o /tmp/confluent.tar.gz https://storage.googleapis.com/cockroach-fixtures/tools/confluent-oss-4.0.0-2.11.tar.gz && break || sleep 15; done && tar xvf /tmp/confluent.tar.gz -C %s`,
 			folder,
 		),
 	)


### PR DESCRIPTION
I do not think curl retries when it hits `curl: (56) GnuTLS recv error
(-54): Error in the pull function.`.

Use a hard bash retry instead.

Resolves #53411 (...?)

Release note: None