### PR TITLE
opt: do not simplify window func with RANGE mode and offset

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3821,3 +3821,20 @@ NULL  7
 NULL  7
 NULL  7
 NULL  7
+
+# Regression test for #53442. Ordering columns are not pruned with RANGE mode
+# and an offset boundary of PRECEDING or FOLLOWING.
+
+statement ok
+CREATE TABLE t53442_a (a INT8 PRIMARY KEY);
+CREATE TABLE t53442_b (b INT2 PRIMARY KEY);
+
+statement ok
+SELECT max(b::INT8) OVER (PARTITION BY b ORDER BY b RANGE 1 PRECEDING)
+FROM t53442_b NATURAL JOIN t53442_a
+WHERE false
+
+statement ok
+SELECT max(b::INT8) OVER (PARTITION BY b ORDER BY a RANGE 1 PRECEDING)
+FROM t53442_b NATURAL JOIN t53442_a
+WHERE false

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2186,20 +2186,14 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		outputIdxs[i] = windowStart + i
 	}
 
-	var rangeOffsetColumn exec.NodeColumnOrdinal
-	if ord.Empty() {
-		idx, _ := input.outputCols.Get(int(w.RangeOffsetColumn))
-		rangeOffsetColumn = exec.NodeColumnOrdinal(idx)
-	}
 	node, err := b.factory.ConstructWindow(input.root, exec.WindowInfo{
-		Cols:              resultCols,
-		Exprs:             exprs,
-		OutputIdxs:        outputIdxs,
-		ArgIdxs:           argIdxs,
-		FilterIdxs:        filterIdxs,
-		Partition:         partitionIdxs,
-		Ordering:          input.sqlOrdering(ord),
-		RangeOffsetColumn: rangeOffsetColumn,
+		Cols:       resultCols,
+		Exprs:      exprs,
+		OutputIdxs: outputIdxs,
+		ArgIdxs:    argIdxs,
+		FilterIdxs: filterIdxs,
+		Partition:  partitionIdxs,
+		Ordering:   input.sqlOrdering(ord),
 	})
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -168,13 +168,6 @@ type WindowInfo struct {
 
 	// Ordering is the set of input columns to order on.
 	Ordering colinfo.ColumnOrdering
-
-	// RangeOffsetColumn is the column ID of a single column from ORDER BY clause
-	// when window frame has RANGE mode of framing and at least one 'offset'
-	// boundary. We store it separately because the ordering might be simplified
-	// (when that single column is in Partition), but the execution still needs
-	// to know the original ordering.
-	RangeOffsetColumn NodeColumnOrdinal
 }
 
 // ExplainEnvData represents the data that's going to be displayed in EXPLAIN (env).

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -520,6 +520,11 @@ type WindowFrame struct {
 	FrameExclusion tree.WindowFrameExclusion
 }
 
+// HasOffset returns true if the WindowFrame contains a specific offset.
+func (f *WindowFrame) HasOffset() bool {
+	return f.StartBoundType.IsOffset() || f.EndBoundType.IsOffset()
+}
+
 func (f *WindowFrame) String() string {
 	var bld strings.Builder
 	switch f.Mode {

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -39,11 +39,18 @@ $input
 )
 
 # SimplifyWindowOrdering reduces an ordering to a simpler form using FDs.
+#
+# This rules does not match when window functions have a RANGE frame with an
+# offset, like max(a) OVER (PARTITION BY a ORDER BY a RANGE 1 PRECEDING). The
+# ordering column cannot be pruned because the execution engine requires an
+# ordering column in this case, even if the ordering is constant.
 [SimplifyWindowOrdering, Normalize]
 (Window
     $input:*
     $fn:*
-    $private:* & (CanSimplifyWindowOrdering $input $private)
+    $private:* &
+        (CanSimplifyWindowOrdering $input $private) &
+        ^(HasRangeFrameWithOffset $fn)
 )
 =>
 (Window $input $fn (SimplifyWindowOrdering $input $private))

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -92,6 +92,28 @@ project
       └── windows
            └── rank [as=rank:7]
 
+# Do not simplify ordering column when in RANGE mode with an offset boundary of
+# PRECEDING, because execution requires a column in this case.
+norm expect-not=SimplifyWindowOrdering
+SELECT rank() OVER (ORDER BY k RANGE 1 PRECEDING) FROM a WHERE false
+----
+values
+ ├── columns: rank:7!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(7)
+
+# Do not simplify ordering column when in RANGE mode with an offset boundary of
+# FOLLOWING, because execution requires a column in this case.
+norm expect-not=SimplifyWindowOrdering
+SELECT rank() OVER (ORDER BY k RANGE BETWEEN 1 FOLLOWING AND 3 FOLLOWING) FROM a WHERE false
+----
+values
+ ├── columns: rank:7!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(7)
+
 # PushSelectIntoWindow
 
 norm expect=PushSelectIntoWindow

--- a/pkg/sql/opt/norm/window_funcs.go
+++ b/pkg/sql/opt/norm/window_funcs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // MakeSegmentedOrdering returns an ordering choice which satisfies both
@@ -147,4 +148,16 @@ func (c *CustomFuncs) OrderingSucceeded(result *physical.OrderingChoice) bool {
 // DerefOrderingChoice returns an OrderingChoice from a pointer.
 func (c *CustomFuncs) DerefOrderingChoice(result *physical.OrderingChoice) physical.OrderingChoice {
 	return *result
+}
+
+// HasRangeFrameWithOffset returns true if w contains a WindowsItem Frame that
+// has a mode of RANGE and has a specific offset, such as OffsetPreceding or
+// OffsetFollowing.
+func (c *CustomFuncs) HasRangeFrameWithOffset(w memo.WindowsExpr) bool {
+	for i := range w {
+		if w[i].Frame.Mode == tree.RANGE && w[i].Frame.HasOffset() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -938,14 +938,6 @@ define WindowPrivate {
     # Ordering is the ordering that the window function is computed relative to
     # within each partition.
     Ordering OrderingChoice
-
-    # RangeOffsetColumn is the column ID of a single column from ORDER BY
-    # clause (when there is only one column). We store it separately because
-    # Ordering might be simplified (when that single column is in Partition),
-    # but the execution still needs to know the original ordering with RANGE
-    # mode of framing when at least one of the bounds has "offset". This column
-    # ID is used to reconstruct the Ordering during exec build phase.
-    RangeOffsetColumn ColumnID
 }
 
 # With executes Binding, making its results available to Main. Within Main, the

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -458,17 +458,12 @@ func (b *Builder) findMatchingFrameIndex(
 		}
 	}
 
-	var rangeOffsetColumn opt.ColumnID
-	if len(ordering.Columns) == 1 {
-		rangeOffsetColumn = ordering.Columns[0].AnyID()
-	}
 	// If we can't reuse an existing frame, make a new one.
 	if frameIdx == -1 {
 		*frames = append(*frames, memo.WindowExpr{
 			WindowPrivate: memo.WindowPrivate{
-				Partition:         partition,
-				Ordering:          ordering,
-				RangeOffsetColumn: rangeOffsetColumn,
+				Partition: partition,
+				Ordering:  ordering,
 			},
 			Windows: memo.WindowsExpr{},
 		})

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -998,17 +998,9 @@ func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec
 		if len(wi.Ordering) == 0 {
 			frame := p.funcs[i].frame
 			if frame.Mode == tree.RANGE && frame.Bounds.HasOffset() {
-				// We have an empty ordering, but RANGE mode when at least one bound
-				// has 'offset' requires a single column in ORDER BY. We have optimized
-				// it out, but the execution still needs information about which column
-				// it was, so we reconstruct the "original" ordering (note that the
-				// direction of the ordering doesn't actually matter, so we leave it
-				// with the default value).
-				p.funcs[i].columnOrdering = colinfo.ColumnOrdering{
-					colinfo.ColumnOrderInfo{
-						ColIdx: int(wi.RangeOffsetColumn),
-					},
-				}
+				// Execution requires a single column to order by when there is
+				// a RANGE mode frame with at least one 'offset' bound.
+				return nil, errors.AssertionFailedf("a RANGE mode frame with an offset bound must have an ORDER BY column")
 			}
 		}
 

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -838,6 +838,11 @@ const (
 	UnboundedFollowing
 )
 
+// IsOffset returns true if the WindowFrameBoundType is an offset.
+func (ft WindowFrameBoundType) IsOffset() bool {
+	return ft == OffsetPreceding || ft == OffsetFollowing
+}
+
 // WindowFrameBound specifies the offset and the type of boundary.
 type WindowFrameBound struct {
 	BoundType  WindowFrameBoundType
@@ -846,7 +851,7 @@ type WindowFrameBound struct {
 
 // HasOffset returns whether node contains an offset.
 func (node *WindowFrameBound) HasOffset() bool {
-	return node.BoundType == OffsetPreceding || node.BoundType == OffsetFollowing
+	return node.BoundType.IsOffset()
 }
 
 // WindowFrameBounds specifies boundaries of the window frame.


### PR DESCRIPTION
This commit updates the SimplifyWindowOrdering normalization rule so
that it does not apply to window functions that have a RANGE mode with a
specific frame offset boundary of PRECEDING or FOLLOWING. The execution
engine panics if an ordering column is not provided in this case, even
if the ordering is a constant ordering.

This provides a more robust solution to the original issue that #44666
attempted to fix. That solution did not cover all edge cases because it
did not consider that the stored RangeOffsetColumn could be pruned if
there were no other references to it. This case is rare and it is often
hidden by other optimizations that eliminate a window function with a
cardinality of zero. But it is possible; see the added logic tests for
examples.

This commit reverts some of the changes from #44666 because they are no
longer necessary.

Fixes #53442

Release justification: This is a high-priority fix for a bug in WINDOW
functions that causes panics.

Release note (bug fix): A bug was fixed that caused a crash when using a
RANGE mode window function with an offset in some cases, e.g, OVER
(PARTITION BY b ORDER BY a RANGE 1 PRECEDING).