### PR TITLE
bors: revert to checking Github CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,7 +2,7 @@
 
 # List of commit statuses that must pass on the merge commit before it is
 # pushed to master.
-status = ["Essential CI (Cockroach)"]
+status = ["GitHub CI (Cockroach)"]
 
 # List of commit statuses that must not be failing on the PR commit when it is
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will


### PR DESCRIPTION
It makes Github statuses complicated.

Release justification: non-production code change

Release note: None