### PR TITLE
release-19.2: stats: fix and unskip flaky test TestCreateStatsProgress

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -548,6 +549,13 @@ func TestCreateStatsProgress(t *testing.T) {
 			fractionCompleted,
 		)
 	}
+
+	// Invalidate the stats cache so that we can be sure to get the latest stats.
+	var tableID sqlbase.ID
+	sqlDB.QueryRow(t, `SELECT id FROM system.namespace WHERE name = 't'`).Scan(&tableID)
+	tc.Servers[0].ExecutorConfig().(sql.ExecutorConfig).TableStatsCache.InvalidateTableStats(
+		ctx, tableID,
+	)
 
 	// Start another CREATE STATISTICS run and wait until it has scanned part of
 	// the table.


### PR DESCRIPTION
Backport 1/1 commits from #53681.

/cc @cockroachdb/release

---

Release justification: non-production code changes

This commit fixes the flaky test `TestCreateStatsProgress` and unskips
it. `TestCreateStatsProgress` was flaky because of the recent changes to
the stats cache, which removed the guarantee that fresh stats would be
available in the cache immediately after stats creation. This commit
fixes the issue by explicitly invalidating the stats cache before the
part of `TestCreateStatsProgress` that expects certain stats to be present.

Fixes #52782

Release note: None
