### PR TITLE
geo: remove GeospatialType

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -57,35 +57,20 @@ const (
 	FnInclusive FnExclusivity = false
 )
 
-//
-// Geospatial Type
-//
-
-// GeospatialType are functions that are common between all Geospatial types.
-type GeospatialType interface {
-	// SRID returns the SRID of the given type.
-	SRID() geopb.SRID
-	// ShapeType returns the ShapeType of the given type.
-	ShapeType() geopb.ShapeType
-}
-
-var _ GeospatialType = (*Geometry)(nil)
-var _ GeospatialType = (*Geography)(nil)
-
-// GeospatialTypeFitsColumnMetadata determines whether a GeospatialType is compatible with the
+// SpatialObjectFitsColumnMetadata determines whether a GeospatialType is compatible with the
 // given SRID and Shape.
 // Returns an error if the types does not fit.
-func GeospatialTypeFitsColumnMetadata(
-	t GeospatialType, srid geopb.SRID, shapeType geopb.ShapeType,
+func SpatialObjectFitsColumnMetadata(
+	so geopb.SpatialObject, srid geopb.SRID, shapeType geopb.ShapeType,
 ) error {
 	// SRID 0 can take in any SRID. Otherwise SRIDs must match.
-	if srid != 0 && t.SRID() != srid {
-		return errors.Newf("object SRID %d does not match column SRID %d", t.SRID(), srid)
+	if srid != 0 && so.SRID != srid {
+		return errors.Newf("object SRID %d does not match column SRID %d", so.SRID, srid)
 	}
 	// Shape_Geometry/Shape_Unset can take in any kind of shape.
 	// Otherwise, shapes must match.
-	if shapeType != geopb.ShapeType_Unset && shapeType != geopb.ShapeType_Geometry && shapeType != t.ShapeType() {
-		return errors.Newf("object type %s does not match column type %s", t.ShapeType(), shapeType)
+	if shapeType != geopb.ShapeType_Unset && shapeType != geopb.ShapeType_Geometry && shapeType != so.ShapeType {
+		return errors.Newf("object type %s does not match column type %s", so.ShapeType, shapeType)
 	}
 	return nil
 }

--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -96,7 +96,7 @@ func mustDecodeEWKBFromString(t *testing.T, h string) geopb.EWKB {
 	return geopb.EWKB(decoded)
 }
 
-func TestGeospatialTypeFitsColumnMetadata(t *testing.T) {
+func TestSpatialObjectFitsColumnMetadata(t *testing.T) {
 	testCases := []struct {
 		t             Geometry
 		srid          geopb.SRID
@@ -113,7 +113,7 @@ func TestGeospatialTypeFitsColumnMetadata(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v_fits_%d_%s", tc.t, tc.srid, tc.shape), func(t *testing.T) {
-			err := GeospatialTypeFitsColumnMetadata(&tc.t, tc.srid, tc.shape)
+			err := SpatialObjectFitsColumnMetadata(tc.t.SpatialObject(), tc.srid, tc.shape)
 			if tc.errorContains != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errorContains)

--- a/pkg/sql/catalog/colinfo/column_type_properties.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties.go
@@ -174,8 +174,8 @@ func AdjustValueToColumnType(
 		}
 	case types.GeometryFamily:
 		if in, ok := inVal.(*tree.DGeometry); ok {
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&in.Geometry,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				in.Geometry.SpatialObject(),
 				typ.InternalType.GeoMetadata.SRID,
 				typ.InternalType.GeoMetadata.ShapeType,
 			); err != nil {
@@ -184,8 +184,8 @@ func AdjustValueToColumnType(
 		}
 	case types.GeographyFamily:
 		if in, ok := inVal.(*tree.DGeography); ok {
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&in.Geography,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				in.Geography.SpatialObject(),
 				typ.InternalType.GeoMetadata.SRID,
 				typ.InternalType.GeoMetadata.ShapeType,
 			); err != nil {

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -729,8 +729,8 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DCollatedString:
 			return ParseDGeography(d.Contents)
 		case *DGeography:
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&d.Geography,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				d.Geography.SpatialObject(),
 				t.InternalType.GeoMetadata.SRID,
 				t.InternalType.GeoMetadata.ShapeType,
 			); err != nil {
@@ -742,8 +742,8 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			if err != nil {
 				return nil, err
 			}
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&g,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				g.SpatialObject(),
 				t.InternalType.GeoMetadata.SRID,
 				t.InternalType.GeoMetadata.ShapeType,
 			); err != nil {
@@ -774,8 +774,8 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DCollatedString:
 			return ParseDGeometry(d.Contents)
 		case *DGeometry:
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&d.Geometry,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				d.Geometry.SpatialObject(),
 				t.InternalType.GeoMetadata.SRID,
 				t.InternalType.GeoMetadata.ShapeType,
 			); err != nil {
@@ -783,8 +783,8 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			}
 			return d, nil
 		case *DGeography:
-			if err := geo.GeospatialTypeFitsColumnMetadata(
-				&d.Geography,
+			if err := geo.SpatialObjectFitsColumnMetadata(
+				d.Geography.SpatialObject(),
 				t.InternalType.GeoMetadata.SRID,
 				t.InternalType.GeoMetadata.ShapeType,
 			); err != nil {


### PR DESCRIPTION
GeospatialType was really a wrapper around SpatialObject, I think we are
able to do away from it. Might get rid of some pointer promotions.

Release justification: bug fixes and low-risk updates to new
functionality
Release note: None