### PR TITLE
release-19.2: ensure that we don't use an old txn to check the status

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -751,7 +751,7 @@ func (sc *SchemaChanger) distBackfill(
 			case <-ctxDone:
 				return nil
 			case <-tickJobCancel.C:
-				if err := sc.job.CheckStatus(ctx); err != nil {
+				if err := sc.job.WithTxn(nil).CheckStatus(ctx); err != nil {
 					return jobs.SimplifyInvalidStatusError(err)
 				}
 			case <-tickLease.C:


### PR DESCRIPTION
This patch is better than nothing but is still not good due to the general
badness of the WithTxn API. Two goroutines concurrently use the job. The
second goroutine uses an explicit transaction which eventually gets committed.

Like there's still a problem if these transactions run concurrently. Before
this though there was a problem if the final transaction had run at all!

Fixes #53615

Release note (bug fix): Fixed a bug which could cause backfills to fail with
an inscrutible TransactionStatus error as they are completing.