### PR TITLE
compose/compare: add PartialIndexMutator to cockroach-cockroach comparison

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -94,6 +94,7 @@ func TestCompare(t *testing.T) {
 						mutations.ColumnFamilyMutator,
 						mutations.StatisticsMutator,
 						mutations.IndexStoringMutator,
+						mutations.PartialIndexMutator,
 					},
 				},
 			},


### PR DESCRIPTION
This commit adds the `PartialIndexMutator` to cockroach-cockroach
comparison tests so that partial index functionality is tested in
nightly builds.

Release justification: non-production code changes

Release note: None