### PR TITLE
partialidx: prove implication of IN filters and OR predicates

### DIFF
--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -199,6 +199,12 @@ func BenchmarkImplicator(b *testing.B) {
 			pred:     "@1 > 0 OR @2 IN ('foo', 'bar')",
 		},
 		{
+			name:     "in-implies-or",
+			varTypes: "int",
+			filters:  "@1 IN (1, 2, 3)",
+			pred:     "@1 = 2 OR @1 IN (1, 3)",
+		},
+		{
 			name:     "and-filters-do-not-imply-pred",
 			varTypes: "int, int, int, int, string",
 			filters:  "@1 < 0 AND @2 > 10 AND @3 >= 10 AND @4 = 4 AND @5 = 'foo'",

--- a/pkg/sql/opt/partialidx/testdata/implicator/known-limitations
+++ b/pkg/sql/opt/partialidx/testdata/implicator/known-limitations
@@ -1,0 +1,30 @@
+# This file contains filters that in theory prove implication of the
+# corresponding predicates, but the Implicator does not currently support.
+
+predtest vars=(int, int)
+@1 IN (1, 2, @2)
+=>
+@1 IN (1, 2) OR @1 = @2
+----
+false
+
+predtest vars=(int, int)
+@1 IN (1, 2, @2)
+=>
+@1 IN (1, 2) OR @2 = @1
+----
+false
+
+predtest vars=(int, int)
+@1 IN (1, 2) OR @2 = 20
+=>
+@1 = 1 OR @2 = 20 OR @1 = 2
+----
+false
+
+predtest vars=(int, int)
+1 IN (@1, @2)
+=>
+@1 = 1 OR @2 = 1
+----
+false

--- a/pkg/sql/opt/partialidx/testdata/implicator/or-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/or-expr
@@ -41,14 +41,29 @@ NOT @2
 ----
 false
 
-# TODO(mgartner): This filter actually implies this predicate, but our logic
-# does not currently handle this case.
 predtest vars=(int)
 @1 IN (1, 2)
 =>
 @1 = 1 OR @1 = 2
 ----
-false
+true
+└── remaining filters: none
+
+predtest vars=(int)
+@1 IN (1)
+=>
+@1 = 1 OR @1 = 2
+----
+true
+└── remaining filters: @1 IN (1,)
+
+predtest vars=(int)
+@1 IN (1, 2, 3)
+=>
+@1 IN (1, 2) OR @1 = 3
+----
+true
+└── remaining filters: none
 
 # Conjunction filters
 
@@ -107,6 +122,22 @@ predtest vars=(int, int)
 ----
 true
 └── remaining filters: (@1 > 10) AND (@2 < 20)
+
+predtest vars=(int)
+@1 IN (1) OR @1 IN (2)
+=>
+@1 = 1 OR @1 = 2
+----
+true
+└── remaining filters: (@1 IN (1,)) OR (@1 IN (2,))
+
+predtest vars=(int,int)
+@1 IN (1, 2)
+=>
+@1 IN (1, 2) OR @2 = 3
+----
+true
+└── remaining filters: @1 IN (1, 2)
 
 predtest vars=(bool, bool)
 @1 AND @2


### PR DESCRIPTION
This commit implements filter/predicate implication for a special case
where the filter is an IN expression and the predicate is an OR
expression. For example:

    a IN (1, 2)
    =>
    a = 1 OR a = 2

In this case, the predicate OR is treated as an atom. This is necessary
to prove implication, because neither the left (a = 1) or right (a = 2)
of the OR individually contain the filter expression. An advantage of
treating the OR as an atom is that we lean on existing logic that uses
constraints to prove implication. This existing logic can already detect
semantically exact expressions in complex cases, giving us the ability
to return an empty set of remaining filters for cases such as:

    a IN (1, 2, 3)
    =>
    a IN (1, 2) OR a = 3

Note that I did explore an alternative implementation that converted
each value of the IN expression tuple into an EqExpr, then checked
containment of each EqExpr in the OR predicate. For example, from
(a IN (1, 2)) both (a = 1) and (a = 2) would be constructed, and
implication was proven true if each was contained within the predicate.
This implementation had the advantage of proving implication in cases
which this commit's implementation cannot, such as:

    a IN (1, 2, b)
    =>
    a IN (1, 2) OR a = b

However, it was almost three times slower with the simple benchmark case
added in this commit. Additionally, there was not a simple way to reduce
the remaining filters to empty expressions in some of the more basic
cases. Given these disadvantages, and the unlikelihood that any user
expects support for extreme edge case implication, this implementation
was not used.

The extreme edge cases have been added to a new test file,
`known-limitations`. This file contains cases where implication can be
proven in theory, but our logic cannot prove in practice. This makes
these cases easier to reference and track.

Fixes #50653

Release justification: This is a low-risk update to new functionality,
partial indexes.

Release note: None