### PR TITLE
opt: eliminate unnecessary index join inside project

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1497,18 +1497,14 @@ output row: [9 3 3 '33']
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-·                distribution         local       ·          ·
-·                vectorized           true        ·          ·
-project          ·                    ·           (a)        ·
- │               estimated row count  3           ·          ·
- └── index join  ·                    ·           (a, b, s)  ·
-      │          estimated row count  3           ·          ·
-      │          table                t2@primary  ·          ·
-      │          key columns          a           ·          ·
-      └── scan   ·                    ·           (a, b)     ·
-·                estimated row count  3           ·          ·
-·                table                t2@bc       ·          ·
-·                spans                /2-/3       ·          ·
+·          distribution         local  ·       ·
+·          vectorized           true   ·       ·
+project    ·                    ·      (a)     ·
+ │         estimated row count  3      ·       ·
+ └── scan  ·                    ·      (a, b)  ·
+·          estimated row count  3      ·       ·
+·          table                t2@bc  ·       ·
+·          spans                /2-/3  ·       ·
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1042,8 +1042,10 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// The Scan operator always goes in a new group, since it's always nested
 		// underneath the IndexJoin. The IndexJoin may also go into its own group,
 		// if there's a remaining filter above it.
-		// TODO(justin): We might not need to do an index join in order to get the
-		// correct columns, but it's difficult to tell at this point.
+		// TODO(mgartner): We don't always need to create an index join. The
+		// index join will be removed by EliminateIndexJoinInsideProject, but
+		// it'd be more efficient to not create the index join in the first
+		// place.
 		sb.setScan(&newScanPrivate)
 
 		// Add an inverted filter if it exists.

--- a/pkg/sql/opt/xform/rules/project.opt
+++ b/pkg/sql/opt/xform/rules/project.opt
@@ -1,0 +1,66 @@
+# =============================================================================
+# project.opt contains exploration rules for the Project operator.
+# =============================================================================
+
+# EliminateIndexJoinInsideProject discards an IndexJoin operator inside a
+# Project operator when the input of the IndexJoin produces all the rows
+# required by the Project.
+#
+# This rule is useful when using partial indexes. When generating partial index
+# scans, expressions can be removed from filters because they exactly match
+# expressions in partial index predicates and there is no need to apply the
+# filter after the scan. Columns referenced in the removed expressions may no
+# longer need to be fetched.
+#
+# Consider the example:
+#
+#   CREATE TABLE t (i INT, s STRING, INDEX (a) WHERE s = 'foo')
+#
+#   SELECT i FROM t WHERE s = 'foo'
+#
+# The normalized expression for the SELECT query is:
+#
+#   project
+#    ├── columns: i:1
+#    └── select
+#         ├── columns: i:1 s:2!null
+#         ├── scan t
+#         │    └── columns: i:1 s:2
+#         └── filters
+#              └── s:2 = 'foo'
+#
+# GeneratePartialIndexScans will generate this expression:
+#
+#   project
+#    ├── columns: i:1
+#    └── index-join t
+#         ├── columns: i:1 s:2!null
+#         └── scan t@secondary,partial
+#              └── columns: i:1 rowid:4!null
+#
+# The IndexJoin is created because the Select expression in the previous
+# expression required s in order to apply the (s = 'foo') filter. However,
+# because rows in the partial index are already filtered by (s = 'foo'), column
+# s does not need to be fetched. The IndexJoin can be eliminated, resulting in
+# the expression:
+#
+#   project
+#    ├── columns: i:1
+#    └── scan t@secondary,partial
+#         └── columns: i:1 rowid:4!null
+#
+[EliminateIndexJoinInsideProject, Explore]
+(Project
+    (IndexJoin $input:*)
+    $projections:*
+    $passthrough:* &
+        (ColsAreSubset
+            (UnionCols
+                (ProjectionOuterCols $projections)
+                $passthrough
+            )
+            (OutputCols $input)
+        )
+)
+=>
+(Project $input $projections $passthrough)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -170,16 +170,11 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── index-join partial_index_tab
-      ├── columns: a:1 b:2!null
-      ├── cardinality: [0 - 1]
+ └── scan partial_index_tab@secondary,partial
+      ├── columns: a:1 rowid:3!null
+      ├── limit: 1
       ├── key: ()
-      ├── fd: ()-->(1,2)
-      └── scan partial_index_tab@secondary,partial
-           ├── columns: a:1 rowid:3!null
-           ├── limit: 1
-           ├── key: ()
-           └── fd: ()-->(1,3)
+      └── fd: ()-->(1,3)
 
 # Limit a constrained partial index scan.
 opt
@@ -190,17 +185,12 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── index-join partial_index_tab
-      ├── columns: a:1!null b:2!null
-      ├── cardinality: [0 - 1]
+ └── scan partial_index_tab@secondary,partial
+      ├── columns: a:1!null rowid:3!null
+      ├── constraint: /1/3: [/11 - ]
+      ├── limit: 1
       ├── key: ()
-      ├── fd: ()-->(1,2)
-      └── scan partial_index_tab@secondary,partial
-           ├── columns: a:1!null rowid:3!null
-           ├── constraint: /1/3: [/11 - ]
-           ├── limit: 1
-           ├── key: ()
-           └── fd: ()-->(1,3)
+      └── fd: ()-->(1,3)
 
 # Don't push when scan doesn't satisfy limit's ordering.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -1,0 +1,124 @@
+exec-ddl
+CREATE TABLE a (
+    k INT PRIMARY KEY,
+    i INT,
+    s STRING,
+    b BOOL,
+    j JSON,
+    INDEX i (i) WHERE s = 'foo',
+    INVERTED INDEX j (j)
+)
+----
+
+# --------------------------------------------------
+# EliminateIndexJoinInsideProject
+# --------------------------------------------------
+
+# Eliminate the IndexJoin when the Project passthrough columns are a subset of
+# the IndexJoin's input columns.
+opt expect=EliminateIndexJoinInsideProject
+SELECT k, i FROM a WHERE s = 'foo'
+----
+project
+ ├── columns: k:1!null i:2
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── scan a@i,partial
+      ├── columns: k:1!null i:2
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# Eliminate the IndexJoin when the Project projection outer columns are a subset of
+# the IndexJoin's input columns.
+opt expect=EliminateIndexJoinInsideProject
+SELECT k + 1, i + 1 FROM a WHERE s = 'foo'
+----
+project
+ ├── columns: "?column?":8!null "?column?":9
+ ├── immutable
+ ├── scan a@i,partial
+ │    ├── columns: k:1!null i:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── projections
+      ├── k:1 + 1 [as="?column?":8, outer=(1), immutable]
+      └── i:2 + 1 [as="?column?":9, outer=(2), immutable]
+
+# Do not eliminate the IndexJoin when the Project passthrough columns are not a
+# subset of the IndexJoin's input columns.
+opt expect-not=EliminateIndexJoinInsideProject
+SELECT k, b FROM a WHERE s = 'foo'
+----
+project
+ ├── columns: k:1!null b:4
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ └── index-join a
+      ├── columns: k:1!null s:3!null b:4
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(4)
+      └── scan a@i,partial
+           ├── columns: k:1!null
+           └── key: (1)
+
+# Do not eliminate the IndexJoin when the Project projection outer columns are
+# not a subset of the IndexJoin's input columns.
+opt expect-not=EliminateIndexJoinInsideProject
+SELECT k, NOT b FROM a WHERE s = 'foo'
+----
+project
+ ├── columns: k:1!null "?column?":8
+ ├── key: (1)
+ ├── fd: (1)-->(8)
+ ├── index-join a
+ │    ├── columns: k:1!null s:3!null b:4
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(4)
+ │    └── scan a@i,partial
+ │         ├── columns: k:1!null
+ │         └── key: (1)
+ └── projections
+      └── NOT b:4 [as="?column?":8, outer=(4)]
+
+# Eliminate the IndexJoin for an inverted index scan when only the primary key
+# column(s) are needed as passthrough columns.
+opt expect=EliminateIndexJoinInsideProject
+SELECT k FROM a WHERE j @> '{"a": "b"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan a@j
+      ├── columns: k:1!null
+      ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+# Eliminate the IndexJoin for an inverted index scan when only the primary key
+# column(s) are needed for projection columns.
+opt expect=EliminateIndexJoinInsideProject
+SELECT k + 1 FROM a WHERE j @> '{"a": "b"}'
+----
+project
+ ├── columns: "?column?":8!null
+ ├── immutable
+ ├── scan a@j
+ │    ├── columns: k:1!null
+ │    ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
+ │    └── key: (1)
+ └── projections
+      └── k:1 + 1 [as="?column?":8, outer=(1), immutable]
+
+# Do not eliminate the IndexJoin when the indexed column is needed. An inverted
+# index scan cannot recreate the JSON column, so it must fetched from the
+# primary index via an IndexJoin.
+opt expect-not=EliminateIndexJoinInsideProject
+SELECT j FROM a WHERE j @> '{"a": "b"}'
+----
+index-join a
+ ├── columns: j:5
+ ├── immutable
+ └── scan a@j
+      ├── columns: k:1!null
+      ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1098,47 +1098,47 @@ memo
 SELECT i FROM p WHERE i = 3 AND s = 'foo'
 ----
 memo (optimized, ~15KB, required=[presentation: i:1])
- ├── G1: (project G2 G3 i)
+ ├── G1: (project G2 G3 i) (project G4 G3 i) (project G5 G3 i)
  │    └── [presentation: i:1]
- │         ├── best: (project G2 G3 i)
- │         └── cost: 15.28
- ├── G2: (select G4 G5) (select G6 G7) (index-join G8 p,cols=(1,3)) (select G9 G7) (index-join G10 p,cols=(1,3))
+ │         ├── best: (project G5 G3 i)
+ │         └── cost: 10.33
+ ├── G2: (select G6 G7) (select G8 G9) (index-join G4 p,cols=(1,3)) (select G10 G9) (index-join G5 p,cols=(1,3))
  │    └── []
- │         ├── best: (index-join G8 p,cols=(1,3))
+ │         ├── best: (index-join G4 p,cols=(1,3))
  │         └── cost: 15.26
  ├── G3: (projections)
- ├── G4: (scan p,cols=(1,3))
+ ├── G4: (select G11 G9)
  │    └── []
- │         ├── best: (scan p,cols=(1,3))
- │         └── cost: 1070.02
- ├── G5: (filters G11 G12)
- ├── G6: (index-join G13 p,cols=(1,3))
- │    └── []
- │         ├── best: (index-join G13 p,cols=(1,3))
- │         └── cost: 363.88
- ├── G7: (filters G11)
- ├── G8: (select G14 G7)
- │    └── []
- │         ├── best: (select G14 G7)
+ │         ├── best: (select G11 G9)
  │         └── cost: 10.53
- ├── G9: (index-join G15 p,cols=(1,3))
- │    └── []
- │         ├── best: (index-join G15 p,cols=(1,3))
- │         └── cost: 47.81
- ├── G10: (scan p@idx2,partial,cols=(1,5),constrained)
+ ├── G5: (scan p@idx2,partial,cols=(1,5),constrained)
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(1,5),constrained)
  │         └── cost: 10.31
- ├── G11: (eq G16 G17)
- ├── G12: (eq G18 G19)
- ├── G13: (select G20 G21)
+ ├── G6: (scan p,cols=(1,3))
  │    └── []
- │         ├── best: (select G20 G21)
- │         └── cost: 350.03
- ├── G14: (scan p@idx2,partial,cols=(1,5))
+ │         ├── best: (scan p,cols=(1,3))
+ │         └── cost: 1070.02
+ ├── G7: (filters G12 G13)
+ ├── G8: (index-join G14 p,cols=(1,3))
+ │    └── []
+ │         ├── best: (index-join G14 p,cols=(1,3))
+ │         └── cost: 363.88
+ ├── G9: (filters G12)
+ ├── G10: (index-join G15 p,cols=(1,3))
+ │    └── []
+ │         ├── best: (index-join G15 p,cols=(1,3))
+ │         └── cost: 47.81
+ ├── G11: (scan p@idx2,partial,cols=(1,5))
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(1,5))
  │         └── cost: 10.41
+ ├── G12: (eq G16 G17)
+ ├── G13: (eq G18 G19)
+ ├── G14: (select G20 G21)
+ │    └── []
+ │         ├── best: (select G20 G21)
+ │         └── cost: 350.03
  ├── G15: (scan p@idx,partial,cols=(3,5),constrained)
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(3,5),constrained)
@@ -1151,7 +1151,7 @@ memo (optimized, ~15KB, required=[presentation: i:1])
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(3,5))
  │         └── cost: 346.68
- └── G21: (filters G12)
+ └── G21: (filters G13)
 
 exec-ddl
 DROP INDEX idx
@@ -1199,7 +1199,7 @@ DROP INDEX idx
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------
-# TODO(justin): these can be serviced without an index join.
+
 # Query only the primary key with no remaining filter.
 opt
 SELECT k FROM b WHERE j @> '{"a": "b"}'
@@ -1208,38 +1208,33 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── index-join b
-      ├── columns: k:1!null j:4
-      ├── immutable
-      ├── key: (1)
-      ├── fd: (1)-->(4)
-      └── scan b@inv_idx
-           ├── columns: k:1!null
-           ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
-           └── key: (1)
+ └── scan b@inv_idx
+      ├── columns: k:1!null
+      ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
 
 memo
 SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
- ├── G1: (project G2 G3 k)
+memo (optimized, ~7KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k) (project G4 G3 k)
  │    └── [presentation: k:1]
- │         ├── best: (project G2 G3 k)
- │         └── cost: 562.14
- ├── G2: (select G4 G5) (index-join G6 b,cols=(1,4))
+ │         ├── best: (project G4 G3 k)
+ │         └── cost: 114.43
+ ├── G2: (select G5 G6) (index-join G4 b,cols=(1,4))
  │    └── []
- │         ├── best: (index-join G6 b,cols=(1,4))
+ │         ├── best: (index-join G4 b,cols=(1,4))
  │         └── cost: 561.02
  ├── G3: (projections)
- ├── G4: (scan b,cols=(1,4))
- │    └── []
- │         ├── best: (scan b,cols=(1,4))
- │         └── cost: 1060.02
- ├── G5: (filters G7)
- ├── G6: (scan b@inv_idx,cols=(1),constrained)
+ ├── G4: (scan b@inv_idx,cols=(1),constrained)
  │    └── []
  │         ├── best: (scan b@inv_idx,cols=(1),constrained)
  │         └── cost: 113.31
+ ├── G5: (scan b,cols=(1,4))
+ │    └── []
+ │         ├── best: (scan b,cols=(1,4))
+ │         └── cost: 1060.02
+ ├── G6: (filters G7)
  ├── G7: (contains G8 G9)
  ├── G8: (variable j)
  └── G9: (const '{"a": "b"}')
@@ -1452,17 +1447,12 @@ project
  ├── columns: k:1!null
  ├── volatile
  ├── key: (1)
- └── index-join b
-      ├── columns: k:1!null j:4
+ └── scan b@inv_idx
+      ├── columns: k:1!null
+      ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      ├── locking: for-update
       ├── volatile
-      ├── key: (1)
-      ├── fd: (1)-->(4)
-      └── scan b@inv_idx
-           ├── columns: k:1!null
-           ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
-           ├── locking: for-update
-           ├── volatile
-           └── key: (1)
+      └── key: (1)
 
 # Tests for array inverted indexes.
 opt
@@ -1472,15 +1462,10 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── index-join c
-      ├── columns: k:1!null a:2
-      ├── immutable
-      ├── key: (1)
-      ├── fd: (1)-->(2)
-      └── scan c@inv_idx
-           ├── columns: k:1!null
-           ├── constraint: /2/1: [/ARRAY[1] - /ARRAY[1]]
-           └── key: (1)
+ └── scan c@inv_idx
+      ├── columns: k:1!null
+      ├── constraint: /2/1: [/ARRAY[1] - /ARRAY[1]]
+      └── key: (1)
 
 opt
 SELECT k FROM c WHERE a @> ARRAY[1,3,1,5]


### PR DESCRIPTION
This commit adds a new rule, EliminateIndexJoinInsideProject, that
removes an IndexJoin inside a Project when the IndexJoin's input
produces all the columns needed by the Project's passthrough and
projection columns. See the comments for the new rule for a detailed
example.

Fixes #51018

Release justification: This is a low-risk update to new functionality,
partial indexes.

Release note: None