### PR TITLE
sql: fix enums in `pg_catalog.pg_attrdef`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -620,7 +620,7 @@ WHERE n.nspname = 'public'
 oid         relname  adrelid  adnum  adbin           adsrc
 1666782879  t1       55       4      12              12
 841178406   t2       56       2      unique_rowid()  unique_rowid()
-2186255414  t3       57       3      'FOO'::STRING   'FOO'::STRING
+2186255414  t3       57       3      'FOO'           'FOO'
 2186255409  t3       57       4      unique_rowid()  unique_rowid()
 581442133   mv1      59       2      unique_rowid()  unique_rowid()
 
@@ -2070,7 +2070,7 @@ WHERE n.nspname = 'public'
 ----
 1666782879  t1   12
 841178406   t2   unique_rowid()
-2186255414  t3   'FOO'::STRING
+2186255414  t3   'FOO'
 2186255409  t3   unique_rowid()
 581442133   mv1  unique_rowid()
 
@@ -2689,7 +2689,7 @@ WHERE
   AND NOT a.attisdropped
   AND attname = 'x'
 ----
-'howdy'::STRING
+'howdy'
 
 # Regression test for limits on virtual index scans. (#53522)
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -418,11 +418,8 @@ CREATE TABLE pg_catalog.pg_attrdef (
 			if err != nil {
 				defSrc = tree.NewDString(*column.DefaultExpr)
 			} else {
-				// Use type check to resolve types in expr. We don't use
-				// DeserializeTableDescExpr here because that returns a typed
-				// expression under the hood. Since typed expressions don't contain
-				// type annotations, we wouldn't format some defaults as intended.
-				if _, err := expr.TypeCheck(ctx, &p.semaCtx, types.Any); err != nil {
+				expr, err := expr.TypeCheck(ctx, &p.semaCtx, column.Type)
+				if err != nil {
 					return err
 				}
 				ctx := tree.NewFmtCtx(tree.FmtPGAttrdefAdbin)


### PR DESCRIPTION
Fixes #53687.

This commit ensures that enums are displayed with their logical
representation in the catalog table `pg_catalog.pg_attrdef`.

Release justification: bug fix
Release note: None