### PR TITLE
roachtest: re-enable acceptance/bank/zerosum-restart

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -31,7 +31,7 @@ func registerAcceptance(r *testRegistry) {
 			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
 				" various errors during its rebalances, see IsExpectedRelocateError)",
 		},
-		// {"bank/zerosum-restart", runBankZeroSumRestart},
+		{name: "bank/zerosum-restart", fn: runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},
 		{name: "cli/node-status", fn: runCLINodeStatus},


### PR DESCRIPTION
Fixes #33683

This test had been flaking earlier in 2019 due to unclean graceful
shutdowns. Since we've heavily reworked that logic since, let's give
the test a second chance.

Release justification: non-production code changes

Release note: None