### PR TITLE
backupccl: prevent temporary tables from backupccl

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -204,8 +204,11 @@ func newDescriptorResolver(descs []catalog.Descriptor) (*descriptorResolver, err
 			continue
 		}
 		var typeToRegister string
-		switch desc.(type) {
+		switch desc := desc.(type) {
 		case catalog.TableDescriptor:
+			if desc.TableDesc().Temporary {
+				continue
+			}
 			typeToRegister = "table"
 		case catalog.TypeDescriptor:
 			typeToRegister = "type"

--- a/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
+++ b/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
@@ -1,0 +1,91 @@
+# Test that temporary tables do not show up in any backup.
+
+new-server name=s1
+----
+
+exec-sql
+SET experimental_enable_temp_tables=true;
+
+CREATE DATABASE d1;
+USE d1;
+CREATE TEMP TABLE temp_table (id int primary key);
+CREATE TABLE perm_table (id int primary key)
+----
+
+query-sql
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+perm_table
+temp_table
+
+query-sql
+SELECT
+  regexp_replace(schema_name, 'pg_temp.*', 'pg_temp') as name
+FROM [SHOW SCHEMAS] ORDER BY name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+pg_temp
+public
+
+exec-sql
+BACKUP TABLE temp_table TO 'nodelocal://0/temp_table_backup'
+----
+pq: table "temp_table" does not exist
+
+exec-sql
+BACKUP DATABASE d1 TO 'nodelocal://0/d1_backup/'
+----
+
+exec-sql
+BACKUP d1.* TO 'nodelocal://0/d1_star_backup/'
+----
+
+exec-sql
+USE defaultdb;
+DROP DATABASE d1;
+RESTORE DATABASE d1 FROM 'nodelocal://0/d1_backup/';
+USE d1
+----
+
+query-sql
+SELECT
+  regexp_replace(schema_name, 'pg_temp.*', 'pg_temp') AS name
+FROM [SHOW SCHEMAS] ORDER BY name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+public
+
+query-sql
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+perm_table
+
+exec-sql
+USE defaultdb;
+DROP DATABASE d1;
+RESTORE DATABASE d1 FROM 'nodelocal://0/d1_star_backup/';
+USE d1
+----
+
+query-sql
+SELECT
+  regexp_replace(schema_name, 'pg_temp.*', 'pg_temp') AS name
+FROM [SHOW SCHEMAS] ORDER BY name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+public
+
+query-sql
+USE d1;
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+perm_table


### PR DESCRIPTION
Filter out temporary tables from resolvable descriptors.

Release justification: low risk, high benefit changes

Resolves: #50902

Release note (sql change): Fix a bug where temporary tables may be
included in `BACKUP` commands.