### PR TITLE
colfetcher: fix recent typo

### DIFF
--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -60,6 +60,7 @@ type ColBatchScan struct {
 	ResultTypes []*types.T
 }
 
+var _ colexecbase.Operator = &ColBatchScan{}
 var _ execinfra.IOReader = &ColBatchScan{}
 
 // Init initializes a ColBatchScan.


### PR DESCRIPTION
In #53371 I mistakenly removed one type assertion.

Release justification: non-production code changes.

Release note: None