### PR TITLE
opt: add rule to normalize Like to Range

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1027,9 +1027,14 @@ select
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── filters
-      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
-           ├── variable: v:3 [type=string]
-           └── const: 'ABC%' [type=string]
+      └── range [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
+           └── and [type=bool]
+                ├── ge [type=bool]
+                │    ├── variable: v:3 [type=string]
+                │    └── const: 'ABC' [type=string]
+                └── lt [type=bool]
+                     ├── variable: v:3 [type=string]
+                     └── const: 'ABD' [type=string]
 
 opt
 SELECT * FROM kuv WHERE v LIKE 'ABC_'
@@ -1087,9 +1092,14 @@ select
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── filters
-      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
-           ├── variable: v:3 [type=string]
-           └── const: 'ABC' [type=string]
+      └── range [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
+           └── and [type=bool]
+                ├── ge [type=bool]
+                │    ├── variable: v:3 [type=string]
+                │    └── const: 'ABC' [type=string]
+                └── le [type=bool]
+                     ├── variable: v:3 [type=string]
+                     └── const: 'ABC' [type=string]
 
 opt
 SELECT * FROM kuv WHERE v LIKE '%'

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -327,7 +327,7 @@ select
  │    └── fd: (1,2)-->(3)
  └── filters
       ├── d_id:1 = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-      └── d_name:3 LIKE 'bob' [type=bool, outer=(3), constraints=(/3: [/'bob' - /'bob']; tight), fd=()-->(3)]
+      └── (d_name:3 >= 'bob') AND (d_name:3 <= 'bob') [type=bool, outer=(3), constraints=(/3: [/'bob' - /'bob']; tight), fd=()-->(3)]
 
 # This tests selectivityFromReducedCols.
 # Since (1,2)-->(3) in order to use selectivityFromReducedCols,

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -176,7 +176,7 @@ sort
            │         │         │         └── filters
            │         │         │              └── ps_availqty:16 > (sum:47 * 0.5) [type=bool, outer=(16,47), immutable, constraints=(/16: (/NULL - ])]
            │         │         └── filters
-           │         │              └── p_name:21 LIKE 'forest%' [type=bool, outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
+           │         │              └── (p_name:21 >= 'forest') AND (p_name:21 < 'foresu') [type=bool, outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
            │         └── filters (true)
            ├── select
            │    ├── save-table-name: q20_select_15

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -391,3 +391,23 @@ $input
     )
     (RemoveFiltersItem $filter $item)
 )
+
+# NormalizeSelectLiketoRange converts a Like operator to a Range operator.
+# It's easier to calculate stats for Range expressions than for Like
+# expressions.
+[NormalizeSelectLikeToRange, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Like
+                $left:(Variable)
+                $right:(Const)
+            )
+        ) & (Succeeded $rng:(ConvertLikeToRange $item))
+        ...
+    ]
+)
+=>
+(Select $input (ReplaceFiltersItem $filters $item $rng))

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -360,7 +360,7 @@ select
  │    └── fd: (1)-->(2-5)
  └── filters
       ├── s:4 NOT LIKE 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
-      ├── s:4 LIKE 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      ├── (s:4 >= 'foo') AND (s:4 <= 'foo') [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
       ├── s:4 NOT ILIKE 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
       └── s:4 ILIKE 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
 

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -261,7 +261,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── (s:4 LIKE 'a%') AND (s:4 = 'aa') [outer=(4), constraints=(/4: [/'aa' - /'aa']; tight), fd=()-->(4)]
+      ├── ((s:4 = 'aa') AND (s:4 >= 'a')) AND (s:4 < 'b') [outer=(4), constraints=(/4: [/'aa' - /'aa']; tight), fd=()-->(4)]
       └── s:4 SIMILAR TO 'a_' [outer=(4), constraints=(/4: [/'a' - /'b'))]
 
 # One of the constraints is not tight, so it should not be consolidated.
@@ -1905,3 +1905,66 @@ select
  │         └── (1.00,)
  └── filters
       └── column1:1::STRING != '1.00' [outer=(1), immutable]
+
+# --------------------------------------------------
+# NormalizeSelectLikeToRange
+# --------------------------------------------------
+
+norm expect=NormalizeSelectLikeToRange
+SELECT * FROM a WHERE s LIKE 'FOREST%'
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── (s:4 >= 'FOREST') AND (s:4 < 'FORESU') [outer=(4), constraints=(/4: [/'FOREST' - /'FORESU'); tight)]
+
+# Case without pattern matching selectors.
+norm expect=NormalizeSelectLikeToRange
+SELECT * FROM a WHERE s LIKE 'foo'
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── (s:4 >= 'foo') AND (s:4 <= 'foo') [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# No-op case because the constraints are not tight.
+norm expect-not=NormalizeSelectLikeToRange
+SELECT * FROM a WHERE s LIKE 'foo_'
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── s:4 LIKE 'foo_' [outer=(4), constraints=(/4: [/'foo' - /'fop'))]
+
+# No-op case because the Like expression does not have a tight constraint.
+norm expect-not=NormalizeSelectLikeToRange
+SELECT * FROM a WHERE s LIKE '%FOREST'
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── s:4 LIKE '%FOREST' [outer=(4), constraints=(/4: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -2245,7 +2245,7 @@ sort
            │         │         │         └── filters
            │         │         │              └── ps_availqty:16 > (sum:47 * 0.5) [outer=(16,47), immutable, constraints=(/16: (/NULL - ])]
            │         │         └── filters
-           │         │              └── p_name:21 LIKE 'forest%' [outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
+           │         │              └── (p_name:21 >= 'forest') AND (p_name:21 < 'foresu') [outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
            │         └── filters (true)
            ├── select
            │    ├── columns: n_nationkey:9!null n_name:10!null

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -2178,7 +2178,7 @@ sort
            │         │         │         └── filters
            │         │         │              └── ps_availqty:16 > (sum:47 * 0.5) [outer=(16,47), immutable, constraints=(/16: (/NULL - ])]
            │         │         └── filters
-           │         │              └── p_name:21 LIKE 'forest%' [outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
+           │         │              └── (p_name:21 >= 'forest') AND (p_name:21 < 'foresu') [outer=(21), constraints=(/21: [/'forest' - /'foresu'); tight)]
            │         └── filters (true)
            └── filters
                 └── n_name:10 = 'CANADA' [outer=(10), constraints=(/10: [/'CANADA' - /'CANADA']; tight), fd=()-->(10)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3489,7 +3489,7 @@ project
       │    └── filters (true)
       └── filters
            ├── st_covers(c.geom:10, n.geom:16) [outer=(10,16), immutable]
-           └── name:15 LIKE 'Upper%' [outer=(15), constraints=(/15: [/'Upper' - /'Uppes'); tight)]
+           └── (name:15 >= 'Upper') AND (name:15 < 'Uppes') [outer=(15), constraints=(/15: [/'Upper' - /'Uppes'); tight)]
 
 # It's not possible to generate an inverted join when there is an OR with a
 # non-geospatial function.


### PR DESCRIPTION
It is easier to calculate stats for a `Range` expression than for
`Like` expressions. This PR adds a rule that converts a `Like` operator
with tight constraints to a `Range` operator.

Fixes #52153

Release note: None

Release justification: This change is small and is unlikely to break
anything.