### PR TITLE
ccl/utilccl: minimize the licenseccl dependencies

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -9,14 +9,20 @@
 package utilccl
 
 import (
+	"bytes"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var enterpriseLicense = func() *settings.StringSetting {
@@ -25,7 +31,7 @@ var enterpriseLicense = func() *settings.StringSetting {
 		"the encoded cluster license",
 		"",
 		func(sv *settings.Values, s string) error {
-			_, err := licenseccl.Decode(s)
+			_, err := decode(s)
 			return err
 		},
 	)
@@ -80,11 +86,11 @@ func checkEnterpriseEnabledAt(
 	// license.
 	if str := enterpriseLicense.Get(&st.SV); str != "" {
 		var err error
-		if lic, err = licenseccl.Decode(str); err != nil {
+		if lic, err = decode(str); err != nil {
 			return err
 		}
 	}
-	return lic.Check(at, cluster, org, feature)
+	return check(lic, at, cluster, org, feature)
 }
 
 func getLicenseType(st *cluster.Settings) (string, error) {
@@ -92,9 +98,83 @@ func getLicenseType(st *cluster.Settings) (string, error) {
 	if str == "" {
 		return "None", nil
 	}
-	lic, err := licenseccl.Decode(str)
+	lic, err := decode(str)
 	if err != nil {
 		return "", err
 	}
 	return lic.Type.String(), nil
+}
+
+// decode attempts to read a base64 encoded License.
+func decode(s string) (*licenseccl.License, error) {
+	lic, err := licenseccl.Decode(s)
+	if err != nil {
+		return nil, pgerror.WithCandidateCode(err, pgcode.Syntax)
+	}
+	return lic, err
+}
+
+// check returns an error if the license is empty or not currently valid.
+func check(l *licenseccl.License, at time.Time, cluster uuid.UUID, org, feature string) error {
+	if l == nil {
+		// TODO(dt): link to some stable URL that then redirects to a helpful page
+		// that explains what to do here.
+		link := "https://cockroachlabs.com/pricing?cluster="
+		return pgerror.Newf(pgcode.CCLValidLicenseRequired,
+			"use of %s requires an enterprise license. "+
+				"see %s%s for details on how to enable enterprise features",
+			errors.Safe(feature),
+			link,
+			cluster.String(),
+		)
+	}
+
+	// We extend some grace period to enterprise license holders rather than
+	// suddenly throwing errors at them.
+	if l.ValidUntilUnixSec > 0 && l.Type != licenseccl.License_Enterprise {
+		if expiration := timeutil.Unix(l.ValidUntilUnixSec, 0); at.After(expiration) {
+			licensePrefix := redact.SafeString("")
+			switch l.Type {
+			case licenseccl.License_NonCommercial:
+				licensePrefix = "non-commercial "
+			case licenseccl.License_Evaluation:
+				licensePrefix = "evaluation "
+			}
+			return pgerror.Newf(pgcode.CCLValidLicenseRequired,
+				"Use of %s requires an enterprise license. Your %slicense expired on %s. If you're "+
+					"interested in getting a new license, please contact subscriptions@cockroachlabs.com "+
+					"and we can help you out.",
+				errors.Safe(feature),
+				licensePrefix,
+				expiration.Format("January 2, 2006"),
+			)
+		}
+	}
+
+	if l.ClusterID == nil {
+		if strings.EqualFold(l.OrganizationName, org) {
+			return nil
+		}
+		return pgerror.Newf(pgcode.CCLValidLicenseRequired,
+			"license valid only for %q", l.OrganizationName)
+	}
+
+	for _, c := range l.ClusterID {
+		if cluster == c {
+			return nil
+		}
+	}
+
+	// no match, so compose an error message.
+	var matches bytes.Buffer
+	for i, c := range l.ClusterID {
+		if i > 0 {
+			matches.WriteString(", ")
+		}
+		matches.WriteString(c.String())
+	}
+	return pgerror.Newf(pgcode.CCLValidLicenseRequired,
+		"license for cluster(s) %s is not valid for cluster %s",
+		matches.String(), cluster.String(),
+	)
 }

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -25,17 +25,17 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 
 	t0 := timeutil.Unix(0, 0)
 
-	licA, _ := licenseccl.License{
+	licA, _ := (&licenseccl.License{
 		ClusterID:         []uuid.UUID{idA},
 		Type:              licenseccl.License_Enterprise,
 		ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
-	}.Encode()
+	}).Encode()
 
-	licB, _ := licenseccl.License{
+	licB, _ := (&licenseccl.License{
 		ClusterID:         []uuid.UUID{idB},
 		Type:              licenseccl.License_Evaluation,
 		ValidUntilUnixSec: t0.AddDate(0, 2, 0).Unix(),
-	}.Encode()
+	}).Encode()
 
 	st := cluster.MakeTestingClusterSettings()
 
@@ -63,7 +63,7 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 		}
 		err := checkEnterpriseEnabledAt(st, tc.checkTime, tc.checkCluster, "", "")
 		if !testutils.IsError(err, tc.err) {
-			l, _ := licenseccl.Decode(tc.lic)
+			l, _ := decode(tc.lic)
 			t.Fatalf("%d: lic %v, update by %T, checked by %s at %s, got %q", i, l, updater, tc.checkCluster, tc.checkTime, err)
 		}
 	}
@@ -80,11 +80,11 @@ func TestGetLicenseTypePresent(t *testing.T) {
 	} {
 		st := cluster.MakeTestingClusterSettings()
 		updater := st.MakeUpdater()
-		lic, _ := licenseccl.License{
+		lic, _ := (&licenseccl.License{
 			ClusterID:         []uuid.UUID{},
 			Type:              tc.licenseType,
 			ValidUntilUnixSec: 0,
-		}.Encode()
+		}).Encode()
 		if err := updater.Set("enterprise.license", lic, "s"); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/utilccl/license_test.go
+++ b/pkg/ccl/utilccl/license_test.go
@@ -6,13 +6,14 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package licenseccl
+package utilccl
 
 import (
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -31,7 +32,7 @@ func TestLicense(t *testing.T) {
 	wayAfter := ts.Add(time.Hour * 24 * 365 * 200)
 
 	for i, tc := range []struct {
-		licType      License_Type
+		licType      licenseccl.License_Type
 		grantedTo    []uuid.UUID
 		expiration   time.Time
 		checkCluster uuid.UUID
@@ -40,49 +41,49 @@ func TestLicense(t *testing.T) {
 		err          string
 	}{
 		{licType: -1, err: "requires an enterprise license"},
-		{License_Evaluation, clustersA, ts, clusterA, "", ts, ""},
-		{License_Enterprise, clustersA, ts, clusterA, "", ts, ""},
-		{License_NonCommercial, clustersA, ts, clusterA, "", ts, ""},
-		{License_Evaluation, clustersA, after, clusterA, "", ts, ""},
-		{License_Evaluation, clustersA, ts, clusterA, "", before, ""},
-		{License_Evaluation, clustersA, wayAfter, clusterA, "", ts, ""},
+		{licenseccl.License_Evaluation, clustersA, ts, clusterA, "", ts, ""},
+		{licenseccl.License_Enterprise, clustersA, ts, clusterA, "", ts, ""},
+		{licenseccl.License_NonCommercial, clustersA, ts, clusterA, "", ts, ""},
+		{licenseccl.License_Evaluation, clustersA, after, clusterA, "", ts, ""},
+		{licenseccl.License_Evaluation, clustersA, ts, clusterA, "", before, ""},
+		{licenseccl.License_Evaluation, clustersA, wayAfter, clusterA, "", ts, ""},
 
 		// expirations.
-		{License_Evaluation, clustersA, ts, clusterA, "", after, "expired"},
-		{License_Evaluation, clustersA, after, clusterA, "", wayAfter, "expired"},
-		{License_NonCommercial, clustersA, after, clusterA, "", wayAfter, "expired"},
-		{License_NonCommercial, clustersA, t0, clusterA, "", wayAfter, ""},
-		{License_Evaluation, clustersA, t0, clusterA, "", wayAfter, ""},
+		{licenseccl.License_Evaluation, clustersA, ts, clusterA, "", after, "expired"},
+		{licenseccl.License_Evaluation, clustersA, after, clusterA, "", wayAfter, "expired"},
+		{licenseccl.License_NonCommercial, clustersA, after, clusterA, "", wayAfter, "expired"},
+		{licenseccl.License_NonCommercial, clustersA, t0, clusterA, "", wayAfter, ""},
+		{licenseccl.License_Evaluation, clustersA, t0, clusterA, "", wayAfter, ""},
 
 		// grace period.
-		{License_Enterprise, clustersA, after, clusterA, "", wayAfter, ""},
+		{licenseccl.License_Enterprise, clustersA, after, clusterA, "", wayAfter, ""},
 
 		// mismatch.
-		{License_Enterprise, clustersA, ts, clusterB, "", ts, "not valid for cluster"},
-		{License_Enterprise, clustersB, ts, clusterA, "", ts, "not valid for cluster"},
-		{License_Enterprise, append(clustersB, clusterA), ts, clusterA, "", ts, ""},
-		{License_Enterprise, nil, ts, clusterA, "", ts, "license valid only for"},
-		{License_Enterprise, nil, ts, clusterA, "tc-17", ts, ""},
+		{licenseccl.License_Enterprise, clustersA, ts, clusterB, "", ts, "not valid for cluster"},
+		{licenseccl.License_Enterprise, clustersB, ts, clusterA, "", ts, "not valid for cluster"},
+		{licenseccl.License_Enterprise, append(clustersB, clusterA), ts, clusterA, "", ts, ""},
+		{licenseccl.License_Enterprise, nil, ts, clusterA, "", ts, "license valid only for"},
+		{licenseccl.License_Enterprise, nil, ts, clusterA, "tc-17", ts, ""},
 	} {
-		var lic *License
+		var lic *licenseccl.License
 		if tc.licType != -1 {
-			s, err := License{
+			s, err := (&licenseccl.License{
 				ClusterID:         tc.grantedTo,
 				ValidUntilUnixSec: tc.expiration.Unix(),
 				Type:              tc.licType,
 				OrganizationName:  fmt.Sprintf("tc-%d", i),
-			}.Encode()
+			}).Encode()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			lic, err = Decode(s)
+			lic, err = decode(s)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
-		if err := lic.Check(
-			tc.checkTime, tc.checkCluster, tc.checkOrg, "",
+		if err := check(
+			lic, tc.checkTime, tc.checkCluster, tc.checkOrg, "",
 		); !testutils.IsError(err, tc.err) {
 			t.Fatalf("%d: lic for %s to %s, checked by %s at %s.\n got %q", i,
 				tc.grantedTo, tc.expiration, tc.checkCluster, tc.checkTime, err)
@@ -96,18 +97,18 @@ func TestBadLicenseStrings(t *testing.T) {
 		{"crl-0-&&&&&", "invalid license string"},
 		{"crl-0-blah", "invalid license string"},
 	} {
-		if _, err := Decode(tc.lic); !testutils.IsError(err, tc.err) {
+		if _, err := decode(tc.lic); !testutils.IsError(err, tc.err) {
 			t.Fatalf("%q: expected err %q, got %v", tc.lic, tc.err, err)
 		}
 	}
 }
 
 func TestExpiredLicenseLanguage(t *testing.T) {
-	lic := License{
-		Type:              License_Evaluation,
+	lic := &licenseccl.License{
+		Type:              licenseccl.License_Evaluation,
 		ValidUntilUnixSec: 1,
 	}
-	err := lic.Check(timeutil.Now(), uuid.MakeV4(), "", "RESTORE")
+	err := check(lic, timeutil.Now(), uuid.MakeV4(), "", "RESTORE")
 	expected := "Use of RESTORE requires an enterprise license. Your evaluation license expired on " +
 		"January 1, 1970. If you're interested in getting a new license, please contact " +
 		"subscriptions@cockroachlabs.com and we can help you out."

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -9,26 +9,19 @@
 package licenseccl
 
 import (
-	"bytes"
 	"encoding/base64"
 	"strings"
-	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 // LicensePrefix is a prefix on license strings to make them easily recognized.
 const LicensePrefix = "crl-0-"
 
 // Encode serializes the License as a base64 string.
-func (l License) Encode() (string, error) {
-	bytes, err := protoutil.Marshal(&l)
+func (l *License) Encode() (string, error) {
+	bytes, err := protoutil.Marshal(l)
 	if err != nil {
 		return "", err
 	}
@@ -41,81 +34,16 @@ func Decode(s string) (*License, error) {
 		return nil, nil
 	}
 	if !strings.HasPrefix(s, LicensePrefix) {
-		return nil, pgerror.Newf(pgcode.Syntax, "invalid license string")
+		return nil, errors.New("invalid license string")
 	}
 	s = strings.TrimPrefix(s, LicensePrefix)
 	data, err := base64.RawStdEncoding.DecodeString(s)
 	if err != nil {
-		return nil, pgerror.Wrapf(err, pgcode.Syntax, "invalid license string")
+		return nil, errors.Wrapf(err, "invalid license string")
 	}
 	var lic License
 	if err := protoutil.Unmarshal(data, &lic); err != nil {
-		return nil, pgerror.Wrap(err, pgcode.Syntax, "invalid license string")
+		return nil, errors.Wrap(err, "invalid license string")
 	}
 	return &lic, nil
-}
-
-// Check returns an error if the license is empty or not currently valid.
-func (l *License) Check(at time.Time, cluster uuid.UUID, org, feature string) error {
-	if l == nil {
-		// TODO(dt): link to some stable URL that then redirects to a helpful page
-		// that explains what to do here.
-		link := "https://cockroachlabs.com/pricing?cluster="
-		return pgerror.Newf(pgcode.CCLValidLicenseRequired,
-			"use of %s requires an enterprise license. "+
-				"see %s%s for details on how to enable enterprise features",
-			errors.Safe(feature),
-			link,
-			cluster.String(),
-		)
-	}
-
-	// We extend some grace period to enterprise license holders rather than
-	// suddenly throwing errors at them.
-	if l.ValidUntilUnixSec > 0 && l.Type != License_Enterprise {
-		if expiration := timeutil.Unix(l.ValidUntilUnixSec, 0); at.After(expiration) {
-			licensePrefix := redact.SafeString("")
-			switch l.Type {
-			case License_NonCommercial:
-				licensePrefix = "non-commercial "
-			case License_Evaluation:
-				licensePrefix = "evaluation "
-			}
-			return pgerror.Newf(pgcode.CCLValidLicenseRequired,
-				"Use of %s requires an enterprise license. Your %slicense expired on %s. If you're "+
-					"interested in getting a new license, please contact subscriptions@cockroachlabs.com "+
-					"and we can help you out.",
-				errors.Safe(feature),
-				licensePrefix,
-				expiration.Format("January 2, 2006"),
-			)
-		}
-	}
-
-	if l.ClusterID == nil {
-		if strings.EqualFold(l.OrganizationName, org) {
-			return nil
-		}
-		return pgerror.Newf(pgcode.CCLValidLicenseRequired,
-			"license valid only for %q", l.OrganizationName)
-	}
-
-	for _, c := range l.ClusterID {
-		if cluster == c {
-			return nil
-		}
-	}
-
-	// no match, so compose an error message.
-	var matches bytes.Buffer
-	for i, c := range l.ClusterID {
-		if i > 0 {
-			matches.WriteString(", ")
-		}
-		matches.WriteString(c.String())
-	}
-	return pgerror.Newf(pgcode.CCLValidLicenseRequired,
-		"license for cluster(s) %s is not valid for cluster %s",
-		matches.String(), cluster.String(),
-	)
 }


### PR DESCRIPTION
Previously, `ccl/utilccl/licenseccl` was pulling in a large number of
dependencies due to the `pgwire/pg{code,error}` imports. In particular,
pulling in the `pkg/util/log` is problematic for CockroachCloud which
needs to encode licenses but doesn't want to use CRDB's logging
infrastructure. Those problematic imports were only needed for the
`Decode` and `Check` methods, but those methods were only used by the
`pkg/utilccl` package. They have no been pulled up to the sole place
they are being used.

Release note: None

Release justification: low risk, high benefit changes to existing
functionality. This is just code movement and has no functional impact
other than reducing dependencies for Cockroach Cloud.