### PR TITLE
opt: better error message for multiple arbiters with CONFLICT DO UPDATE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -900,7 +900,7 @@ statement ok
 CREATE UNIQUE INDEX i2 ON u (a) WHERE b < 0
 
 # Error if the arbiter predicate does not imply the partial index predicate.
-statement error pgcode 42P10 there are multiple unique or exclusion constraints matching the ON CONFLICT specification
+statement error pgcode 0A000 there are multiple unique or exclusion constraints matching the ON CONFLICT specification
 INSERT INTO u VALUES (1, 1) ON CONFLICT (a) WHERE b < 0 AND b > 0 DO UPDATE SET b = 10
 
 statement ok

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -830,7 +831,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// TODO(mgartner): Add support for multiple arbiter indexes, similar to
 	// buildInputForDoNothing.
 	if arbiterIndexes.Len() > 1 {
-		panic(pgerror.Newf(pgcode.InvalidColumnReference,
+		panic(unimplemented.NewWithIssue(53170,
 			"there are multiple unique or exclusion constraints matching the ON CONFLICT specification"))
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2381,7 +2381,7 @@ DROP INDEX u4
 build
 INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO UPDATE SET b = 10
 ----
-error (42P10): there are multiple unique or exclusion constraints matching the ON CONFLICT specification
+error (0A000): unimplemented: there are multiple unique or exclusion constraints matching the ON CONFLICT specification
 
 build
 INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' DO UPDATE SET b = 10


### PR DESCRIPTION
This commit improves the error message and adds telemetry for INSERT ON
CONFLICT DO UPDATE statements that find multiple matching arbiter
indexes.

Release justification: This is a low-risk update to new functionality,
partial indexes.

Release note: None