### PR TITLE
sql: add cluster setting for maximum read buffer size

### DIFF
--- a/pkg/sql/conn_buffer_test.go
+++ b/pkg/sql/conn_buffer_test.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/jackc/pgx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBigClientMessage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	params, _ := tests.CreateTestServerParams()
+	s, mainDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	// Form a 64kB string.
+	str := "a"
+	for len(str) < 1<<16 {
+		str += str
+	}
+
+	// Check we can send a 1MB string.
+	_, err := mainDB.Exec(fmt.Sprintf(`SELECT '%s'`, str))
+	require.NoError(t, err)
+
+	// Set the cluster setting to be less than 1MB.
+	_, err = mainDB.Exec(`SET CLUSTER SETTING sql.conn.max_read_buffer_message_size = '32kB'`)
+	require.NoError(t, err)
+
+	// On a new connection, try send the same string back.
+	{
+		pgURL, cleanup := sqlutils.PGUrl(
+			t,
+			s.ServingSQLAddr(),
+			"big message size",
+			url.User(security.RootUser),
+		)
+		defer cleanup()
+
+		conf, err := pgx.ParseConnectionString(pgURL.String())
+		require.NoError(t, err)
+		c, err := pgx.Connect(conf)
+		require.NoError(t, err)
+		defer func() { _ = c.Close() }()
+
+		// A smaller string is ok.
+		_, err = c.Exec(fmt.Sprintf(`SELECT '%s'`, "a"))
+		require.NoError(t, err)
+
+		// A 64kB string is too big.
+		_, err = c.Exec(fmt.Sprintf(`SELECT '%s'`, str))
+		require.Error(t, err)
+		// TODO(#50330): assert a finer tune error message.
+		// At the moment, this can be EOF or connection reset by peer.
+	}
+}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -185,8 +185,9 @@ func (c *copyMachine) run(ctx context.Context) error {
 	}
 
 	// Read from the connection until we see an ClientMsgCopyDone.
-	readBuf := pgwirebase.ReadBuffer{}
-
+	readBuf := pgwirebase.MakeReadBuffer(
+		pgwirebase.ReadBufferOptionWithClusterSettings(&c.p.execCfg.Settings.SV),
+	)
 Loop:
 	for {
 		typ, _, err := readBuf.ReadTypedMsg(c.conn.Rd())

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -15,3 +15,9 @@ SET CLUSTER SETTING sql.log.slow_query.latency_threshold = 'true'
 
 statement error pq: invalid cluster setting argument type
 SET CLUSTER SETTING sql.log.slow_query.latency_threshold = true
+
+statement error buffer message size must be at least 16 kB
+SET CLUSTER SETTING sql.conn.max_read_buffer_message_size = '1b'
+
+statement ok
+SET CLUSTER SETTING sql.conn.max_read_buffer_message_size = '64MB'

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -163,6 +163,7 @@ func newConn(
 		metrics:     metrics,
 		rd:          *bufio.NewReader(netConn),
 		sv:          sv,
+		readBuf:     pgwirebase.MakeReadBuffer(pgwirebase.ReadBufferOptionWithClusterSettings(sv)),
 	}
 	c.stmtBuf.Init()
 	c.res.released = true

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -318,7 +318,7 @@ func waitForClientConn(ln net.Listener) (*conn, error) {
 		return nil, err
 	}
 
-	var buf pgwirebase.ReadBuffer
+	buf := pgwirebase.MakeReadBuffer()
 	_, err = buf.ReadUntypedMsg(conn)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -22,6 +22,7 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -36,11 +37,29 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
+	"github.com/dustin/go-humanize"
 	"github.com/jackc/pgx/pgtype"
 	"github.com/lib/pq/oid"
 )
 
-const maxMessageSize = 1 << 24
+const (
+	defaultMaxReadBufferMessageSize = 1 << 24
+	minReadBufferMessageSize        = 1 << 14
+)
+
+// ReadBufferMaxMessageSizeClusterSetting is the cluster setting for configuring
+// ReadBuffer default message sizes.
+var ReadBufferMaxMessageSizeClusterSetting = settings.RegisterValidatedByteSizeSetting(
+	"sql.conn.max_read_buffer_message_size",
+	"maximum buffer size to allow for ingesting sql statements. Connections must be restarted for this to take effect.",
+	defaultMaxReadBufferMessageSize,
+	func(val int64) error {
+		if val < minReadBufferMessageSize {
+			return errors.Newf("buffer message size must be at least %s", humanize.Bytes(minReadBufferMessageSize))
+		}
+		return nil
+	},
+)
 
 // FormatCode represents a pgwire data format.
 //
@@ -66,8 +85,33 @@ type BufferedReader interface {
 
 // ReadBuffer provides a convenient way to read pgwire protocol messages.
 type ReadBuffer struct {
-	Msg []byte
-	tmp [4]byte
+	Msg            []byte
+	tmp            [4]byte
+	maxMessageSize int
+}
+
+// ReadBufferOption is an optional argument to use with ReadBuffer.
+type ReadBufferOption func(*ReadBuffer)
+
+// ReadBufferOptionWithClusterSettings utilizes the cluster settings for setting
+// various defaults in the ReadBuffer.
+func ReadBufferOptionWithClusterSettings(sv *settings.Values) ReadBufferOption {
+	return func(b *ReadBuffer) {
+		if sv != nil {
+			b.maxMessageSize = int(ReadBufferMaxMessageSizeClusterSetting.Get(sv))
+		}
+	}
+}
+
+// MakeReadBuffer returns a new ReaderBuffer with the given size.
+func MakeReadBuffer(opts ...ReadBufferOption) ReadBuffer {
+	buf := ReadBuffer{
+		maxMessageSize: defaultMaxReadBufferMessageSize,
+	}
+	for _, opt := range opts {
+		opt(&buf)
+	}
+	return buf
 }
 
 // reset sets b.Msg to exactly size, attempting to use spare capacity
@@ -104,9 +148,12 @@ func (b *ReadBuffer) ReadUntypedMsg(rd io.Reader) (int, error) {
 	size := int(binary.BigEndian.Uint32(b.tmp[:]))
 	// size includes itself.
 	size -= 4
-	if size > maxMessageSize || size < 0 {
-		return nread, NewProtocolViolationErrorf("message size %d out of bounds (0..%d)",
-			size, maxMessageSize)
+	if size > b.maxMessageSize || size < 0 {
+		return nread, NewProtocolViolationErrorf(
+			"message size %d out of bounds (0..%d)",
+			size,
+			b.maxMessageSize,
+		)
 	}
 
 	b.reset(size)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -267,7 +267,7 @@ func MakeServer(
 
 // Match returns true if rd appears to be a Postgres connection.
 func Match(rd io.Reader) bool {
-	var buf pgwirebase.ReadBuffer
+	buf := pgwirebase.MakeReadBuffer()
 	_, err := buf.ReadUntypedMsg(rd)
 	if err != nil {
 		return false
@@ -795,6 +795,9 @@ func (s *Server) readVersion(
 	conn io.Reader,
 ) (version uint32, buf pgwirebase.ReadBuffer, err error) {
 	var n int
+	buf = pgwirebase.MakeReadBuffer(
+		pgwirebase.ReadBufferOptionWithClusterSettings(&s.execCfg.Settings.SV),
+	)
 	n, err = buf.ReadUntypedMsg(conn)
 	if err != nil {
 		return

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -472,7 +472,8 @@ func BenchmarkDecodeBinaryDecimal(b *testing.B) {
 	}
 	wbuf.writeBinaryDatum(context.Background(), expected, nil /* sessionLoc */, nil /* t */)
 
-	rbuf := pgwirebase.ReadBuffer{Msg: wbuf.wrapped.Bytes()}
+	rbuf := pgwirebase.MakeReadBuffer()
+	rbuf.Msg = wbuf.wrapped.Bytes()
 
 	plen, err := rbuf.GetUint32()
 	if err != nil {


### PR DESCRIPTION
Resolves #50335.
Refs #50330 (TODO for better error messaging)

Release note (sql change): Add a cluster setting
`sql.conn.max_read_buffer_message_size` that allows users to configure
sql statement maximum sizes across the cluster. This effect will take
place upon connection restart.


Release justification: low risk, high benefit changes to existing
functionality