### PR TITLE
backupccl: fix SHOW BACKUP on backup with tables with enum columns

### DIFF
--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -42,6 +42,7 @@ func TestShowBackup(t *testing.T) {
 CREATE TYPE data.welcome AS ENUM ('hello', 'hi');
 USE data; CREATE SCHEMA sc;
 CREATE TABLE data.sc.t1 (a INT);
+CREATE TABLE data.sc.t2 (a data.welcome);
 `)
 
 	const full, inc, inc2 = LocalFoo + "/full", LocalFoo + "/inc", LocalFoo + "/inc2"
@@ -61,6 +62,7 @@ ORDER BY object_type, object_name`, full)
 		{"data", "NULL", "sc", "schema", "NULL", beforeTS, "NULL", "false"},
 		{"data", "public", "bank", "table", "NULL", beforeTS, strconv.Itoa(numAccounts), "false"},
 		{"data", "sc", "t1", "table", "NULL", beforeTS, strconv.Itoa(0), "false"},
+		{"data", "sc", "t2", "table", "NULL", beforeTS, strconv.Itoa(0), "false"},
 		{"data", "public", "_welcome", "type", "NULL", beforeTS, "NULL", "false"},
 		{"data", "public", "welcome", "type", "NULL", beforeTS, "NULL", "false"},
 	}
@@ -89,6 +91,7 @@ ORDER BY object_type, object_name`, full)
 		{"_welcome", "NULL", beforeTS, "NULL", "false"},
 		{"sc", "NULL", beforeTS, "NULL", "false"},
 		{"t1", "NULL", beforeTS, "0", "false"},
+		{"t2", "NULL", beforeTS, "0", "false"},
 		// Incremental.
 		{"data", beforeTS, incTS, "NULL", "false"},
 		{"bank", beforeTS, incTS, strconv.Itoa(int(affectedRows * 2)), "false"},
@@ -96,6 +99,7 @@ ORDER BY object_type, object_name`, full)
 		{"_welcome", beforeTS, incTS, "NULL", "false"},
 		{"sc", beforeTS, incTS, "NULL", "false"},
 		{"t1", beforeTS, incTS, "0", "false"},
+		{"t2", beforeTS, incTS, "0", "false"},
 	}, res)
 
 	// Check the separate inc backup.
@@ -120,10 +124,13 @@ ORDER BY object_type, object_name`, full)
 	require.Equal(t, [][]string{
 		{"bank", "NULL", beforeTS, strconv.Itoa(numAccounts)},
 		{"t1", "NULL", beforeTS, "0"},
+		{"t2", "NULL", beforeTS, "0"},
 		{"bank", beforeTS, incTS, strconv.Itoa(int(affectedRows * 2))},
 		{"t1", beforeTS, incTS, "0"},
+		{"t2", beforeTS, incTS, "0"},
 		{"bank", incTS, inc2TS, "0"},
 		{"t1", incTS, inc2TS, "0"},
+		{"t2", incTS, inc2TS, "0"},
 		{"auth", incTS, inc2TS, "0"},
 		{"users", incTS, inc2TS, "3"},
 	}, res)
@@ -133,6 +140,7 @@ ORDER BY object_type, object_name`, full)
 	require.Equal(t, [][]string{
 		{"bank", incTS, inc2TS, "0"},
 		{"t1", incTS, inc2TS, "0"},
+		{"t2", incTS, inc2TS, "0"},
 		{"auth", incTS, inc2TS, "0"},
 		{"users", incTS, inc2TS, "3"},
 	}, res)
@@ -150,15 +158,15 @@ ORDER BY object_type, object_name`, full)
 	details2Key := roachpb.Key(rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec, details2Desc, details2Desc.PrimaryIndex.ID))
 
 	sqlDBRestore.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
-		{"/Table/60/1", "/Table/60/2", string(details1Key), string(details1Key.PrefixEnd())},
-		{"/Table/61/1", "/Table/61/2", string(details2Key), string(details2Key.PrefixEnd())},
+		{"/Table/61/1", "/Table/61/2", string(details1Key), string(details1Key.PrefixEnd())},
+		{"/Table/62/1", "/Table/62/2", string(details2Key), string(details2Key.PrefixEnd())},
 	})
 
 	var showFiles = fmt.Sprintf(`SELECT start_pretty, end_pretty, size_bytes, rows
 		FROM [SHOW BACKUP FILES '%s']`, details)
 	sqlDBRestore.CheckQueryResults(t, showFiles, [][]string{
-		{"/Table/60/1/1", "/Table/60/1/42", "369", "41"},
-		{"/Table/60/1/42", "/Table/60/2", "531", "59"},
+		{"/Table/61/1/1", "/Table/61/1/42", "369", "41"},
+		{"/Table/61/1/42", "/Table/61/2", "531", "59"},
 	})
 	sstMatcher := regexp.MustCompile(`\d+\.sst`)
 	pathRows := sqlDB.QueryStr(t, `SELECT path FROM [SHOW BACKUP FILES $1]`, details)

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -151,7 +151,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		return err
 	}
 
-	lCtx := newInternalLookupCtx(descs, nil /*prefix - we want all descriptors */)
+	lCtx := newInternalLookupCtx(params.ctx, descs, nil /*prefix - we want all descriptors */)
 	// TODO(richardjcai): Also need to add privilege checking for types and
 	// user defined schemas when they are added.
 	// privileges are added.

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1625,7 +1625,7 @@ func forEachTypeDesc(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
 	for _, id := range lCtx.typIDs {
 		typ := lCtx.typDescs[id]
 		dbDesc, parentExists := lCtx.dbDescs[typ.ParentID]
@@ -1777,7 +1777,7 @@ func forEachTableDescWithTableLookupInternal(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
 
 	if virtualOpts == virtualMany || virtualOpts == virtualOnce {
 		// Virtual descriptors first.

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -220,7 +220,7 @@ func formatQuoteNames(buf *bytes.Buffer, names ...string) {
 }
 
 // ShowCreate returns a valid SQL representation of the CREATE
-// statement used to create the descriptor passed in. The
+// statement used to create the descriptor passed in.
 //
 // The names of the tables references by foreign keys, and the
 // interleaved parent if any, are prefixed by their own database name
@@ -242,7 +242,10 @@ func (p *planner) ShowCreate(
 	} else if desc.IsSequence() {
 		stmt, err = ShowCreateSequence(ctx, &tn, desc)
 	} else {
-		lCtx := newInternalLookupCtxFromDescriptors(allDescs, nil /* want all tables */)
+		lCtx, lErr := newInternalLookupCtxFromDescriptors(ctx, allDescs, nil /* want all tables */)
+		if lErr != nil {
+			return "", lErr
+		}
 		stmt, err = ShowCreateTable(ctx, p, &tn, dbPrefix, desc, lCtx, displayOptions)
 	}
 


### PR DESCRIPTION
This commit updates the lookup context used by SHOW BACKUP when
re-creating the create statement for its tables to hydrate the table
descriptors appropriately if there is type information.

Fixes https://github.com/cockroachdb/cockroach/issues/53659.

Release justification: bug fix
Release note: None