### PR TITLE
sql: update `format_type` to handle user defined types

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // DummySequenceOperators implements the tree.SequenceOperators interface by
@@ -116,6 +117,18 @@ func (ep *DummyEvalPlanner) ParseType(sql string) (*types.T, error) {
 
 // EvalSubquery is part of the tree.EvalPlanner interface.
 func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ResolveTypeByOID implements the tree.TypeReferenceResolver interface.
+func (ep *DummyEvalPlanner) ResolveTypeByOID(_ context.Context, _ oid.Oid) (*types.T, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ResolveType implements the tree.TypeReferenceResolver interface.
+func (ep *DummyEvalPlanner) ResolveType(
+	_ context.Context, _ *tree.UnresolvedObjectName,
+) (*types.T, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -18,3 +18,18 @@ SELECT pg_my_temp_schema()
 # Regression test for #49072.
 statement ok
 SELECT has_table_privilege('root'::NAME, 0, 'select')
+
+# Regression test for #53684.
+statement ok
+CREATE TYPE typ AS ENUM ('hello')
+
+query T
+SELECT format_type(oid, 0) FROM pg_catalog.pg_type WHERE typname = 'typ'
+----
+typ
+
+# Nothing breaks if we put a non-existing oid into format_type.
+query T
+SELECT format_type(152100, 0)
+----
+unknown (OID=152100)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2993,6 +2993,7 @@ type EvalDatabase interface {
 // EvalPlanner is a limited planner that can be used from EvalContext.
 type EvalPlanner interface {
 	EvalDatabase
+	TypeReferenceResolver
 	// ParseType parses a column type.
 	ParseType(sql string) (*types.T, error)
 


### PR DESCRIPTION
Fixes #53684.

Update the `format_type` builtin to handle user defined types.

Release justification: bug fix
Release note: None