### PR TITLE
kvfollowerreads: unskip TestFollowerReadsWithStaleDescriptor

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -197,7 +197,6 @@ func TestOracleFactory(t *testing.T) {
 func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	skip.WithIssue(t, 52681)
 	// This test sleeps for a few sec.
 	skip.UnderShort(t)
 


### PR DESCRIPTION
Fixes #52681

This was fixed by recent stopper improvements.

Release justification: non-production code changes

Release note: None