### PR TITLE
partialidx: reduce remaining filters of semantically equivalent expressions

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -113,8 +113,8 @@ import (
 // remaining filters. It would be difficult to support this case without
 // breaking the other cases prevented by each of the three rules.
 //
-// A set of opt.Expr keeps track of exact matches encountered while exploring
-// the filters and predicate expressions. If implication is proven, the filters
+// An exprSet keeps track of exact matches encountered while exploring the
+// filters and predicate expressions. If implication is proven, the filters
 // expression is traversed and the expressions in the opt.Expr set are removed.
 // While proving implication this set is not passed to recursive calls when a
 // disjunction is encountered in the predicate (rule #2), and disjunctions in
@@ -178,7 +178,7 @@ func (im *Implicator) FiltersImplyPredicate(
 	// filters and predicate. Use exactMatches to keep track of expressions in
 	// filters that exactly match expressions in pred, so that they can be
 	// removed from the remaining filters.
-	exactMatches := make(map[opt.Expr]struct{})
+	exactMatches := make(exprSet)
 	if im.scalarExprImpliesPredicate(&filters, &pred, exactMatches) {
 		remainingFilters = im.simplifyFiltersExpr(filters, exactMatches)
 		return remainingFilters, true
@@ -254,14 +254,12 @@ func (im *Implicator) filtersImplyPredicateFastPath(
 // Also note that exactMatches is optional, and nil can be passed when it is not
 // necessary to keep track of exactly matching expressions.
 func (im *Implicator) scalarExprImpliesPredicate(
-	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) bool {
 
 	// If the expressions are an exact match, then e implies pred.
 	if e == pred {
-		if exactMatches != nil {
-			exactMatches[e] = struct{}{}
-		}
+		exactMatches.add(e)
 		return true
 	}
 
@@ -287,7 +285,7 @@ func (im *Implicator) scalarExprImpliesPredicate(
 // filtersExprImpliesPredicate returns true if the FiltersExpr e implies the
 // ScalarExpr pred.
 func (im *Implicator) filtersExprImpliesPredicate(
-	e *memo.FiltersExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e *memo.FiltersExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) bool {
 	switch pt := pred.(type) {
 	case *memo.FiltersExpr:
@@ -351,7 +349,7 @@ func (im *Implicator) filtersExprImpliesPredicate(
 // passed to filtersExprImpliesPredicate to prevent duplicating logic for both
 // types of conjunctions.
 func (im *Implicator) andExprImpliesPredicate(
-	e *memo.AndExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e *memo.AndExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) bool {
 	f := make(memo.FiltersExpr, 2)
 	f[0] = memo.FiltersItem{Condition: e.Left}
@@ -419,7 +417,7 @@ func (im *Implicator) orExprImpliesPredicate(e *memo.OrExpr, pred opt.ScalarExpr
 // ScalarExpr pred. The atom e cannot be an AndExpr, OrExpr, RangeExpr, or
 // FiltersExpr.
 func (im *Implicator) atomImpliesPredicate(
-	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) bool {
 	switch pt := pred.(type) {
 	case *memo.FiltersExpr:
@@ -463,7 +461,7 @@ func (im *Implicator) atomImpliesPredicate(
 // if one expression contains another, handling many types of expressions
 // including comparison operators, IN operators, and tuples.
 func (im *Implicator) atomImpliesAtom(
-	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) bool {
 	// Check for containment of comparison expressions with two variables, like
 	// a = b.
@@ -527,11 +525,10 @@ func (im *Implicator) atomImpliesAtom(
 		// they are semantically equivalent because there are no integers
 		// between 17 and 18. Therefore, there is no need to apply (a > 17) as a
 		// filter after the partial index scan.
-		if exactMatches != nil &&
-			eConstraint.Columns.IsPrefixOf(&predConstraint.Columns) &&
-			eConstraint.Contains(im.evalCtx, predConstraint) {
-			exactMatches[e] = struct{}{}
-		}
+		exactMatches.addIf(e, func() bool {
+			return eConstraint.Columns.IsPrefixOf(&predConstraint.Columns) &&
+				eConstraint.Contains(im.evalCtx, predConstraint)
+		})
 		return true
 	}
 
@@ -547,7 +544,7 @@ func (im *Implicator) atomImpliesAtom(
 // values of a and b that satisfy the first expression also satisfy the second
 // expression.
 func (im *Implicator) twoVarComparisonImpliesTwoVarComparison(
-	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches exprSet,
 ) (containment bool, ok bool) {
 	if !isTwoVarComparison(e) || !isTwoVarComparison(pred) {
 		return false, false
@@ -608,9 +605,9 @@ func (im *Implicator) twoVarComparisonImpliesTwoVarComparison(
 		// pred's operator, then e is an exact match to pred and it should be
 		// removed from the remaining filters. For example, (a > b) and
 		// (b < a) both individually imply (a > b) with no remaining filters.
-		if exactMatches != nil && (e.Op() == pred.Op() || commutedOp(e.Op()) == pred.Op()) {
-			exactMatches[e] = struct{}{}
-		}
+		exactMatches.addIf(e, func() bool {
+			return e.Op() == pred.Op() || commutedOp(e.Op()) == pred.Op()
+		})
 		return true, true
 	}
 
@@ -657,14 +654,14 @@ func (im *Implicator) warmCache(filters memo.FiltersExpr) {
 // is omitted from the returned FiltersItem. If not, the FiltersItem is
 // recursively searched. See simplifyScalarExpr for more details.
 func (im *Implicator) simplifyFiltersExpr(
-	e memo.FiltersExpr, exactMatches map[opt.Expr]struct{},
+	e memo.FiltersExpr, exactMatches exprSet,
 ) memo.FiltersExpr {
 	filters := make(memo.FiltersExpr, 0, len(e))
 
 	for i := range e {
 		// If an entire FiltersItem exists in exactMatches, don't add it to the
 		// output filters.
-		if _, ok := exactMatches[e[i].Condition]; ok {
+		if exactMatches.contains(e[i].Condition) {
 			continue
 		}
 
@@ -690,9 +687,7 @@ func (im *Implicator) simplifyFiltersExpr(
 //
 // Also note that we do not attempt to traverse OrExprs. See
 // FiltersImplyPredicate (rule #3) for more details.
-func (im *Implicator) simplifyScalarExpr(
-	e opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
-) opt.ScalarExpr {
+func (im *Implicator) simplifyScalarExpr(e opt.ScalarExpr, exactMatches exprSet) opt.ScalarExpr {
 
 	switch t := e.(type) {
 	case *memo.RangeExpr:
@@ -700,8 +695,8 @@ func (im *Implicator) simplifyScalarExpr(
 		return im.f.ConstructRange(and)
 
 	case *memo.AndExpr:
-		_, leftIsExactMatch := exactMatches[t.Left]
-		_, rightIsExactMatch := exactMatches[t.Right]
+		leftIsExactMatch := exactMatches.contains(t.Left)
+		rightIsExactMatch := exactMatches.contains(t.Right)
 		if leftIsExactMatch && rightIsExactMatch {
 			return memo.TrueSingleton
 		}
@@ -756,4 +751,36 @@ func isTwoVarComparison(e opt.ScalarExpr) bool {
 	return (op == opt.EqOp || op == opt.LtOp || op == opt.GtOp || op == opt.LeOp || op == opt.GeOp || op == opt.NeOp) &&
 		e.Child(0).Op() == opt.VariableOp &&
 		e.Child(1).Op() == opt.VariableOp
+}
+
+// exprSet represents a set of opt.Expr. It prevents nil pointer exceptions when
+// tracking exact expression matches during implication. The nil value is passed
+// in several places to avoid adding child expressions to the exact matches set,
+// such as when traversing an OrExpr.
+type exprSet map[opt.Expr]struct{}
+
+// add adds an expression to the set if the set is non-nil.
+func (s exprSet) add(e opt.Expr) {
+	if s != nil {
+		s[e] = struct{}{}
+	}
+}
+
+// addIf adds an expression to the set if the set is non-nil and the given
+// function returns true. addIf short-circuits and does not call the function if
+// the set is nil.
+func (s exprSet) addIf(e opt.Expr, fn func() bool) {
+	if s != nil && fn() {
+		s[e] = struct{}{}
+	}
+}
+
+// contains returns true if the set is non-nil and the given expression exists
+// in the set.
+func (s exprSet) contains(e opt.Expr) bool {
+	if s != nil {
+		_, ok := s[e]
+		return ok
+	}
+	return false
 }

--- a/pkg/sql/opt/partialidx/testdata/implicator/atom
+++ b/pkg/sql/opt/partialidx/testdata/implicator/atom
@@ -64,7 +64,7 @@ predtest vars=(bool)
 @1 = true
 ----
 true
-└── remaining filters: @1
+└── remaining filters: none
 
 predtest vars=(bool)
 @1
@@ -72,7 +72,7 @@ predtest vars=(bool)
 @1 IN (true)
 ----
 true
-└── remaining filters: @1
+└── remaining filters: none
 
 predtest vars=(bool)
 NOT @1
@@ -178,6 +178,14 @@ predtest vars=(int)
 ----
 true
 └── remaining filters: @1 > 10
+
+predtest vars=(int)
+@1 > 17
+=>
+@1 >= 18
+----
+true
+└── remaining filters: none
 
 predtest vars=(int, int)
 @1 > @2


### PR DESCRIPTION
#### partialidx: reduce remaining filters of semantically equivalent expressions

This commit reduces the remaining filters returned from the Implicator
in cases where expressions in the filter are semantically equivalent to
expression in the predicate, but not syntactically equivalent.

For example:

    (a::INT > 17)
    =>
    (a::INT >= 18)

Prior to this commit, `(a > 17)` would remain as a filter to be applied
after a partial index scan. However, this filter is unnecessary, because
there are no integers between `17` and `18`. With this change,
`(a > 17)` is removed from the remaining filters.

Release justification: Low risk update to new functionality, partial
indexes.

Release note (performance improvement): The optimizer reduces filters
applied after partial index scans in more cases where the filters are
implicitly applied by the partial index predicate. This could lead to
more efficient query plans in some cases.

#### partialidx: add safer set operations for tracking exact matches

This commit adds a typed set for tracking filter expressions that are
exact matches of predicate expressions. This will help prevent a common
developer mistake of not checking whether or not the set it `nil` before
manipulating it, such as the bug fixed by #53222.

Benchmarks show performance improvements of the Implicator for some
cases as a result of this change.

    name                                               old time/op  new time/op  delta
    Implicator/single-exact-match-16                   81.2ns ± 1%  77.8ns ± 1%  -4.24%  (p=0.008 n=5+5)
    Implicator/single-inexact-match-16                  916ns ± 1%   914ns ± 0%    ~     (p=0.254 n=5+5)
    Implicator/range-inexact-match-16                  2.40µs ± 0%  2.46µs ± 1%  +2.56%  (p=0.008 n=5+5)
    Implicator/single-exact-match-extra-filters-16      313ns ± 0%   305ns ± 1%  -2.74%  (p=0.008 n=5+5)
    Implicator/single-inexact-match-extra-filters-16   3.85µs ± 1%  3.85µs ± 1%    ~     (p=0.952 n=5+5)
    Implicator/multi-column-and-exact-match-16         90.0ns ± 1%  84.3ns ± 1%  -6.29%  (p=0.008 n=5+5)
    Implicator/multi-column-and-inexact-match-16       1.99µs ± 0%  2.02µs ± 1%  +1.53%  (p=0.016 n=4+5)
    Implicator/multi-column-or-exact-match-16          82.3ns ± 3%  78.1ns ± 1%  -5.10%  (p=0.008 n=5+5)
    Implicator/multi-column-or-exact-match-reverse-16  1.72µs ± 1%  1.74µs ± 2%    ~     (p=0.397 n=5+5)
    Implicator/multi-column-or-inexact-match-16        2.23µs ± 2%  2.31µs ± 3%  +3.74%  (p=0.008 n=5+5)
    Implicator/and-filters-do-not-imply-pred-16        3.61µs ± 1%  3.63µs ± 4%    ~     (p=0.548 n=5+5)
    Implicator/or-filters-do-not-imply-pred-16          916ns ± 2%   905ns ± 2%    ~     (p=0.095 n=5+5)
    Implicator/many-columns-exact-match10-16            305ns ± 1%   278ns ± 1%  -8.97%  (p=0.008 n=5+5)
    Implicator/many-columns-inexact-match10-16         12.9µs ± 1%  12.9µs ± 1%    ~     (p=0.841 n=5+5)
    Implicator/many-columns-exact-match100-16          21.3µs ± 1%  19.2µs ± 2%  -9.94%  (p=0.008 n=5+5)
    Implicator/many-columns-inexact-match100-16         502µs ± 1%   503µs ± 1%    ~     (p=0.421 n=5+5)

Release justification: Low risk update to new functionality, partial
indexes.

Release note: None
