### PR TITLE
backupccl: rename backup manifest file

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -521,14 +521,14 @@ func TestBackupRestoreAppend(t *testing.T) {
 	// Find the backup times in the collection and try RESTORE'ing to each, and
 	// within each also check if we can restore to individual times captured with
 	// incremental backups that were appended to that backup.
-	full1, full2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "*/*/*/BACKUP"))
+	full1, full2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "*/*/*/"+backupManifestName))
 	runRestores(collections, full1, full2)
 
 	// Find the full-backups written to the specified subdirectories, and within
 	// each also check if we can restore to individual times captured with
 	// incremental backups that were appended to that backup.
 	full1, full2 = findFullBackupPaths(path.Join(tmpDir, "foo"),
-		path.Join(tmpDir, "foo", fmt.Sprintf("%s*", specifiedSubdir), "BACKUP"))
+		path.Join(tmpDir, "foo", fmt.Sprintf("%s*", specifiedSubdir), backupManifestName))
 	runRestores(collectionsWithSubdir, full1, full2)
 
 	// TODO(dt): test restoring to other backups via AOST.
@@ -563,7 +563,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
-	matches, err := filepath.Glob(path.Join(tmpDir, "*/*/*/BACKUP"))
+	matches, err := filepath.Glob(path.Join(tmpDir, "*/*/*/"+backupManifestName))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 	for i := range matches {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -42,10 +42,10 @@ import (
 const (
 	// backupManifestName is the file name used for serialized BackupManifest
 	// protos.
-	backupManifestName = "BACKUP"
-	// backupNewManifestName is a future name for the serialized BackupManifest
-	// proto.
-	backupNewManifestName = "BACKUP_MANIFEST"
+	backupManifestName = "BACKUP_MANIFEST"
+	// backupOldManifestName is an old name for the serialized BackupManifest
+	// proto. It is used by 20.1 nodes and earlier.
+	backupOldManifestName = "BACKUP"
 	// backupManifestChecksumSuffix indicates where the checksum for the manifest
 	// is stored if present. It can be found in the name of the backup manifest +
 	// this suffix.
@@ -118,16 +118,15 @@ func readBackupManifestFromStore(
 	exportStore cloud.ExternalStorage,
 	encryption *jobspb.BackupEncryptionOptions,
 ) (BackupManifest, error) {
-
 	backupManifest, err := readBackupManifest(ctx, exportStore, backupManifestName,
 		encryption)
 	if err != nil {
-		newManifest, newErr := readBackupManifest(ctx, exportStore, backupNewManifestName,
+		oldManifest, newErr := readBackupManifest(ctx, exportStore, backupOldManifestName,
 			encryption)
 		if newErr != nil {
 			return BackupManifest{}, err
 		}
-		backupManifest = newManifest
+		backupManifest = oldManifest
 	}
 	backupManifest.Dir = exportStore.Conf()
 	// TODO(dan): Sanity check this BackupManifest: non-empty EndTime,

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -495,12 +495,12 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/*/BACKUP")
+		res, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
 		if err != nil {
 			return err
 		}
 		for _, i := range res {
-			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/BACKUP"))}
+			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/"+backupManifestName))}
 		}
 		return nil
 	}


### PR DESCRIPTION
This commit renames the backup manifest file from BACKUP to
BACKUP_MANIFEST to be more descriptive and consistent with other naming.

Conversation about limiting 20.2 nodes from not auto-appending to locations
created by 20.1 nodes, and why this is the case was discussed:
https://github.com/cockroachdb/cockroach/pull/53294#discussion_r475834668

Release justification: low-risk update to existing functionality
Release note (enterprise change): Backups run from 20.2 nodes should
not be run in an auto-appended backup location that was created by 20.1
nodes.