### PR TITLE
roachtest: set cluster settings and zone configs in typeorm, adjust a bit

### DIFF
--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -32,37 +32,37 @@ func alterZoneConfigAndClusterSettings(
 	defer db.Close()
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER TABLE system.public.jobs CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER TABLE system.public.jobs CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER RANGE meta CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER RANGE meta CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER RANGE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER RANGE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
 
 	if _, err := db.ExecContext(
-		ctx, `ALTER RANGE liveness CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+		ctx, `ALTER RANGE liveness CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 60;`,
 	); err != nil {
 		return err
 	}
@@ -74,6 +74,13 @@ func alterZoneConfigAndClusterSettings(
 
 	if _, err := db.ExecContext(
 		ctx, `SET CLUSTER SETTING jobs.retention_time = '180s';`,
+	); err != nil {
+		return err
+	}
+
+	// Shorten the merge queue interval to clean up ranges due to dropped tables.
+	if _, err := db.ExecContext(
+		ctx, `SET CLUSTER SETTING kv.range_merge.queue_interval = '200ms'`,
 	); err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -35,6 +35,15 @@ func registerTypeORM(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
 		t.Status("cloning TypeORM and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm", typeORMReleaseTagRegex)
 		if err != nil {


### PR DESCRIPTION
The roachtest really benefits from setting these settings. This commit
also makes the settings a tad more aggressive.

Release justification: non-production code changes
Release note: None