### PR TITLE
rowenc,encoding: pre-allocate EWKB slice for unmarshalling

### DIFF
--- a/pkg/sql/rowenc/datum_alloc.go
+++ b/pkg/sql/rowenc/datum_alloc.go
@@ -11,6 +11,7 @@
 package rowenc
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -51,10 +52,17 @@ type DatumAlloc struct {
 	doidAlloc         []tree.DOid
 	scratch           []byte
 	env               tree.CollationEnvironment
+
+	// Allocations for geopb.SpatialObject.EWKB
+	ewkbAlloc               []byte
+	curEWKBAllocSize        int
+	lastEWKBBeyondAllocSize bool
 }
 
-const defaultDatumAllocSize = 16 // Arbitrary, could be tuned.
-const datumAllocMultiplier = 4   // Arbitrary, could be tuned.
+const defaultDatumAllocSize = 16  // Arbitrary, could be tuned.
+const datumAllocMultiplier = 4    // Arbitrary, could be tuned.
+const defaultEWKBAllocSize = 4096 // Arbitrary, could be tuned.
+const maxEWKBAllocSize = 16384    // Arbitrary, could be tuned.
 
 // NewDatums allocates Datums of the specified size.
 func (a *DatumAlloc) NewDatums(num int) tree.Datums {
@@ -229,6 +237,30 @@ func (a *DatumAlloc) NewDGeography(v tree.DGeography) *tree.DGeography {
 	return r
 }
 
+// NewDGeographyEmpty allocates a new empty DGeography for unmarshalling.
+// After unmarshalling, DoneInitNewDGeo must be called to return unused
+// pre-allocated space to the DatumAlloc.
+func (a *DatumAlloc) NewDGeographyEmpty() *tree.DGeography {
+	r := a.NewDGeography(tree.DGeography{})
+	a.giveBytesToEWKB(r.SpatialObjectRef())
+	return r
+}
+
+// DoneInitNewDGeo is called after unmarshalling a SpatialObject allocated via
+// NewDGeographyEmpty/NewDGeometryEmpty, to return space to the DatumAlloc.
+func (a *DatumAlloc) DoneInitNewDGeo(so *geopb.SpatialObject) {
+	// Don't allocate next time if the allocation was wasted and there is no way
+	// to pre-allocate enough. This is just a crude heuristic to avoid wasting
+	// allocations if the EWKBs are very large.
+	a.lastEWKBBeyondAllocSize = len(so.EWKB) > maxEWKBAllocSize
+	c := cap(so.EWKB)
+	l := len(so.EWKB)
+	if (c - l) > l {
+		a.ewkbAlloc = so.EWKB[l:l:c]
+		so.EWKB = so.EWKB[:l:l]
+	}
+}
+
 // NewDGeometry allocates a DGeometry.
 func (a *DatumAlloc) NewDGeometry(v tree.DGeometry) *tree.DGeometry {
 	if a.AllocSize == 0 {
@@ -242,6 +274,29 @@ func (a *DatumAlloc) NewDGeometry(v tree.DGeometry) *tree.DGeometry {
 	*r = v
 	*buf = (*buf)[1:]
 	return r
+}
+
+// NewDGeometryEmpty allocates a new empty DGeometry for unmarshalling. After
+// unmarshalling, DoneInitNewDGeo must be called to return unused
+// pre-allocated space to the DatumAlloc.
+func (a *DatumAlloc) NewDGeometryEmpty() *tree.DGeometry {
+	r := a.NewDGeometry(tree.DGeometry{})
+	a.giveBytesToEWKB(r.SpatialObjectRef())
+	return r
+}
+
+func (a *DatumAlloc) giveBytesToEWKB(so *geopb.SpatialObject) {
+	if a.ewkbAlloc == nil && !a.lastEWKBBeyondAllocSize {
+		if a.curEWKBAllocSize == 0 {
+			a.curEWKBAllocSize = defaultEWKBAllocSize
+		} else if a.curEWKBAllocSize < maxEWKBAllocSize {
+			a.curEWKBAllocSize *= 2
+		}
+		so.EWKB = make([]byte, 0, a.curEWKBAllocSize)
+	} else {
+		so.EWKB = a.ewkbAlloc
+		a.ewkbAlloc = nil
+	}
 }
 
 // NewDTime allocates a DTime.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -982,6 +982,7 @@ func TestLint(t *testing.T) {
 			":!*.pb.go",
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",
+			":!util/encoding/encoding.go",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1095,7 +1095,8 @@ func EncodeGeoDescending(b []byte, curveIndex uint64, so *geopb.SpatialObject) (
 }
 
 // DecodeGeoAscending decodes a geopb.SpatialObject value that was encoded
-// in ascending order back into a geopb.SpatialObject.
+// in ascending order back into a geopb.SpatialObject. The so parameter
+// must already be empty/reset.
 func DecodeGeoAscending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if PeekType(b) != Geo {
 		return nil, errors.Errorf("did not find Geo marker")
@@ -1112,12 +1113,15 @@ func DecodeGeoAscending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	err = protoutil.Unmarshal(pbBytes, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(pbBytes)
 	return b, err
 }
 
 // DecodeGeoDescending decodes a geopb.SpatialObject value that was encoded
-// in descending order back into a geopb.SpatialObject.
+// in descending order back into a geopb.SpatialObject. The so parameter
+// must already be empty/reset.
 func DecodeGeoDescending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if PeekType(b) != GeoDesc {
 		return nil, errors.Errorf("did not find Geo marker")
@@ -1135,7 +1139,9 @@ func DecodeGeoDescending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 		return b, err
 	}
 	onesComplement(pbBytes)
-	err = protoutil.Unmarshal(pbBytes, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(pbBytes)
 	return b, err
 }
 
@@ -2579,14 +2585,17 @@ func DecodeUntaggedBox2DValue(
 }
 
 // DecodeUntaggedGeoValue decodes a value encoded by EncodeUntaggedGeoValue into
-// the provided geopb.SpatialObject reference.
+// the provided geopb.SpatialObject reference. The so parameter must already be
+// empty/reset.
 func DecodeUntaggedGeoValue(b []byte, so *geopb.SpatialObject) (remaining []byte, err error) {
 	var data []byte
 	remaining, data, err = DecodeUntaggedBytesValue(b)
 	if err != nil {
 		return b, err
 	}
-	err = protoutil.Unmarshal(data, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(data)
 	return remaining, err
 }
 


### PR DESCRIPTION
Unmarshalling a geopb.SpatialObject needs to allocate a
byte slice for EWKB. This is now pre-allocated using
DatumAlloc in a 2-step process: claim the complete unused
byte slice in DatumAlloc, and then after unmarshalling
return the unused space.

This improves expensive queries
```
name                                   old ms     new ms     delta
Test/postgis_geometry_tutorial/11.2b   1.38 ±31%  1.35 ±32%     ~     (p=0.352 n=50+49)
Test/postgis_geometry_tutorial/11.6    1.43 ±21%  1.45 ±28%     ~     (p=0.810 n=47+48)
Test/postgis_geometry_tutorial/12.1.2  0.81 ±28%  0.84 ±27%     ~     (p=0.174 n=47+50)
Test/postgis_geometry_tutorial/12.2.3  1.22 ±19%  1.23 ±20%     ~     (p=0.879 n=46+49)
Test/postgis_geometry_tutorial/12.2.4  1.18 ±20%  1.19 ±20%     ~     (p=0.659 n=47+48)
Test/postgis_geometry_tutorial/13.0    1.30 ±17%  1.38 ±25%   +5.81%  (p=0.007 n=45+48)
Test/postgis_geometry_tutorial/13.1a    242 ±19%   232 ±10%   -3.98%  (p=0.001 n=49+48)
Test/postgis_geometry_tutorial/13.1c   25.7 ±28%  24.2 ±19%   -5.87%  (p=0.000 n=50+50)
Test/postgis_geometry_tutorial/13.2     327 ±18%   315 ±12%   -3.66%  (p=0.001 n=49+49)
Test/postgis_geometry_tutorial/14.1a   1.48 ±22%  1.75 ±35%  +17.82%  (p=0.000 n=48+50)
Test/postgis_geometry_tutorial/14.2b   6.20 ±23%  7.03 ±22%  +13.33%  (p=0.000 n=48+50)
Test/postgis_geometry_tutorial/14.2c   3.77 ±19%  3.76 ±12%     ~     (p=0.418 n=47+49)
Test/postgis_geometry_tutorial/14.3c   32.7 ±12%  32.2 ± 8%     ~     (p=0.187 n=44+50)
Test/postgis_geometry_tutorial/15.0    1.51 ±25%  1.49 ±25%     ~     (p=0.404 n=48+47)
Test/nyc/nyc-intersects                80.8 ±19%  78.1 ±17%   -3.24%  (p=0.042 n=48+48)
Test/nyc/nyc-dwithin                    233 ±19%   223 ±12%   -4.66%  (p=0.000 n=47+50)
Test/nyc/nyc-coveredby                 83.9 ±19%  79.1 ±18%   -5.79%  (p=0.000 n=48+49)
Test/nyc/nyc-expand-blocks             89.6 ±18%  87.6 ±11%     ~     (p=0.077 n=46+45)
```

Release justification: The geospatial functionality is
new for this release so this falls under category 2
(low-risk updates to new functionality)

Release note: None