### PR TITLE
colconv: optimize required length calculation with selection vector

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -41,8 +41,8 @@ type Batch interface {
 	// ColVecs returns all of the underlying Vecs in this batch.
 	ColVecs() []Vec
 	// Selection, if not nil, returns the selection vector on this batch: a
-	// densely-packed list of the indices in each column that have not been
-	// filtered out by a previous step.
+	// densely-packed list of the *increasing* indices in each column that have
+	// not been filtered out by a previous step.
 	Selection() []int
 	// SetSelection sets whether this batch is using its selection vector or not.
 	SetSelection(bool)

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -120,13 +120,9 @@ func (c *VecToDatumConverter) ConvertVecs(vecs []coldata.Vec, inputLen int, sel 
 	requiredLength := inputLen
 	if sel != nil {
 		// When sel is non-nil, it might be something like sel = [1023], so we
-		// need to allocate up to the largest index mentioned in sel.
-		requiredLength = 0
-		for _, idx := range sel[:inputLen] {
-			if idx+1 > requiredLength {
-				requiredLength = idx + 1
-			}
-		}
+		// need to allocate up to the largest index mentioned in sel. Here, we
+		// rely on the fact that selection vectors are increasing sequences.
+		requiredLength = sel[inputLen-1] + 1
 	}
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < requiredLength {
 		for _, vecIdx := range c.vecIdxsToConvert {

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -123,13 +123,9 @@ func (c *VecToDatumConverter) ConvertVecs(vecs []coldata.Vec, inputLen int, sel 
 	requiredLength := inputLen
 	if sel != nil {
 		// When sel is non-nil, it might be something like sel = [1023], so we
-		// need to allocate up to the largest index mentioned in sel.
-		requiredLength = 0
-		for _, idx := range sel[:inputLen] {
-			if idx+1 > requiredLength {
-				requiredLength = idx + 1
-			}
-		}
+		// need to allocate up to the largest index mentioned in sel. Here, we
+		// rely on the fact that selection vectors are increasing sequences.
+		requiredLength = sel[inputLen-1] + 1
 	}
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < requiredLength {
 		for _, vecIdx := range c.vecIdxsToConvert {


### PR DESCRIPTION
`vec_to_datum` conversion has been adjusted to take advantage of the fact
that the selection vectors are increasing sequences when calculating the
required length for the converted buffer when selection vector is present.
This assumption is now additionally enforced in `invariants_checker`.

Release note: None