### PR TITLE
sql: cap the number of statementIDs stored in TransactionStatistics

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -106,6 +106,14 @@ var stmtStatsEnable = settings.RegisterPublicBoolSetting(
 	"sql.metrics.statement_details.enabled", "collect per-statement query statistics", true,
 )
 
+// TxnStatsNumStmtIDsToRecord limits the number of statementIDs stored for in
+// transactions statistics for a single transaction. This defaults to 1000, and
+// currently is non-configurable (hidden setting).
+var TxnStatsNumStmtIDsToRecord = settings.RegisterPositiveIntSetting(
+	"sql.metrics.transaction_details.max_statement_ids",
+	"max number of statement IDs to store for transaction statistics",
+	1000)
+
 // txnStatsEnable determines whether to collect per-application transaction
 // statistics.
 var txnStatsEnable = settings.RegisterPublicBoolSetting(

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"hash"
 	"io"
 	"math"
 	"strings"
@@ -1042,8 +1043,18 @@ type connExecutor struct {
 		savepointsAtTxnRewindPos savepointStack
 
 		// transactionStatementIDs tracks all statement IDs that make up the current
-		// transaction.
+		// transaction. It's length is bound by the TxnStatsNumStmtIDsToRecord
+		// cluster setting.
 		transactionStatementIDs []roachpb.StmtID
+
+		// transactionStatementsHash is the hashed accumulation of all statementIDs
+		// that comprise the transaction. It is used to construct the key when
+		// recording transaction statistics. It's important to accumulate this hash
+		// as we go along in addition to the transactionStatementIDs as
+		// transactionStatementIDs are capped to prevent unbound expansion, but we
+		// still need the statementID hash to disambiguate beyond the capped
+		// statements.
+		transactionStatementsHash hash.Hash
 	}
 
 	// sessionData contains the user-configurable connection variables.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1484,16 +1484,18 @@ func (ex *connExecutor) recordTransactionStart() (onTxnFinish func(txnEvent), on
 	ex.phaseTimes[sessionTransactionReceived] = ex.phaseTimes[sessionQueryReceived]
 	ex.phaseTimes[sessionFirstStartExecTransaction] = timeutil.Now()
 	ex.phaseTimes[sessionMostRecentStartExecTransaction] = ex.phaseTimes[sessionFirstStartExecTransaction]
+	ex.extraTxnState.transactionStatementsHash = fnv.New128()
+	ex.extraTxnState.transactionStatementIDs = nil
+	ex.extraTxnState.numRows = 0
 
 	onTxnFinish = func(ev txnEvent) {
 		ex.phaseTimes[sessionEndExecTransaction] = timeutil.Now()
 		ex.recordTransaction(ev, implicit, txnStart)
-		ex.extraTxnState.transactionStatementIDs = nil
-		ex.extraTxnState.numRows = 0
 	}
 	onTxnRestart = func() {
 		ex.phaseTimes[sessionMostRecentStartExecTransaction] = timeutil.Now()
 		ex.extraTxnState.transactionStatementIDs = nil
+		ex.extraTxnState.transactionStatementsHash = fnv.New128()
 		ex.extraTxnState.numRows = 0
 	}
 	return onTxnFinish, onTxnRestart
@@ -1504,19 +1506,11 @@ func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart t
 	txnTime := txnEnd.Sub(txnStart)
 	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
 
-	// First we go through all the statements in the transaction and hash their
-	// queries to get their IDs.
-	h := fnv.New128()
-	for _, stmtID := range ex.extraTxnState.transactionStatementIDs {
-		// Add the current statementID to the running hash state we've been
-		// accumulating.
-		h.Write([]byte(stmtID))
-	}
-	key := txnKey(fmt.Sprintf("%x", h.Sum(nil)))
-
 	txnServiceLat := ex.phaseTimes.getTransactionServiceLatency()
 	txnRetryLat := ex.phaseTimes.getTransactionRetryLatency()
 	commitLat := ex.phaseTimes.getCommitLatency()
+
+	key := txnKey(fmt.Sprintf("%x", ex.extraTxnState.transactionStatementsHash.Sum(nil)))
 
 	ex.statsCollector.recordTransaction(
 		key,


### PR DESCRIPTION
Previously, every statement ID that belonged to a transaction would be
recorded and returned by `TransactionStatistics`. In the pathalogical
case, this could get arbitrarily large, which is not ideal for an in
memory datastrcutre. This patch adds an artificial cap of 1000
statement IDs that will be stored as part of a transaction. Individual
statements beyond the 1000th statement are still used for
disambiguation during statistics collection -- they just aren't stored
in memory.

Closes #53505

Release justification: low risk update to new functionality.

Release note (sql change): The `TransactionStatistics` proto will only
include the first 1000 statment IDs that comprise a transaction. Any
statement IDs beyond 1000 will be ommited.