### PR TITLE
roachtest: re-enable acceptance/bank/zerosum-splits (revert #34080) 

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -31,7 +31,7 @@ func registerAcceptance(r *testRegistry) {
 			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
 				" various errors during its rebalances, see IsExpectedRelocateError)",
 		},
-		// {"bank/zerosum-restart", runBankZeroSumRestart},
+		{name: "bank/zerosum-restart", fn: runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},
 		{name: "cli/node-status", fn: runCLINodeStatus},

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -26,11 +26,7 @@ func registerAcceptance(r *testRegistry) {
 		// Sorted. Please keep it that way.
 		{name: "bank/cluster-recovery", fn: runBankClusterRecovery},
 		{name: "bank/node-restart", fn: runBankNodeRestart},
-		{
-			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
-			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
-				" various errors during its rebalances, see IsExpectedRelocateError)",
-		},
+		{name: "bank/zerosum-splits", fn: runBankNodeZeroSum},
 		{name: "bank/zerosum-restart", fn: runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},


### PR DESCRIPTION
First commit from #53693.

PR #34080 which intended to skip `bank/zerosum-restarts`,
mistakenly skipped `bank/zerosum-splits` instead.
(As `zerosum-restarts` had been skipped already prior)

There was no reason to skip `zerosum-splits`, so this commit
re-enables it.

Release justification: non-production code changes

Release note: None