### PR TITLE
sql: improve error message for comparison of different enum types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -107,13 +107,13 @@ true true true false true NULL NULL true true false true
 statement ok
 CREATE TYPE farewell AS ENUM ('bye', 'seeya')
 
-statement error pq: unsupported comparison operator: <greeting> = <farewell>
+statement error pq: invalid comparison between different enum types: <greeting> = <farewell>
 SELECT 'hello'::greeting = 'bye'::farewell
 
-statement error pq: unsupported comparison operator: <greeting> < <farewell>
+statement error pq: invalid comparison between different enum types: <greeting> < <farewell>
 SELECT 'hello'::greeting < 'bye'::farewell
 
-statement error pq: unsupported comparison operator: <greeting> <= <farewell>
+statement error pq: invalid comparison between different enum types: <greeting> <= <farewell>
 SELECT 'hello'::greeting <= 'bye'::farewell
 
 query T


### PR DESCRIPTION
Fixes #52297.

Improve the release note for comparison between different enum types to
say "invalid comparison", rather than "unsupported".

Release justification: low-risk update to new functionality

Release note: None