### PR TITLE
backupccl: fix database resolution for revision_history cluster backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -662,7 +662,7 @@ func backupPlanHook(
 		var revs []BackupManifest_DescriptorRevision
 		if mvccFilter == MVCCFilter_All {
 			priorIDs = make(map[descpb.ID]descpb.ID)
-			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs)
+			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.Coverage())
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -478,4 +479,109 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 			{"zones"},
 		},
 	)
+}
+
+// TestClusterRevisionHistory tests that cluster backups can be taken with
+// revision_history and correctly restore into various points in time.
+func TestClusterRevisionHistory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type testCase struct {
+		ts    string
+		check func(t *testing.T, runner *sqlutils.SQLRunner)
+	}
+
+	testCases := make([]testCase, 0, 6)
+	ts := make([]string, 6)
+
+	var tc testCase
+	const numAccounts = 1
+	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	defer cleanupFn()
+	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[0])
+	tc = testCase{
+		ts: ts[0],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+
+	sqlDB.Exec(t, `CREATE DATABASE d2`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[1])
+	tc = testCase{
+		ts: ts[1],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			// Expect both databases to exist at this point.
+			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
+			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+
+	sqlDB.Exec(t, `DROP DATABASE d1`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[2])
+	tc = testCase{
+		ts: ts[2],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
+
+	// Now let's test an incremental backup with revision history. At the start of
+	// the incremental backup, we expect only d2 to exist.
+	sqlDB.Exec(t, `DROP DATABASE d2;`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[3])
+	tc = testCase{
+		ts: ts[3],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			// Neither database should exist at this point in time.
+			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
+
+	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[4])
+	tc = testCase{
+		ts: ts[4],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+
+	sqlDB.Exec(t, `DROP DATABASE d1`)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[5])
+	tc = testCase{
+		ts: ts[5],
+		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
+			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+		},
+	}
+	testCases = append(testCases, tc)
+	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("t%d", i), func(t *testing.T) {
+			_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
+				t, singleNode, tempDir, InitNone,
+			)
+			defer cleanupEmptyCluster()
+
+			sqlDBRestore.Exec(t, `RESTORE FROM $1 AS OF SYSTEM TIME `+testCase.ts, LocalFoo)
+			testCase.check(t, sqlDBRestore)
+		})
+	}
+
 }


### PR DESCRIPTION
Previously database descriptor changes were not tracked when performing
cluster backups with revision history.

Fixes https://github.com/cockroachdb/cockroach/issues/52392.

Release justification: bug fix
Release note (bug fix): Database creation/deletion was previously not
correctly tracked by revision_history cluster backups. This is now
fixed.