### PR TITLE
roachtest: add expected passes to ORM tests, stabilize sqlalchemy

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -20,7 +20,6 @@ var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
 var djangoSupportedTag = "cockroach-3.0.x"
-var djangoCockroachDBSupportedTag = "3.0.2"
 
 func registerDjango(r *testRegistry) {
 	runDjango := func(
@@ -127,7 +126,6 @@ func registerDjango(r *testRegistry) {
 			t.Fatal(err)
 		}
 		c.l.Printf("Latest django-cockroachdb release is %s.", djangoCockroachDBLatestTag)
-		c.l.Printf("Supported django-cockroachdb release is %s.", djangoCockroachDBSupportedTag)
 
 		if err := repeatGitCloneE(
 			ctx,
@@ -135,7 +133,7 @@ func registerDjango(r *testRegistry) {
 			c,
 			"https://github.com/cockroachdb/django-cockroachdb",
 			"/mnt/data1/django/tests/django-cockroachdb",
-			djangoCockroachDBSupportedTag,
+			"master",
 			node,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/pgjdbc_blocklist.go
@@ -615,7 +615,6 @@ var pgjdbcBlockList20_2 = blocklist{
 	"org.postgresql.test.jdbc2.ResultSetMetaDataTest.testUnexecutedStatement[databaseMetadataCacheFields = 0, databaseMetadataCacheFieldsMib = null]":                          "32565",
 	"org.postgresql.test.jdbc2.ResultSetMetaDataTest.testUnexecutedStatement[databaseMetadataCacheFields = null, databaseMetadataCacheFieldsMib = 0]":                          "32565",
 	"org.postgresql.test.jdbc2.ResultSetMetaDataTest.testUnexecutedStatement[databaseMetadataCacheFields = null, databaseMetadataCacheFieldsMib = null]":                       "32565",
-	"org.postgresql.test.jdbc2.ResultSetTest.testUpdateWithPGobject":                                                                                                           "41781",
 	"org.postgresql.test.jdbc2.ResultSetTest.testgetBadBoolean":                                                                                                                "32552",
 	"org.postgresql.test.jdbc2.SearchPathLookupTest.testSearchPathBackwardsCompatibleLookup":                                                                                   "26443",
 	"org.postgresql.test.jdbc2.SearchPathLookupTest.testSearchPathHiddenLookup":                                                                                                "26443",

--- a/pkg/cmd/roachtest/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/pgx_blocklist.go
@@ -27,7 +27,6 @@ var pgxBlocklist20_2 = blocklist{
 	"v4.TestConnQueryErrorWhileReturningRows":                      "26925",
 	"v4.TestConnQueryReadRowMultipleTimes":                         "26925",
 	"v4.TestConnQueryValues":                                       "26925",
-	"v4.TestConnQueryValuesWithUnknownOID":                         "26925",
 	"v4.TestConnSendBatch":                                         "44712",
 	"v4.TestConnSendBatchWithPreparedStatement":                    "41558",
 	"v4.TestConnSimpleProtocol":                                    "21286",

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -102,7 +102,7 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 
 	t.Status("installing sqlalchemy-cockroachdb")
 	if err := repeatRunE(ctx, c, node, "installing sqlalchemy=cockroachdb", `
-		cd /mnt/data1/sqlalchemy-cockroachdb && sudo python3 setup.py install
+		cd /mnt/data1/sqlalchemy-cockroachdb && sudo pip3 install .
 	`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixes #53598 

Release note: None
Release justification: test-only change