### PR TITLE
bulkio: Fix schedule retry logic.

### DIFF
--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -153,8 +153,7 @@ func (e *scheduledBackupExecutor) NotifyJobTermination(
 		"backup job %d scheduled by %d failed with status %s",
 		jobID, schedule.ScheduleID(), jobStatus)
 	log.Errorf(ctx, "backup error: %v	", err)
-	jobs.DefaultHandleFailedRun(schedule, jobID, err)
-
+	jobs.DefaultHandleFailedRun(schedule, "backup job %d failed with err=%v", jobID, err)
 	return nil
 }
 

--- a/pkg/jobs/executor_impl.go
+++ b/pkg/jobs/executor_impl.go
@@ -81,7 +81,7 @@ func (e *inlineScheduledJobExecutor) NotifyJobTermination(
 ) error {
 	// For now, only interested in failed status.
 	if jobStatus == StatusFailed {
-		DefaultHandleFailedRun(schedule, jobID, nil)
+		DefaultHandleFailedRun(schedule, "job %d failed", jobID)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #53227

Handle schedule execution errors based on the schedules
error handling setting.

Prior to this change, we only handled errors encountered
during schedule job execution.  Now, we treat errors encountered
while planning execution the same way.

Release Notes: None

Release Justification: Low impact bug fix