### PR TITLE
jobs: allow progress updates on *Requested statuses

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -81,6 +81,18 @@ func (j *Job) Paused(ctx context.Context) error {
 	return j.paused(ctx, nil /* fn */)
 }
 
+// Reverted is a wrapper around the internal function that moves a job to the
+// reverted state.
+func (j *Job) Reverted(ctx context.Context, err error) error {
+	return j.reverted(ctx, err, nil /* fn */)
+}
+
+// Canceled is a wrapper around the internal function that moves a job to the
+// canceled state.
+func (j *Job) Canceled(ctx context.Context) error {
+	return j.canceled(ctx, nil /* fn */)
+}
+
 // Failed is a wrapper around the internal function that moves a job to the
 // failed state.
 func (j *Job) Failed(ctx context.Context, causingErr error) error {

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -45,7 +45,10 @@ type JobMetadata struct {
 // CheckRunningOrReverting returns an InvalidStatusError if md.Status is not
 // StatusRunning or StatusReverting.
 func (md *JobMetadata) CheckRunningOrReverting() error {
-	if md.Status != StatusRunning && md.Status != StatusReverting {
+	if md.Status != StatusRunning &&
+		md.Status != StatusReverting &&
+		md.Status != StatusCancelRequested &&
+		md.Status != StatusPauseRequested {
 		return &InvalidStatusError{md.ID, md.Status, "update progress on", md.Payload.Error}
 	}
 	return nil


### PR DESCRIPTION
Previously, we would not allow jobs to update their progress while the
job is either of the PauseRequested or CancelRequested states. However,
jobs don't know if they are in a *Requested state, so can't stop
updating their progress when they are in this state.

This commit updates CheckRunningOrReverting to include the *Requested
states since the job is indeed still running while it is in those
states.

Fixes #52075.
Fixes #48194.
Part of resolving #52284.

Release justification: bug fix
Release note (bug fix): Jobs would previously fail if they were updating
their progress shortly after being paused or canceled. This is now
fixed.