### PR TITLE
kv: attach txn to error from detectIntentMissingDueToIntentResolution

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -960,7 +960,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 			// to intent resolution and can be safely ignored.
 			ignoreMissing, err = ds.detectIntentMissingDueToIntentResolution(ctx, br.Txn)
 			if err != nil {
-				return nil, roachpb.NewError(err)
+				return nil, roachpb.NewErrorWithTxn(err, br.Txn)
 			}
 		}
 		if !ignoreMissing {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -2906,6 +2906,11 @@ func TestParallelCommitsDetectIntentMissingCause(t *testing.T) {
 				if !testutils.IsPError(pErr, regexp.QuoteMeta(test.expErr)) {
 					t.Fatalf("expected error %q; found %v", test.expErr, pErr)
 				}
+				expErr := txn.Clone()
+				expErr.Status = roachpb.STAGING
+				if !reflect.DeepEqual(expErr, pErr.GetTxn()) {
+					t.Fatalf("expected txn %v on error, found %v", expErr, pErr.GetTxn())
+				}
 			}
 		})
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -391,7 +391,7 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 	// Issue a batch containing only the EndTxn request.
 	baSuffix := ba
 	baSuffix.Requests = ba.Requests[etIdx:]
-	baSuffix.Txn = brPrefix.Txn
+	baSuffix.UpdateTxn(brPrefix.Txn)
 	brSuffix, pErr := sr.SendLocked(ctx, baSuffix)
 	if pErr != nil {
 		return nil, pErr


### PR DESCRIPTION
Fixes #53189.
Fixes #53282.
Fixes #53285.
Fixes #53469.

3dcb6f1 improved the detection of missing intents during parallel commit attempts to distinguish between certain classes of ambiguous errors and transaction aborted errors. This was a nice improvement, as it dramatically reduced the number of situations where we returned ambiguous errors during normal operation (see #52566).

However, in introducing a new location where transaction retry errors could be generated, it accidentally violated the invariant that all transaction retry errors have transaction protos attached to them. This was causing panics in TPC-C roachtests. This commit fixes this issue by properly attaching transaction protos to these new errors, along with any others returned from `detectIntentMissingDueToIntentResolution`.

Release justification: bug fix