### PR TITLE
sql: fix panic when index joining to include system column

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -186,5 +186,15 @@ SELECT tableoid, crdb_internal_mvcc_timestamp IS NOT NULL FROM tab1
 56 true
 56 true
 
+# We should be able to index join against the primary key to get the tableoid column.
+statement ok
+CREATE TABLE tab3 (x INT, INDEX i (x));
+INSERT INTO tab3 VALUES (1)
+
+query OI
+SELECT tableoid, x FROM tab3@i WHERE x = 1
+----
+58 1
+
 statement error pq: column name "tableoid" conflicts with a system column name
 CREATE TABLE bad (tableoid int)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -937,8 +937,12 @@ func (ot *optTable) getColDesc(i int) *descpb.ColumnDescriptor {
 	if i < len(ot.desc.DeletableColumns()) {
 		return &ot.desc.DeletableColumns()[i]
 	}
-	if ot.columns[i].ColID() == cat.StableID(colinfo.MVCCTimestampColumnID) {
-		return &colinfo.MVCCTimestampColumnDesc
+	// Check if the column matches any registered system columns.
+	for j := range colinfo.AllSystemColumnDescs {
+		colDesc := &colinfo.AllSystemColumnDescs[j]
+		if descpb.ColumnID(ot.columns[i].ColID()) == colDesc.ID {
+			return colDesc
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #53619.
Fixes #53620.
Fixes #53621.
Fixes #53622.
Fixes #53623.
Fixes #53624.
Fixes #53625.
Fixes #53626.
Fixes #53627.
Fixes #53628.
Fixes #53629.

Release justification: bug fix to new functionality
Release note: None