### PR TITLE
vendor: Bump pebble to e6a9f9a3c936adb8ee8642e4afb2c1ff8dee4562

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200824180455-875ca32696b6
+	github.com/cockroachdb/pebble v0.0.0-20200831143935-e6a9f9a3c936
 	github.com/cockroachdb/redact v1.0.2
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200824180455-875ca32696b6 h1:erL/39EP/sn3v5oEwYHCPcewADqwQhgzXGRbaRilAjc=
-github.com/cockroachdb/pebble v0.0.0-20200824180455-875ca32696b6/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200831143935-e6a9f9a3c936 h1:MaPvrDBbbWMzmI3uuBMKvcpDfZDY/QHx22T1pb9J6YI=
+github.com/cockroachdb/pebble v0.0.0-20200831143935-e6a9f9a3c936/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.2 h1:bRktqHBXPqI+9bkOx0ikn9RS09G9k83oAdLx6rXRVTQ=


### PR DESCRIPTION
Changes pulled in:
 - e6a9f9a3c936adb8ee8642e4afb2c1ff8dee4562 compaction: Don't set grandparent limit "behind" keys in fragmenter
 - 04c6a8caf99b691124110f869ef288832cb89356 cmd/pebble: fix rocksdb build errors
 - 4c3a7a171486d287c872cd9bfb38fd811fb0199b internal/manifest: add clone method to iterator
 - 778e980e984175bcb1adb1d09c88a5e04b7762e1 internal/manifest: update FileMetadata refcounts within B-Tree
 - 841f44b62f4bba532d646486928a75c24b66d380 internal/manifest: prohibit overwritten keys in B-Tree
 - 341164583f87cb754452e7c085d22e0119f25c24 *: Add diskHealthChecking{FS,File}, use it to wrap disk writes

Only changes that affect Cockroach are the first and last list items
above.

Release justification: Bugfix change in Pebble, plus a low-risk
change for better visibility into slow disks.

Release note: None.