### PR TITLE
sql: plumb proper context in a few places

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -345,7 +345,7 @@ func (b *memBuffer) getRow(ctx context.Context) (tree.Datums, error) {
 		b.mu.Lock()
 		if b.mu.entries.Len() > 0 {
 			row = b.mu.entries.At(0)
-			b.mu.entries.PopFirst()
+			b.mu.entries.PopFirst(ctx)
 		}
 		b.mu.Unlock()
 		if row != nil {

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -626,7 +626,7 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 0); err != nil {
 				return r, err
 			}
-			scanOp, err := colfetcher.NewColBatchScan(streamingAllocator, flowCtx, core.TableReader, post)
+			scanOp, err := colfetcher.NewColBatchScan(ctx, streamingAllocator, flowCtx, core.TableReader, post)
 			if err != nil {
 				return r, err
 			}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -64,9 +64,7 @@ var _ execinfra.IOReader = &ColBatchScan{}
 
 // Init initializes a ColBatchScan.
 func (s *ColBatchScan) Init() {
-	s.ctx = context.Background()
 	s.init = true
-
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
 		s.ctx, s.flowCtx.Txn, s.spans,
@@ -125,6 +123,7 @@ func (s *ColBatchScan) GetBytesRead() int64 {
 
 // NewColBatchScan creates a new ColBatchScan operator.
 func NewColBatchScan(
+	ctx context.Context,
 	allocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	spec *execinfrapb.TableReaderSpec,
@@ -199,6 +198,7 @@ func NewColBatchScan(
 		spans[i] = spec.Spans[i].Span
 	}
 	return &ColBatchScan{
+		ctx:       ctx,
 		spans:     spans,
 		flowCtx:   flowCtx,
 		rf:        &fetcher,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -155,7 +155,7 @@ func NewDistSQLPlanner(
 		metadataTestTolerance: execinfra.NoExplain,
 	}
 
-	dsp.initRunners()
+	dsp.initRunners(ctx)
 	return dsp
 }
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -92,12 +92,12 @@ func (req runnerRequest) run() {
 	req.resultChan <- res
 }
 
-func (dsp *DistSQLPlanner) initRunners() {
+func (dsp *DistSQLPlanner) initRunners(ctx context.Context) {
 	// This channel has to be unbuffered because we want to only be able to send
 	// requests if a worker is actually there to receive them.
 	dsp.runnerChan = make(chan runnerRequest)
 	for i := 0; i < numRunners; i++ {
-		dsp.stopper.RunWorker(context.TODO(), func(context.Context) {
+		dsp.stopper.RunWorker(ctx, func(context.Context) {
 			runnerChan := dsp.runnerChan
 			stopChan := dsp.stopper.ShouldStop()
 			for {
@@ -915,7 +915,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		var result tree.DTuple
 		for rows.Len() > 0 {
 			row := rows.At(0)
-			rows.PopFirst()
+			rows.PopFirst(ctx)
 			if row.Len() == 1 {
 				// This seems hokey, but if we don't do this then the subquery expands
 				// to a tuple of tuples instead of a tuple of values and an expression

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -277,7 +277,7 @@ func (c *RowContainer) Swap(i, j int) {
 }
 
 // PopFirst discards the first row in the RowContainer.
-func (c *RowContainer) PopFirst() {
+func (c *RowContainer) PopFirst(ctx context.Context) {
 	if c.numRows == 0 {
 		panic("no rows added to container, nothing to pop")
 	}
@@ -295,10 +295,7 @@ func (c *RowContainer) PopFirst() {
 			c.chunks[0] = nil
 			c.deletedRows = 0
 			c.chunks = c.chunks[1:]
-
-			// We don't have a context plumbed here, but that's ok: it's not actually
-			// used in the shrink paths.
-			c.memAcc.Shrink(context.TODO(), size)
+			c.memAcc.Shrink(ctx, size)
 		}
 	}
 }

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -314,14 +314,16 @@ func (i *memRowIterator) Close() {}
 // rows as soon as they are iterated over to free up memory eagerly.
 type memRowFinalIterator struct {
 	*MemRowContainer
+
+	ctx context.Context
 }
 
 // NewFinalIterator returns an iterator that can be used to iterate over a
 // MemRowContainer. Note that this iterator doesn't iterate over a snapshot
 // of MemRowContainer and that it deletes rows as soon as they are iterated
 // over.
-func (mc *MemRowContainer) NewFinalIterator(_ context.Context) RowIterator {
-	return memRowFinalIterator{MemRowContainer: mc}
+func (mc *MemRowContainer) NewFinalIterator(ctx context.Context) RowIterator {
+	return memRowFinalIterator{MemRowContainer: mc, ctx: ctx}
 }
 
 // GetRow implements IndexedRowContainer.
@@ -341,7 +343,7 @@ func (i memRowFinalIterator) Valid() (bool, error) {
 
 // Next implements the RowIterator interface.
 func (i memRowFinalIterator) Next() {
-	i.PopFirst()
+	i.PopFirst(i.ctx)
 }
 
 // Row implements the RowIterator interface.

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -124,7 +124,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	// Now pop the rows, which shrinks the memory account according to the current
 	// row sizes. If we did not account for the larger rows, this will panic.
 	for mc.Len() > 0 {
-		mc.PopFirst()
+		mc.PopFirst(ctx)
 	}
 }
 

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -422,7 +422,7 @@ func (h *hashJoiner) readProbeSide() (
 	// First process the rows that were already buffered.
 	if h.rows[side].Len() > 0 {
 		row = h.rows[side].EncRow(0)
-		h.rows[side].PopFirst()
+		h.rows[side].PopFirst(h.Ctx)
 	} else {
 		var meta *execinfrapb.ProducerMetadata
 		var emitDirectly bool

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -274,7 +274,7 @@ func (v *vTableLookupJoinNode) Next(params runParams) (bool, error) {
 		// Check if there are any rows left to emit from the last input row.
 		if v.run.rows.Len() > 0 {
 			v.run.row = v.run.rows.At(0)
-			v.run.rows.PopFirst()
+			v.run.rows.PopFirst(params.ctx)
 			return true, nil
 		}
 


### PR DESCRIPTION
This commit plumbs proper context object in several places instead of
`context.TODO` and `context.Background`.

Fixes: #53696.

Release justification: low risk, high benefit changes (we'll be able to
see the statement in the sentry report).

Release note: None