### PR TITLE
roachtest: Extend the deprecated FK fix over to engine/switch roachtests

### DIFF
--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
 	"golang.org/x/exp/rand"
@@ -39,9 +40,14 @@ func registerEngineSwitch(r *testRegistry) {
 
 		loadDuration := " --duration=" + (time.Duration(numIters) * stageDuration).String()
 
+		var deprecatedWorkloadsStr string
+		if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
+			deprecatedWorkloadsStr += " --deprecated-fk-indexes"
+		}
+
 		workloads := []string{
 			// Currently tpcc is the only one with CheckConsistency. We can add more later.
-			"./workload run tpcc --tolerate-errors --wait=false --drop --init --warehouses=1 " + loadDuration + " {pgurl:1-%d}",
+			"./workload run tpcc --tolerate-errors --wait=false --drop --init" + deprecatedWorkloadsStr + " --warehouses=1 " + loadDuration + " {pgurl:1-%d}",
 		}
 		checkWorkloads := []string{
 			"./workload check tpcc --warehouses=1 --expensive-checks=true {pgurl:1}",


### PR DESCRIPTION
The fix in #53367 to make TPCC workload based roachtests work again
on pre-20.2 builds needs to also be carried over to the engine/switch
roachtests.

Release justification: Roachtest fix, doesn't affect the cockroach binary.
Release note: None.