### PR TITLE
cli: remove the "experimental" disclaimer from `workload --help`

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1432,7 +1432,7 @@ Available Commands:
   version           output version information
   debug             debugging commands
   sqlfmt            format SQL statements
-  workload          [experimental] generators for data and query loads
+  workload          generators for data and query loads
   systembench       Run systembench
   help              Help about any command
 

--- a/pkg/workload/cli/cli.go
+++ b/pkg/workload/cli/cli.go
@@ -37,17 +37,16 @@ func WorkloadCmd(userFacing bool) *cobra.Command {
 		for _, m := range workload.Registered() {
 			allowlist[m.Name] = struct{}{}
 		}
-		var addExperimental func(c *cobra.Command)
-		addExperimental = func(c *cobra.Command) {
-			c.Short = `[experimental] ` + c.Short
+		var hideNonPublic func(c *cobra.Command)
+		hideNonPublic = func(c *cobra.Command) {
 			if _, ok := allowlist[c.Name()]; !ok {
 				c.Hidden = true
 			}
 			for _, sub := range c.Commands() {
-				addExperimental(sub)
+				hideNonPublic(sub)
 			}
 		}
-		addExperimental(rootCmd)
+		hideNonPublic(rootCmd)
 	}
 	return rootCmd
 }


### PR DESCRIPTION
Fixes #46561

Release justification: low risk, high benefit changes to existing functionality

Release note (cli change): the `workload` sub-commands are not any
more marked as "experimental" - their interface hasn't changed for at
least two releases and there are no plans to significantly alter them.