### PR TITLE
jobs: improve job adoption

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1334,11 +1334,7 @@ func createAndWaitForJob(
 func TestBackupRestoreResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	ctx := context.Background()
 
@@ -1478,11 +1474,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 
 	// force every call to update
 	defer jobs.TestingSetProgressThresholds()()
-
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	serverArgs := base.TestServerArgs{}
 	// Disable external processing of mutations so that the final check of

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -126,10 +126,9 @@ func restoreMidSchemaChange(backupDir, schemaChangeName string) func(t *testing.
 
 	return func(t *testing.T) {
 		params := base.TestServerArgs{}
-		defer func(oldInterval time.Duration) {
-			jobs.DefaultAdoptInterval = oldInterval
-		}(jobs.DefaultAdoptInterval)
-		jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
+		defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
+
 		const numAccounts = 1000
 		_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
 			InitNone, base.TestClusterArgs{ServerArgs: params})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2014,8 +2014,7 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -2074,9 +2073,7 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 func TestChangefeedPauseUnpauseCursorAndInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -2135,9 +2132,7 @@ func TestChangefeedPauseUnpauseCursorAndInitialScan(t *testing.T) {
 func TestChangefeedProtectedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	var (
 		ctx      = context.Background()
@@ -2303,9 +2298,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 func TestChangefeedProtectedTimestampOnPause(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	testutils.RunTrueAndFalse(t, "protect_on_pause", func(t *testing.T, shouldPause bool) {
 		t.Run(`enterprise`, enterpriseTest(func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
@@ -2384,8 +2377,7 @@ func TestChangefeedProtectedTimestampsVerificationFails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	verifyRequestCh := make(chan *roachpb.AdminVerifyProtectedTimestampRequest, 1)
 	requestFilter := kvserverbase.ReplicaRequestFilter(func(
@@ -2520,10 +2512,7 @@ func TestChangefeedNodeShutdown(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.WithIssue(t, 32232)
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	flushCh := make(chan struct{}, 1)
 	defer close(flushCh)
@@ -2685,9 +2674,7 @@ func TestChangefeedMemBufferCapacity(t *testing.T) {
 func TestChangefeedRestartDuringBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -25,8 +25,7 @@ import (
 func TestChangefeedNemeses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -4025,10 +4025,7 @@ func TestImportControlJob(t *testing.T) {
 
 	skip.WithIssue(t, 51792, "TODO(dt): add knob to force faster progress checks.")
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	var serverArgs base.TestServerArgs
 	// Disable external processing of mutations so that the final check of
@@ -4290,10 +4287,7 @@ func TestImportWorkerFailure(t *testing.T) {
 	// node down are detected and retried.
 	skip.WithIssue(t, 51793, "flaky due to undetected kinds of failures when the node is shutdown")
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
@@ -4371,11 +4365,7 @@ func TestImportLivenessWithRestart(t *testing.T) {
 	skip.WithIssue(t, 51794, "TODO(dt): this relies on chunking done by prior version of IMPORT."+
 		"Rework this test, or replace it with resume-tests + jobs infra tests.")
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
-	jobs.DefaultCancelInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	const nodes = 1
 	nl := jobs.NewFakeNodeLiveness(nodes)
@@ -4506,11 +4496,7 @@ func TestImportLivenessWithLeniency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
-	jobs.DefaultCancelInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	const nodes = 1
 	nl := jobs.NewFakeNodeLiveness(nodes)

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -77,7 +77,7 @@ WHERE (status = $1 OR status = $2) AND (claim_session_id = $3 AND claim_instance
 func (r *Registry) resumeClaimedJobs(
 	ctx context.Context, s sqlliveness.Session, claimedToResume map[int64]struct{},
 ) {
-	const resumeConcurrency = 10
+	const resumeConcurrency = 64
 	sem := make(chan struct{}, resumeConcurrency)
 	var wg sync.WaitGroup
 	add := func() { sem <- struct{}{}; wg.Add(1) }

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -13,6 +13,7 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -47,7 +48,7 @@ WHERE claim_session_id IS NULL ORDER BY created DESC LIMIT $3 RETURNING id`,
 // processClaimedJobs processes all jobs currently claimed by the registry.
 func (r *Registry) processClaimedJobs(ctx context.Context, s sqlliveness.Session) error {
 	rows, err := r.ex.QueryEx(
-		ctx, "select-running/reverting-jobs", nil,
+		ctx, "select-running/get-claimed-jobs", nil,
 		sessiondata.InternalExecutorOverride{User: security.NodeUser}, `
 SELECT id FROM system.jobs
 WHERE (status = $1 OR status = $2) AND (claim_session_id = $3 AND claim_instance_id = $4)`,
@@ -58,20 +59,54 @@ WHERE (status = $1 OR status = $2) AND (claim_session_id = $3 AND claim_instance
 	}
 
 	// This map will eventually contain the job ids that must be resumed.
-	claimedToResume := make(map[int64]bool, len(rows))
+	claimedToResume := make(map[int64]struct{}, len(rows))
 	// Initially all claimed jobs are supposed to be resumed but some may be
 	// running on this registry already so we will filter them out later.
 	for _, row := range rows {
 		id := int64(*row[0].(*tree.DInt))
-		claimedToResume[id] = true
+		claimedToResume[id] = struct{}{}
 	}
 
+	r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, claimedToResume)
+	r.resumeClaimedJobs(ctx, s, claimedToResume)
+	return nil
+}
+
+// resumeClaimedJobs invokes r.resumeJob for each job in claimedToResume. It
+// does so concurrently.
+func (r *Registry) resumeClaimedJobs(
+	ctx context.Context, s sqlliveness.Session, claimedToResume map[int64]struct{},
+) {
+	const resumeConcurrency = 10
+	sem := make(chan struct{}, resumeConcurrency)
+	var wg sync.WaitGroup
+	add := func() { sem <- struct{}{}; wg.Add(1) }
+	done := func() { <-sem; wg.Done() }
+	for id := range claimedToResume {
+		add()
+		go func(id int64) {
+			defer done()
+			if err := r.resumeJob(ctx, id, s); err != nil && ctx.Err() == nil {
+				log.Errorf(ctx, "could not run claimed job %d: %v", id, err)
+			}
+		}(id)
+	}
+	wg.Wait()
+}
+
+// filterAlreadyRunningAndCancelFromPreviousSessions will lock the registry and
+// inspect the set of currently running jobs, removing those entries from
+// claimedToResume. Additionally it verifies that the session associated with the
+// running job matches the current session, canceling the job if not.
+func (r *Registry) filterAlreadyRunningAndCancelFromPreviousSessions(
+	ctx context.Context, s sqlliveness.Session, claimedToResume map[int64]struct{},
+) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// Process all current adopted jobs in our in-memory jobs map.
 	for id, aj := range r.mu.adoptedJobs {
 		if aj.sid != s.ID() {
-			log.Warningf(ctx, "job %d: running without having a live claim; killed.", id)
+			log.Warningf(ctx, "job %d: running without having a live claim; canceling", id)
 			aj.cancel()
 			delete(r.mu.adoptedJobs, id)
 		} else {
@@ -82,15 +117,9 @@ WHERE (status = $1 OR status = $2) AND (claim_session_id = $3 AND claim_instance
 			}
 		}
 	}
-
-	for id := range claimedToResume {
-		if err := r.resumeJob(ctx, id, s); err != nil {
-			log.Errorf(ctx, "could not run claimed job: %v", err)
-		}
-	}
-	return nil
 }
 
+// resumeJob resumes a claimed job.
 func (r *Registry) resumeJob(ctx context.Context, jobID int64, s sqlliveness.Session) error {
 	log.Infof(ctx, "job %d: resuming execution", jobID)
 	row, err := r.ex.QueryRowEx(
@@ -146,11 +175,12 @@ FROM system.jobs WHERE id = $1 AND claim_session_id = $2`,
 	resultsCh := make(chan tree.Datums)
 
 	errCh := make(chan error, 1)
-	r.mu.adoptedJobs[jobID] = &adoptedJob{sid: s.ID(), cancel: cancel}
+	aj := &adoptedJob{sid: s.ID(), cancel: cancel}
+	r.addAdoptedJob(jobID, aj)
 	if err := r.stopper.RunAsyncTask(ctx, job.taskName(), func(ctx context.Context) {
 		r.runJob(resumeCtx, resumer, resultsCh, errCh, job, status, job.taskName(), nil)
 	}); err != nil {
-		delete(r.mu.adoptedJobs, jobID)
+		r.removeAdoptedJob(jobID)
 		return err
 	}
 	go func() {
@@ -165,6 +195,18 @@ FROM system.jobs WHERE id = $1 AND claim_session_id = $2`,
 		close(resultsCh)
 	}()
 	return nil
+}
+
+func (r *Registry) removeAdoptedJob(jobID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.mu.adoptedJobs, jobID)
+}
+
+func (r *Registry) addAdoptedJob(jobID int64, aj *adoptedJob) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mu.adoptedJobs[jobID] = aj
 }
 
 func (r *Registry) runJob(

--- a/pkg/jobs/deprecated.go
+++ b/pkg/jobs/deprecated.go
@@ -304,7 +304,9 @@ func (r *Registry) deprecatedCancelAllLocked(ctx context.Context) {
 		log.Warningf(ctx, "job %d: canceling due to liveness failure", jobID)
 		cancel()
 	}
-	r.mu.deprecatedJobs = make(map[int64]context.CancelFunc)
+	for jobID := range r.mu.deprecatedJobs {
+		delete(r.mu.deprecatedJobs, jobID)
+	}
 }
 
 // deprecatedRegister registers an about to be resumed job in memory so that it can be

--- a/pkg/jobs/executor_impl_test.go
+++ b/pkg/jobs/executor_impl_test.go
@@ -25,6 +25,7 @@ import (
 func TestInlineExecutorFailedJobsHandling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	defer TestingSetAdoptAndCancelIntervals(time.Millisecond, time.Microsecond)()
 	h, cleanup := newTestHelper(t)
 	defer cleanup()
 

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -301,6 +301,8 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
 	for i, id := range jobs {
 		select {
 		case r.adoptionCh <- struct{}{}:
+		case <-r.stopper.ShouldQuiesce():
+			return stop.ErrUnavailable
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -534,7 +536,7 @@ func (r *Registry) LoadJobWithTxn(ctx context.Context, jobID int64, txn *kv.Txn)
 
 // DefaultCancelInterval is a reasonable interval at which to poll this node
 // for liveness failures and cancel running jobs.
-var DefaultCancelInterval = base.DefaultTxnHeartbeatInterval
+var DefaultCancelInterval = 10 * time.Second
 
 // DefaultAdoptInterval is a reasonable interval at which to poll system.jobs
 // for jobs with expired leases.
@@ -542,6 +544,19 @@ var DefaultCancelInterval = base.DefaultTxnHeartbeatInterval
 // DefaultAdoptInterval is mutable for testing. NB: Updates to this value after
 // Registry.Start has been called will not have any effect.
 var DefaultAdoptInterval = 30 * time.Second
+
+// TestingSetAdoptAndCancelIntervals can be used to accelerate job adoption and
+// state changes.
+func TestingSetAdoptAndCancelIntervals(adopt, cancel time.Duration) (cleanup func()) {
+	prevAdopt := DefaultAdoptInterval
+	prevCancel := DefaultCancelInterval
+	DefaultAdoptInterval = adopt
+	DefaultCancelInterval = cancel
+	return func() {
+		DefaultAdoptInterval = prevAdopt
+		DefaultCancelInterval = prevCancel
+	}
+}
 
 var maxAdoptionsPerLoop = envutil.EnvOrDefaultInt(`COCKROACH_JOB_ADOPTIONS_PER_PERIOD`, 10)
 
@@ -556,35 +571,64 @@ func (r *Registry) Start(
 	ctx context.Context, stopper *stop.Stopper, cancelInterval, adoptInterval time.Duration,
 ) error {
 
-	stopper.RunWorker(context.Background(), func(ctx context.Context) {
-		// Calling maybeCancelJobs once at the start ensures we have an up-to-date
-		// liveness epoch before we wait out the first cancelInterval.
-		r.maybeCancelJobs(ctx, r.nl)
-		for {
-			select {
-			case <-stopper.ShouldStop():
+	every := log.Every(time.Second)
+	withSession := func(
+		f func(ctx context.Context, s sqlliveness.Session),
+	) func(ctx context.Context) {
+		return func(ctx context.Context) {
+			if !r.startUsingSQLLivenessAdoption(ctx) {
 				return
-			case <-time.After(cancelInterval):
-				r.maybeCancelJobs(ctx, r.nl)
 			}
-		}
-	})
-
-	stopper.RunWorker(context.Background(), func(ctx context.Context) {
-		for {
-			select {
-			case <-stopper.ShouldStop():
-				return
-			case <-time.After(gcInterval):
-				old := timeutil.Now().Add(-1 * gcSetting.Get(&r.settings.SV))
-				if err := r.cleanupOldJobs(ctx, old); err != nil {
-					log.Warningf(ctx, "error cleaning up old job records: %v", err)
+			s, err := r.sqlInstance.Session(ctx)
+			if err != nil {
+				if log.ExpensiveLogEnabled(ctx, 2) || (ctx.Err() == nil && every.ShouldLog()) {
+					log.Errorf(ctx, "error getting live session: %s", err)
 				}
+				return
 			}
+			log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
+			f(ctx, s)
+		}
+	}
+
+	removeClaimsFromDeadSessions := func(ctx context.Context, s sqlliveness.Session) {
+		if _, err := r.ex.QueryRowEx(
+			ctx, "expire-sessions", nil,
+			sessiondata.InternalExecutorOverride{User: security.RootUser}, `
+UPDATE system.jobs
+   SET claim_session_id = NULL
+ WHERE claim_session_id <> $1
+   AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id)`,
+			s.ID().UnsafeBytes()); err != nil {
+			log.Errorf(ctx, "error expiring job sessions: %s", err)
+		}
+	}
+	servePauseAndCancelRequests := func(ctx context.Context, s sqlliveness.Session) {
+		if err := r.servePauseAndCancelRequests(ctx, s); err != nil {
+			log.Errorf(ctx, "failed to serve pause and cancel requests: %v", err)
+		}
+	}
+	cancelLoopTask := withSession(func(ctx context.Context, s sqlliveness.Session) {
+		removeClaimsFromDeadSessions(ctx, s)
+		r.maybeCancelJobs(ctx, s)
+		servePauseAndCancelRequests(ctx, s)
+	})
+	claimJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+		if err := r.claimJobs(ctx, s); err != nil {
+			log.Errorf(ctx, "error claiming jobs: %s", err)
 		}
 	})
-
-	maybeAdoptJobs := func(ctx context.Context, randomizeJobOrder bool) {
+	processClaimedJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+		if r.adoptionDisabled(ctx) {
+			log.Warningf(ctx, "canceling all adopted jobs due to liveness failure")
+			r.cancelAllAdoptedJobs()
+			return
+		}
+		if err := r.processClaimedJobs(ctx, s); err != nil {
+			log.Errorf(ctx, "error processing claimed jobs: %s", err)
+		}
+	})
+	maybeAdoptJobsDeprecated := func(ctx context.Context, randomizeJobOrder bool) {
 		if r.adoptionDisabled(ctx) {
 			r.deprecatedCancelAll(ctx)
 			return
@@ -594,137 +638,128 @@ func (r *Registry) Start(
 		}
 	}
 
-	claimAndProcessJobs := func(ctx context.Context) {
-		if r.adoptionDisabled(ctx) {
-			log.Warningf(ctx, "canceling all adopted jobs due to liveness failure")
-			r.cancelAllAdoptedJobs()
-			return
-		}
-		s, err := r.sqlInstance.Session(ctx)
-		if err != nil {
-			log.Errorf(ctx, "error getting live session: %s", err)
-			return
-		}
-		log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
-
-		if _, err := r.ex.QueryRowEx(
-			ctx, "expire-sessions", nil,
-			sessiondata.InternalExecutorOverride{User: security.RootUser}, `
-UPDATE system.jobs SET claim_session_id = NULL
-WHERE NOT(crdb_internal.sql_liveness_is_alive(claim_session_id))`,
-		); err != nil {
-			log.Errorf(ctx, "error expiring job sessions: %s", err)
-			return
-		}
-
-		if err := r.claimJobs(ctx, s); err != nil {
-			log.Errorf(ctx, "error claiming jobs: %s", err)
-		}
-
-		if err := r.servePauseAndCancelRequests(ctx, s); err != nil {
-			log.Errorf(ctx, "error processing cancel/pause requests: %s", err)
-		}
-
-		if err := r.processClaimedJobs(ctx, s); err != nil {
-			log.Errorf(ctx, "error processing claimed jobs: %s", err)
-		}
-	}
-
-	stopper.RunWorker(context.Background(), func(ctx context.Context) {
+	if err := stopper.RunAsyncTask(context.Background(), "jobs/cancel", func(ctx context.Context) {
+		// Calling maybeCancelJobs once at the start ensures we have an up-to-date
+		// liveness epoch before we wait out the first cancelInterval.
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+		r.maybeCancelJobsDeprecated(ctx, r.nl)
+		cancelLoopTask(ctx)
 		for {
 			select {
-			case <-stopper.ShouldStop():
+			case <-r.stopper.ShouldQuiesce():
+				log.Warningf(ctx, "canceling all adopted jobs due to stopper quiescing")
+				r.deprecatedCancelAll(ctx)
+				r.cancelAllAdoptedJobs()
+				return
+			case <-time.After(cancelInterval):
+				r.maybeCancelJobsDeprecated(ctx, r.nl)
+				cancelLoopTask(ctx)
+			}
+		}
+	}); err != nil {
+		return err
+	}
+	if err := stopper.RunAsyncTask(context.Background(), "jobs/gc", func(ctx context.Context) {
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+		for {
+			select {
+			case <-stopper.ShouldQuiesce():
+				return
+			case <-time.After(gcInterval):
+				old := timeutil.Now().Add(-1 * gcSetting.Get(&r.settings.SV))
+				if err := r.cleanupOldJobs(ctx, old); err != nil {
+					log.Warningf(ctx, "error cleaning up old job records: %v", err)
+				}
+			}
+		}
+	}); err != nil {
+		return err
+	}
+	return stopper.RunAsyncTask(context.Background(), "jobs/adopt", func(ctx context.Context) {
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+		timer.Reset(adoptInterval)
+		for {
+			select {
+			case <-stopper.ShouldQuiesce():
 				return
 			case <-r.adoptionCh:
 				// Try to adopt the most recently created job.
 				if r.startUsingSQLLivenessAdoption(ctx) {
-					claimAndProcessJobs(ctx)
+					processClaimedJobs(ctx)
 				} else {
 					// TODO(spaskob): remove in 20.2 as this code path is only needed while
 					// migrating to 20.2 cluster.
-					maybeAdoptJobs(ctx, false /* randomizeJobOrder */)
+					maybeAdoptJobsDeprecated(ctx, false /* randomizeJobOrder */)
 				}
-			case <-time.After(adoptInterval):
+			case <-timer.C:
+				timer.Read = true
 				if r.startUsingSQLLivenessAdoption(ctx) {
-					claimAndProcessJobs(ctx)
+					claimJobs(ctx)
+					processClaimedJobs(ctx)
 				} else {
 					// TODO(spaskob): remove in 20.2 as this code path is only needed while
 					// migrating to 20.2 cluster.
-					maybeAdoptJobs(ctx, true /* randomizeJobOrder */)
+					maybeAdoptJobsDeprecated(ctx, true /* randomizeJobOrder */)
 				}
+				timer.Reset(adoptInterval)
 			}
 		}
 	})
-
-	return nil
 }
 
-func (r *Registry) maybeCancelJobs(ctx context.Context, nlw optionalnodeliveness.Container) {
-	// Cancel all jobs if the stopper is quiescing.
-	select {
-	case <-r.stopper.ShouldQuiesce():
-		r.deprecatedCancelAll(ctx)
-		log.Warningf(ctx, "canceling all adopted jobs due to stopper quiescing")
-		r.cancelAllAdoptedJobs()
+func (r *Registry) maybeCancelJobs(ctx context.Context, s sqlliveness.Session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// If the cluster is finalized, kill any remaining legacy jobs. They will be
+	// re-adopted with the new epoch based leasing.
+	r.deprecatedCancelAllLocked(ctx)
+
+	for id, aj := range r.mu.adoptedJobs {
+		if aj.sid != s.ID() {
+			log.Warningf(ctx, "job %d: running without having a live claim; killed.", id)
+			aj.cancel()
+			delete(r.mu.adoptedJobs, id)
+		}
+	}
+}
+
+// TODO(spaskob): remove in 20.2 as this code path is only needed while
+// migrating to 20.2 cluster.
+func (r *Registry) maybeCancelJobsDeprecated(
+	ctx context.Context, nlw optionalnodeliveness.Container,
+) {
+	nl, ok := nlw.Optional(47892)
+	if !ok {
+		// At most one container is running on behalf of a SQL tenant, so it must be
+		// this one, and there's no point canceling anything.
+		//
+		// TODO(ajwerner): don't rely on this. Instead fix this issue:
+		// https://github.com/cockroachdb/cockroach/issues/47892
 		return
-	default:
+	}
+	liveness, err := nl.Self()
+	if err != nil {
+		if nodeLivenessLogLimiter.ShouldLog() {
+			log.Warningf(ctx, "unable to get node liveness: %s", err)
+		}
+		// Conservatively assume our lease has expired. Abort all jobs.
+		r.deprecatedCancelAll(ctx)
+		return
 	}
 
-	if r.startUsingSQLLivenessAdoption(ctx) {
+	// If we haven't persisted a liveness record within the leniency
+	// interval, we'll cancel all of our jobs.
+	if !liveness.IsLive(r.lenientNow()) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		// If the cluster is finalized, kill any remaining legacy jobs. They will be
-		// re-adopted with the new epoch based leasing.
 		r.deprecatedCancelAllLocked(ctx)
-
-		// This gets the current live epoch and pushes forward its expiration. If
-		// another regitry has bumped it, we don;t need to know - as it suffices to
-		// cancel all jobs with lower epoch from than the one returned.
-		s, err := r.sqlInstance.Session(ctx)
-		if err != nil {
-			// We may be failing due to a partition, it odes not make sense to
-			// preemptively kill the jobs because when we egt online again we will
-			// query the new epoch and will cancel jobs with older epochs after that.
-			return
-		}
-		for id, aj := range r.mu.adoptedJobs {
-			if aj.sid != s.ID() {
-				log.Warningf(ctx, "job %d: running without having a live claim; killed.", id)
-				aj.cancel()
-				delete(r.mu.adoptedJobs, id)
-			}
-		}
-	} else {
-		// TODO(spaskob): remove in 20.2 as this code path is only needed while
-		// migrating to 20.2 cluster.
-		nl, ok := nlw.Optional(47892)
-		if !ok {
-			// At most one container is running on behalf of a SQL tenant, so it must be
-			// this one, and there's no point canceling anything.
-			//
-			// TODO(ajwerner): don't rely on this. Instead fix this issue:
-			// https://github.com/cockroachdb/cockroach/issues/47892
-			return
-		}
-		liveness, err := nl.Self()
-		if err != nil {
-			if nodeLivenessLogLimiter.ShouldLog() {
-				log.Warningf(ctx, "unable to get node liveness: %s", err)
-			}
-			// Conservatively assume our lease has expired. Abort all jobs.
-			r.deprecatedCancelAll(ctx)
-			return
-		}
-
-		// If we haven't persisted a liveness record within the leniency
-		// interval, we'll cancel all of our jobs.
-		if !liveness.IsLive(r.lenientNow()) {
-			r.mu.Lock()
-			defer r.mu.Unlock()
-			r.deprecatedCancelAllLocked(ctx)
-			r.mu.deprecatedEpoch = liveness.Epoch
-			return
-		}
+		r.mu.deprecatedEpoch = liveness.Epoch
+		return
 	}
 }
 

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -298,15 +298,23 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
 	}
 	log.Infof(ctx, "scheduled jobs %+v", jobs)
 	buf := bytes.Buffer{}
+	usingSQLLiveness := r.startUsingSQLLivenessAdoption(ctx)
 	for i, id := range jobs {
-		select {
-		case r.adoptionCh <- struct{}{}:
-		case <-r.stopper.ShouldQuiesce():
-			return stop.ErrUnavailable
-		case <-ctx.Done():
-			return ctx.Err()
+		// In the pre-20.2 and mixed-version state, the adoption loop needs to be
+		// notified once per job (in the worst case) in order to ensure that all
+		// newly created jobs get adopted in a timely manner. In the sqlliveness
+		// world of 20.2 and later, we only need to notify the loop once as the
+		// newly created jobs are already claimed. The adoption loop will merely
+		// start all previously claimed jobs.
+		if !usingSQLLiveness || i == 0 {
+			select {
+			case r.adoptionCh <- struct{}{}:
+			case <-r.stopper.ShouldQuiesce():
+				return stop.ErrUnavailable
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
-
 		if i > 0 {
 			buf.WriteString(",")
 		}
@@ -320,9 +328,9 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
        AND (status != 'succeeded' AND status != 'failed' AND status != 'canceled')`,
 		buf.String())
 	for r := retry.StartWithCtx(ctx, retry.Options{
-		InitialBackoff: 10 * time.Millisecond,
+		InitialBackoff: 5 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
+		Multiplier:     1.5,
 	}); r.Next(); {
 		// We poll the number of queued jobs that aren't finished. As with SHOW JOBS
 		// WHEN COMPLETE, if one of the jobs is missing from the jobs table for
@@ -586,6 +594,7 @@ func (r *Registry) Start(
 				}
 				return
 			}
+
 			log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
 			f(ctx, s)
 		}

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -255,10 +255,7 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	resumeCh := make(chan int64)
 	defer jobs.ResetConstructors()()

--- a/pkg/jobs/schedule_control_test.go
+++ b/pkg/jobs/schedule_control_test.go
@@ -123,7 +123,8 @@ func TestScheduleControl(t *testing.T) {
 
 func TestJobsControlForSchedules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables)
+	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables,
+		true /* accelerateIntervals */)
 	defer cleanup()
 
 	registry := th.server.JobRegistry().(*Registry)
@@ -226,7 +227,8 @@ func TestJobsControlForSchedules(t *testing.T) {
 func TestFilterJobsControlForSchedules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer ResetConstructors()()
-	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables)
+	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables,
+		false /* accelerateIntervals */)
 	defer cleanup()
 
 	registry := th.server.JobRegistry().(*Registry)

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -41,11 +40,7 @@ import (
 // TODO(pbardea): Add more testing around the timer calculations.
 func TestSchemaChangeGCJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	defer func(oldAdoptInterval, oldGCInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-	}(jobs.DefaultAdoptInterval, gcjob.MaxSQLGCInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	type DropItem int
 	const (
@@ -254,10 +249,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 func TestSchemaChangeGCJobTableGCdWhileWaitingForExpiration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	defer func(oldAdoptInterval, oldGCInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-	}(jobs.DefaultAdoptInterval, gcjob.MaxSQLGCInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	// We're going to drop a table then manually delete it, then update the
 	// database zone config and ensure the job finishes successfully.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -941,9 +941,9 @@ func WaitToUpdateLeases(ctx context.Context, leaseMgr *lease.Manager, descID des
 	// Aggressively retry because there might be a user waiting for the
 	// schema change to complete.
 	retryOpts := retry.Options{
-		InitialBackoff: 20 * time.Millisecond,
-		MaxBackoff:     200 * time.Millisecond,
-		Multiplier:     2,
+		InitialBackoff: 5 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		Multiplier:     1.5,
 	}
 	log.Infof(ctx, "waiting for a single version...")
 	version, err := leaseMgr.WaitForOneVersion(ctx, descID, retryOpts)
@@ -1960,7 +1960,7 @@ func (r schemaChangeResumer) Resume(
 			},
 		}
 		opts := retry.Options{
-			InitialBackoff: 100 * time.Millisecond,
+			InitialBackoff: 20 * time.Millisecond,
 			MaxBackoff:     20 * time.Second,
 			Multiplier:     1.5,
 		}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -69,12 +69,7 @@ import (
 // and returns a function to reset it after the test. The intention is that
 // the returned function should be deferred.
 func setTestJobsAdoptInterval() (reset func()) {
-	const testingJobsAdoptionInverval = 100 * time.Millisecond
-	old := jobs.DefaultAdoptInterval
-	jobs.DefaultAdoptInterval = testingJobsAdoptionInverval
-	return func() {
-		jobs.DefaultAdoptInterval = old
-	}
+	return jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)
 }
 
 // TestSchemaChangeProcess adds mutations manually to a table descriptor and

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -46,10 +46,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	// Test with 3 nodes and rowexec.SamplerProgressInterval=100 to ensure
 	// that progress metadata is sent correctly after every 100 input rows.
@@ -138,12 +135,7 @@ func TestCreateStatsLivenessWithRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldAdoptInterval, oldCancelInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-		jobs.DefaultCancelInterval = oldCancelInterval
-	}(jobs.DefaultAdoptInterval, jobs.DefaultCancelInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
-	jobs.DefaultCancelInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	const nodes = 1
 	nl := jobs.NewFakeNodeLiveness(nodes)
@@ -252,12 +244,7 @@ func TestCreateStatsLivenessWithLeniency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldAdoptInterval, oldCancelInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-		jobs.DefaultCancelInterval = oldCancelInterval
-	}(jobs.DefaultAdoptInterval, jobs.DefaultCancelInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
-	jobs.DefaultCancelInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	const nodes = 1
 	nl := jobs.NewFakeNodeLiveness(nodes)
@@ -345,10 +332,7 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldAdoptInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	var allowRequest chan struct{}
 
@@ -459,10 +443,7 @@ func TestDeleteFailedJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer func(oldAdoptInterval time.Duration) {
-		jobs.DefaultAdoptInterval = oldAdoptInterval
-	}(jobs.DefaultAdoptInterval)
-	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})


### PR DESCRIPTION
#### jobs: don't hold mutex during adoption, launch in parallel

#### jobs: break up new stages of job lifecycle movement

In the PR which adopted the sqlliveness sessions, we shoved all of the stages
of adopting jobs into the same stage and we invoked that stage on each adoption
interval and on each sent to the adoption channel.

These stages are:

 * Cancel jobs
 * Serve pause and cancel requests
 * Delete claims due to dead sessions
 * Claim jobs
 * Process claimed jobs

This is problematic for tests which send on the adoption channel at a high
rate. One important thing to note is that all jobs which are sent on the
adoption channel are already claimed.

After this PR we move the first three steps above into the cancellation
loop we were already running. We also increase the default interval for
that loop as it was exceedingly frequent at 1s for no obvious reason.

Much of the testing changes are due to this cancelation loop duration
change. The tests in this package now run 3x faster (10s vs 30s).

Then, upon sends on the adoption channel, we just process claimed jobs.
When the adoption interval rolls around, then we attempt to both claim
and process jobs.

Release justification: bug fixes and low-risk updates to new functionality
Release note: None