### PR TITLE
sql: populate the NumRows field in TransactionStatistics

### DIFF
--- a/pkg/roachpb/app_stats.pb.go
+++ b/pkg/roachpb/app_stats.pb.go
@@ -85,7 +85,7 @@ func (m *StatementStatistics) Reset()         { *m = StatementStatistics{} }
 func (m *StatementStatistics) String() string { return proto.CompactTextString(m) }
 func (*StatementStatistics) ProtoMessage()    {}
 func (*StatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{0}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{0}
 }
 func (m *StatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -117,8 +117,8 @@ type TransactionStatistics struct {
 	// MaxRetries collects the maximum observed number of automatic
 	// retries in the reporting period.
 	MaxRetries int64 `protobuf:"varint,2,opt,name=max_retries,json=maxRetries" json:"max_retries"`
-	// NumRows collects the total number of rows returned or observed across all
-	// statements.
+	// NumRows collects the total number of rows returned, observed or affected
+	// across all statements.
 	NumRows NumericStat `protobuf:"bytes,3,opt,name=num_rows,json=numRows" json:"num_rows"`
 	// ServiceLat is the time to service the transaction, from the time a
 	// transaction was received to end of execution.
@@ -134,7 +134,7 @@ func (m *TransactionStatistics) Reset()         { *m = TransactionStatistics{} }
 func (m *TransactionStatistics) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatistics) ProtoMessage()    {}
 func (*TransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{1}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{1}
 }
 func (m *TransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -174,7 +174,7 @@ func (m *SensitiveInfo) Reset()         { *m = SensitiveInfo{} }
 func (m *SensitiveInfo) String() string { return proto.CompactTextString(m) }
 func (*SensitiveInfo) ProtoMessage()    {}
 func (*SensitiveInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{2}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{2}
 }
 func (m *SensitiveInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -216,7 +216,7 @@ func (m *NumericStat) Reset()         { *m = NumericStat{} }
 func (m *NumericStat) String() string { return proto.CompactTextString(m) }
 func (*NumericStat) ProtoMessage()    {}
 func (*NumericStat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{3}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{3}
 }
 func (m *NumericStat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -255,7 +255,7 @@ func (m *StatementStatisticsKey) Reset()         { *m = StatementStatisticsKey{}
 func (m *StatementStatisticsKey) String() string { return proto.CompactTextString(m) }
 func (*StatementStatisticsKey) ProtoMessage()    {}
 func (*StatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{4}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{4}
 }
 func (m *StatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -295,7 +295,7 @@ func (m *CollectedStatementStatistics) Reset()         { *m = CollectedStatement
 func (m *CollectedStatementStatistics) String() string { return proto.CompactTextString(m) }
 func (*CollectedStatementStatistics) ProtoMessage()    {}
 func (*CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{5}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{5}
 }
 func (m *CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -335,7 +335,7 @@ func (m *CollectedTransactionStatistics) Reset()         { *m = CollectedTransac
 func (m *CollectedTransactionStatistics) String() string { return proto.CompactTextString(m) }
 func (*CollectedTransactionStatistics) ProtoMessage()    {}
 func (*CollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{6}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{6}
 }
 func (m *CollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -375,7 +375,7 @@ func (m *ExplainTreePlanNode) Reset()         { *m = ExplainTreePlanNode{} }
 func (m *ExplainTreePlanNode) String() string { return proto.CompactTextString(m) }
 func (*ExplainTreePlanNode) ProtoMessage()    {}
 func (*ExplainTreePlanNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{7}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{7}
 }
 func (m *ExplainTreePlanNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -409,7 +409,7 @@ func (m *ExplainTreePlanNode_Attr) Reset()         { *m = ExplainTreePlanNode_At
 func (m *ExplainTreePlanNode_Attr) String() string { return proto.CompactTextString(m) }
 func (*ExplainTreePlanNode_Attr) ProtoMessage()    {}
 func (*ExplainTreePlanNode_Attr) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{7, 0}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{7, 0}
 }
 func (m *ExplainTreePlanNode_Attr) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -448,7 +448,7 @@ func (m *TxnStats) Reset()         { *m = TxnStats{} }
 func (m *TxnStats) String() string { return proto.CompactTextString(m) }
 func (*TxnStats) ProtoMessage()    {}
 func (*TxnStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_174ce174eec61b36, []int{8}
+	return fileDescriptor_app_stats_ba11ef7e1d77017c, []int{8}
 }
 func (m *TxnStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3100,9 +3100,9 @@ var (
 	ErrIntOverflowAppStats   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/app_stats.proto", fileDescriptor_app_stats_174ce174eec61b36) }
+func init() { proto.RegisterFile("roachpb/app_stats.proto", fileDescriptor_app_stats_ba11ef7e1d77017c) }
 
-var fileDescriptor_app_stats_174ce174eec61b36 = []byte{
+var fileDescriptor_app_stats_ba11ef7e1d77017c = []byte{
 	// 1113 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0xbd, 0x6e, 0x1b, 0x47,
 	0x17, 0xd5, 0xf2, 0x47, 0x24, 0x2f, 0x49, 0xc9, 0xdf, 0xf8, 0x6f, 0x3f, 0x42, 0x20, 0x15, 0xc2,

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -98,8 +98,8 @@ message TransactionStatistics {
   // retries in the reporting period.
   optional int64 max_retries = 2 [(gogoproto.nullable) = false];
 
-  // NumRows collects the total number of rows returned or observed across all
-  // statements.
+  // NumRows collects the total number of rows returned, observed or affected
+  // across all statements.
   optional NumericStat num_rows = 3 [(gogoproto.nullable) = false];
 
   // ServiceLat is the time to service the transaction, from the time a

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -385,6 +385,7 @@ func (a *appStats) recordTransaction(
 	serviceLat time.Duration,
 	retryLat time.Duration,
 	commitLat time.Duration,
+	numRows int,
 ) {
 	if !txnStatsEnable.Get(&a.st.SV) {
 		return
@@ -405,6 +406,7 @@ func (a *appStats) recordTransaction(
 
 	s.mu.data.Count++
 
+	s.mu.data.NumRows.Record(s.mu.data.Count, float64(numRows))
 	s.mu.data.ServiceLat.Record(s.mu.data.Count, serviceLat.Seconds())
 	s.mu.data.RetryLat.Record(s.mu.data.Count, retryLat.Seconds())
 	s.mu.data.CommitLat.Record(s.mu.data.Count, commitLat.Seconds())

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -984,6 +984,11 @@ type connExecutor struct {
 		// executed so far.
 		numDDL int
 
+		// numRows keeps track of the number of rows that have been observed by this
+		// transaction. This is simply the summation of number of rows observed by
+		// comprising statements.
+		numRows int
+
 		// txnRewindPos is the position within stmtBuf to which we'll rewind when
 		// performing automatic retries. This is more or less the position where the
 		// current transaction started.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1489,10 +1489,12 @@ func (ex *connExecutor) recordTransactionStart() (onTxnFinish func(txnEvent), on
 		ex.phaseTimes[sessionEndExecTransaction] = timeutil.Now()
 		ex.recordTransaction(ev, implicit, txnStart)
 		ex.extraTxnState.transactionStatementIDs = nil
+		ex.extraTxnState.numRows = 0
 	}
 	onTxnRestart = func() {
 		ex.phaseTimes[sessionMostRecentStartExecTransaction] = timeutil.Now()
 		ex.extraTxnState.transactionStatementIDs = nil
+		ex.extraTxnState.numRows = 0
 	}
 	return onTxnFinish, onTxnRestart
 }
@@ -1526,5 +1528,6 @@ func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart t
 		txnServiceLat,
 		txnRetryLat,
 		commitLat,
+		ex.extraTxnState.numRows,
 	)
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2250,9 +2250,10 @@ func (s *sqlStatsCollector) recordTransaction(
 	serviceLat time.Duration,
 	retryLat time.Duration,
 	commitLat time.Duration,
+	numRows int,
 ) {
 	s.appStats.recordTransactionCounts(txnTimeSec, ev, implicit)
-	s.appStats.recordTransaction(key, int64(retryCount), statementIDs, serviceLat, retryLat, commitLat)
+	s.appStats.recordTransaction(key, int64(retryCount), statementIDs, serviceLat, retryLat, commitLat, numRows)
 }
 
 func (s *sqlStatsCollector) reset(sqlStats *sqlStats, appStats *appStats, phaseTimes *phaseTimes) {

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -187,6 +187,7 @@ func (ex *connExecutor) recordStatementSummary(
 	// as well.
 	ex.extraTxnState.transactionStatementIDs = append(
 		ex.extraTxnState.transactionStatementIDs, stmtID)
+	ex.extraTxnState.numRows += rowsAffected
 
 	if log.V(2) {
 		// ages since significant epochs


### PR DESCRIPTION
Previously, this field was not being populated when recording
transaction level metrics. This is now fixed, and with that, all fields
in the `TransactionStatistics` proto are populated as expected.

Closes #53433

Release justification: low risk change to new functionality
Release note: None