### PR TITLE
cli: skip TestUnavailableZip

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -184,6 +184,7 @@ create table defaultdb."../system"(x int);
 // need the SSL certs dir to run a CLI test securely.
 func TestUnavailableZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 53306, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	skip.UnderShort(t)


### PR DESCRIPTION
Refs: #53306

Reason: flaky test

Generated by bin/skip-test.

Release note: None

Release justification: non-production code changes