### PR TITLE
roachtest: improve binaryUpgradeStep

### DIFF
--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -321,7 +321,11 @@ func uploadAndStartFromCheckpointFixture(nodes nodeListOption, v string) version
 func binaryUpgradeStep(nodes nodeListOption, newVersion string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		c := u.c
-		args := u.uploadVersion(ctx, t, nodes, newVersion)
+
+		// NB: We could technically stage the binary on all nodes before
+		// restarting each one, but on Unix it's invalid to write to an
+		// executable file while it is currently running. So we do the
+		// simple thing and upload it serially instead.
 
 		// Restart nodes in a random order; otherwise node 1 would be running all
 		// the migrations and it probably also has all the leases.
@@ -331,6 +335,7 @@ func binaryUpgradeStep(nodes nodeListOption, newVersion string) versionStep {
 		for _, node := range nodes {
 			t.l.Printf("restarting node %d", node)
 			c.Stop(ctx, c.Node(node))
+			args := u.uploadVersion(ctx, t, c.Node(node), newVersion)
 			c.Start(ctx, t, c.Node(node), args, startArgsDontEncrypt)
 			t.l.Printf("node %d now running binary version %s", node, u.binaryVersion(ctx, t, node))
 


### PR DESCRIPTION
Fixes #52760.
Fixes #53617.

We could technically stage the binary on all nodes before restarting
each one, but on Unix it's invalid to write to an executable file while
it is currently running. So we do the simple thing and upload it
serially instead, while the crdb server is stopped.

Previously we were careful to write tests such that they weren't simply
bouncing servers (using the same binary). With the introduction of more
randomized tests (such as join-init/mixed and
decommission/mixed-versions), this was no longer true, so we might as
well make this less of a footgun.

Release justification: non-production code changes
Release note: None