### PR TITLE
build: fix roachtest skip when stats.json is not present

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -59,7 +59,9 @@ function upload_stats {
       # a `.` folder in ${stats_dir}, which we don't want.
       (cd "${artifacts}" && \
         while IFS= read -r f; do
-          gsutil cp "${f}" "gs://${bucket}/artifacts/${stats_dir}/${f}"
+          if [[ -n "${f}" ]]; then
+            gsutil cp "${f}" "gs://${bucket}/artifacts/${stats_dir}/${f}"
+          fi
         done <<< "$(find . -name stats.json | sed 's/^\.\///')")
   fi
 }


### PR DESCRIPTION
Adds an if condition which prevents an upload attempt to
gs if `stats.json` is not present to begin with. gsutil
fails with a CommandException if one tries to upload `''`.

Release justification: non-production code changes