### PR TITLE
sql: disallow GRANT/REVOKE on system tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1078,3 +1078,9 @@ b              public       t2          root     ALL
 
 statement error pq: invalid privilege type USAGE for table
 GRANT USAGE ON t TO testuser
+
+statement error pq: cannot GRANT on system object
+GRANT SELECT ON system.lease TO testuser
+
+statement error pq: cannot REVOKE on system object
+REVOKE SELECT ON system.lease FROM testuser


### PR DESCRIPTION
Fixes #43842.

Disallow GRANT/REVOKE operations on system objects to avoid potential
deadlocks related to version bumps.

Release justification: bug fix
Release note (sql change): Disallow `GRANT/REVOKE` operations on system
tables.
Release note (bug fix): Fix a bug where `GRANT/REVOKE` on the
`system.lease` table would result in a deadlock.