### PR TITLE
changefeedccl: support changefeeds with user defined types

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -232,8 +232,8 @@ func createBenchmarkChangefeed(
 		NeedsInitialScan: needsInitialScan,
 	}
 
-	rowsFn := kvsToRows(s.ExecutorConfig().(sql.ExecutorConfig).Codec,
-		s.LeaseManager().(*lease.Manager), details, buf.Get)
+	cfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	rowsFn := kvsToRows(ctx, cfg.Codec, cfg.Settings, cfg.DB, cfg.LeaseManager, cfg.HydratedTables, details, buf.Get)
 	sf := span.MakeFrontier(spans...)
 	tickFn := emitEntries(s.ClusterSettings(), details, hlc.Timestamp{}, sf,
 		encoder, sink, rowsFn, TestingKnobs{}, metrics)

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -205,7 +205,8 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	_, withDiff := ca.spec.Feed.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := makeKVFeedCfg(ca.flowCtx.Cfg, leaseMgr, ca.kvFeedMemMon, ca.spec,
 		spans, withDiff, buf, metrics)
-	rowsFn := kvsToRows(ca.flowCtx.Codec(), leaseMgr, ca.spec.Feed, buf.Get)
+	cfg := ca.flowCtx.Cfg
+	rowsFn := kvsToRows(ctx, cfg.Codec, cfg.Settings, cfg.DB, leaseMgr, cfg.HydratedTables, ca.spec.Feed, buf.Get)
 	ca.tickFn = emitEntries(ca.flowCtx.Cfg.Settings, ca.spec.Feed,
 		kvfeedCfg.InitialHighWater, sf, ca.encoder, ca.sink, rowsFn, knobs, metrics)
 	ca.startKVFeed(ctx, kvfeedCfg)

--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -232,3 +232,12 @@ func TableFromDescriptor(desc *Descriptor, ts hlc.Timestamp) *TableDescriptor {
 	}
 	return t
 }
+
+// TypeFromDescriptor is the same thing as TableFromDescriptor, but for types.
+func TypeFromDescriptor(desc *Descriptor, ts hlc.Timestamp) *TypeDescriptor {
+	t := desc.GetType()
+	if t != nil {
+		MaybeSetDescriptorModificationTimeFromMVCCTimestamp(context.TODO(), desc, ts)
+	}
+	return t
+}

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2545,6 +2545,12 @@ func (desc *Immutable) ContainsUserDefinedTypes() bool {
 	return len(desc.columnsWithUDTs) > 0
 }
 
+// GetColumnOrdinalsWithUserDefinedTypes returns a slice of column ordinals
+// of columns that contain user defined types.
+func (desc *Immutable) GetColumnOrdinalsWithUserDefinedTypes() []int {
+	return desc.columnsWithUDTs
+}
+
 // UserDefinedTypeColsHaveSameVersion returns whether this descriptor's columns
 // with user defined type metadata have the same versions of metadata as in the
 // other descriptor. Note that this function is only valid on two descriptors

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -511,6 +511,15 @@ func (rf *Fetcher) Init(
 	return nil
 }
 
+// GetTables returns all tables that this Fetcher was initialized with.
+func (rf *Fetcher) GetTables() []catalog.Descriptor {
+	ret := make([]catalog.Descriptor, len(rf.tables))
+	for i := range rf.tables {
+		ret[i] = rf.tables[i].desc
+	}
+	return ret
+}
+
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
 func (rf *Fetcher) StartScan(


### PR DESCRIPTION
Fixes #49981.

Support changefeeds on tables that contain user defined types.

Release justification: fixes for high-severity bugs in existing
functionality

Release note: None