### PR TITLE
builtins: implement ST_ForceCollection

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1235,6 +1235,8 @@ Bottom Left.</p>
 </span></td></tr>
 <tr><td><a name="st_force2d"></a><code>st_force2d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry which only contains X and Y coordinates.</p>
 </span></td></tr>
+<tr><td><a name="st_forcecollection"></a><code>st_forcecollection(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Converts the geometry into a GeometryCollection.</p>
+</span></td></tr>
 <tr><td><a name="st_forcepolygonccw"></a><code>st_forcepolygonccw(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry where all Polygon objects have exterior rings in the counter-clockwise orientation and interior rings in the clockwise orientation. Non-Polygon objects are unchanged.</p>
 </span></td></tr>
 <tr><td><a name="st_forcepolygoncw"></a><code>st_forcepolygoncw(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry where all Polygon objects have exterior rings in the clockwise orientation and interior rings in the counter-clockwise orientation. Non-Polygon objects are unchanged.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1257,26 +1257,27 @@ Square (right)                            POINT (0.5 0.5)
 Square overlapping left and right square  POINT (0.45 0.5)
 
 # Collections
-query TTT
+query TTTT
 SELECT
   dsc,
-  ST_AsEWKT(ST_Multi(geom)),
-  ST_AsEWKT(ST_CollectionHomogenize(geom))
+  ST_AsText(ST_Multi(geom)),
+  ST_AsText(ST_CollectionHomogenize(geom)),
+  ST_AsText(ST_ForceCollection(geom))
 FROM geom_operators_test
 ORDER BY dsc ASC
 ----
-Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
-Empty LineString                          MULTILINESTRING EMPTY                                  LINESTRING EMPTY
-Empty Point                               MULTIPOINT EMPTY                                       POINT EMPTY
-Faraway point                             MULTIPOINT (5 5)                                       POINT (5 5)
-Line going through left and right square  MULTILINESTRING ((-0.5 0.5, 0.5 0.5))                  LINESTRING (-0.5 0.5, 0.5 0.5)
-NULL                                      NULL                                                   NULL
-Nested Geometry Collection                GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  POINT (0 0)
-Point middle of Left Square               MULTIPOINT (-0.5 0.5)                                  POINT (-0.5 0.5)
-Point middle of Right Square              MULTIPOINT (0.5 0.5)                                   POINT (0.5 0.5)
-Square (left)                             MULTIPOLYGON (((-1 0, 0 0, 0 1, -1 1, -1 0)))          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Square (right)                            MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Square overlapping left and right square  MULTIPOLYGON (((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                      GEOMETRYCOLLECTION EMPTY
+Empty LineString                          MULTILINESTRING EMPTY                                  LINESTRING EMPTY                              GEOMETRYCOLLECTION (LINESTRING EMPTY)
+Empty Point                               MULTIPOINT EMPTY                                       POINT EMPTY                                   GEOMETRYCOLLECTION (POINT EMPTY)
+Faraway point                             MULTIPOINT (5 5)                                       POINT (5 5)                                   GEOMETRYCOLLECTION (POINT (5 5))
+Line going through left and right square  MULTILINESTRING ((-0.5 0.5, 0.5 0.5))                  LINESTRING (-0.5 0.5, 0.5 0.5)                GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5))
+NULL                                      NULL                                                   NULL                                          NULL
+Nested Geometry Collection                GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  POINT (0 0)                                   GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+Point middle of Left Square               MULTIPOINT (-0.5 0.5)                                  POINT (-0.5 0.5)                              GEOMETRYCOLLECTION (POINT (-0.5 0.5))
+Point middle of Right Square              MULTIPOINT (0.5 0.5)                                   POINT (0.5 0.5)                               GEOMETRYCOLLECTION (POINT (0.5 0.5))
+Square (left)                             MULTIPOLYGON (((-1 0, 0 0, 0 1, -1 1, -1 0)))          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))        GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))
+Square (right)                            MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))           GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))
+Square overlapping left and right square  MULTIPOLYGON (((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))  GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))
 
 query TTTT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2413,6 +2413,23 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_forcecollection": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceCollection(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeometry{Geometry: ret}, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Converts the geometry into a GeometryCollection.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 
 	//
 	// Unary predicates


### PR DESCRIPTION
Some test cases deviate from PostGIS due to a bug in the WKT encoder (see #53632). The behavior of `ST_ForceCollection` is correct, but the WKT output does not accurately represent the resulting geometry. Not sure if we should wait for the upstream fix or merge this as-is. 

Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): Implement the geometry builtin
`ST_ForceCollection`.

Closes #48934.