### PR TITLE
tree: fix window functions in an edge case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3804,3 +3804,20 @@ SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dis
 0  2  2  2  1  1
 1  1  1  1  0  0.5
 1  2  2  2  1  1
+
+# Regression test for peer group number computation overflow (#53654).
+query II rowsort
+SELECT
+  max(k) OVER (w GROUPS BETWEEN 9223372036854775807 FOLLOWING AND UNBOUNDED FOLLOWING),
+  max(k) OVER (w GROUPS BETWEEN UNBOUNDED PRECEDING AND 9223372036854775807 FOLLOWING)
+FROM kv WINDOW w AS (PARTITION BY b ORDER BY v)
+----
+NULL  11
+NULL  11
+NULL  11
+NULL  8
+NULL  8
+NULL  7
+NULL  7
+NULL  7
+NULL  7

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -234,7 +234,7 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 			offset := MustBeDInt(wfr.StartBoundOffset)
 			peerGroupNum := wfr.CurRowPeerGroupNum + int(offset)
 			lastPeerGroupNum := wfr.PeerHelper.GetLastPeerGroupNum()
-			if peerGroupNum > lastPeerGroupNum {
+			if peerGroupNum > lastPeerGroupNum || peerGroupNum < 0 {
 				// peerGroupNum is out of bounds, so we return the index of the first
 				// row after the partition.
 				return wfr.unboundedFollowing(), nil
@@ -413,7 +413,7 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 			offset := MustBeDInt(wfr.EndBoundOffset)
 			peerGroupNum := wfr.CurRowPeerGroupNum + int(offset)
 			lastPeerGroupNum := wfr.PeerHelper.GetLastPeerGroupNum()
-			if peerGroupNum > lastPeerGroupNum {
+			if peerGroupNum > lastPeerGroupNum || peerGroupNum < 0 {
 				// peerGroupNum is out of bounds, so we return the index of the first
 				// row after the partition.
 				return wfr.unboundedFollowing(), nil


### PR DESCRIPTION
Fixes: #53654.

Release justification: bug fix.

Release note (bug fix): CockroachDB could previously crash when
evaluating queries with window functions with GROUPS mode of framing
when OFFSET FOLLOWING boundary was used and when the offset was a very
large value such that it could result in an integer overflow. This is
now fixed.