### PR TITLE
[WIP] geo,geomfn,builtins: remember previously unmarshalled geom.T and lazily marshal to EWKB

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -97,6 +97,10 @@ func GeospatialTypeFitsColumnMetadata(
 // Geometry is planar spatial object.
 type Geometry struct {
 	spatialObject geopb.SpatialObject
+	// spatialObject and GeomT represent the same shape. GeomT may contain an
+	// unmarshalled spatialObject, or a newly constructed Geometry using a
+	// geom.T may not have yet marshalled to the spatialObject.
+	GeomT geom.T
 }
 
 // MakeGeometry returns a new Geometry. Assumes the input EWKB is validated and in little endian.
@@ -129,11 +133,17 @@ func MakeGeometryFromPointCoords(x, y float64) (Geometry, error) {
 
 // MakeGeometryFromGeomT creates a new Geometry object from a geom.T object.
 func MakeGeometryFromGeomT(g geom.T) (Geometry, error) {
-	spatialObject, err := spatialObjectFromGeomT(g, geopb.SpatialObjectType_GeometryType)
-	if err != nil {
-		return Geometry{}, err
-	}
-	return MakeGeometry(spatialObject)
+	// Initialize the GeomT but don't marshal to SpatialObject until it is needed,
+	// since it may not needed for intermediate results.
+	// TODO: this is delaying the error checking.
+	return Geometry{GeomT: g}, nil
+	/*
+		spatialObject, err := spatialObjectFromGeomT(g, geopb.SpatialObjectType_GeometryType)
+		if err != nil {
+			return Geometry{}, err
+		}
+		return MakeGeometry(spatialObject)
+	*/
 }
 
 // ParseGeometry parses a Geometry from a given text.
@@ -230,6 +240,9 @@ func (g *Geometry) AsGeography() (Geography, error) {
 // CloneWithSRID sets a given Geometry's SRID to another, without any transformations.
 // Returns a new Geometry object.
 func (g *Geometry) CloneWithSRID(srid geopb.SRID) (Geometry, error) {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	spatialObject, err := adjustSpatialObject(g.spatialObject, srid, geopb.SpatialObjectType_GeometryType)
 	if err != nil {
 		return Geometry{}, err
@@ -251,47 +264,92 @@ func adjustSpatialObject(
 
 // AsGeomT returns the geometry as a geom.T object.
 func (g *Geometry) AsGeomT() (geom.T, error) {
-	return ewkb.Unmarshal(g.spatialObject.EWKB)
+	var err error
+	if g.GeomT == nil {
+		// TODO: This initialization of GeomT may not pass all the
+		// way up the stack if the original caller passed Geometry
+		// by value. Ensure everything is passing the pointer.
+		g.GeomT, err = ewkb.Unmarshal(g.spatialObject.EWKB)
+	}
+	return g.GeomT, err
 }
 
 // Empty returns whether the given Geometry is empty.
 func (g *Geometry) Empty() bool {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject.BoundingBox == nil
 }
 
 // EWKB returns the EWKB representation of the Geometry.
 func (g *Geometry) EWKB() geopb.EWKB {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject.EWKB
+}
+
+func (g *Geometry) initSpatialObject() {
+	spatialObject, err := spatialObjectFromGeomT(g.GeomT, geopb.SpatialObjectType_GeometryType)
+	if err != nil {
+		// TODO: don't panic here.
+		panic("SpatialObject")
+	}
+	gg, err := MakeGeometry(spatialObject)
+	if err != nil {
+		// TODO: don't panic here.
+		panic("SpatialObject2")
+	}
+	g.spatialObject = gg.spatialObject
 }
 
 // SpatialObject returns the SpatialObject representation of the Geometry.
 func (g *Geometry) SpatialObject() geopb.SpatialObject {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject
 }
 
 // SpatialObjectRef return a pointer to the SpatialObject representation of the
 // Geometry.
 func (g *Geometry) SpatialObjectRef() *geopb.SpatialObject {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return &g.spatialObject
 }
 
 // EWKBHex returns the EWKBHex representation of the Geometry.
 func (g *Geometry) EWKBHex() string {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject.EWKBHex()
 }
 
 // SRID returns the SRID representation of the Geometry.
 func (g *Geometry) SRID() geopb.SRID {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject.SRID
 }
 
 // ShapeType returns the shape type of the Geometry.
 func (g *Geometry) ShapeType() geopb.ShapeType {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	return g.spatialObject.ShapeType
 }
 
 // CartesianBoundingBox returns a Cartesian bounding box.
 func (g *Geometry) CartesianBoundingBox() *CartesianBoundingBox {
+	if g.spatialObject.Type == geopb.SpatialObjectType_Unknown && g.GeomT != nil {
+		g.initSpatialObject()
+	}
 	if g.spatialObject.BoundingBox == nil {
 		return nil
 	}

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -35,7 +35,7 @@ const (
 
 // MinDistance returns the minimum distance between geometries A and B.
 // This returns a geo.EmptyGeometryError if either A or B is EMPTY.
-func MinDistance(a geo.Geometry, b geo.Geometry) (float64, error) {
+func MinDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 	if a.SRID() != b.SRID() {
 		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
 	}
@@ -44,7 +44,7 @@ func MinDistance(a geo.Geometry, b geo.Geometry) (float64, error) {
 
 // MaxDistance returns the maximum distance across every pair of points comprising
 // geometries A and B.
-func MaxDistance(a geo.Geometry, b geo.Geometry) (float64, error) {
+func MaxDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 	if a.SRID() != b.SRID() {
 		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
 	}
@@ -55,7 +55,7 @@ func MaxDistance(a geo.Geometry, b geo.Geometry) (float64, error) {
 // If exclusive, DWithin is equivalent to Distance(a, b) < d. Otherwise, DWithin
 // is equivalent to Distance(a, b) <= d.
 func DWithin(
-	a geo.Geometry, b geo.Geometry, d float64, exclusivity geo.FnExclusivity,
+	a *geo.Geometry, b *geo.Geometry, d float64, exclusivity geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
@@ -85,7 +85,7 @@ func DWithin(
 // DFullyWithin is equivalent to MaxDistance(a, b) < d. Otherwise, DFullyWithin
 // is equivalent to MaxDistance(a, b) <= d.
 func DFullyWithin(
-	a geo.Geometry, b geo.Geometry, d float64, exclusivity geo.FnExclusivity,
+	a *geo.Geometry, b *geo.Geometry, d float64, exclusivity geo.FnExclusivity,
 ) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
@@ -112,7 +112,7 @@ func DFullyWithin(
 
 // LongestLineString returns the LineString corresponds to maximum distance across
 // every pair of points comprising geometries A and B.
-func LongestLineString(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
+func LongestLineString(a *geo.Geometry, b *geo.Geometry) (geo.Geometry, error) {
 	if a.SRID() != b.SRID() {
 		return geo.Geometry{}, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
 	}
@@ -122,7 +122,7 @@ func LongestLineString(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
 
 // ShortestLineString returns the LineString corresponds to minimum distance across
 // every pair of points comprising geometries A and B.
-func ShortestLineString(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
+func ShortestLineString(a *geo.Geometry, b *geo.Geometry) (geo.Geometry, error) {
 	if a.SRID() != b.SRID() {
 		return geo.Geometry{}, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
 	}
@@ -136,7 +136,7 @@ func ShortestLineString(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
 // EmptyGeometryError if A or B contains only EMPTY geometries, even if emptyBehavior
 // is set to EmptyBehaviorOmit.
 func distanceLineStringInternal(
-	a geo.Geometry, b geo.Geometry, u geodist.DistanceUpdater, emptyBehavior geo.EmptyBehavior,
+	a *geo.Geometry, b *geo.Geometry, u geodist.DistanceUpdater, emptyBehavior geo.EmptyBehavior,
 ) (geo.Geometry, error) {
 	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox())}
 	_, err := distanceInternal(a, b, c, emptyBehavior)
@@ -162,8 +162,8 @@ func distanceLineStringInternal(
 // We can re-use the same algorithm as min-distance, allowing skips of checks that involve
 // the interiors or intersections as those will always be less then the maximum min-distance.
 func maxDistanceInternal(
-	a geo.Geometry,
-	b geo.Geometry,
+	a *geo.Geometry,
+	b *geo.Geometry,
 	stopAfter float64,
 	emptyBehavior geo.EmptyBehavior,
 	exclusivity geo.FnExclusivity,
@@ -176,8 +176,8 @@ func maxDistanceInternal(
 // minDistanceInternal finds the minimum distance between two geometries.
 // This implementation is done in-house, as compared to using GEOS.
 func minDistanceInternal(
-	a geo.Geometry,
-	b geo.Geometry,
+	a *geo.Geometry,
+	b *geo.Geometry,
 	stopAfter float64,
 	emptyBehavior geo.EmptyBehavior,
 	exclusivity geo.FnExclusivity,
@@ -193,7 +193,7 @@ func minDistanceInternal(
 // EmptyGeometryError if A or B contains only EMPTY geometries, even if emptyBehavior
 // is set to EmptyBehaviorOmit.
 func distanceInternal(
-	a geo.Geometry, b geo.Geometry, c geodist.DistanceCalculator, emptyBehavior geo.EmptyBehavior,
+	a *geo.Geometry, b *geo.Geometry, c geodist.DistanceCalculator, emptyBehavior geo.EmptyBehavior,
 ) (float64, error) {
 	// If either side has no geoms, then we error out regardless of emptyBehavior.
 	if a.Empty() || b.Empty() {

--- a/pkg/geo/geomfn/unary_operators.go
+++ b/pkg/geo/geomfn/unary_operators.go
@@ -114,7 +114,7 @@ func Area(g geo.Geometry) (float64, error) {
 }
 
 // Dimension returns the topological dimension of a given Geometry.
-func Dimension(g geo.Geometry) (int, error) {
+func Dimension(g *geo.Geometry) (int, error) {
 	t, err := g.AsGeomT()
 	if err != nil {
 		return 0, err

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1589,7 +1589,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 		defProps(),
 		geometryOverload1(
 			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				dim, err := geomfn.Dimension(g.Geometry)
+				dim, err := geomfn.Dimension(&g.Geometry)
 				if err != nil {
 					return nil, err
 				}
@@ -2449,7 +2449,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 		defProps(),
 		geometryOverload2(
 			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
-				ret, err := geomfn.MinDistance(a.Geometry, b.Geometry)
+				ret, err := geomfn.MinDistance(&a.Geometry, &b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
 						return tree.DNull, nil
@@ -2574,7 +2574,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 		defProps(),
 		geometryOverload2(
 			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
-				ret, err := geomfn.MaxDistance(a.Geometry, b.Geometry)
+				ret, err := geomfn.MaxDistance(&a.Geometry, &b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
 						return tree.DNull, nil
@@ -2595,7 +2595,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 		defProps(),
 		geometryOverload2(
 			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
-				longestLineString, err := geomfn.LongestLineString(a.Geometry, b.Geometry)
+				longestLineString, err := geomfn.LongestLineString(&a.Geometry, &b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
 						return tree.DNull, nil
@@ -2620,7 +2620,7 @@ Note if geometries are the same, it will return the LineString with the maximum 
 		defProps(),
 		geometryOverload2(
 			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
-				shortestLineString, err := geomfn.ShortestLineString(a.Geometry, b.Geometry)
+				shortestLineString, err := geomfn.ShortestLineString(&a.Geometry, &b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
 						return tree.DNull, nil
@@ -2735,7 +2735,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist), geo.FnInclusive)
+				ret, err := geomfn.DFullyWithin(&a.Geometry, &b.Geometry, float64(*dist), geo.FnInclusive)
 				if err != nil {
 					return nil, err
 				}
@@ -4285,7 +4285,7 @@ Bottom Left.`,
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist), geo.FnExclusive)
+				ret, err := geomfn.DFullyWithin(&a.Geometry, &b.Geometry, float64(*dist), geo.FnExclusive)
 				if err != nil {
 					return nil, err
 				}
@@ -4886,7 +4886,7 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				dist := args[2].(*tree.DFloat)
-				ret, err := geomfn.DWithin(a.Geometry, b.Geometry, float64(*dist), exclusivity)
+				ret, err := geomfn.DWithin(&a.Geometry, &b.Geometry, float64(*dist), exclusivity)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1095,7 +1095,8 @@ func EncodeGeoDescending(b []byte, curveIndex uint64, so *geopb.SpatialObject) (
 }
 
 // DecodeGeoAscending decodes a geopb.SpatialObject value that was encoded
-// in ascending order back into a geopb.SpatialObject.
+// in ascending order back into a geopb.SpatialObject. The so parameter
+// must already be empty/reset.
 func DecodeGeoAscending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if PeekType(b) != Geo {
 		return nil, errors.Errorf("did not find Geo marker")
@@ -1112,12 +1113,15 @@ func DecodeGeoAscending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	err = protoutil.Unmarshal(pbBytes, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(pbBytes)
 	return b, err
 }
 
 // DecodeGeoDescending decodes a geopb.SpatialObject value that was encoded
-// in descending order back into a geopb.SpatialObject.
+// in descending order back into a geopb.SpatialObject. The so parameter
+// must already be empty/reset.
 func DecodeGeoDescending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 	if PeekType(b) != GeoDesc {
 		return nil, errors.Errorf("did not find Geo marker")
@@ -1135,7 +1139,9 @@ func DecodeGeoDescending(b []byte, so *geopb.SpatialObject) ([]byte, error) {
 		return b, err
 	}
 	onesComplement(pbBytes)
-	err = protoutil.Unmarshal(pbBytes, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(pbBytes)
 	return b, err
 }
 
@@ -2579,14 +2585,17 @@ func DecodeUntaggedBox2DValue(
 }
 
 // DecodeUntaggedGeoValue decodes a value encoded by EncodeUntaggedGeoValue into
-// the provided geopb.SpatialObject reference.
+// the provided geopb.SpatialObject reference. The so parameter must already be
+// empty/reset.
 func DecodeUntaggedGeoValue(b []byte, so *geopb.SpatialObject) (remaining []byte, err error) {
 	var data []byte
 	remaining, data, err = DecodeUntaggedBytesValue(b)
 	if err != nil {
 		return b, err
 	}
-	err = protoutil.Unmarshal(data, so)
+	// Not using protoutil.Unmarshal since the call to so.Reset() will waste the
+	// pre-allocated EWKB.
+	err = so.Unmarshal(data)
 	return remaining, err
 }
 


### PR DESCRIPTION
The unmarshalled `geom.T` is remembered in the `Geometry`, and adds 16 bytes to the `Geometry`
size. The callers that have a `*DGeometry` need to pass a pointer to the `DGeometry.Geometry`
so that when the `geom.T` is unmarshalled, it is remembered. Access to
`Geometry.spatialObject` is completely mediated by geo.go, so one can lazily marshal the
`SpatialObject` from the `geom.T`.

The changes here are incomplete in that they don't change all the callers (including tests),
and don't change Geography.

These changes were meant to help significantly for intermediate states that don't
need to be marshalled and for repeated unmarshalling of geom.T. The `nyc-expand-blocks`
query is a contrived example with intermediate state so is helped by the lazy
marshalling (`SELECT Sum(ST_Dimension(ST_Expand(census.geom, 5))) FROM nyc_census_blocks AS census`).

The `nyc-dwithin-and-dfullywithin` query is
```
SELECT Count(census.blkid), Count(subways.name) FROM nyc_census_blocks AS census
JOIN nyc_subway_stations AS subways
ON ST_DWithin(subways.geom, census.geom, 100) AND ST_DFullyWithin(subways.geom, census.geom, 200)
```
There is very little improvement since this query is dominated by the construction
of the coverings in the invertedJoiner and not the ON condition computation in the
subsequent lookup join.
I was surprised by the improvement to `nyc-dwithin`. I think this is happening because
the looked up row in the lookup join is relevant for multiple left rows and the `geom.T`
construction for it (done by `minDistanceInternal`) needs to happen only once.
`nyc-intersects` calls directly into `geos` for the ON condition evaluation and does not
construct `geom.T`, so sees no change.

```
name                                   old ms     new ms     delta
Test/nyc/nyc-intersects                76.6 ±14%  78.6 ±25%     ~     (p=0.317 n=47+49)
Test/nyc/nyc-dwithin                    224 ±12%   217 ±13%   -3.02%  (p=0.002 n=49+48)
Test/nyc/nyc-coveredby                 79.1 ±21%  77.3 ±15%     ~     (p=0.093 n=49+44)
Test/nyc/nyc-expand-blocks             89.0 ±13%  46.3 ±16%  -47.94%  (p=0.000 n=47+48)
Test/nyc/nyc-dwithin-and-dfullywithin   194 ±11%   189 ± 9%   -2.77%  (p=0.001 n=48+44)
Test/postgis_geometry_tutorial/11.2b   1.51 ±37%  1.55 ±32%     ~     (p=0.393 n=50+48)
Test/postgis_geometry_tutorial/11.6    1.67 ±28%  1.70 ±24%     ~     (p=0.668 n=50+49)
Test/postgis_geometry_tutorial/12.1.2  0.89 ±23%  0.92 ±21%     ~     (p=0.132 n=47+48)
Test/postgis_geometry_tutorial/12.2.3  1.34 ±15%  1.39 ±29%     ~     (p=0.198 n=48+50)
Test/postgis_geometry_tutorial/12.2.4  1.33 ±22%  1.31 ±19%     ~     (p=0.431 n=49+48)
Test/postgis_geometry_tutorial/13.0    1.54 ±27%  1.55 ±28%     ~     (p=0.964 n=50+50)
Test/postgis_geometry_tutorial/13.1a    235 ±10%   232 ±10%     ~     (p=0.064 n=48+50)
Test/postgis_geometry_tutorial/13.1c   23.9 ±14%  24.5 ±19%     ~     (p=0.190 n=46+49)
Test/postgis_geometry_tutorial/13.2     319 ±11%   304 ±14%   -4.47%  (p=0.000 n=49+49)
Test/postgis_geometry_tutorial/14.1a   1.51 ±28%  1.73 ±37%  +14.66%  (p=0.000 n=50+49)
Test/postgis_geometry_tutorial/14.2b   6.20 ±15%  7.12 ±42%  +14.93%  (p=0.000 n=49+50)
Test/postgis_geometry_tutorial/14.2c   3.69 ±12%  3.73 ±13%     ~     (p=0.264 n=49+46)
Test/postgis_geometry_tutorial/14.3c   31.8 ±11%  32.3 ±12%     ~     (p=0.077 n=48+48)
Test/postgis_geometry_tutorial/15.0    1.49 ±23%  1.53 ±37%     ~     (p=0.302 n=48+49)
```

Release justification: this is still WIP

Release note: None