### PR TITLE
[DNM] build: switch AWS nightlies to use teamcity-nightly-roachtest.sh

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -73,6 +73,7 @@ ARTIFACTS="${artifacts}"
 PARALLELISM=16
 CPUQUOTA=1024
 ZONES=""
+TESTS="acceptance/version-upgrade"
 case "${CLOUD}" in
   gce)
     # We specify --zones below so that nodes are created in us-central1-b by
@@ -83,10 +84,6 @@ case "${CLOUD}" in
   aws)
     PARALLELISM=3
     CPUQUOTA=384
-    if [ -z "${TESTS}" ]; then
-      TESTS="kv(0|95)|ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/
-      (nodes=3/ops=2000/conc=1)|backup/(KMS/n3cpu4)"
-    fi
     ;;
   *)
     echo "unknown cloud ${CLOUD}"


### PR DESCRIPTION
This branch is being used to test if the template added to TC Nightly Roachtest infra works as expected.