### PR TITLE
geo/geomfn: implement ST_Rotate

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1981,6 +1981,8 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_reverse"></a><code>st_reverse(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified geometry by reversing the order of its vertices.</p>
 </span></td></tr>
+<tr><td><a name="st_rotate"></a><code>st_rotate(g: geometry, rot_radians: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry whose coordinates are rotated around the origin by a rotation angle.</p>
+</span></td></tr>
 <tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by taking in a Geometry as the factor.</p>
 </span></td></tr>
 <tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry, origin: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by the Geometry factor relative to a false origin.</p>

--- a/pkg/geo/geomfn/rotate.go
+++ b/pkg/geo/geomfn/rotate.go
@@ -1,0 +1,113 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/twpayne/go-geom"
+)
+
+// Rotate returns a modified Geometry whose coordinates are rotated
+// around the origin by a rotation angle.
+func Rotate(geometry geo.Geometry, rotRadians float64) (geo.Geometry, error) {
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+
+	g, err = rotateGeomT(g, rotRadians)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+
+	return geo.MakeGeometryFromGeomT(g)
+}
+
+// rotateGeomT returns a modified geom.T whose coordinates are
+// rotated around the origin by a rotation angle.
+func rotateGeomT(g geom.T, rotRadians float64) (geom.T, error) {
+	if geomCollection, ok := g.(*geom.GeometryCollection); ok {
+		return rotateCollection(geomCollection, rotRadians)
+	}
+
+	newCoords, err := rotateCoords(g, rotRadians)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := g.(type) {
+	case *geom.Point:
+		g = geom.NewPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.LineString:
+		g = geom.NewLineStringFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.Polygon:
+		g = geom.NewPolygonFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPoint:
+		g = geom.NewMultiPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.MultiLineString:
+		g = geom.NewMultiLineStringFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPolygon:
+		g = geom.NewMultiPolygonFlat(t.Layout(), newCoords, t.Endss()).SetSRID(g.SRID())
+	default:
+		return nil, geom.ErrUnsupportedType{Value: g}
+	}
+
+	return g, nil
+}
+
+// rotateCoords rotates the coordinates around the origin by
+// a rotation angle.
+func rotateCoords(g geom.T, rotRadians float64) ([]float64, error) {
+	stride := g.Stride()
+	coords := g.FlatCoords()
+	layout := g.Layout()
+
+	newCoords := make([]float64, len(coords))
+
+	for i := 0; i < len(coords); i += stride {
+		newCoords[i] = coords[i]*math.Cos(rotRadians) - coords[i+1]*math.Sin(rotRadians)
+		newCoords[i+1] = coords[i]*math.Sin(rotRadians) + coords[i+1]*math.Cos(rotRadians)
+
+		z := layout.ZIndex()
+		if z != -1 {
+			newCoords[i+z] = coords[i+z]
+		}
+
+		// m coords are only copied over
+		m := layout.MIndex()
+		if m != -1 {
+			newCoords[i+m] = coords[i+m]
+		}
+	}
+
+	return newCoords, nil
+}
+
+// rotateCollection iterates through a GeometryCollection and
+// calls rotateGeomT() on each item.
+func rotateCollection(
+	geomCollection *geom.GeometryCollection, rotRadians float64,
+) (*geom.GeometryCollection, error) {
+	res := geom.NewGeometryCollection()
+	for _, subG := range geomCollection.Geoms() {
+		subGeom, err := rotateGeomT(subG, rotRadians)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := res.Push(subGeom); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/geo/geomfn/rotate_test.go
+++ b/pkg/geo/geomfn/rotate_test.go
@@ -1,0 +1,209 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestRotateGeom(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		input      geom.T
+		rotRadians float64
+		expected   []float64
+	}{
+		{
+			desc:       "rotate a 2D point where angle is 2Pi",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: 2 * math.Pi,
+			expected:   []float64{10, 10},
+		},
+		{
+			desc:       "rotate a 2D point where angle is Pi",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: math.Pi,
+			expected:   []float64{-10, -10},
+		},
+		{
+			desc:       "rotate a 2D point where angle is Pi/4",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: 0.785,
+			expected:   []float64{0.00563088, 14.1421345},
+		},
+		{
+			desc:       "rotate a line string",
+			input:      geom.NewLineStringFlat(geom.XY, []float64{10, 15, 20, 25}),
+			rotRadians: 0.5,
+			expected:   []float64{1.58444, 17.95799, 5.56601, 31.52807},
+		},
+		{
+			desc:       "rotate a line polygon",
+			input:      geom.NewPolygonFlat(geom.XY, []float64{1, 1, 5, 5, 1, 10, 1, 1}, []int{8}),
+			rotRadians: math.Pi,
+			expected:   []float64{-1, -1, -5, -5, -1, -10, -1, -1},
+		},
+		{
+			desc:       "rotate multiple 2D points",
+			input:      geom.NewMultiPointFlat(geom.XY, []float64{10, 10, 20, 20}),
+			rotRadians: math.Pi / 2,
+			expected:   []float64{-10, 10, -20, 20},
+		},
+		{
+			desc:       "rotate multiple line strings",
+			input:      geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}, []int{4, 8}),
+			rotRadians: (3 * math.Pi) / 2,
+			expected:   []float64{1, -1, 2, -2, 3, -3, 4, -4},
+		},
+		{
+			desc:       "rotate multiple polygon strings",
+			input:      geom.NewMultiPolygonFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5, 6, 6, 4, 4}, [][]int{{8}, {16}}),
+			rotRadians: math.Pi,
+			expected:   []float64{-1, -1, -2, -2, -3, -3, -1, -1, -4, -4, -5, -5, -6, -6, -4, -4},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual, err := rotateGeomT(tc.input, tc.rotRadians)
+			require.NoError(t, err)
+
+			require.InEpsilonSlice(t, tc.expected, actual.FlatCoords(), 0.00001)
+			require.EqualValues(t, reflect.TypeOf(tc.input), reflect.TypeOf(actual))
+			require.EqualValues(t, tc.input.SRID(), actual.SRID())
+		})
+	}
+}
+
+func TestRotateCollection(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		input      *geom.GeometryCollection
+		rotRadians float64
+		expected   *geom.GeometryCollection
+	}{
+		{
+			desc:       "rotate empty collection",
+			input:      geom.NewGeometryCollection(),
+			rotRadians: math.Pi,
+			expected:   geom.NewGeometryCollection(),
+		},
+		{
+			desc: "rotate non-empty collection",
+			input: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1, 1}),
+				geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+				geom.NewMultiPointFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3}),
+			),
+			rotRadians: math.Pi,
+			expected: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{-1, -1}),
+				geom.NewLineStringFlat(geom.XY, []float64{-1, -1, -2, -2}),
+				geom.NewMultiPointFlat(geom.XY, []float64{-1, -1, -2, -2, -3, -3}),
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.MakeGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			geometry, err = Rotate(geometry, tc.rotRadians)
+			require.NoError(t, err)
+
+			g, err := geometry.AsGeomT()
+			require.NoError(t, err)
+
+			_, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+		})
+	}
+}
+
+func TestRotate(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		input      geom.T
+		rotRadians float64
+		expected   geom.T
+	}{
+		{
+			desc:       "rotate a 2D point where angle is 2Pi",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: 2 * math.Pi,
+			expected:   geom.NewPointFlat(geom.XY, []float64{10, 10}),
+		},
+		{
+			desc:       "rotate a 2D point where angle is Pi",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: math.Pi,
+			expected:   geom.NewPointFlat(geom.XY, []float64{-10, -10}),
+		},
+		{
+			desc:       "rotate a 2D point where angle is Pi/4",
+			input:      geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			rotRadians: 0.785,
+			expected:   geom.NewPointFlat(geom.XY, []float64{0.00563088, 14.1421345}),
+		},
+		{
+			desc:       "rotate a line string",
+			input:      geom.NewLineStringFlat(geom.XY, []float64{10, 15, 20, 25}),
+			rotRadians: 0.5,
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{1.58444, 17.95799, 5.56601, 31.52807}),
+		},
+		{
+			desc:       "rotate a line polygon",
+			input:      geom.NewPolygonFlat(geom.XY, []float64{1, 1, 5, 5, 1, 10, 1, 1}, []int{8}),
+			rotRadians: math.Pi,
+			expected:   geom.NewPolygonFlat(geom.XY, []float64{-1, -1, -5, -5, -1, -10, -1, -1}, []int{8}),
+		},
+		{
+			desc:       "rotate multiple 2D points",
+			input:      geom.NewMultiPointFlat(geom.XY, []float64{10, 10, 20, 20}),
+			rotRadians: math.Pi / 2,
+			expected:   geom.NewMultiPointFlat(geom.XY, []float64{-10, 10, -20, 20}),
+		},
+		{
+			desc:       "rotate multiple line strings",
+			input:      geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}, []int{4, 8}),
+			rotRadians: (3 * math.Pi) / 2,
+			expected:   geom.NewMultiLineStringFlat(geom.XY, []float64{1, -1, 2, -2, 3, -3, 4, -4}, []int{4, 8}),
+		},
+		{
+			desc:       "rotate multiple polygon strings",
+			input:      geom.NewMultiPolygonFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5, 6, 6, 4, 4}, [][]int{{8}, {16}}),
+			rotRadians: math.Pi,
+			expected:   geom.NewMultiPolygonFlat(geom.XY, []float64{-1, -1, -2, -2, -3, -3, -1, -1, -4, -4, -5, -5, -6, -6, -4, -4}, [][]int{{8}, {16}}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.MakeGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			actual, err := Rotate(geometry, tc.rotRadians)
+			require.NoError(t, err)
+
+			_, err = geo.MakeGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.EqualValues(t, tc.input.SRID(), actual.SRID())
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4645,3 +4645,24 @@ POINT EMPTY                                            POINT EMPTY
 POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0 -0.1, 0 1, 1 1, 1 -0.1, 0 -0.1))
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((0 -1, 0 0, 1 0, 1 -1, 0 -1))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+
+query TTT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Rotate(a.geom, pi())),
+  ST_AsText(ST_Rotate(a.geom, pi()/4))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL                                                    NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (-0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                                GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (0.5 -0.5, -0.5 -0.5)                        LINESTRING (-0.707106781186547 0, 0 0.707106781186547)
+LINESTRING EMPTY                                       LINESTRING EMPTY                                        LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (0.5 -0.5)                                        POINT (-0.707106781186547 0)
+POINT (0.5 0.5)                                        POINT (-0.5 -0.5)                                       POINT (0 0.707106781186547)
+POINT (5 5)                                            POINT (-5.000000000000001 -4.999999999999999)           POINT (0 7.071067811865476)
+POINT EMPTY                                            POINT EMPTY                                             POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0.1 -0, -1 0, -1 -1, 0.1 -1, 0.1 -0))         POLYGON ((-0.070710678118655 -0.070710678118655, 0.707106781186548 0.707106781186547, 0 1.414213562373095, -0.777817459305202 0.636396103067893, -0.070710678118655 -0.070710678118655))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((1 -0, -0 0, -0 -1, 1 -1, 1 -0))               POLYGON ((-0.707106781186548 -0.707106781186547, 0 0, -0.707106781186547 0.707106781186548, -1.414213562373095 0, -0.707106781186548 -0.707106781186547))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((-0 0, -1 0, -1 -1, -0 -1, -0 0))              POLYGON ((0 0, 0.707106781186548 0.707106781186547, 0 1.414213562373095, -0.707106781186547 0.707106781186548, 0 0))

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3597,6 +3597,31 @@ The paths themselves are given in the direction of the first geometry.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_rotate": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"g", types.Geometry},
+				{"rot_radians", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				rotRadians := float64(tree.MustBeDFloat(args[1]))
+
+				ret, err := geomfn.Rotate(g.Geometry, rotRadians)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a modified Geometry whose coordinates are rotated around the origin by a rotation angle.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_setpoint": makeBuiltin(
 		defProps(),
 		tree.Overload{
@@ -4478,7 +4503,6 @@ Bottom Left.`,
 	"st_polygonize":               makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49011}),
 	"st_quantizecoordinates":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49012}),
 	"st_removerepeatedpoints":     makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49017}),
-	"st_rotate":                   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49019}),
 	"st_seteffectivearea":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49030}),
 	"st_shiftlongitude":           makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49034}),
 	"st_simplify":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49036}),


### PR DESCRIPTION
implement ST_Rotate on arguments {geometry, float8} which should adopt PostGIS behaviour.

Release note (sql change): Implemented the geometry builtin `ST_Rotate`

Release justification: low risk update to new functionality

Resolves #49020