### PR TITLE
geo/geomfn: implement ST_SymmetricDifference

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1641,6 +1641,9 @@ The paths themselves are given in the direction of the first geometry.</p>
 <tr><td><a name="st_symdifference"></a><code>st_symdifference(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the symmetric difference of both geometries.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
+<tr><td><a name="st_symmetricdifference"></a><code>st_symmetricdifference(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the symmetric difference of both geometries.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
 <tr><td><a name="st_touches"></a><code>st_touches(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the only points in common between geometry_a and geometry_b are on the boundary. Note points do not touch other points.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant will attempt to utilize any available geospatial index.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1013,161 +1013,160 @@ SELECT ST_IsRing('POINT(0 0)')
 
 # Topology operators
 
-query TTTBT
+query TTTB
 SELECT
   a.dsc,
   b.dsc,
   ST_AsEWKT(ST_Intersection(a.geom, b.geom)),
-  ST_Intersection(a.geom, b.geom) = ST_Intersection(a.geom::string, b.geom::string),
-  ST_AsEWKT(ST_SymDifference(a.geom, b.geom))
+  ST_Intersection(a.geom, b.geom) = ST_Intersection(a.geom::string, b.geom::string)
 FROM geom_operators_test a
 JOIN geom_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc
 ----
-Empty GeometryCollection                  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION EMPTY
-Empty GeometryCollection                  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  LINESTRING EMPTY
-Empty GeometryCollection                  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT EMPTY
-Empty GeometryCollection                  Faraway point                             GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Empty GeometryCollection                  Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Empty GeometryCollection                  NULL                                      NULL                                       NULL  NULL
-Empty GeometryCollection                  Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Empty GeometryCollection                  Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Empty GeometryCollection                  Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Empty GeometryCollection                  Square (left)                             GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Empty GeometryCollection                  Square (right)                            GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Empty GeometryCollection                  Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Empty LineString                          Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION EMPTY
-Empty LineString                          Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  LINESTRING EMPTY
-Empty LineString                          Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT EMPTY
-Empty LineString                          Faraway point                             GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Empty LineString                          Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Empty LineString                          NULL                                      NULL                                       NULL  NULL
-Empty LineString                          Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Empty LineString                          Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Empty LineString                          Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Empty LineString                          Square (left)                             GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Empty LineString                          Square (right)                            GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Empty LineString                          Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Empty Point                               Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION EMPTY
-Empty Point                               Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  LINESTRING EMPTY
-Empty Point                               Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT EMPTY
-Empty Point                               Faraway point                             GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Empty Point                               Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Empty Point                               NULL                                      NULL                                       NULL  NULL
-Empty Point                               Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Empty Point                               Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Empty Point                               Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Empty Point                               Square (left)                             GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Empty Point                               Square (right)                            GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Empty Point                               Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Faraway point                             Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Faraway point                             Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Faraway point                             Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT (5 5)
-Faraway point                             Faraway point                             POINT (5 5)                                true  POINT EMPTY
-Faraway point                             Line going through left and right square  POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (-0.5 0.5, 0.5 0.5))
-Faraway point                             NULL                                      NULL                                       NULL  NULL
-Faraway point                             Nested Geometry Collection                POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (5 5), GEOMETRYCOLLECTION (POINT (0 0)))
-Faraway point                             Point middle of Left Square               POINT EMPTY                                true  MULTIPOINT (5 5, -0.5 0.5)
-Faraway point                             Point middle of Right Square              POINT EMPTY                                true  MULTIPOINT (5 5, 0.5 0.5)
-Faraway point                             Square (left)                             POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))
-Faraway point                             Square (right)                            POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))
-Faraway point                             Square overlapping left and right square  POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))
-Line going through left and right square  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Faraway point                             POINT EMPTY                                true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), POINT (5 5))
-Line going through left and right square  Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)             true  LINESTRING EMPTY
-Line going through left and right square  NULL                                      NULL                                       NULL  NULL
-Line going through left and right square  Nested Geometry Collection                POINT EMPTY                                true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
-Line going through left and right square  Point middle of Left Square               POINT (-0.5 0.5)                           true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Point middle of Right Square              POINT (0.5 0.5)                            true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Square (left)                             LINESTRING (-0.5 0.5, 0 0.5)               true  GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))
-Line going through left and right square  Square (right)                            LINESTRING (0 0.5, 0.5 0.5)                true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))
-Line going through left and right square  Square overlapping left and right square  LINESTRING (-0.1 0.5, 0.5 0.5)             true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))
-NULL                                      Empty GeometryCollection                  NULL                                       NULL  NULL
-NULL                                      Empty LineString                          NULL                                       NULL  NULL
-NULL                                      Empty Point                               NULL                                       NULL  NULL
-NULL                                      Faraway point                             NULL                                       NULL  NULL
-NULL                                      Line going through left and right square  NULL                                       NULL  NULL
-NULL                                      NULL                                      NULL                                       NULL  NULL
-NULL                                      Nested Geometry Collection                NULL                                       NULL  NULL
-NULL                                      Point middle of Left Square               NULL                                       NULL  NULL
-NULL                                      Point middle of Right Square              NULL                                       NULL  NULL
-NULL                                      Square (left)                             NULL                                       NULL  NULL
-NULL                                      Square (right)                            NULL                                       NULL  NULL
-NULL                                      Square overlapping left and right square  NULL                                       NULL  NULL
-Nested Geometry Collection                Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Nested Geometry Collection                Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Nested Geometry Collection                Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Nested Geometry Collection                Faraway point                             POINT EMPTY                                true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (5 5))
-Nested Geometry Collection                Line going through left and right square  POINT EMPTY                                true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), LINESTRING (-0.5 0.5, 0.5 0.5))
-Nested Geometry Collection                NULL                                      NULL                                       NULL  NULL
-Nested Geometry Collection                Nested Geometry Collection                POINT (0 0)                                true  POINT EMPTY
-Nested Geometry Collection                Point middle of Left Square               POINT EMPTY                                true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (-0.5 0.5))
-Nested Geometry Collection                Point middle of Right Square              POINT EMPTY                                true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (0.5 0.5))
-Nested Geometry Collection                Square (left)                             POINT (0 0)                                true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
-Nested Geometry Collection                Square (right)                            POINT (0 0)                                true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
-Nested Geometry Collection                Square overlapping left and right square  POINT (0 0)                                true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
-Point middle of Left Square               Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Point middle of Left Square               Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Point middle of Left Square               Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT (-0.5 0.5)
-Point middle of Left Square               Faraway point                             POINT EMPTY                                true  MULTIPOINT (-0.5 0.5, 5 5)
-Point middle of Left Square               Line going through left and right square  POINT (-0.5 0.5)                           true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Point middle of Left Square               NULL                                      NULL                                       NULL  NULL
-Point middle of Left Square               Nested Geometry Collection                POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (-0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
-Point middle of Left Square               Point middle of Left Square               POINT (-0.5 0.5)                           true  POINT EMPTY
-Point middle of Left Square               Point middle of Right Square              POINT EMPTY                                true  MULTIPOINT (-0.5 0.5, 0.5 0.5)
-Point middle of Left Square               Square (left)                             POINT (-0.5 0.5)                           true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
-Point middle of Left Square               Square (right)                            POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))
-Point middle of Left Square               Square overlapping left and right square  POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))
-Point middle of Right Square              Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Point middle of Right Square              Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Point middle of Right Square              Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POINT (0.5 0.5)
-Point middle of Right Square              Faraway point                             POINT EMPTY                                true  MULTIPOINT (0.5 0.5, 5 5)
-Point middle of Right Square              Line going through left and right square  POINT (0.5 0.5)                            true  LINESTRING (-0.5 0.5, 0.5 0.5)
-Point middle of Right Square              NULL                                      NULL                                       NULL  NULL
-Point middle of Right Square              Nested Geometry Collection                POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
-Point middle of Right Square              Point middle of Left Square               POINT EMPTY                                true  MULTIPOINT (0.5 0.5, -0.5 0.5)
-Point middle of Right Square              Point middle of Right Square              POINT (0.5 0.5)                            true  POINT EMPTY
-Point middle of Right Square              Square (left)                             POINT EMPTY                                true  GEOMETRYCOLLECTION (POINT (0.5 0.5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))
-Point middle of Right Square              Square (right)                            POINT (0.5 0.5)                            true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
-Point middle of Right Square              Square overlapping left and right square  POINT (0.5 0.5)                            true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
-Square (left)                             Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Square (left)                             Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Square (left)                             Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Square (left)                             Faraway point                             POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (5 5))
-Square (left)                             Line going through left and right square  LINESTRING (-0.5 0.5, 0 0.5)               true  GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))
-Square (left)                             NULL                                      NULL                                       NULL  NULL
-Square (left)                             Nested Geometry Collection                POINT (0 0)                                true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
-Square (left)                             Point middle of Left Square               POINT (-0.5 0.5)                           true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
-Square (left)                             Point middle of Right Square              POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (0.5 0.5))
-Square (left)                             Square (left)                             POLYGON ((0 0, -1 0, -1 1, 0 1, 0 0))      true  POLYGON EMPTY
-Square (left)                             Square (right)                            LINESTRING (0 0, 0 1)                      true  POLYGON ((0 0, -1 0, -1 1, 0 1, 1 1, 1 0, 0 0))
-Square (left)                             Square overlapping left and right square  POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))  true  MULTIPOLYGON (((-0.1 0, -1 0, -1 1, -0.1 1, -0.1 0)), ((0 0, 0 1, 1 1, 1 0, 0 0)))
-Square (right)                            Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Square (right)                            Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Square (right)                            Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Square (right)                            Faraway point                             POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (5 5))
-Square (right)                            Line going through left and right square  LINESTRING (0 0.5, 0.5 0.5)                true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))
-Square (right)                            NULL                                      NULL                                       NULL  NULL
-Square (right)                            Nested Geometry Collection                POINT (0 0)                                true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
-Square (right)                            Point middle of Left Square               POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (-0.5 0.5))
-Square (right)                            Point middle of Right Square              POINT (0.5 0.5)                            true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
-Square (right)                            Square (left)                             LINESTRING (0 1, 0 0)                      true  POLYGON ((0 1, 1 1, 1 0, 0 0, -1 0, -1 1, 0 1))
-Square (right)                            Square (right)                            POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true  POLYGON EMPTY
-Square (right)                            Square overlapping left and right square  POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true  POLYGON ((0 1, 0 0, -0.1 0, -0.1 1, 0 1))
-Square overlapping left and right square  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Square overlapping left and right square  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Square overlapping left and right square  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
-Square overlapping left and right square  Faraway point                             POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (5 5))
-Square overlapping left and right square  Line going through left and right square  LINESTRING (-0.1 0.5, 0.5 0.5)             true  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))
-Square overlapping left and right square  NULL                                      NULL                                       NULL  NULL
-Square overlapping left and right square  Nested Geometry Collection                POINT (0 0)                                true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
-Square overlapping left and right square  Point middle of Left Square               POINT EMPTY                                true  GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (-0.5 0.5))
-Square overlapping left and right square  Point middle of Right Square              POINT (0.5 0.5)                            true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
-Square overlapping left and right square  Square (left)                             POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))  true  MULTIPOLYGON (((0 1, 1 1, 1 0, 0 0, 0 1)), ((-0.1 1, -0.1 0, -1 0, -1 1, -0.1 1)))
-Square overlapping left and right square  Square (right)                            POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true  POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))
-Square overlapping left and right square  Square overlapping left and right square  POLYGON ((1 0, -0.1 0, -0.1 1, 1 1, 1 0))  true  POLYGON EMPTY
+Empty GeometryCollection                  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Faraway point                             GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  NULL                                      NULL                                       NULL
+Empty GeometryCollection                  Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Square (left)                             GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Square (right)                            GEOMETRYCOLLECTION EMPTY                   true
+Empty GeometryCollection                  Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Faraway point                             GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          NULL                                      NULL                                       NULL
+Empty LineString                          Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Square (left)                             GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Square (right)                            GEOMETRYCOLLECTION EMPTY                   true
+Empty LineString                          Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Faraway point                             GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Line going through left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               NULL                                      NULL                                       NULL
+Empty Point                               Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Point middle of Left Square               GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Point middle of Right Square              GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Square (left)                             GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Square (right)                            GEOMETRYCOLLECTION EMPTY                   true
+Empty Point                               Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY                   true
+Faraway point                             Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Faraway point                             Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Faraway point                             Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Faraway point                             Faraway point                             POINT (5 5)                                true
+Faraway point                             Line going through left and right square  POINT EMPTY                                true
+Faraway point                             NULL                                      NULL                                       NULL
+Faraway point                             Nested Geometry Collection                POINT EMPTY                                true
+Faraway point                             Point middle of Left Square               POINT EMPTY                                true
+Faraway point                             Point middle of Right Square              POINT EMPTY                                true
+Faraway point                             Square (left)                             POINT EMPTY                                true
+Faraway point                             Square (right)                            POINT EMPTY                                true
+Faraway point                             Square overlapping left and right square  POINT EMPTY                                true
+Line going through left and right square  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Line going through left and right square  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Line going through left and right square  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Line going through left and right square  Faraway point                             POINT EMPTY                                true
+Line going through left and right square  Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)             true
+Line going through left and right square  NULL                                      NULL                                       NULL
+Line going through left and right square  Nested Geometry Collection                POINT EMPTY                                true
+Line going through left and right square  Point middle of Left Square               POINT (-0.5 0.5)                           true
+Line going through left and right square  Point middle of Right Square              POINT (0.5 0.5)                            true
+Line going through left and right square  Square (left)                             LINESTRING (-0.5 0.5, 0 0.5)               true
+Line going through left and right square  Square (right)                            LINESTRING (0 0.5, 0.5 0.5)                true
+Line going through left and right square  Square overlapping left and right square  LINESTRING (-0.1 0.5, 0.5 0.5)             true
+NULL                                      Empty GeometryCollection                  NULL                                       NULL
+NULL                                      Empty LineString                          NULL                                       NULL
+NULL                                      Empty Point                               NULL                                       NULL
+NULL                                      Faraway point                             NULL                                       NULL
+NULL                                      Line going through left and right square  NULL                                       NULL
+NULL                                      NULL                                      NULL                                       NULL
+NULL                                      Nested Geometry Collection                NULL                                       NULL
+NULL                                      Point middle of Left Square               NULL                                       NULL
+NULL                                      Point middle of Right Square              NULL                                       NULL
+NULL                                      Square (left)                             NULL                                       NULL
+NULL                                      Square (right)                            NULL                                       NULL
+NULL                                      Square overlapping left and right square  NULL                                       NULL
+Nested Geometry Collection                Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Nested Geometry Collection                Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Nested Geometry Collection                Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Nested Geometry Collection                Faraway point                             POINT EMPTY                                true
+Nested Geometry Collection                Line going through left and right square  POINT EMPTY                                true
+Nested Geometry Collection                NULL                                      NULL                                       NULL
+Nested Geometry Collection                Nested Geometry Collection                POINT (0 0)                                true
+Nested Geometry Collection                Point middle of Left Square               POINT EMPTY                                true
+Nested Geometry Collection                Point middle of Right Square              POINT EMPTY                                true
+Nested Geometry Collection                Square (left)                             POINT (0 0)                                true
+Nested Geometry Collection                Square (right)                            POINT (0 0)                                true
+Nested Geometry Collection                Square overlapping left and right square  POINT (0 0)                                true
+Point middle of Left Square               Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Left Square               Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Left Square               Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Left Square               Faraway point                             POINT EMPTY                                true
+Point middle of Left Square               Line going through left and right square  POINT (-0.5 0.5)                           true
+Point middle of Left Square               NULL                                      NULL                                       NULL
+Point middle of Left Square               Nested Geometry Collection                POINT EMPTY                                true
+Point middle of Left Square               Point middle of Left Square               POINT (-0.5 0.5)                           true
+Point middle of Left Square               Point middle of Right Square              POINT EMPTY                                true
+Point middle of Left Square               Square (left)                             POINT (-0.5 0.5)                           true
+Point middle of Left Square               Square (right)                            POINT EMPTY                                true
+Point middle of Left Square               Square overlapping left and right square  POINT EMPTY                                true
+Point middle of Right Square              Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Right Square              Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Right Square              Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Point middle of Right Square              Faraway point                             POINT EMPTY                                true
+Point middle of Right Square              Line going through left and right square  POINT (0.5 0.5)                            true
+Point middle of Right Square              NULL                                      NULL                                       NULL
+Point middle of Right Square              Nested Geometry Collection                POINT EMPTY                                true
+Point middle of Right Square              Point middle of Left Square               POINT EMPTY                                true
+Point middle of Right Square              Point middle of Right Square              POINT (0.5 0.5)                            true
+Point middle of Right Square              Square (left)                             POINT EMPTY                                true
+Point middle of Right Square              Square (right)                            POINT (0.5 0.5)                            true
+Point middle of Right Square              Square overlapping left and right square  POINT (0.5 0.5)                            true
+Square (left)                             Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Square (left)                             Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Square (left)                             Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Square (left)                             Faraway point                             POINT EMPTY                                true
+Square (left)                             Line going through left and right square  LINESTRING (-0.5 0.5, 0 0.5)               true
+Square (left)                             NULL                                      NULL                                       NULL
+Square (left)                             Nested Geometry Collection                POINT (0 0)                                true
+Square (left)                             Point middle of Left Square               POINT (-0.5 0.5)                           true
+Square (left)                             Point middle of Right Square              POINT EMPTY                                true
+Square (left)                             Square (left)                             POLYGON ((0 0, -1 0, -1 1, 0 1, 0 0))      true
+Square (left)                             Square (right)                            LINESTRING (0 0, 0 1)                      true
+Square (left)                             Square overlapping left and right square  POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))  true
+Square (right)                            Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Square (right)                            Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Square (right)                            Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Square (right)                            Faraway point                             POINT EMPTY                                true
+Square (right)                            Line going through left and right square  LINESTRING (0 0.5, 0.5 0.5)                true
+Square (right)                            NULL                                      NULL                                       NULL
+Square (right)                            Nested Geometry Collection                POINT (0 0)                                true
+Square (right)                            Point middle of Left Square               POINT EMPTY                                true
+Square (right)                            Point middle of Right Square              POINT (0.5 0.5)                            true
+Square (right)                            Square (left)                             LINESTRING (0 1, 0 0)                      true
+Square (right)                            Square (right)                            POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true
+Square (right)                            Square overlapping left and right square  POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true
+Square overlapping left and right square  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY                   true
+Square overlapping left and right square  Empty LineString                          GEOMETRYCOLLECTION EMPTY                   true
+Square overlapping left and right square  Empty Point                               GEOMETRYCOLLECTION EMPTY                   true
+Square overlapping left and right square  Faraway point                             POINT EMPTY                                true
+Square overlapping left and right square  Line going through left and right square  LINESTRING (-0.1 0.5, 0.5 0.5)             true
+Square overlapping left and right square  NULL                                      NULL                                       NULL
+Square overlapping left and right square  Nested Geometry Collection                POINT (0 0)                                true
+Square overlapping left and right square  Point middle of Left Square               POINT EMPTY                                true
+Square overlapping left and right square  Point middle of Right Square              POINT (0.5 0.5)                            true
+Square overlapping left and right square  Square (left)                             POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))  true
+Square overlapping left and right square  Square (right)                            POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))        true
+Square overlapping left and right square  Square overlapping left and right square  POLYGON ((1 0, -0.1 0, -0.1 1, 1 1, 1 0))  true
 
 query TTTT
 SELECT
@@ -1210,6 +1209,159 @@ Point middle of Right Square              GEOMETRYCOLLECTION EMPTY
 Square (left)                             GEOMETRYCOLLECTION EMPTY
 Square (right)                            POLYGON ((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0))
 Square overlapping left and right square  POLYGON ((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0))
+
+query TT
+SELECT
+ ST_AsEWKT(ST_SymDifference(a.geom, b.geom)),
+ ST_AsEWKT(ST_SymmetricDifference(a.geom, b.geom))
+FROM geom_operators_test a
+JOIN geom_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+GEOMETRYCOLLECTION EMPTY                                                                                        GEOMETRYCOLLECTION EMPTY
+LINESTRING EMPTY                                                                                                LINESTRING EMPTY
+POINT EMPTY                                                                                                     POINT EMPTY
+POINT (5 5)                                                                                                     POINT (5 5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+GEOMETRYCOLLECTION EMPTY                                                                                        GEOMETRYCOLLECTION EMPTY
+LINESTRING EMPTY                                                                                                LINESTRING EMPTY
+POINT EMPTY                                                                                                     POINT EMPTY
+POINT (5 5)                                                                                                     POINT (5 5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+GEOMETRYCOLLECTION EMPTY                                                                                        GEOMETRYCOLLECTION EMPTY
+LINESTRING EMPTY                                                                                                LINESTRING EMPTY
+POINT EMPTY                                                                                                     POINT EMPTY
+POINT (5 5)                                                                                                     POINT (5 5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+POINT (5 5)                                                                                                     POINT (5 5)
+POINT (5 5)                                                                                                     POINT (5 5)
+POINT (5 5)                                                                                                     POINT (5 5)
+POINT EMPTY                                                                                                     POINT EMPTY
+GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (-0.5 0.5, 0.5 0.5))                                                GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (-0.5 0.5, 0.5 0.5))
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (POINT (5 5), GEOMETRYCOLLECTION (POINT (0 0)))                                              GEOMETRYCOLLECTION (POINT (5 5), GEOMETRYCOLLECTION (POINT (0 0)))
+MULTIPOINT (5 5, -0.5 0.5)                                                                                      MULTIPOINT (5 5, -0.5 0.5)
+MULTIPOINT (5 5, 0.5 0.5)                                                                                       MULTIPOINT (5 5, 0.5 0.5)
+GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))                                        GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))
+GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))                                           GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))
+GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))                                  GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), POINT (5 5))                                                GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), POINT (5 5))
+LINESTRING EMPTY                                                                                                LINESTRING EMPTY
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))                           GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))                GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))                 GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))                                                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (5 5))                                              GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (5 5))
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), LINESTRING (-0.5 0.5, 0.5 0.5))                           GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), LINESTRING (-0.5 0.5, 0.5 0.5))
+NULL                                                                                                            NULL
+POINT EMPTY                                                                                                     POINT EMPTY
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (-0.5 0.5))                                         GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (-0.5 0.5))
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (0.5 0.5))                                          GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)), POINT (0.5 0.5))
+POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                                                                          POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                                                                             POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))                                                                    POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+POINT (-0.5 0.5)                                                                                                POINT (-0.5 0.5)
+MULTIPOINT (-0.5 0.5, 5 5)                                                                                      MULTIPOINT (-0.5 0.5, 5 5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (POINT (-0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))                                         GEOMETRYCOLLECTION (POINT (-0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
+POINT EMPTY                                                                                                     POINT EMPTY
+MULTIPOINT (-0.5 0.5, 0.5 0.5)                                                                                  MULTIPOINT (-0.5 0.5, 0.5 0.5)
+POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                                                                          POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))                                      GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))
+GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))                             GEOMETRYCOLLECTION (POINT (-0.5 0.5), POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)))
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+POINT (0.5 0.5)                                                                                                 POINT (0.5 0.5)
+MULTIPOINT (0.5 0.5, 5 5)                                                                                       MULTIPOINT (0.5 0.5, 5 5)
+LINESTRING (-0.5 0.5, 0.5 0.5)                                                                                  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                                                                                            NULL
+GEOMETRYCOLLECTION (POINT (0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))                                          GEOMETRYCOLLECTION (POINT (0.5 0.5), GEOMETRYCOLLECTION (POINT (0 0)))
+MULTIPOINT (0.5 0.5, -0.5 0.5)                                                                                  MULTIPOINT (0.5 0.5, -0.5 0.5)
+POINT EMPTY                                                                                                     POINT EMPTY
+GEOMETRYCOLLECTION (POINT (0.5 0.5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))                                    GEOMETRYCOLLECTION (POINT (0.5 0.5), POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)))
+POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                                                                             POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))                                                                    POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                                                                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (5 5))                                        GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (5 5))
+GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))                GEOMETRYCOLLECTION (LINESTRING (0 0.5, 0.5 0.5), POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5)))
+NULL                                                                                                            NULL
+POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                                                                          POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                                                                          POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (0.5 0.5))                                    GEOMETRYCOLLECTION (POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0)), POINT (0.5 0.5))
+POLYGON EMPTY                                                                                                   POLYGON EMPTY
+POLYGON ((0 0, -1 0, -1 1, 0 1, 1 1, 1 0, 0 0))                                                                 POLYGON ((0 0, -1 0, -1 1, 0 1, 1 1, 1 0, 0 0))
+MULTIPOLYGON (((-0.1 0, -1 0, -1 1, -0.1 1, -0.1 0)), ((0 0, 0 1, 1 1, 1 0, 0 0)))                              MULTIPOLYGON (((-0.1 0, -1 0, -1 1, -0.1 1, -0.1 0)), ((0 0, 0 1, 1 1, 1 0, 0 0)))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                                                             POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (5 5))                                           GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (5 5))
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))                 GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, 0 0.5), POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5)))
+NULL                                                                                                            NULL
+POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                                                                             POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (-0.5 0.5))                                      GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (-0.5 0.5))
+POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                                                                             POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+POLYGON ((0 1, 1 1, 1 0, 0 0, -1 0, -1 1, 0 1))                                                                 POLYGON ((0 1, 1 1, 1 0, 0 0, -1 0, -1 1, 0 1))
+POLYGON EMPTY                                                                                                   POLYGON EMPTY
+POLYGON ((0 1, 0 0, -0.1 0, -0.1 1, 0 1))                                                                       POLYGON ((0 1, 0 0, -0.1 0, -0.1 1, 0 1))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))                                                                    POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (5 5))                                  GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (5 5))
+GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))  GEOMETRYCOLLECTION (LINESTRING (-0.5 0.5, -0.1 0.5), POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5)))
+NULL                                                                                                            NULL
+POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))                                                                    POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (-0.5 0.5))                             GEOMETRYCOLLECTION (POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)), POINT (-0.5 0.5))
+POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))                                                                    POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+MULTIPOLYGON (((0 1, 1 1, 1 0, 0 0, 0 1)), ((-0.1 1, -0.1 0, -1 0, -1 1, -0.1 1)))                              MULTIPOLYGON (((0 1, 1 1, 1 0, 0 0, 0 1)), ((-0.1 1, -0.1 0, -1 0, -1 1, -0.1 1)))
+POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))                                                                       POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))
+POLYGON EMPTY                                                                                                   POLYGON EMPTY
 
 # CW/CCW predicates.
 query TBBTT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4622,6 +4622,7 @@ func initGeoBuiltins() {
 		{"st_geomfromtext", "st_geometryfromtext"},
 		{"st_numinteriorring", "st_numinteriorrings"},
 		{"st_makepoint", "st_point"},
+		{"st_symmetricdifference", "st_symdifference"},
 	} {
 		if _, ok := geoBuiltins[alias.builtinName]; !ok {
 			panic("expected builtin definition for alias: " + alias.builtinName)


### PR DESCRIPTION
Added ST_SymmetricDifference builtin.

ST_SymmetricDifference is simply an alias for ST_SymDifference.

Release justification: low-risk update to new functionality
Release note (sql change): Implemented the geometry based builtin
`ST_SymmetricDifference`.

Resolves: #49052