### PR TITLE
sql: create and fill `crdb_internal.node_transaction_statistics` table

### DIFF
--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -40,6 +40,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/1/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/1/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
@@ -128,6 +129,9 @@ writing: debug/nodes/2/crdb_internal.node_sessions.txt.err.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt
 writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt.err.txt
   ^- resulted in ...
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/2/crdb_internal.node_transaction_statistics.txt
+writing: debug/nodes/2/crdb_internal.node_transaction_statistics.txt.err.txt
+  ^- resulted in ...
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/2/crdb_internal.node_transactions.txt
 writing: debug/nodes/2/crdb_internal.node_transactions.txt.err.txt
   ^- resulted in ...
@@ -168,6 +172,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/3/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/3/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/3/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/3/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/3/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/3/details... writing: debug/nodes/3/details.json

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -40,6 +40,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/1/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/1/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
@@ -105,6 +106,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/3/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/3/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/3/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/3/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/3/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/3/details... writing: debug/nodes/3/details.json

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -40,6 +40,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/1/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/1/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
@@ -104,6 +105,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/3/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/3/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/3/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/3/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/3/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/3/details... writing: debug/nodes/3/details.json

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -42,6 +42,7 @@ retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crd
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
 retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
 retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transaction_statistics... writing: debug/nodes/1/crdb_internal.node_transaction_statistics.txt
 retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/1/crdb_internal.node_transactions.txt
 retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
 requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -96,6 +96,7 @@ var debugZipTablesPerNode = []string{
 	"crdb_internal.node_runtime_info",
 	"crdb_internal.node_sessions",
 	"crdb_internal.node_statement_statistics",
+	"crdb_internal.node_transaction_statistics",
 	"crdb_internal.node_transactions",
 	"crdb_internal.node_txn_stats",
 }

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -78,6 +78,7 @@ const (
 	CrdbInternalTableIndexesTableID
 	CrdbInternalTablesTableID
 	CrdbInternalTablesTableLastStatsID
+	CrdbInternalTransactionStatsTableID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalZonesTableID
 	InformationSchemaID

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -11,46 +11,47 @@ DROP DATABASE crdb_internal
 query TTTI
 SHOW TABLES FROM crdb_internal
 ----
-crdb_internal  backward_dependencies      table  NULL
-crdb_internal  builtin_functions          table  NULL
-crdb_internal  cluster_queries            table  NULL
-crdb_internal  cluster_sessions           table  NULL
-crdb_internal  cluster_settings           table  NULL
-crdb_internal  cluster_transactions       table  NULL
-crdb_internal  create_statements          table  NULL
-crdb_internal  create_type_statements     table  NULL
-crdb_internal  databases                  table  NULL
-crdb_internal  feature_usage              table  NULL
-crdb_internal  forward_dependencies       table  NULL
-crdb_internal  gossip_alerts              table  NULL
-crdb_internal  gossip_liveness            table  NULL
-crdb_internal  gossip_network             table  NULL
-crdb_internal  gossip_nodes               table  NULL
-crdb_internal  index_columns              table  NULL
-crdb_internal  jobs                       table  NULL
-crdb_internal  kv_node_status             table  NULL
-crdb_internal  kv_store_status            table  NULL
-crdb_internal  leases                     table  NULL
-crdb_internal  node_build_info            table  NULL
-crdb_internal  node_metrics               table  NULL
-crdb_internal  node_queries               table  NULL
-crdb_internal  node_runtime_info          table  NULL
-crdb_internal  node_sessions              table  NULL
-crdb_internal  node_statement_statistics  table  NULL
-crdb_internal  node_transactions          table  NULL
-crdb_internal  node_txn_stats             table  NULL
-crdb_internal  partitions                 table  NULL
-crdb_internal  predefined_comments        table  NULL
-crdb_internal  ranges                     view   NULL
-crdb_internal  ranges_no_leases           table  NULL
-crdb_internal  schema_changes             table  NULL
-crdb_internal  session_trace              table  NULL
-crdb_internal  session_variables          table  NULL
-crdb_internal  table_columns              table  NULL
-crdb_internal  table_indexes              table  NULL
-crdb_internal  table_row_statistics       table  NULL
-crdb_internal  tables                     table  NULL
-crdb_internal  zones                      table  NULL
+crdb_internal  backward_dependencies        table  NULL
+crdb_internal  builtin_functions            table  NULL
+crdb_internal  cluster_queries              table  NULL
+crdb_internal  cluster_sessions             table  NULL
+crdb_internal  cluster_settings             table  NULL
+crdb_internal  cluster_transactions         table  NULL
+crdb_internal  create_statements            table  NULL
+crdb_internal  create_type_statements       table  NULL
+crdb_internal  databases                    table  NULL
+crdb_internal  feature_usage                table  NULL
+crdb_internal  forward_dependencies         table  NULL
+crdb_internal  gossip_alerts                table  NULL
+crdb_internal  gossip_liveness              table  NULL
+crdb_internal  gossip_network               table  NULL
+crdb_internal  gossip_nodes                 table  NULL
+crdb_internal  index_columns                table  NULL
+crdb_internal  jobs                         table  NULL
+crdb_internal  kv_node_status               table  NULL
+crdb_internal  kv_store_status              table  NULL
+crdb_internal  leases                       table  NULL
+crdb_internal  node_build_info              table  NULL
+crdb_internal  node_metrics                 table  NULL
+crdb_internal  node_queries                 table  NULL
+crdb_internal  node_runtime_info            table  NULL
+crdb_internal  node_sessions                table  NULL
+crdb_internal  node_statement_statistics    table  NULL
+crdb_internal  node_transaction_statistics  table  NULL
+crdb_internal  node_transactions            table  NULL
+crdb_internal  node_txn_stats               table  NULL
+crdb_internal  partitions                   table  NULL
+crdb_internal  predefined_comments          table  NULL
+crdb_internal  ranges                       view   NULL
+crdb_internal  ranges_no_leases             table  NULL
+crdb_internal  schema_changes               table  NULL
+crdb_internal  session_trace                table  NULL
+crdb_internal  session_variables            table  NULL
+crdb_internal  table_columns                table  NULL
+crdb_internal  table_indexes                table  NULL
+crdb_internal  table_row_statistics         table  NULL
+crdb_internal  tables                       table  NULL
+crdb_internal  zones                        table  NULL
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)
@@ -132,6 +133,11 @@ query ITTTTIIITFFFFFFFFFFFFFFFFF colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
 node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  implicit_txn
+
+query ITTTIIRRRRRRRR colnames
+SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0
+----
+node_id  application_name  key  statement_ids  count  max_retries  service_lat_avg  service_lat_var  retry_lat_avg  retry_lat_var  commit_lat_avg  commit_lat_var  rows_read_avg  rows_read_var
 
 query IITTTTTTT colnames
 SELECT * FROM crdb_internal.session_trace WHERE span_idx < 0
@@ -636,3 +642,34 @@ SELECT * FROM crdb_internal.create_type_statements
 52  test  public  62  enum2  CREATE TYPE public.enum2 AS ENUM ()              {}
 
 # Test the virtual index as well.
+
+statement ok
+SET application_name = "test_txn_statistics"
+
+statement ok
+CREATE TABLE t_53504()
+
+statement ok
+BEGIN; SELECT * FROM t_53504; SELECT * FROM t_53504; SELECT * FROM t_53504; COMMIT;
+
+statement ok
+BEGIN; SELECT * FROM t_53504; SELECT * FROM t_53504; COMMIT;
+
+statement ok
+BEGIN; SELECT * FROM t_53504; SELECT * FROM t_53504; COMMIT;
+
+statement ok
+BEGIN; SELECT * FROM t_53504; COMMIT;
+
+statement ok
+SELECT * FROM t_53504
+
+query ITTTI colnames
+SELECT node_id, application_name, key, statement_ids, count FROM crdb_internal.node_transaction_statistics where application_name = 'test_txn_statistics'
+----
+node_id  application_name     key                               statement_ids                                                                                         count
+1        test_txn_statistics  02c92b698a5cb4c59708e7de50bdbf53  {7d5470c38539309ff3b933fec35fefad,7d5470c38539309ff3b933fec35fefad,7d5470c38539309ff3b933fec35fefad}  1
+1        test_txn_statistics  5a29a80adae483c4cfa89f5b228682fb  {94a482186de515de23eca3d1b443e033}                                                                    1
+1        test_txn_statistics  8199fcfefafda1121b286c08b21559c3  {7d5470c38539309ff3b933fec35fefad}                                                                    1
+1        test_txn_statistics  cb83bd7423a1016e148d2d9a6d89427d  {7d5470c38539309ff3b933fec35fefad,7d5470c38539309ff3b933fec35fefad}                                   2
+1        test_txn_statistics  cd8858558756fb4a4917ccfface8c12b  {ca672b3b015c5f7ca3b4d8488eb2f528}                                                                    1

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -62,6 +62,7 @@ test           crdb_internal       node_queries                       public   S
 test           crdb_internal       node_runtime_info                  public   SELECT
 test           crdb_internal       node_sessions                      public   SELECT
 test           crdb_internal       node_statement_statistics          public   SELECT
+test           crdb_internal       node_transaction_statistics        public   SELECT
 test           crdb_internal       node_transactions                  public   SELECT
 test           crdb_internal       node_txn_stats                     public   SELECT
 test           crdb_internal       partitions                         public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -246,6 +246,7 @@ crdb_internal       node_queries
 crdb_internal       node_runtime_info
 crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
+crdb_internal       node_transaction_statistics
 crdb_internal       node_transactions
 crdb_internal       node_txn_stats
 crdb_internal       partitions
@@ -397,6 +398,7 @@ node_queries
 node_runtime_info
 node_sessions
 node_statement_statistics
+node_transaction_statistics
 node_transactions
 node_txn_stats
 partitions
@@ -556,6 +558,7 @@ system         crdb_internal       node_queries                       SYSTEM VIE
 system         crdb_internal       node_runtime_info                  SYSTEM VIEW  NO                  1
 system         crdb_internal       node_sessions                      SYSTEM VIEW  NO                  1
 system         crdb_internal       node_statement_statistics          SYSTEM VIEW  NO                  1
+system         crdb_internal       node_transaction_statistics        SYSTEM VIEW  NO                  1
 system         crdb_internal       node_transactions                  SYSTEM VIEW  NO                  1
 system         crdb_internal       node_txn_stats                     SYSTEM VIEW  NO                  1
 system         crdb_internal       partitions                         SYSTEM VIEW  NO                  1
@@ -1662,6 +1665,7 @@ NULL     public   system         crdb_internal       node_queries               
 NULL     public   system         crdb_internal       node_runtime_info                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          YES
+NULL     public   system         crdb_internal       node_transaction_statistics        SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_transactions                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_txn_stats                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          YES
@@ -2038,6 +2042,7 @@ NULL     public   system         crdb_internal       node_queries               
 NULL     public   system         crdb_internal       node_runtime_info                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          YES
+NULL     public   system         crdb_internal       node_transaction_statistics        SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_transactions                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_txn_stats                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -945,8 +945,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967220  2143281868  0         4294967222  450499961  0            n
-4294967220  4089604113  0         4294967222  450499960  0            n
+4294967219  2143281868  0         4294967221  450499961  0            n
+4294967219  4089604113  0         4294967221  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -958,7 +958,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967220  4294967222  pg_constraint  pg_class
+4294967219  4294967221  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1628,121 +1628,122 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967222  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967222  0         built-in functions (RAM/static)
-4294967291  4294967222  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967222  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967222  0         cluster settings (RAM)
-4294967290  4294967222  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967222  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967222  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967222  0         databases accessible by the current user (KV scan)
-4294967284  4294967222  0         telemetry counters (RAM; local node only)
-4294967283  4294967222  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967222  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967222  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967222  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967222  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967222  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967277  4294967222  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967222  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967222  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967222  0         acquired table leases (RAM; local node only)
-4294967293  4294967222  0         detailed identification strings (RAM, local node only)
-4294967270  4294967222  0         current values for metrics (RAM; local node only)
-4294967273  4294967222  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967222  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967222  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967222  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967222  0         running user transactions visible by the current user (RAM; local node only)
-4294967256  4294967222  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967222  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967222  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967222  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967222  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967222  0         session trace accumulated so far (RAM)
-4294967262  4294967222  0         session variables (RAM)
-4294967260  4294967222  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967222  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967222  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967222  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967255  4294967222  0         decoded zone configurations from system.zones (KV scan)
-4294967253  4294967222  0         roles for which the current user has admin option
-4294967252  4294967222  0         roles available to the current user
-4294967251  4294967222  0         check constraints
-4294967250  4294967222  0         column privilege grants (incomplete)
-4294967248  4294967222  0         columns with user defined types
-4294967249  4294967222  0         table and view columns (incomplete)
-4294967247  4294967222  0         columns usage by constraints
-4294967246  4294967222  0         roles for the current user
-4294967245  4294967222  0         column usage by indexes and key constraints
-4294967244  4294967222  0         built-in function parameters (empty - introspection not yet supported)
-4294967243  4294967222  0         foreign key constraints
-4294967242  4294967222  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967241  4294967222  0         built-in functions (empty - introspection not yet supported)
-4294967239  4294967222  0         schema privileges (incomplete; may contain excess users or roles)
-4294967240  4294967222  0         database schemas (may contain schemata without permission)
-4294967238  4294967222  0         sequences
-4294967237  4294967222  0         index metadata and statistics (incomplete)
-4294967236  4294967222  0         table constraints
-4294967235  4294967222  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967234  4294967222  0         tables and views
-4294967232  4294967222  0         grantable privileges (incomplete)
-4294967233  4294967222  0         views (incomplete)
-4294967230  4294967222  0         aggregated built-in functions (incomplete)
-4294967229  4294967222  0         index access methods (incomplete)
-4294967228  4294967222  0         column default values
-4294967227  4294967222  0         table columns (incomplete - see also information_schema.columns)
-4294967225  4294967222  0         role membership
-4294967226  4294967222  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967224  4294967222  0         available extensions
-4294967223  4294967222  0         casts (empty - needs filling out)
-4294967222  4294967222  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967221  4294967222  0         available collations (incomplete)
-4294967220  4294967222  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967219  4294967222  0         encoding conversions (empty - unimplemented)
-4294967218  4294967222  0         available databases (incomplete)
-4294967217  4294967222  0         default ACLs (empty - unimplemented)
-4294967216  4294967222  0         dependency relationships (incomplete)
-4294967215  4294967222  0         object comments
-4294967213  4294967222  0         enum types and labels (empty - feature does not exist)
-4294967212  4294967222  0         event triggers (empty - feature does not exist)
-4294967211  4294967222  0         installed extensions (empty - feature does not exist)
-4294967210  4294967222  0         foreign data wrappers (empty - feature does not exist)
-4294967209  4294967222  0         foreign servers (empty - feature does not exist)
-4294967208  4294967222  0         foreign tables (empty  - feature does not exist)
-4294967207  4294967222  0         indexes (incomplete)
-4294967206  4294967222  0         index creation statements
-4294967205  4294967222  0         table inheritance hierarchy (empty - feature does not exist)
-4294967204  4294967222  0         available languages (empty - feature does not exist)
-4294967203  4294967222  0         locks held by active processes (empty - feature does not exist)
-4294967202  4294967222  0         available materialized views (empty - feature does not exist)
-4294967201  4294967222  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967200  4294967222  0         operators (incomplete)
-4294967199  4294967222  0         prepared statements
-4294967198  4294967222  0         prepared transactions (empty - feature does not exist)
-4294967197  4294967222  0         built-in functions (incomplete)
-4294967196  4294967222  0         range types (empty - feature does not exist)
-4294967195  4294967222  0         rewrite rules (empty - feature does not exist)
-4294967194  4294967222  0         database roles
-4294967181  4294967222  0         security labels (empty - feature does not exist)
-4294967193  4294967222  0         security labels (empty)
-4294967192  4294967222  0         sequences (see also information_schema.sequences)
-4294967191  4294967222  0         session variables (incomplete)
-4294967190  4294967222  0         shared dependencies (empty - not implemented)
-4294967214  4294967222  0         shared object comments
-4294967180  4294967222  0         shared security labels (empty - feature not supported)
-4294967182  4294967222  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967187  4294967222  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967186  4294967222  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967185  4294967222  0         triggers (empty - feature does not exist)
-4294967184  4294967222  0         scalar types (incomplete)
-4294967189  4294967222  0         database users
-4294967188  4294967222  0         local to remote user mapping (empty - feature does not exist)
-4294967183  4294967222  0         view definitions (incomplete - see also information_schema.views)
-4294967178  4294967222  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967177  4294967222  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967176  4294967222  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967221  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967221  0         built-in functions (RAM/static)
+4294967291  4294967221  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967221  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967221  0         cluster settings (RAM)
+4294967290  4294967221  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967221  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967221  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967221  0         databases accessible by the current user (KV scan)
+4294967284  4294967221  0         telemetry counters (RAM; local node only)
+4294967283  4294967221  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967221  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967221  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967221  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967221  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967221  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967277  4294967221  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967221  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967221  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967221  0         acquired table leases (RAM; local node only)
+4294967293  4294967221  0         detailed identification strings (RAM, local node only)
+4294967270  4294967221  0         current values for metrics (RAM; local node only)
+4294967273  4294967221  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967221  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967221  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967221  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967256  4294967221  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967221  0         running user transactions visible by the current user (RAM; local node only)
+4294967255  4294967221  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967221  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967221  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967221  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967221  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967221  0         session trace accumulated so far (RAM)
+4294967262  4294967221  0         session variables (RAM)
+4294967260  4294967221  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967221  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967221  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967221  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967254  4294967221  0         decoded zone configurations from system.zones (KV scan)
+4294967252  4294967221  0         roles for which the current user has admin option
+4294967251  4294967221  0         roles available to the current user
+4294967250  4294967221  0         check constraints
+4294967249  4294967221  0         column privilege grants (incomplete)
+4294967247  4294967221  0         columns with user defined types
+4294967248  4294967221  0         table and view columns (incomplete)
+4294967246  4294967221  0         columns usage by constraints
+4294967245  4294967221  0         roles for the current user
+4294967244  4294967221  0         column usage by indexes and key constraints
+4294967243  4294967221  0         built-in function parameters (empty - introspection not yet supported)
+4294967242  4294967221  0         foreign key constraints
+4294967241  4294967221  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967240  4294967221  0         built-in functions (empty - introspection not yet supported)
+4294967238  4294967221  0         schema privileges (incomplete; may contain excess users or roles)
+4294967239  4294967221  0         database schemas (may contain schemata without permission)
+4294967237  4294967221  0         sequences
+4294967236  4294967221  0         index metadata and statistics (incomplete)
+4294967235  4294967221  0         table constraints
+4294967234  4294967221  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967233  4294967221  0         tables and views
+4294967231  4294967221  0         grantable privileges (incomplete)
+4294967232  4294967221  0         views (incomplete)
+4294967229  4294967221  0         aggregated built-in functions (incomplete)
+4294967228  4294967221  0         index access methods (incomplete)
+4294967227  4294967221  0         column default values
+4294967226  4294967221  0         table columns (incomplete - see also information_schema.columns)
+4294967224  4294967221  0         role membership
+4294967225  4294967221  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967223  4294967221  0         available extensions
+4294967222  4294967221  0         casts (empty - needs filling out)
+4294967221  4294967221  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967220  4294967221  0         available collations (incomplete)
+4294967219  4294967221  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967218  4294967221  0         encoding conversions (empty - unimplemented)
+4294967217  4294967221  0         available databases (incomplete)
+4294967216  4294967221  0         default ACLs (empty - unimplemented)
+4294967215  4294967221  0         dependency relationships (incomplete)
+4294967214  4294967221  0         object comments
+4294967212  4294967221  0         enum types and labels (empty - feature does not exist)
+4294967211  4294967221  0         event triggers (empty - feature does not exist)
+4294967210  4294967221  0         installed extensions (empty - feature does not exist)
+4294967209  4294967221  0         foreign data wrappers (empty - feature does not exist)
+4294967208  4294967221  0         foreign servers (empty - feature does not exist)
+4294967207  4294967221  0         foreign tables (empty  - feature does not exist)
+4294967206  4294967221  0         indexes (incomplete)
+4294967205  4294967221  0         index creation statements
+4294967204  4294967221  0         table inheritance hierarchy (empty - feature does not exist)
+4294967203  4294967221  0         available languages (empty - feature does not exist)
+4294967202  4294967221  0         locks held by active processes (empty - feature does not exist)
+4294967201  4294967221  0         available materialized views (empty - feature does not exist)
+4294967200  4294967221  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967199  4294967221  0         operators (incomplete)
+4294967198  4294967221  0         prepared statements
+4294967197  4294967221  0         prepared transactions (empty - feature does not exist)
+4294967196  4294967221  0         built-in functions (incomplete)
+4294967195  4294967221  0         range types (empty - feature does not exist)
+4294967194  4294967221  0         rewrite rules (empty - feature does not exist)
+4294967193  4294967221  0         database roles
+4294967180  4294967221  0         security labels (empty - feature does not exist)
+4294967192  4294967221  0         security labels (empty)
+4294967191  4294967221  0         sequences (see also information_schema.sequences)
+4294967190  4294967221  0         session variables (incomplete)
+4294967189  4294967221  0         shared dependencies (empty - not implemented)
+4294967213  4294967221  0         shared object comments
+4294967179  4294967221  0         shared security labels (empty - feature not supported)
+4294967181  4294967221  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967186  4294967221  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967185  4294967221  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967184  4294967221  0         triggers (empty - feature does not exist)
+4294967183  4294967221  0         scalar types (incomplete)
+4294967188  4294967221  0         database users
+4294967187  4294967221  0         local to remote user mapping (empty - feature does not exist)
+4294967182  4294967221  0         view definitions (incomplete - see also information_schema.views)
+4294967177  4294967221  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967176  4294967221  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967175  4294967221  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -558,6 +558,7 @@ node_queries                       NULL
 node_runtime_info                  NULL
 node_sessions                      NULL
 node_statement_statistics          NULL
+node_transaction_statistics        NULL
 node_transactions                  NULL
 node_txn_stats                     NULL
 partitions                         NULL


### PR DESCRIPTION
Previously there was no way to query the transaction level metrics
collected by individual nodes. This patch adds this capability by
exposing a new internal table called
`crdb_internal.node_transaction_statistics` which is analagous to
`crdb_internal.node_statement_statistics` albeit for transactions.

Closes #53504

Release justification: low risk update to new functionality
Release note (sql change): A new crdb_internal table called
`node_transaction_statistics` is exposed as part of this change,
which allows users to query transaction metrics collected on a
particular node.