### PR TITLE
geos: improve dlopen error handling

### DIFF
--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -170,12 +170,14 @@ func initGEOS(dirs []string) (*C.CR_GEOS, string, error) {
 	var err error
 	for _, dir := range dirs {
 		var ret *C.CR_GEOS
-		errStr := C.CR_GEOS_Init(
-			goToCSlice([]byte(filepath.Join(dir, getLibraryExt(libgeoscFileName)))),
-			goToCSlice([]byte(filepath.Join(dir, getLibraryExt(libgeosFileName)))),
-			&ret,
+		newErr := statusToError(
+			C.CR_GEOS_Init(
+				goToCSlice([]byte(filepath.Join(dir, getLibraryExt(libgeoscFileName)))),
+				goToCSlice([]byte(filepath.Join(dir, getLibraryExt(libgeosFileName)))),
+				&ret,
+			),
 		)
-		if errStr.data == nil {
+		if newErr == nil {
 			return ret, dir, nil
 		}
 		err = errors.CombineErrors(
@@ -183,7 +185,7 @@ func initGEOS(dirs []string) (*C.CR_GEOS, string, error) {
 			errors.Newf(
 				"geos: cannot load GEOS from dir %q: %s",
 				dir,
-				string(cSliceToUnsafeGoBytes(errStr)),
+				newErr,
 			),
 		)
 	}
@@ -204,13 +206,9 @@ func goToCSlice(b []byte) C.CR_GEOS_Slice {
 	}
 }
 
-// c{String,Slice}ToUnsafeGoBytes convert a CR_GEOS_{String,Slice} to a Go
+// cStringToUnsafeGoBytes convert a CR_GEOS_String to a Go
 // byte slice that refer to the underlying C memory.
 func cStringToUnsafeGoBytes(s C.CR_GEOS_String) []byte {
-	return cToUnsafeGoBytes(s.data, s.len)
-}
-
-func cSliceToUnsafeGoBytes(s C.CR_GEOS_Slice) []byte {
 	return cToUnsafeGoBytes(s.data, s.len)
 }
 

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -55,8 +55,7 @@ typedef struct CR_GEOS CR_GEOS;
 // Returns a string containing an error if an error was found. The loc slice
 // must be convertible to a NUL character terminated C string.
 // The CR_GEOS object will be stored in lib.
-// The error returned does not need to be freed (see comment for CR_GEOS_Slice).
-CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice geoscLoc, CR_GEOS_Slice geosLoc, CR_GEOS** lib);
+CR_GEOS_Status CR_GEOS_Init(CR_GEOS_Slice geoscLoc, CR_GEOS_Slice geosLoc, CR_GEOS** lib);
 
 // CR_GEOS_WKTToWKB converts a given WKT into it's EWKB form. The wkt slice must be
 // convertible to a NUL character terminated C string.


### PR DESCRIPTION
* Fix dlopen to return the dlerror messages. dlerror must be called
  before dlclose.

Release justification: low risk, high benefit changes

Release note: None

