### PR TITLE
sql: miscellaneous fixes to the `CONVERT TO SCHEMA` command

### DIFF
--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -52,6 +52,10 @@ func (p *planner) ReparentDatabase(
 			clusterversion.VersionByKey(clusterversion.VersionUserDefinedSchemas))
 	}
 
+	if string(n.Name) == p.CurrentDatabase() {
+		return nil, pgerror.DangerousStatementf("CONVERT TO SCHEMA on current database")
+	}
+
 	db, err := p.ResolveMutableDatabaseDescriptor(ctx, string(n.Name), true /* required */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -596,7 +596,7 @@ func (*RenameDatabase) StatementTag() string { return "RENAME DATABASE" }
 func (*ReparentDatabase) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ReparentDatabase) StatementTag() string { return "TODO (rohany): Implement" }
+func (*ReparentDatabase) StatementTag() string { return "CONVERT TO SCHEMA" }
 
 // StatementType implements the Statement interface.
 func (*RenameIndex) StatementType() StatementType { return DDL }


### PR DESCRIPTION
Fixes #53563.

Release justification: low risk updates to new functionality
Release note (sql change): Disallow the `CONVERT TO SCHEMA` command on
the current database.