### PR TITLE
roachtest: fix dump-backwards-compatability roachtest

### DIFF
--- a/pkg/cmd/roachtest/dump.go
+++ b/pkg/cmd/roachtest/dump.go
@@ -62,7 +62,7 @@ func runDump(nodes nodeListOption, mainVersion, expected string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		// Put the new version of Cockroach onto the node.
 		u.uploadVersion(ctx, t, nodes, mainVersion)
-		raw, err := u.c.RunWithBuffer(ctx, t.logger(), nodes, `./cockroach dump --insecure d`)
+		raw, err := u.c.RunWithStdout(ctx, t.logger(), nodes, `./cockroach dump --insecure d`)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Elide the --insecure flag deprecation message until roachtest
is taught to run on a secure cluster.

Fixes: #53514, #53460

Release justification: non-production code changes