### PR TITLE
roachprod: Build Charybdefs against thrift 0.13

### DIFF
--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -39,7 +39,7 @@ sudo service cassandra stop;
     sudo mkdir -p "${thrift_dir}"
     sudo chmod 777 "${thrift_dir}"
     cd "${thrift_dir}"
-    curl "https://downloads.apache.org/thrift/0.10.0/thrift-0.10.0.tar.gz" | sudo tar xvz --strip-components 1
+    curl "https://downloads.apache.org/thrift/0.13.0/thrift-0.13.0.tar.gz" | sudo tar xvz --strip-components 1
     sudo ./configure --prefix=/usr
     sudo make -j$(nproc)
     sudo make install
@@ -54,7 +54,8 @@ sudo service cassandra stop;
     sudo rm -rf "${charybde_dir}" "${nemesis_path}" /usr/local/bin/charybdefs{,-nemesis}
     sudo mkdir -p "${charybde_dir}"
     sudo chmod 777 "${charybde_dir}"
-    git clone --depth 1 "https://github.com/scylladb/charybdefs.git" "${charybde_dir}"
+    # TODO(bilal): Change URL back to scylladb/charybdefs once https://github.com/scylladb/charybdefs/pull/21 is merged.
+    git clone --depth 1 "https://github.com/itsbilal/charybdefs.git" "${charybde_dir}"
 
     cd "${charybde_dir}"
     thrift -r --gen cpp server.thrift


### PR DESCRIPTION
As we use Ubuntu 18.04 on Roachprod clusters, which has
a newer version of bundler and ruby, we have to use a newer
version of Thrift. Using newer Thrift also necessitates some
changes in Charybdefs' build files, so I've forked it, used
the fork here, and submitted the changes upstream:
https://github.com/scylladb/charybdefs/pull/21

Fixes #52533.

Release justification: Roachtest/roachprod only fix.
Release note: None.