### PR TITLE
rowexec,colfetcher: remove redundant calls to tabledesc.NewImmutable

### DIFF
--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -387,6 +387,7 @@ func newInterleavedReaderJoiner(
 	if err := irj.initRowFetcher(
 		flowCtx,
 		spec.Tables,
+		tableDescs,
 		tables,
 		spec.Reverse,
 		spec.LockingStrength,
@@ -426,6 +427,7 @@ func newInterleavedReaderJoiner(
 func (irj *interleavedReaderJoiner) initRowFetcher(
 	flowCtx *execinfra.FlowCtx,
 	tables []execinfrapb.InterleavedReaderJoinerSpec_Table,
+	tableDescs []*tabledesc.Immutable,
 	tableInfos []tableInfo,
 	reverseScan bool,
 	lockStrength descpb.ScanLockingStrength,
@@ -435,7 +437,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	args := make([]row.FetcherTableArgs, len(tables))
 
 	for i, table := range tables {
-		desc := tabledesc.NewImmutable(table.Desc)
+		desc := tableDescs[i]
 		var err error
 		args[i].Index, args[i].IsSecondaryIndex, err = desc.FindIndexByIndexIdx(int(table.IndexIdx))
 		if err != nil {


### PR DESCRIPTION
#### colfetcher: reuse already constructed wrapped table descriptor 

We already constructed a tabledesc.Immutable one call up, use it rather
than constructing another.

#### rowexec: reuse already constructed wrapped table descriptors

We already constructed a []*tabledesc.Immutable one call up, use it rather
than constructing another.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None