### PR TITLE
release-20.1: kv: split EndTxn into sub-batch on auto-retry after successful refresh

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1289,16 +1289,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				br := ba.CreateReply()
 				br.Txn = ba.Txn.Clone()
 
-				if _, hasPut := ba.GetArg(roachpb.Put); hasPut {
-					if _, ok := ba.Requests[0].GetInner().(*roachpb.PutRequest); !ok {
-						t.Fatalf("expected Put")
-					}
-					union := &br.Responses[0] // avoid operating on copy
-					union.MustSetInner(&roachpb.PutResponse{})
-					if ba.Txn != nil && br.Txn == nil {
-						br.Txn.Status = roachpb.PENDING
-					}
-				} else if et, hasET := ba.GetArg(roachpb.EndTxn); hasET {
+				if et, hasET := ba.GetArg(roachpb.EndTxn); hasET {
 					if et.(*roachpb.EndTxnRequest).Commit {
 						commit.Store(true)
 						if test.errFn != nil {
@@ -1307,8 +1298,6 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 						return nil, roachpb.NewErrorWithTxn(test.err, ba.Txn)
 					}
 					abort.Store(true)
-				} else {
-					t.Fatalf("unexpected batch: %s", ba)
 				}
 				return br, nil
 			}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -166,7 +166,30 @@ func (sr *txnSpanRefresher) SendLocked(
 	ba.CanForwardReadTimestamp = canFwdRTS
 	if rArgs, hasET := ba.GetArg(roachpb.EndTxn); hasET {
 		et := rArgs.(*roachpb.EndTxnRequest)
-		et.CanCommitAtHigherTimestamp = canFwdRTS
+		// Assign the EndTxn's CanCommitAtHigherTimestamp flag if it isn't
+		// already set correctly. We don't write blindly because we could be
+		// dealing with a re-issued batch from splitEndTxnAndRetrySend after a
+		// refresh and we don't want to mutate previously issued requests or we
+		// risk a data race (checked by raceTransport). In these cases, we need
+		// to clone the EndTxn request first before mutating.
+		//
+		// We know this is a re-issued batch if the flag is already set and we
+		// need to unset it. We aren't able to detect the case where the flag is
+		// not set and we now need to set it to true, but such cases don't
+		// happen in practice (i.e. we'll never begin setting the flag after a
+		// refresh).
+		//
+		// TODO(nvanbenschoten): this is ugly. If we weren't about to delete
+		// this field, we'd want to do something better. Just delete this ASAP.
+		if et.CanCommitAtHigherTimestamp != canFwdRTS {
+			isReissue := et.CanCommitAtHigherTimestamp
+			if isReissue {
+				etCpy := *et
+				ba.Requests[len(ba.Requests)-1].SetInner(&etCpy)
+				et = &etCpy
+			}
+			et.CanCommitAtHigherTimestamp = canFwdRTS
+		}
 	}
 
 	maxAttempts := maxTxnRefreshAttempts
@@ -326,11 +349,28 @@ func (sr *txnSpanRefresher) maybeRetrySend(
 		}
 		return nil, pErr
 	}
-	sr.refreshSuccess.Inc(1)
-	log.Eventf(ctx, "refresh succeeded; retrying original request")
 
 	// We've refreshed all of the read spans successfully and bumped
 	// ba.Txn's timestamps. Attempt the request again.
+	sr.refreshSuccess.Inc(1)
+	log.Eventf(ctx, "refresh succeeded; retrying original request")
+
+	// To prevent starvation of batches that are trying to commit, split off the
+	// EndTxn request into its own batch on auto-retries. This avoids starvation
+	// in two ways. First, it helps ensure that we lay down intents if any of
+	// the other requests in the batch are writes. Second, it ensures that if
+	// any writes are getting pushed due to contention with reads or due to the
+	// closed timestamp, they will still succeed and allow the batch to make
+	// forward progress. Without this, each retry attempt may get pushed because
+	// of writes in the batch and then rejected wholesale when the EndTxn tries
+	// to evaluate the pushed batch. When split, the writes will be pushed but
+	// succeed, the transaction will be refreshed, and the EndTxn will succeed.
+	args, hasET := ba.GetArg(roachpb.EndTxn)
+	if len(ba.Requests) > 1 && hasET && !args.(*roachpb.EndTxnRequest).Require1PC {
+		log.Eventf(ctx, "sending EndTxn separately from rest of batch on retry")
+		return sr.splitEndTxnAndRetrySend(ctx, ba)
+	}
+
 	retryBr, retryErr := sr.sendLockedWithRefreshAttempts(
 		ctx, ba, maxRefreshAttempts-1,
 	)
@@ -341,6 +381,45 @@ func (sr *txnSpanRefresher) maybeRetrySend(
 
 	log.VEventf(ctx, 2, "retry successful @%s", retryBr.Txn.ReadTimestamp)
 	return retryBr, nil
+}
+
+// splitEndTxnAndRetrySend splits the batch in two, with a prefix containing all
+// requests up to but not including the EndTxn request and a suffix containing
+// only the EndTxn request. It then issues the two partial batches in order,
+// stitching their results back together at the end.
+func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
+	// NOTE: call back into SendLocked with each partial batch, not into
+	// sendLockedWithRefreshAttempts. This ensures that we properly set
+	// CanForwardReadTimestamp on each partial batch and that we provide
+	// the EndTxn batch with a chance to perform a preemptive refresh.
+
+	// Issue a batch up to but not including the EndTxn request.
+	etIdx := len(ba.Requests) - 1
+	baPrefix := ba
+	baPrefix.Requests = ba.Requests[:etIdx]
+	brPrefix, pErr := sr.SendLocked(ctx, baPrefix)
+	if pErr != nil {
+		return nil, pErr
+	}
+
+	// Issue a batch containing only the EndTxn request.
+	baSuffix := ba
+	baSuffix.Requests = ba.Requests[etIdx:]
+	baSuffix.Txn = brPrefix.Txn
+	brSuffix, pErr := sr.SendLocked(ctx, baSuffix)
+	if pErr != nil {
+		return nil, pErr
+	}
+
+	// Combine the responses.
+	br := brPrefix
+	br.Responses = append(br.Responses, roachpb.ResponseUnion{})
+	if err := br.Combine(brSuffix, []int{etIdx}); err != nil {
+		return nil, roachpb.NewError(err)
+	}
+	return br, nil
 }
 
 // tryUpdatingTxnSpans sends Refresh and RefreshRange commands to all spans read

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -12,10 +12,13 @@ package kvcoord
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -312,7 +315,6 @@ func TestTxnSpanRefresherMaxRefreshAttempts(t *testing.T) {
 	br, pErr := tsr.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-
 	require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
 	require.False(t, tsr.refreshInvalid)
 	require.Equal(t, br.Txn.ReadTimestamp, tsr.refreshedTimestamp)
@@ -358,6 +360,311 @@ func TestTxnSpanRefresherMaxRefreshAttempts(t *testing.T) {
 	exp := roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, "")
 	require.Equal(t, exp, pErr.GetDetail())
 	require.Equal(t, tsr.knobs.MaxTxnRefreshAttempts, refreshes)
+}
+
+// TestTxnSpanRefresherSplitEndTxnOnAutoRetry tests that EndTxn requests are
+// split into their own sub-batch on auto-retries after a successful refresh.
+// This is done to avoid starvation.
+func TestTxnSpanRefresherSplitEndTxnOnAutoRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	txn := makeTxnProto()
+	origTs := txn.ReadTimestamp
+	pushedTs1 := txn.ReadTimestamp.Add(1, 0)
+	pushedTs2 := txn.ReadTimestamp.Add(2, 0)
+	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
+
+	scanArgs := roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{Key: keyA, EndKey: keyB}}
+	putArgs := roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyB}}
+	etArgs := roachpb.EndTxnRequest{Commit: true}
+
+	// Run the test with two slightly different configurations. When priorReads
+	// is true, issue a {Put, EndTxn} batch after having previously accumulated
+	// refresh spans due to a Scan. When priorReads is false, issue a {Scan,
+	// Put, EndTxn} batch with no previously accumulated refresh spans.
+	testutils.RunTrueAndFalse(t, "prior_reads", func(t *testing.T, priorReads bool) {
+		var mockFns []func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
+		if priorReads {
+			// Hook up a chain of mocking functions. Expected order of requests:
+			// 1. {Put, EndTxn} -> retry error with pushed timestamp
+			// 2. {Refresh}     -> successful
+			// 3. {Put}         -> successful with pushed timestamp
+			// 4. {EndTxn}      -> retry error with pushed timestamp
+			// 5. {Refresh}     -> successful
+			// 6. {EndTxn}      -> successful
+			onPutAndEndTxn := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 2)
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.IsType(t, &roachpb.PutRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[1].GetInner())
+
+				pushedTxn := ba.Txn.Clone()
+				pushedTxn.WriteTimestamp = pushedTs1
+				return nil, roachpb.NewErrorWithTxn(
+					roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, ""), pushedTxn)
+			}
+			onRefresh1 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.Equal(t, pushedTs1, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.RefreshRangeRequest{}, ba.Requests[0].GetInner())
+
+				refReq := ba.Requests[0].GetRefreshRange()
+				require.Equal(t, scanArgs.Span(), refReq.Span())
+				require.Equal(t, origTs, refReq.RefreshFrom)
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn
+				return br, nil
+			}
+			onPut := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs1, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.PutRequest{}, ba.Requests[0].GetInner())
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn.Clone()
+				br.Txn.WriteTimestamp = pushedTs2
+				return br, nil
+			}
+			onEndTxn1 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs1, ba.Txn.ReadTimestamp)
+				require.Equal(t, pushedTs2, ba.Txn.WriteTimestamp)
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+				return nil, roachpb.NewErrorWithTxn(
+					roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, ""), ba.Txn)
+			}
+			onRefresh2 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.Equal(t, pushedTs2, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.RefreshRangeRequest{}, ba.Requests[0].GetInner())
+
+				refReq := ba.Requests[0].GetRefreshRange()
+				require.Equal(t, scanArgs.Span(), refReq.Span())
+				require.Equal(t, pushedTs1, refReq.RefreshFrom)
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn
+				return br, nil
+			}
+			onEndTxn2 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs2, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn.Clone()
+				br.Txn.Status = roachpb.COMMITTED
+				return br, nil
+			}
+			mockFns = append(mockFns, onPutAndEndTxn, onRefresh1, onPut, onEndTxn1, onRefresh2, onEndTxn2)
+		} else {
+			// Hook up a chain of mocking functions. Expected order of requests:
+			// 1. {Scan, Put, EndTxn} -> retry error with pushed timestamp
+			// 2. {Scan, Put}         -> successful with pushed timestamp
+			// 3. {EndTxn}            -> retry error with pushed timestamp
+			// 4. {Refresh}           -> successful
+			// 5. {EndTxn}            -> successful
+			onScanPutAndEndTxn := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 3)
+				require.True(t, ba.CanForwardReadTimestamp)
+				require.IsType(t, &roachpb.ScanRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &roachpb.PutRequest{}, ba.Requests[1].GetInner())
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[2].GetInner())
+
+				pushedTxn := ba.Txn.Clone()
+				pushedTxn.WriteTimestamp = pushedTs1
+				return nil, roachpb.NewErrorWithTxn(
+					roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, ""), pushedTxn)
+			}
+			onScanAndPut := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 2)
+				require.True(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs1, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.ScanRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &roachpb.PutRequest{}, ba.Requests[1].GetInner())
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn.Clone()
+				br.Txn.WriteTimestamp = pushedTs2
+				return br, nil
+			}
+			onEndTxn1 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs1, ba.Txn.ReadTimestamp)
+				require.Equal(t, pushedTs2, ba.Txn.WriteTimestamp)
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+				return nil, roachpb.NewErrorWithTxn(
+					roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, ""), ba.Txn)
+			}
+			onRefresh := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.Equal(t, pushedTs2, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.RefreshRangeRequest{}, ba.Requests[0].GetInner())
+
+				refReq := ba.Requests[0].GetRefreshRange()
+				require.Equal(t, scanArgs.Span(), refReq.Span())
+				require.Equal(t, pushedTs1, refReq.RefreshFrom)
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn
+				return br, nil
+			}
+			onEndTxn2 := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				// IMPORTANT! CanForwardReadTimestamp should no longer be set
+				// for EndTxn batch, because the Scan in the earlier batch needs
+				// to be refreshed if the read timestamp changes.
+				require.False(t, ba.CanForwardReadTimestamp)
+				require.Equal(t, pushedTs2, ba.Txn.ReadTimestamp)
+				require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn.Clone()
+				br.Txn.Status = roachpb.COMMITTED
+				return br, nil
+			}
+			mockFns = append(mockFns, onScanPutAndEndTxn, onScanAndPut, onEndTxn1, onRefresh, onEndTxn2)
+		}
+
+		// Iterate over each RPC to inject an error to test error propagation.
+		// Include a test case where no error is returned and the entire chain
+		// of requests succeeds.
+		for errIdx := 0; errIdx <= len(mockFns); errIdx++ {
+			errIdxStr := strconv.Itoa(errIdx)
+			if errIdx == len(mockFns) {
+				errIdxStr = "none"
+			}
+			t.Run(fmt.Sprintf("error_index=%s", errIdxStr), func(t *testing.T) {
+				ctx := context.Background()
+				tsr, mockSender := makeMockTxnSpanRefresher()
+
+				var ba roachpb.BatchRequest
+				if priorReads {
+					// Collect some refresh spans first.
+					ba.Header = roachpb.Header{Txn: &txn}
+					ba.Add(&scanArgs)
+
+					br, pErr := tsr.SendLocked(ctx, ba)
+					require.Nil(t, pErr)
+					require.NotNil(t, br)
+					require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
+					require.False(t, tsr.refreshInvalid)
+					require.Equal(t, br.Txn.ReadTimestamp, tsr.refreshedTimestamp)
+
+					ba.Requests = nil
+					ba.Add(&putArgs, &etArgs)
+				} else {
+					// No refresh spans to begin with.
+					require.Equal(t, []roachpb.Span(nil), tsr.refreshFootprint.asSlice())
+
+					ba.Header = roachpb.Header{Txn: &txn}
+					ba.Add(&scanArgs, &putArgs, &etArgs)
+				}
+
+				// Construct the mock sender chain, injecting an error where
+				// appropriate. Make a copy of mockFns to avoid sharing state
+				// between subtests.
+				mockFnsCpy := append([]func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)(nil), mockFns...)
+				if errIdx < len(mockFnsCpy) {
+					errFn := mockFnsCpy[errIdx]
+					newErrFn := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+						_, pErr := errFn(ba)
+						_ = pErr // ignore
+						return nil, roachpb.NewErrorf("error")
+					}
+					mockFnsCpy[errIdx] = newErrFn
+				}
+				unexpected := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+					require.Fail(t, "unexpected")
+					return nil, nil
+				}
+				mockSender.ChainMockSend(append(mockFnsCpy, unexpected)...)
+
+				br, pErr := tsr.SendLocked(ctx, ba)
+				if priorReads {
+					if errIdx < 6 {
+						require.Nil(t, br)
+						require.NotNil(t, pErr)
+					} else {
+						require.Nil(t, pErr)
+						require.NotNil(t, br)
+						require.Len(t, br.Responses, 2)
+						require.IsType(t, &roachpb.PutResponse{}, br.Responses[0].GetInner())
+						require.IsType(t, &roachpb.EndTxnResponse{}, br.Responses[1].GetInner())
+						require.Equal(t, roachpb.COMMITTED, br.Txn.Status)
+						require.Equal(t, pushedTs2, br.Txn.ReadTimestamp)
+						require.Equal(t, pushedTs2, br.Txn.WriteTimestamp)
+					}
+
+					var expSuccess, expFail int64
+					switch errIdx {
+					case 0:
+						expSuccess, expFail = 0, 0
+					case 1:
+						expSuccess, expFail = 0, 1
+					case 2, 3:
+						expSuccess, expFail = 1, 0
+					case 4:
+						expSuccess, expFail = 1, 1
+					case 5, 6:
+						expSuccess, expFail = 2, 0
+					default:
+						require.Fail(t, "unexpected")
+					}
+					require.Equal(t, expSuccess, tsr.refreshSuccess.Count())
+					require.Equal(t, expFail, tsr.refreshFail.Count())
+
+					require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
+					require.False(t, tsr.refreshInvalid)
+				} else {
+					if errIdx < 5 {
+						require.Nil(t, br)
+						require.NotNil(t, pErr)
+					} else {
+						require.Nil(t, pErr)
+						require.NotNil(t, br)
+						require.Len(t, br.Responses, 3)
+						require.IsType(t, &roachpb.ScanResponse{}, br.Responses[0].GetInner())
+						require.IsType(t, &roachpb.PutResponse{}, br.Responses[1].GetInner())
+						require.IsType(t, &roachpb.EndTxnResponse{}, br.Responses[2].GetInner())
+						require.Equal(t, roachpb.COMMITTED, br.Txn.Status)
+						require.Equal(t, pushedTs2, br.Txn.ReadTimestamp)
+						require.Equal(t, pushedTs2, br.Txn.WriteTimestamp)
+					}
+
+					var expSuccess, expFail int64
+					switch errIdx {
+					case 0:
+						expSuccess, expFail = 0, 0
+					case 1, 2:
+						expSuccess, expFail = 1, 0
+					case 3:
+						expSuccess, expFail = 1, 1
+					case 4, 5:
+						expSuccess, expFail = 2, 0
+					default:
+						require.Fail(t, "unexpected")
+					}
+					require.Equal(t, expSuccess, tsr.refreshSuccess.Count())
+					require.Equal(t, expFail, tsr.refreshFail.Count())
+
+					if errIdx < 2 {
+						require.Equal(t, []roachpb.Span(nil), tsr.refreshFootprint.asSlice())
+					} else {
+						require.Equal(t, []roachpb.Span{scanArgs.Span()}, tsr.refreshFootprint.asSlice())
+					}
+					require.False(t, tsr.refreshInvalid)
+				}
+			})
+		}
+	})
 }
 
 type singleRangeIterator struct{}


### PR DESCRIPTION
Backport 1/1 commits from #52885.

/cc @cockroachdb/release

This was not a clean backport. Notably, this is only a backport of #52885 and not of #52884. I deemed #52884 to be too much of a behavioral change which could have unintended consequences and, therefore, too risky to backport. This means that the interactions are a little bit different in `TestTxnSpanRefresherSplitEndTxnOnAutoRetry`, so reviewers should take a close look at that test in particular.

@irfansharif do you mind giving this a look? @andreimatei is out for the week and this is coming up in a few support issues that you're looking at. Also, do you know whether the customers in those issues would be interested in testing this out before it makes itself into an official point release?

---

Fixes #51294.

This commit updates the txnSpanRefresher to split off EndTxn requests into their own partial batches on auto-retries after successful refreshes as a means of preventing starvation. This avoids starvation in two ways. First, it helps ensure that we lay down intents if any of the other requests in the batch are writes. Second, it ensures that if any writes are getting pushed due to contention with reads or due to the closed timestamp, they will still succeed and allow the batch to make forward progress. Without this, each retry attempt may get pushed because of writes in the batch and then rejected wholesale when the EndTxn tries to evaluate the pushed batch. When split, the writes will be pushed but succeed, the transaction will be refreshed, and the EndTxn will succeed.

I still need to confirm that this fixes this indefinite stall [here](https://github.com/cockroachlabs/misc_projects_glenn/tree/master/rw_blockage#implicit-query-hangs--explict-query-works), but I suspect that it will.

Release note (bug fix): A change in v20.1 caused a certain class of bulk UPDATEs and DELETE statements to hang indefinitely if run in an implicit transaction. We now break up these statements to avoid starvation and prevent them from hanging indefinitely.
