### PR TITLE
sqltelemetry: report all cluster setting changes

### DIFF
--- a/pkg/server/telemetry/duration.go
+++ b/pkg/server/telemetry/duration.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package telemetry
+
+import "time"
+
+// BucketDuration quantizes a duration.
+//
+// Values under or equal to a second are quantized as an integer.
+//    e.g. 300ms -> 100ms, 40ns -> 10ns
+// Values under or equal to a minute are quantized to the nearest 10-second bucket that's smaller or equal.
+//    e.g. 35s500ms -> 30s
+// Values under or equal to an hour are quantized to the nearest 10-minute bucket that's smaller or equal.
+//    e.g. 35m40s -> 30m
+// Values under or equal to a day are quantized to the nearest half hour that's smaller or equal.
+//    e.g. 5h50m -> 5h30m
+// Values between 1 and 10 day inclusive are quantized to the nearest day smaller or equal:
+//    - day exactly if the number of days is round, e.g. 10d -> 10d
+//    - day+1s if the number is in-between days.    e.g. 4d4h -> 4d1s
+// Values above 10 days are quantized as an integer number of days.
+//    e.g. 20days -> 10days, 101days -> 100days
+func BucketDuration(dur time.Duration) time.Duration {
+	sign := time.Duration(1)
+	if dur < 0 {
+		sign = -1
+	}
+	if dur <= time.Second && dur >= -time.Second {
+		return time.Duration(Bucket10(int64(dur)))
+	}
+	if dur <= time.Minute && dur >= -time.Minute {
+		tenSecondBucket := dur / (10 * time.Second)
+		quantized := tenSecondBucket * 10 * time.Second
+		if quantized == 0 {
+			quantized = time.Second * sign
+		}
+		return quantized
+	}
+	if dur <= time.Hour && dur >= -time.Hour {
+		tenMinuteBucket := dur / (10 * time.Minute)
+		quantized := tenMinuteBucket * 10 * time.Minute
+		if quantized == 0 {
+			quantized = time.Minute * sign
+		}
+		return quantized
+	}
+	const timeDay = 24 * time.Hour
+	if dur <= timeDay && dur >= -timeDay {
+		halfHourBucket := dur / (30 * time.Minute)
+		quantized := halfHourBucket * 30 * time.Minute
+		if quantized == 0 {
+			quantized = time.Hour * sign
+		}
+		return quantized
+	}
+	if dur <= 10*timeDay && dur >= -10*timeDay {
+		dayBucket := dur / timeDay
+		quantized := dayBucket * timeDay
+		if quantized == 0 {
+			quantized = timeDay * sign
+		}
+		if dur != quantized {
+			quantized += time.Second * sign
+		}
+		return quantized
+	}
+	days := dur / timeDay
+	quantized := time.Duration(Bucket10(int64(days))) * timeDay
+	return quantized
+}

--- a/pkg/server/telemetry/duration_test.go
+++ b/pkg/server/telemetry/duration_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+func TestBucketDuration(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected string
+	}{
+		{"0s", "0s"},
+		{"1ns", "1ns"},
+		{"200ms", "100ms"},
+		{"450µs", "100µs"},
+		{"100µs10ns", "100µs"},
+		{"100ms10µs", "100ms"},
+		{"1s", "1s"},
+		{"5s30ms", "1s"},
+		{"10s30ms", "10s"},
+		{"25s30ms", "20s"},
+		{"1m", "1m"},
+		{"1m10s", "1m"},
+		{"5m100ms", "1m"},
+		{"25m", "20m"},
+		{"20m10s", "20m"},
+		{"1h", "1h"},
+		{"1h10s", "1h"},
+		{"3h10s", "3h"},
+		{"3h40m", "3h30m"},
+		{"23h59m", "23h30m"},
+		{"24h", "24h"},
+		{"24h10s", "24h1s"},
+		{"26h10ms", "24h1s"},
+		{"72h", "72h"},
+		{"77h10m", "72h0m1s"},
+		{"240h", "240h"},   // 10 days
+		{"264h", "240h"},   // 11 days
+		{"2400h", "2400h"}, // 100 days
+	}
+
+	for _, tc := range testData {
+		input, err := time.ParseDuration(tc.input)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.input, err)
+		}
+		expected, err := time.ParseDuration(tc.expected)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.input, err)
+		}
+		if actual := telemetry.BucketDuration(input); actual != expected {
+			t.Errorf("%s (%d): expected %q (%d), got %q (%d)",
+				tc.input, int64(input),
+				expected, int64(expected),
+				actual, int64(actual))
+		}
+
+		negInput := -input
+		negExpected := -expected
+		if actual := telemetry.BucketDuration(negInput); actual != negExpected {
+			t.Errorf("-%s (%d): expected %q (%d), got %q (%d)",
+				tc.input, int64(negInput),
+				expected, int64(negExpected),
+				actual, int64(actual))
+		}
+	}
+}

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -27,6 +27,8 @@ import (
 // feature, such as file sizes, qps, etc, without being as revealing as the
 // raw numbers.
 // The numbers 0-10 are reported unchanged.
+//
+// See BucketDuration() to quantize durations instead of integers.
 func Bucket10(num int64) int64 {
 	if num == math.MinInt64 {
 		// This is needed to prevent overflow in the negation below.

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -59,6 +59,15 @@ func (e *EnumSetting) ParseEnum(raw string) (int64, bool) {
 	return v, ok
 }
 
+// ValueAsString returns the string representation of the enum value encoded as an integer.
+func (e *EnumSetting) ValueAsString(raw string) string {
+	v, ok := e.ParseEnum(raw)
+	if !ok {
+		return raw
+	}
+	return e.enumValues[v]
+}
+
 // GetAvailableValuesAsHint returns the possible enum settings as a string that
 // can be provided as an error hint to a user.
 func (e *EnumSetting) GetAvailableValuesAsHint() string {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -482,24 +482,6 @@ func (p *planner) CheckRoleOption(ctx context.Context, roleOption roleoption.Opt
 	return nil
 }
 
-// ConnAuditingClusterSettingName is the name of the cluster setting
-// for the cluster setting that enables pgwire-level connection audit
-// logs.
-//
-// This name is defined here because it is needed in the telemetry
-// counts in SetClusterSetting() and importing pgwire here would
-// create a circular dependency.
-const ConnAuditingClusterSettingName = "server.auth_log.sql_connections.enabled"
-
-// AuthAuditingClusterSettingName is the name of the cluster setting
-// for the cluster setting that enables pgwire-level authentication audit
-// logs.
-//
-// This name is defined here because it is needed in the telemetry
-// counts in SetClusterSetting() and importing pgwire here would
-// create a circular dependency.
-const AuthAuditingClusterSettingName = "server.auth_log.sql_sessions.enabled"
-
 func (p *planner) canCreateOnSchema(ctx context.Context, schemaID descpb.ID, user string) error {
 	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -145,7 +146,7 @@ var traceSessionEventLogEnabled = settings.RegisterPublicBoolSetting(
 
 // ReorderJoinsLimitClusterSettingName is the name of the cluster setting for
 // the maximum number of joins to reorder.
-const ReorderJoinsLimitClusterSettingName = "sql.defaults.reorder_joins_limit"
+const ReorderJoinsLimitClusterSettingName = sqltelemetry.ReorderJoinsLimitClusterSettingName
 
 // ReorderJoinsLimitClusterValue controls the cluster default for the maximum
 // number of joins reordered.
@@ -276,7 +277,7 @@ var experimentalDistSQLPlanningClusterMode = settings.RegisterEnumSetting(
 
 // VectorizeClusterSettingName is the name for the cluster setting that controls
 // the VectorizeClusterMode below.
-const VectorizeClusterSettingName = "sql.defaults.vectorize"
+const VectorizeClusterSettingName = sqltelemetry.VectorizeClusterSettingName
 
 // VectorizeClusterMode controls the cluster default for when automatic
 // vectorization is enabled.

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -65,12 +65,12 @@ var connResultsBufferSize = settings.RegisterPublicByteSizeSetting(
 )
 
 var logConnAuth = settings.RegisterPublicBoolSetting(
-	sql.ConnAuditingClusterSettingName,
+	sqltelemetry.ConnAuditingClusterSettingName,
 	"if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)",
 	false)
 
 var logSessionAuth = settings.RegisterPublicBoolSetting(
-	sql.AuthAuditingClusterSettingName,
+	sqltelemetry.AuthAuditingClusterSettingName,
 	"if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)",
 	false)
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -221,7 +221,9 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 		}
 
 		// Report tracked cluster settings via telemetry.
-		sqltelemetry.RegisterSettingChange(n.setting, n.name, expectedEncodedValue, usingDefault)
+		if err := sqltelemetry.RegisterSettingChange(n.setting, n.name, expectedEncodedValue, usingDefault); err != nil {
+			return err
+		}
 
 		return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 			ctx,

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -33,3 +33,15 @@ func VecModeCounter(mode string) telemetry.Counter {
 // CascadesLimitReached is to be incremented whenever the limit of foreign key
 // cascade for a single query is exceeded.
 var CascadesLimitReached = telemetry.GetCounterOnce("sql.exec.cascade-limit-reached")
+
+// AutoStatsClusterSettingName is the name of the automatic stats collection
+// cluster setting.
+const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
+
+// VectorizeClusterSettingName is the name for the cluster setting that controls
+// the VectorizeClusterMode.
+const VectorizeClusterSettingName = "sql.defaults.vectorize"
+
+// ReorderJoinsLimitClusterSettingName is the name of the cluster setting for
+// the maximum number of joins to reorder.
+const ReorderJoinsLimitClusterSettingName = "sql.defaults.reorder_joins_limit"

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -10,11 +10,7 @@
 
 package sqltelemetry
 
-import (
-	"fmt"
-
-	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-)
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
 
 // DistSQLExecCounter is to be incremented whenever a query is distributed
 // across multiple nodes.
@@ -23,12 +19,6 @@ var DistSQLExecCounter = telemetry.GetCounterOnce("sql.exec.query.is-distributed
 // VecExecCounter is to be incremented whenever a query runs with the vectorized
 // execution engine.
 var VecExecCounter = telemetry.GetCounterOnce("sql.exec.query.is-vectorized")
-
-// VecModeCounter is to be incremented every time the vectorized execution mode
-// is changed (including turned off).
-func VecModeCounter(mode string) telemetry.Counter {
-	return telemetry.GetCounter(fmt.Sprintf("sql.exec.vectorized-setting.%s", mode))
-}
 
 // CascadesLimitReached is to be incremented whenever the limit of foreign key
 // cascade for a single query is exceeded.

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -98,13 +98,17 @@ func IncIAMRevokePrivilegesCounter(on string) {
 }
 
 // TurnConnAuditingOnUseCounter counts how many time connection audit logs were enabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnConnAuditingOnUseCounter = telemetry.GetCounterOnce("auditing.connection.enabled")
 
 // TurnConnAuditingOffUseCounter counts how many time connection audit logs were disabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnConnAuditingOffUseCounter = telemetry.GetCounterOnce("auditing.connection.disabled")
 
 // TurnAuthAuditingOnUseCounter counts how many time connection audit logs were enabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnAuthAuditingOnUseCounter = telemetry.GetCounterOnce("auditing.authentication.enabled")
 
 // TurnAuthAuditingOffUseCounter counts how many time connection audit logs were disabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnAuthAuditingOffUseCounter = telemetry.GetCounterOnce("auditing.authentication.disabled")

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -44,3 +44,21 @@ var InterleavedPortalRequestCounter = telemetry.GetCounterOnce("pgwire.#40195.in
 // PortalWithLimitRequestCounter is to be incremented every time a portal request is
 // made.
 var PortalWithLimitRequestCounter = telemetry.GetCounterOnce("pgwire.portal_with_limit_request")
+
+// ConnAuditingClusterSettingName is the name of the cluster setting
+// for the cluster setting that enables pgwire-level connection audit
+// logs.
+//
+// This name is defined here because it is needed in the telemetry
+// counts in SetClusterSetting() and importing pgwire here would
+// create a circular dependency.
+const ConnAuditingClusterSettingName = "server.auth_log.sql_connections.enabled"
+
+// AuthAuditingClusterSettingName is the name of the cluster setting
+// for the cluster setting that enables pgwire-level authentication audit
+// logs.
+//
+// This name is defined here because it is needed in the telemetry
+// counts in SetClusterSetting() and importing pgwire here would
+// create a circular dependency.
+const AuthAuditingClusterSettingName = "server.auth_log.sql_sessions.enabled"

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -107,10 +107,12 @@ var CreateStatisticsUseCounter = telemetry.GetCounterOnce("sql.plan.stats.create
 
 // TurnAutoStatsOnUseCounter is to be incremented whenever automatic stats
 // collection is explicitly enabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnAutoStatsOnUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.enabled")
 
 // TurnAutoStatsOffUseCounter is to be incremented whenever automatic stats
 // collection is explicitly disabled.
+// TODO(knz): This is obsolete. See RegisterSettingChange().
 var TurnAutoStatsOffUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.disabled")
 
 // StatsHistogramOOMCounter is to be incremented whenever statistics histogram
@@ -160,39 +162,6 @@ var CancelQueriesUseCounter = telemetry.GetCounterOnce("sql.session.cancel-queri
 // CancelSessionsUseCounter is to be incremented whenever CANCEL SESSION or
 // CANCEL SESSIONS is run.
 var CancelSessionsUseCounter = telemetry.GetCounterOnce("sql.session.cancel-sessions")
-
-// We can't parameterize these telemetry counters, so just make a bunch of
-// buckets for setting the join reorder limit since the range of reasonable
-// values for the join reorder limit is quite small.
-// reorderJoinLimitUseCounters is a list of counters. The entry at position i
-// is the counter for SET reorder_join_limit = i.
-var reorderJoinLimitUseCounters []telemetry.Counter
-
-const reorderJoinsCounters = 12
-
-func init() {
-	reorderJoinLimitUseCounters = make([]telemetry.Counter, reorderJoinsCounters)
-
-	for i := 0; i < reorderJoinsCounters; i++ {
-		reorderJoinLimitUseCounters[i] = telemetry.GetCounterOnce(
-			fmt.Sprintf("sql.plan.reorder-joins.set-limit-%d", i),
-		)
-	}
-}
-
-// ReorderJoinLimitMoreCounter is the counter for the number of times someone
-// set the join reorder limit above reorderJoinsCounters.
-var reorderJoinLimitMoreCounter = telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-more")
-
-// ReportJoinReorderLimit is to be called whenever the reorder joins session variable
-// is set.
-func ReportJoinReorderLimit(value int) {
-	if value < reorderJoinsCounters {
-		telemetry.Inc(reorderJoinLimitUseCounters[value])
-	} else {
-		telemetry.Inc(reorderJoinLimitMoreCounter)
-	}
-}
 
 // WindowFunctionCounter is to be incremented every time a window function is
 // being planned.

--- a/pkg/sql/sqltelemetry/settings.go
+++ b/pkg/sql/sqltelemetry/settings.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+)
+
+// RegisterSettingChange registers a cluster setting change performed
+// via SQL to telemetry.
+func RegisterSettingChange(
+	setting settings.Setting, settingName, encodedValue string, usingDefault bool,
+) {
+	switch settingName {
+	case stats.AutoStatsClusterSettingName:
+		switch encodedValue {
+		case "true":
+			telemetry.Inc(TurnAutoStatsOnUseCounter)
+		case "false":
+			telemetry.Inc(TurnAutoStatsOffUseCounter)
+		}
+	case ConnAuditingClusterSettingName:
+		switch encodedValue {
+		case "true":
+			telemetry.Inc(TurnConnAuditingOnUseCounter)
+		case "false":
+			telemetry.Inc(TurnConnAuditingOffUseCounter)
+		}
+	case AuthAuditingClusterSettingName:
+		switch encodedValue {
+		case "true":
+			telemetry.Inc(TurnAuthAuditingOnUseCounter)
+		case "false":
+			telemetry.Inc(TurnAuthAuditingOffUseCounter)
+		}
+	case ReorderJoinsLimitClusterSettingName:
+		val, err := strconv.ParseInt(encodedValue, 10, 64)
+		if err != nil {
+			break
+		}
+		ReportJoinReorderLimit(int(val))
+	case VectorizeClusterSettingName:
+		val, err := strconv.Atoi(encodedValue)
+		if err != nil {
+			break
+		}
+		validatedExecMode, isValid := sessiondata.VectorizeExecModeFromString(sessiondata.VectorizeExecMode(val).String())
+		if !isValid {
+			break
+		}
+		telemetry.Inc(VecModeCounter(validatedExecMode.String()))
+	}
+}

--- a/pkg/sql/sqltelemetry/settings.go
+++ b/pkg/sql/sqltelemetry/settings.go
@@ -11,56 +11,130 @@
 package sqltelemetry
 
 import (
+	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/errors"
 )
 
 // RegisterSettingChange registers a cluster setting change performed
 // via SQL to telemetry.
 func RegisterSettingChange(
 	setting settings.Setting, settingName, encodedValue string, usingDefault bool,
-) {
-	switch settingName {
-	case stats.AutoStatsClusterSettingName:
-		switch encodedValue {
-		case "true":
-			telemetry.Inc(TurnAutoStatsOnUseCounter)
-		case "false":
-			telemetry.Inc(TurnAutoStatsOffUseCounter)
+) error {
+	reportedValue := "changed"
+	if usingDefault || safeReportableSettings[settingName] {
+		// The default value is always safe.
+		// A value is also safe if the setting declares it is.
+		reportedValue = encodedValue
+	} else {
+		// Maybe we can report some details.
+		switch setting.Typ() {
+		case "b" /* boolean */ :
+			// Always safe. Can report the value as-is.
+			reportedValue = encodedValue
+
+		case "e" /* enum */ :
+			// Let's represent the enum value as a string.
+			e, ok := setting.(*settings.EnumSetting)
+			if !ok {
+				return errors.AssertionFailedf("a non-enum setting pretends to be an enum: %T", setting)
+			}
+			reportedValue = e.ValueAsString(encodedValue)
+
+		case "i" /* integer */, "z" /* size */ :
+			// Quantize it. This reduces the amount of different values
+			// accumulated in the counter sub-system, and somewhat
+			// anonymizes the data.
+			val, err := strconv.ParseInt(encodedValue, 10, 64)
+			if err != nil {
+				// Unsure what kind of int that is. Bail out: the value is not
+				// reportable.
+				break
+			}
+			reportedValue = strconv.FormatInt(telemetry.Bucket10(val), 10)
+
+		case "f":
+			val, err := strconv.ParseFloat(encodedValue, 64)
+			if err != nil {
+				// Unsure what kind of float that is. Bail out: value not reportable.
+				break
+			}
+			// At this point, all float settings are really percentages.
+			// Quantize to two digits: that's a good precision for a
+			// percentage.
+			reportedValue = fmt.Sprintf("%.2f", val)
+
+		case "d" /* duration */ :
+			val, err := time.ParseDuration(encodedValue)
+			if err != nil {
+				// Unsure what kind of float that is. Bail out: value not reportable.
+				break
+			}
+			reportedValue = telemetry.BucketDuration(val).String()
+
+		case "s":
+			// Definitely unsafe. Not reporting the string.
+		case "m":
+			// State machine. Currently only the version setting uses this,
+			// where the state labels (and thus encodedValue) would be safe
+			// for reporting. However nothing in the API mandates that state
+			// machine labels remain safe for reporting; so in case new state
+			// machines are added in the future, we don't want to silently
+			// start leaking information here.
+		default:
+			// If this panic is encountered, this means a new setting type
+			// was added. Add a case above.
+			return errors.AssertionFailedf("unknown setting type: %s", setting.Typ())
 		}
-	case ConnAuditingClusterSettingName:
-		switch encodedValue {
-		case "true":
-			telemetry.Inc(TurnConnAuditingOnUseCounter)
-		case "false":
-			telemetry.Inc(TurnConnAuditingOffUseCounter)
-		}
-	case AuthAuditingClusterSettingName:
-		switch encodedValue {
-		case "true":
-			telemetry.Inc(TurnAuthAuditingOnUseCounter)
-		case "false":
-			telemetry.Inc(TurnAuthAuditingOffUseCounter)
-		}
-	case ReorderJoinsLimitClusterSettingName:
-		val, err := strconv.ParseInt(encodedValue, 10, 64)
-		if err != nil {
-			break
-		}
-		ReportJoinReorderLimit(int(val))
-	case VectorizeClusterSettingName:
-		val, err := strconv.Atoi(encodedValue)
-		if err != nil {
-			break
-		}
-		validatedExecMode, isValid := sessiondata.VectorizeExecModeFromString(sessiondata.VectorizeExecMode(val).String())
-		if !isValid {
-			break
-		}
-		telemetry.Inc(VecModeCounter(validatedExecMode.String()))
 	}
+
+	counterName := fmt.Sprintf("%s%s=%s", settingChangePrefix, settingName, reportedValue)
+	telemetry.Inc(telemetry.GetCounter(counterName))
+
+	// For compatibility with pre-v20.2 telemetry
+	if legacyCounter, ok := legacyCounters[counterName]; ok {
+		telemetry.Inc(legacyCounter)
+	}
+
+	return nil
+}
+
+var safeReportableSettings = map[string]bool{
+	// The reorder join limit is really an enum with 63 values.
+	// We consider all of them as interesting.
+	ReorderJoinsLimitClusterSettingName: true,
+}
+
+const settingChangePrefix = "setting-change."
+
+var legacyCounters = map[string]telemetry.Counter{
+	// The following pick up the values as of v20.2 for compatibility
+	// with pre-v20.2 telemetry.
+	settingChangePrefix + VectorizeClusterSettingName + "=on":      telemetry.GetCounterOnce("sql.exec.vectorized-setting.on"),
+	settingChangePrefix + VectorizeClusterSettingName + "=off":     telemetry.GetCounterOnce("sql.exec.vectorized-setting.off"),
+	settingChangePrefix + VectorizeClusterSettingName + "=201auto": telemetry.GetCounterOnce("sql.exec.vectorized-setting.201auto"),
+	// More compatibility with pre-v20.2 telemetry.
+	settingChangePrefix + AutoStatsClusterSettingName + "=true":       TurnAutoStatsOnUseCounter,
+	settingChangePrefix + AutoStatsClusterSettingName + "=false":      TurnAutoStatsOffUseCounter,
+	settingChangePrefix + ConnAuditingClusterSettingName + "=true":    TurnConnAuditingOnUseCounter,
+	settingChangePrefix + ConnAuditingClusterSettingName + "=false":   TurnConnAuditingOffUseCounter,
+	settingChangePrefix + AuthAuditingClusterSettingName + "=true":    TurnAuthAuditingOnUseCounter,
+	settingChangePrefix + AuthAuditingClusterSettingName + "=false":   TurnAuthAuditingOffUseCounter,
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=0":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-0"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=1":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-1"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=2":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-2"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=3":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-3"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=4":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-4"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=5":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-5"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=6":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-6"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=7":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-7"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=8":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-8"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=9":  telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-9"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=10": telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-10"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=11": telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-11"),
+	settingChangePrefix + ReorderJoinsLimitClusterSettingName + "=12": telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-12"),
 }

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -33,7 +34,7 @@ import (
 
 // AutoStatsClusterSettingName is the name of the automatic stats collection
 // cluster setting.
-const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
+const AutoStatsClusterSettingName = sqltelemetry.AutoStatsClusterSettingName
 
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.

--- a/pkg/sql/testdata/telemetry/execution
+++ b/pkg/sql/testdata/telemetry/execution
@@ -1,23 +1,37 @@
 # This file contains telemetry tests for sql.exec.* counters.
 
 # Tests for vectorization counters.
+#
+# Note: the bare counters sql.exec.* are obsolete.
+# See ReportSettingChange() in sqltelemetry.
+#
 feature-allowlist
 sql.exec.vectorized-setting.on
 sql.exec.vectorized-setting.off
 sql.exec.vectorized-setting.201auto
+setting-change.*
 ----
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.vectorize='on'
 ----
+setting-change.sql.defaults.vectorize=on
 sql.exec.vectorized-setting.on
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.vectorize='off'
 ----
+setting-change.sql.defaults.vectorize=off
 sql.exec.vectorized-setting.off
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.vectorize='201auto'
 ----
+setting-change.sql.defaults.vectorize=201auto
 sql.exec.vectorized-setting.201auto
+
+# Duration values get quantized. See telemetry.BucketDuration().
+feature-usage
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold='20h10m'
+----
+setting-change.sql.log.slow_query.latency_threshold=20h0m0s

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -83,45 +83,62 @@ sql.plan.hints.index
 sql.plan.hints.index.delete
 
 # Tests for tracking important setting changes.
-
+#
+# Note: the bare counters sql.plan.* are obsolete.
+# See ReportSettingChange() in sqltelemetry.
+#
 feature-allowlist
 sql.plan.reorder-joins.*
 sql.plan.automatic-stats.*
+setting-change.sql.defaults.reorder_joins_limit.*
+setting-change.sql.stats.automatic_collection.enabled.*
 ----
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 0
 ----
+setting-change.sql.defaults.reorder_joins_limit=0
 sql.plan.reorder-joins.set-limit-0
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 3
 ----
+setting-change.sql.defaults.reorder_joins_limit=3
 sql.plan.reorder-joins.set-limit-3
 
 feature-usage
 SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 6
 ----
+setting-change.sql.defaults.reorder_joins_limit=6
 sql.plan.reorder-joins.set-limit-6
 
 feature-usage
-SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 20 
+SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 12
 ----
-sql.plan.reorder-joins.set-limit-more
+setting-change.sql.defaults.reorder_joins_limit=12
+sql.plan.reorder-joins.set-limit-12
+
+feature-usage
+SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 60
+----
+setting-change.sql.defaults.reorder_joins_limit=60
 
 feature-usage
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = on
 ----
+setting-change.sql.stats.automatic_collection.enabled=true
 sql.plan.automatic-stats.enabled
 
 feature-usage
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = off
 ----
+setting-change.sql.stats.automatic_collection.enabled=false
 sql.plan.automatic-stats.disabled
 
 feature-usage
 RESET CLUSTER SETTING sql.stats.automatic_collection.enabled
 ----
+setting-change.sql.stats.automatic_collection.enabled=true
 sql.plan.automatic-stats.enabled
 
 # Test telemetry for manual statistics creation.


### PR DESCRIPTION
Fixes #53473
First commit from #53604

Requested by @awoods187 @thtruo @piyush-singh @johnrk 

This change ensures that all cluster setting changes are reported to
telemetry, without the need to "opt in" particular settings.

The values are partially anonymized:

- booleans and enums are reported as-is.
- integer, duration and float values get quantized to a near round value.
- other values (e.g. strings) get scrubbed.

The name of the telemetry counter for changing a setting X to value Y
is `setting-change.X=Y`

For example:

```
root@127.0.0.1:59986/defaultdb> set cluster setting server.web_session_timeout = '11m';
SET CLUSTER SETTING

root@127.0.0.1:59986/defaultdb> select * from [table crdb_internal.feature_usage] where feature_name like 'setting-change%';
                   feature_name                   | usage_count
--------------------------------------------------+--------------
  setting-change.server.web_session_timeout=10m0s |           1

```



Release justification: low risk, high benefit changes to existing functionality