### PR TITLE
changefeedccl: add enum creation and columns to the changefeed nemeses

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -114,6 +114,9 @@ func RunNemesis(f TestFeedFactory, db *gosql.DB, isSinkless bool) (Validator, er
 			eventRemoveColumn{
 				CanRemoveColumnAfter: fsm.False,
 			}: 5,
+
+			// eventCreateEnum creates a new enum type.
+			eventCreateEnum{}: 5,
 		},
 	}
 
@@ -240,6 +243,8 @@ type nemeses struct {
 	openTxnType            openTxnType
 	openTxnID              int
 	openTxnTs              string
+
+	enumCount int
 }
 
 // nextEvent selects the next state transition.
@@ -319,6 +324,7 @@ type eventAddColumn struct {
 type eventRemoveColumn struct {
 	CanRemoveColumnAfter fsm.Bool
 }
+type eventCreateEnum struct{}
 type eventFinished struct{}
 
 func (eventOpenTxn) Event()      {}
@@ -332,6 +338,7 @@ func (eventRollback) Event()     {}
 func (eventSplit) Event()        {}
 func (eventAddColumn) Event()    {}
 func (eventRemoveColumn) Event() {}
+func (eventCreateEnum) Event()   {}
 func (eventFinished) Event()     {}
 
 var stateTransitions = fsm.Pattern{
@@ -416,6 +423,15 @@ var stateTransitions = fsm.Pattern{
 				CanAddColumn:    fsm.Var("CanAddColumn"),
 				CanRemoveColumn: fsm.Var("CanRemoveColumn")},
 			Action: logEvent(openTxn),
+		},
+		eventCreateEnum{}: {
+			Next: stateRunning{
+				FeedPaused:      fsm.Var("FeedPaused"),
+				TxnOpen:         fsm.False,
+				CanAddColumn:    fsm.Var("CanAddColumn"),
+				CanRemoveColumn: fsm.Var("CanRemoveColumn"),
+			},
+			Action: logEvent(createEnum),
 		},
 	},
 	stateRunning{
@@ -574,6 +590,16 @@ func rollback(a fsm.Args) error {
 	return ns.txn.Rollback()
 }
 
+func createEnum(a fsm.Args) error {
+	ns := a.Extended.(*nemeses)
+
+	if _, err := ns.db.Exec(fmt.Sprintf(`CREATE TYPE enum%d AS ENUM ('hello')`, ns.enumCount)); err != nil {
+		return err
+	}
+	ns.enumCount++
+	return nil
+}
+
 func addColumn(a fsm.Args) error {
 	ns := a.Extended.(*nemeses)
 
@@ -582,10 +608,22 @@ func addColumn(a fsm.Args) error {
 			`there are less than %d columns.`, ns.maxTestColumnCount)
 	}
 
-	if _, err := ns.db.Exec(fmt.Sprintf(`ALTER TABLE foo ADD COLUMN test%d STRING DEFAULT 'x'`,
-		ns.currentTestColumnCount)); err != nil {
-		return err
+	// Some of the time, add a column of an enum type.
+	if ns.enumCount > 0 && rand.Intn(4) < 1 {
+		// Pick a random enum to add.
+		enum := rand.Intn(ns.enumCount)
+		if _, err := ns.db.Exec(fmt.Sprintf(`ALTER TABLE foo ADD COLUMN test%d enum%d DEFAULT 'hello'`,
+			ns.currentTestColumnCount, enum)); err != nil {
+			return err
+		}
+	} else {
+		// Otherwise, just add a normal string column.
+		if _, err := ns.db.Exec(fmt.Sprintf(`ALTER TABLE foo ADD COLUMN test%d STRING DEFAULT 'x'`,
+			ns.currentTestColumnCount)); err != nil {
+			return err
+		}
 	}
+
 	ns.currentTestColumnCount++
 	var rows int
 	// Adding a column should trigger a full table scan.


### PR DESCRIPTION
This commit updates the changefeed nemeses to create enums and use these
enums in added columns as part of the nemeses test.

Release justification: non-production code change
Release note: None