### PR TITLE
geos: fix compile error with -Wsign-conversion

### DIFF
--- a/c-deps/geos-rebuild
+++ b/c-deps/geos-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing geos configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+4


### PR DESCRIPTION
Not sure why this wasn't caught in #53647.

Release justification: bug fixes and low-risk updates to new
functionality

Release note: None