### PR TITLE
workload: mark deprecated-fk-indexes as a runtime only flag

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -162,6 +162,9 @@ var tpccMeta = workload.Meta{
 			`workers`:            {RuntimeOnly: true},
 			`conns`:              {RuntimeOnly: true},
 			`expensive-checks`:   {RuntimeOnly: true, CheckConsistencyOnly: true},
+			// We set runtime only to true for deprecated-fk-indexes so that it
+			// doesn't appear in the fixture name output.
+			`deprecated-fk-indexes`: {RuntimeOnly: true},
 		}
 
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Random number generator seed`)


### PR DESCRIPTION
Move the `deprecated-fk-indexes` flag to a "runtime only" flag so that
it doesn't affect existing tpcc fixtures.

Release justification: non-production code change
Release note: None