### PR TITLE
roachtest: use a short GC TTL and merge aggressively in typeorm test

### DIFF
--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -34,6 +34,11 @@ func registerTypeORM(r *testRegistry) {
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
+		if _, err := c.Conn(ctx, 1).ExecContext(ctx, `
+ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 10;
+SET CLUSTER SETTING kv.range_merge.queue_interval = '200ms';`); err != nil {
+			t.Fatal(err)
+		}
 
 		t.Status("cloning TypeORM and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm", typeORMReleaseTagRegex)


### PR DESCRIPTION
This test creates and destroys tables like crazy. This leads to tons of splits
and, worse, tons of descriptors with zone configs getting gossipped. This is
super expensive because for each gossip event we need to scan all of the
descriptors and then somehow we end up unmarshaling most of them in the queues.
Decreasing the GC TTL lets us actually delete these descriptors quickly and
then increasing the merge rate lets us merge away these ranges.

Release justification: Non-production code
Release note: None