### PR TITLE
sql: volatility for casts between tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1741,3 +1741,12 @@ SELECT x FROM t GROUP BY x
 {1,2}
 {NULL,NULL}
 {1,2,NULL,4,NULL}
+
+# Regression test for #53395: cast between tuples.
+query T
+SELECT CASE
+  WHEN NULL THEN (('1':::INT8, ARRAY[]:::INT2[]))
+  ELSE ('2':::INT8, ARRAY[(-23791):::INT8])
+END
+----
+(2,{-23791})


### PR DESCRIPTION
#### sql: volatility for casts between tuples

We were missing code for determining volatility when casting between tuples.
This is because there is no way to express such a cast directly in SQL, but
there are cases where these casts appear implicitly (such as a conditional).

This change adds the missing logic and a corresponding test.

Fixes #53395.

Release justification: low-risk fix of regression.

Release note (bug fix): fixed an internal error related to casts between tuples.