### PR TITLE
opt: push limit into unconstrained partial index scan

### DIFF
--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -17,16 +17,20 @@
 =>
 (GenerateLimitedScans $scanPrivate $limit $ordering)
 
-# PushLimitIntoConstrainedScan constructs a new Scan operator that adds a hard
-# row limit to an existing Scan operator that already has a constraint
-# associated with it (added by the ConstrainScans rule). The Scan operator
-# always applies the limit after any constraint.
-[PushLimitIntoConstrainedScan, Explore]
+# PushLimitIntoFilteredScan constructs a new Scan operator that adds a hard row
+# limit to an existing Scan operator that already has a constraint or scans a
+# partial index. The scan operator always applies the limit after any
+# constraint.
+#
+# Note that PushLimitIntoFilteredScan does not push limits into inverted index
+# scans. Inverted index scans are not guaranteed to produce a specific number of
+# result rows because they contain multiple entries for a single row indexed.
+# Therefore, they cannot be considered for limited scans.
+[PushLimitIntoFilteredScan, Explore]
 (Limit
     (Scan $scanPrivate:*)
     (Const $limit:* & (IsPositiveInt $limit))
-    $ordering:* &
-        (CanLimitConstrainedScan $scanPrivate $ordering)
+    $ordering:* & (CanLimitFilteredScan $scanPrivate $ordering)
 )
 =>
 (Scan (LimitScanPrivate $scanPrivate $limit $ordering))

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -57,6 +57,15 @@ CREATE TABLE index_tab
 ----
 
 exec-ddl
+CREATE TABLE partial_index_tab
+(
+    a INT,
+    b INT,
+    INDEX (a) WHERE b > 0
+)
+----
+
+exec-ddl
 ALTER TABLE index_tab INJECT STATISTICS '[
   {
     "columns": ["val"],
@@ -98,7 +107,7 @@ ALTER TABLE index_tab INJECT STATISTICS '[
 ----
 
 # ---------------------------------------------------
-# GenerateLimitedScans / PushLimitIntoConstrainedScan
+# GenerateLimitedScans / PushLimitIntoFilteredScan
 # ---------------------------------------------------
 
 opt
@@ -151,6 +160,47 @@ limit
  │         ├── limit: 10
  │         └── ordering: +4
  └── 1
+
+# Limit an unconstrained partial index scan.
+opt
+SELECT a FROM partial_index_tab where b > 0 LIMIT 1
+----
+project
+ ├── columns: a:1
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── index-join partial_index_tab
+      ├── columns: a:1 b:2!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      └── scan partial_index_tab@secondary,partial
+           ├── columns: a:1 rowid:3!null
+           ├── limit: 1
+           ├── key: ()
+           └── fd: ()-->(1,3)
+
+# Limit a constrained partial index scan.
+opt
+SELECT a FROM partial_index_tab where b > 0 and a > 10 LIMIT 1
+----
+project
+ ├── columns: a:1!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── index-join partial_index_tab
+      ├── columns: a:1!null b:2!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      └── scan partial_index_tab@secondary,partial
+           ├── columns: a:1!null rowid:3!null
+           ├── constraint: /1/3: [/11 - ]
+           ├── limit: 1
+           ├── key: ()
+           └── fd: ()-->(1,3)
 
 # Don't push when scan doesn't satisfy limit's ordering.
 opt
@@ -220,7 +270,7 @@ scan a
  ├── key: ()
  └── fd: ()-->(1-5)
 
-# PushLimitIntoConstrainedScan propagates row-level locking information.
+# PushLimitIntoFilteredScan propagates row-level locking information.
 opt
 SELECT s FROM a WHERE s='foo' LIMIT 1 FOR UPDATE
 ----


### PR DESCRIPTION
This commit updates the PushLimitIntoConstrainedScan rule to push
limits into unconstrained partial index scans. The rule has been renamed
to PushLimitIntoFilteredScan to better reflect this new logic.

Release justification: This is a low-risk update to new functionality,
partial indexes.

Fixes #50828

Release note: None