### PR TITLE
release-20.1: opt: fix internal error when FK check should be elided

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -70,8 +70,9 @@ func (mb *mutationBuilder) buildFKChecksForInsert() {
 
 	h := &mb.fkCheckHelper
 	for i, n := 0, mb.tab.OutboundForeignKeyCount(); i < n; i++ {
-		h.initWithOutboundFK(mb, i)
-		mb.checks = append(mb.checks, h.buildInsertionCheck())
+		if h.initWithOutboundFK(mb, i) {
+			mb.checks = append(mb.checks, h.buildInsertionCheck())
+		}
 	}
 	telemetry.Inc(sqltelemetry.ForeignKeyChecksUseCounter)
 }
@@ -238,8 +239,9 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 	for i, n := 0, mb.tab.OutboundForeignKeyCount(); i < n; i++ {
 		// Verify that at least one FK column is actually updated.
 		if mb.outboundFKColsUpdated(i) {
-			h.initWithOutboundFK(mb, i)
-			mb.checks = append(mb.checks, h.buildInsertionCheck())
+			if h.initWithOutboundFK(mb, i) {
+				mb.checks = append(mb.checks, h.buildInsertionCheck())
+			}
 		}
 	}
 
@@ -347,8 +349,9 @@ func (mb *mutationBuilder) buildFKChecksForUpsert() {
 
 	h := &mb.fkCheckHelper
 	for i := 0; i < numOutbound; i++ {
-		h.initWithOutboundFK(mb, i)
-		mb.checks = append(mb.checks, h.buildInsertionCheck())
+		if h.initWithOutboundFK(mb, i) {
+			mb.checks = append(mb.checks, h.buildInsertionCheck())
+		}
 	}
 
 	for i := 0; i < numInbound; i++ {


### PR DESCRIPTION
This change fixes a bug in the code where we aren't checking the
result of `initWithOutboundFK`. If we proceed with building the FK
when this returns false, we fail with an internal error.

I am not sure how to reproduce this condition, as this function only
returns false when the other table descriptor is in the process of
being created. Note though that this bug has been fixed on `master`,
where we have more cases where this function can return `false`.

Fixes #53352.

Release note (bug fix): fixed a rare internal error related to foreign
key checks.

CC @cockroachdb/release 