### PR TITLE
geoindex,invertedidx,rowexec,...: add bbox to inverted column

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -283,6 +283,10 @@ func (g *Geometry) CartesianBoundingBox() *CartesianBoundingBox {
 	return &CartesianBoundingBox{BoundingBox: *g.spatialObject.BoundingBox}
 }
 
+func (g *Geometry) BoundingBoxRef() *geopb.BoundingBox {
+	return g.spatialObject.BoundingBox
+}
+
 // SpaceCurveIndex returns an uint64 index to use representing an index into a space-filling curve.
 // This will return 0 for empty spatial objects, and math.MaxUint64 for any object outside
 // the defined bounds of the given SRID projection.

--- a/pkg/geo/geoindex/geoindex.go
+++ b/pkg/geo/geoindex/geoindex.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geogfn"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/golang/geo/s2"
 )
 
@@ -114,8 +115,9 @@ var CommuteRelationshipMap = map[RelationshipType]RelationshipType{
 // GeographyIndex is an index over the unit sphere.
 type GeographyIndex interface {
 	// InvertedIndexKeys returns the keys to store this object under when adding
-	// it to the index.
-	InvertedIndexKeys(c context.Context, g geo.Geography) ([]Key, error)
+	// it to the index. Additionally returns a bounding box, which is non-empty
+	// iff the key slice is non-empty.
+	InvertedIndexKeys(c context.Context, g geo.Geography) ([]Key, geopb.BoundingBox, error)
 
 	// Acceleration for topological relationships (see
 	// https://postgis.net/docs/reference.html#Spatial_Relationships). Distance
@@ -153,8 +155,9 @@ type GeographyIndex interface {
 // GeometryIndex is an index over 2D cartesian coordinates.
 type GeometryIndex interface {
 	// InvertedIndexKeys returns the keys to store this object under when adding
-	// it to the index.
-	InvertedIndexKeys(c context.Context, g geo.Geometry) ([]Key, error)
+	// it to the index. Additionally returns a bounding box, which is non-empty
+	// iff the key slice is non-empty.
+	InvertedIndexKeys(c context.Context, g geo.Geometry) ([]Key, geopb.BoundingBox, error)
 
 	// Acceleration for topological relationships (see
 	// https://postgis.net/docs/reference.html#Spatial_Relationships). Distance

--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -172,14 +172,16 @@ func isBadGeomCovering(cu s2.CellUnion) bool {
 }
 
 // InvertedIndexKeys implements the GeometryIndex interface.
-func (s *s2GeometryIndex) InvertedIndexKeys(c context.Context, g geo.Geometry) ([]Key, error) {
+func (s *s2GeometryIndex) InvertedIndexKeys(
+	c context.Context, g geo.Geometry,
+) ([]Key, geopb.BoundingBox, error) {
 	// If the geometry exceeds the bounds, we index the clipped geometry in
 	// addition to the special cell, so that queries for geometries that don't
 	// exceed the bounds don't need to query the special cell (which would
 	// become a hotspot in the key space).
 	gt, clipped, err := s.convertToGeomTAndTryClip(g)
 	if err != nil {
-		return nil, err
+		return nil, geopb.BoundingBox{}, err
 	}
 	var keys []Key
 	if gt != nil {
@@ -189,7 +191,15 @@ func (s *s2GeometryIndex) InvertedIndexKeys(c context.Context, g geo.Geometry) (
 	if clipped {
 		keys = append(keys, Key(exceedsBoundsCellID))
 	}
-	return keys, nil
+	bbox := geopb.BoundingBox{}
+	bboxRef := g.BoundingBoxRef()
+	if bboxRef == nil && len(keys) > 0 {
+		return keys, bbox, errors.Errorf("non-empty geometry should have bounding box")
+	}
+	if bboxRef != nil {
+		bbox = *bboxRef
+	}
+	return keys, bbox, nil
 }
 
 // Covers implements the GeometryIndex interface.

--- a/pkg/geo/geoindex/s2_geometry_index_test.go
+++ b/pkg/geo/geoindex/s2_geometry_index_test.go
@@ -140,7 +140,7 @@ func TestNoClippingAtSRIDBounds(t *testing.T) {
 			for i := range xCorners {
 				g, err := geo.MakeGeometryFromPointCoords(xCorners[i], yCorners[i])
 				require.NoError(t, err)
-				keys, err := index.InvertedIndexKeys(context.Background(), g)
+				keys, _, err := index.InvertedIndexKeys(context.Background(), g)
 				require.NoError(t, err)
 				require.Equal(t, 1, len(keys))
 				require.NotEqual(t, Key(exceedsBoundsCellID), keys[0],

--- a/pkg/geo/geoindex/utils_test.go
+++ b/pkg/geo/geoindex/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/datadriven"
 	"github.com/golang/geo/s2"
 )
@@ -39,7 +40,7 @@ func s2Config(t *testing.T, d *datadriven.TestData) S2Config {
 	}
 }
 
-func keysToString(keys []Key, err error) string {
+func keysToString(keys []Key, _ geopb.BoundingBox, err error) string {
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/sql/opt/invertedexpr/geo_expression.go
+++ b/pkg/sql/opt/invertedexpr/geo_expression.go
@@ -42,6 +42,7 @@ func geoKeyToEncInvertedVal(k geoindex.Key, end bool, b []byte) (EncInvertedVal,
 		}
 	}
 	prev := len(b)
+	b = encoding.EncodeGeoInvertedAscending(b)
 	b = encoding.EncodeUvarintAscending(b, uint64(k))
 	// Set capacity so that the caller appending does not corrupt later keys.
 	enc := b[prev:len(b):len(b)]
@@ -64,7 +65,7 @@ func GeoUnionKeySpansToSpanExpr(ukSpans geoindex.UnionKeySpans) *SpanExpression 
 		return nil
 	}
 	// Avoid per-span heap allocations.
-	b := make([]byte, 0, len(ukSpans)*(2*encoding.MaxVarintLen))
+	b := make([]byte, 0, len(ukSpans)*(2*encoding.MaxVarintLen+2))
 	spans := make([]InvertedSpan, len(ukSpans))
 	for i, ukSpan := range ukSpans {
 		spans[i], b = geoToSpan(ukSpan, b)

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -830,31 +831,36 @@ func EncodeGeoInvertedIndexTableKeys(
 	switch val.ResolvedType().Family() {
 	case types.GeographyFamily:
 		index := geoindex.NewS2GeographyIndex(*index.GeoConfig.S2Geography)
-		intKeys, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeography).Geography)
+		intKeys, bbox, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeography).Geography)
 		if err != nil {
 			return nil, err
 		}
-		return encodeGeoKeys(inKey, intKeys)
+		return encodeGeoKeys(encoding.EncodeGeoInvertedAscending(inKey), intKeys, bbox)
 	case types.GeometryFamily:
 		index := geoindex.NewS2GeometryIndex(*index.GeoConfig.S2Geometry)
-		intKeys, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeometry).Geometry)
+		intKeys, bbox, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeometry).Geometry)
 		if err != nil {
 			return nil, err
 		}
-		return encodeGeoKeys(inKey, intKeys)
+		return encodeGeoKeys(encoding.EncodeGeoInvertedAscending(inKey), intKeys, bbox)
 	default:
 		return nil, errors.Errorf("internal error: unexpected type: %s", val.ResolvedType().Family())
 	}
 }
 
-func encodeGeoKeys(inKey []byte, geoKeys []geoindex.Key) (keys [][]byte, err error) {
+func encodeGeoKeys(
+	inKey []byte, geoKeys []geoindex.Key, bbox geopb.BoundingBox,
+) (keys [][]byte, err error) {
+	encodedBBox := make([]byte, 0, 4*encoding.MaxVarintLen)
+	encodedBBox = encoding.EncodeGeoInvertedBBox(encodedBBox, bbox.LoX, bbox.LoY, bbox.HiX, bbox.HiY)
 	// Avoid per-key heap allocations.
-	b := make([]byte, 0, len(geoKeys)*(len(inKey)+encoding.MaxVarintLen))
+	b := make([]byte, 0, len(geoKeys)*(len(inKey)+len(encodedBBox)+encoding.MaxVarintLen))
 	keys = make([][]byte, len(geoKeys))
 	for i, k := range geoKeys {
 		prev := len(b)
 		b = append(b, inKey...)
 		b = encoding.EncodeUvarintAscending(b, uint64(k))
+		b = append(b, encodedBBox...)
 		// Set capacity so that the caller appending does not corrupt later keys.
 		newKey := b[prev:len(b):len(b)]
 		keys[i] = newKey

--- a/pkg/sql/rowexec/inverted_expr_evaluator.go
+++ b/pkg/sql/rowexec/inverted_expr_evaluator.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
+	"github.com/cockroachdb/errors"
 )
 
 // The abstractions in this file help with evaluating (batches of)
@@ -218,13 +219,27 @@ type exprAndSetIndex struct {
 	setIndex int
 }
 
+type exprAndSetIndexSorter []exprAndSetIndex
+
+// Implement sort.Interface. Sorts in increasing order of exprIndex.
+func (esis exprAndSetIndexSorter) Len() int      { return len(esis) }
+func (esis exprAndSetIndexSorter) Swap(i, j int) { esis[i], esis[j] = esis[j], esis[i] }
+func (esis exprAndSetIndexSorter) Less(i, j int) bool {
+	return esis[i].exprIndex < esis[j].exprIndex
+}
+
 // invertedSpanRoutingInfo contains the list of exprAndSetIndex pairs that
 // need rows from the inverted index span. A []invertedSpanRoutingInfo with
 // spans that are sorted and non-overlapping is used to route an added row to
 // all the expressions and sets that need that row.
 type invertedSpanRoutingInfo struct {
-	span                invertedSpan
+	span invertedSpan
+	// Sorted in increasing order of exprIndex.
 	exprAndSetIndexList []exprAndSetIndex
+	// A de-duped and sorted list of exprIndex values from exprAndSetIndexList.
+	// Used for pre-filtering, since the pre-filter is applied on a per
+	// exprIndex basis.
+	exprIndexList []int
 }
 
 // invertedSpanRoutingInfosByEndKey is a slice of invertedSpanRoutingInfo that
@@ -247,11 +262,24 @@ func (s invertedSpanRoutingInfosByEndKey) Less(i, j int) bool {
 // init() must be called before calls to addIndexRow() -- it builds the
 // fragmentedSpans used for routing the added rows.
 type batchedInvertedExprEvaluator struct {
-	exprs []*invertedexpr.SpanExpressionProto
+	canPreFilter bool
+	preFilterer  invertedexpr.DatumsToInvertedExpr
+	exprs        []*invertedexpr.SpanExpressionProto
+
+	// The pre-filtering state for each expression. When pre-filtering, this
+	// is the same length as exprs.
+	preFilterState []interface{}
+	// The parameters and result of pre-filtering for an inverted row are
+	// kept in this temporary state.
+	tempPreFilters      []interface{}
+	tempPreFilterResult []bool
+
 	// The evaluators for all the exprs.
 	exprEvals []*invertedExprEvaluator
 	// Spans here are in sorted order and non-overlapping.
 	fragmentedSpans []invertedSpanRoutingInfo
+	// The routing index computed by prepareAddIndexRow
+	routingIndex int
 
 	// Temporary state used during initialization.
 	routingSpans       []invertedSpanRoutingInfo
@@ -337,6 +365,15 @@ func (b *batchedInvertedExprEvaluator) fragmentPendingSpans(
 			// All spans in pendingSpans contribute to exprAndSetIndexList.
 			nextSpan.exprAndSetIndexList =
 				append(nextSpan.exprAndSetIndexList, pendingSpans[i].exprAndSetIndexList...)
+		}
+		sort.Sort(exprAndSetIndexSorter(nextSpan.exprAndSetIndexList))
+		nextSpan.exprIndexList = make([]int, 0, len(nextSpan.exprAndSetIndexList))
+		for i := range nextSpan.exprAndSetIndexList {
+			length := len(nextSpan.exprIndexList)
+			exprIndex := nextSpan.exprAndSetIndexList[i].exprIndex
+			if length == 0 || nextSpan.exprIndexList[length-1] != exprIndex {
+				nextSpan.exprIndexList = append(nextSpan.exprIndexList, exprIndex)
+			}
 		}
 		b.fragmentedSpans = append(b.fragmentedSpans, nextSpan)
 		pendingSpans = pendingSpans[removeSize:]
@@ -438,16 +475,61 @@ func (b *batchedInvertedExprEvaluator) init() []invertedSpan {
 
 // TODO(sumeer): if this will be called in non-decreasing order of enc,
 // use that to optimize the binary search.
-func (b *batchedInvertedExprEvaluator) addIndexRow(
-	enc invertedexpr.EncInvertedVal, keyIndex KeyIndex,
-) {
+func (b *batchedInvertedExprEvaluator) prepareAddIndexRow(
+	enc invertedexpr.EncInvertedVal,
+) (bool, error) {
 	i := sort.Search(len(b.fragmentedSpans), func(i int) bool {
 		return bytes.Compare(b.fragmentedSpans[i].span.Start, enc) > 0
 	})
 	i--
-	for _, elem := range b.fragmentedSpans[i].exprAndSetIndexList {
-		b.exprEvals[elem.exprIndex].addIndexRow(elem.setIndex, keyIndex)
+	b.routingIndex = i
+	if b.canPreFilter {
+		exprIndexList := b.fragmentedSpans[i].exprIndexList
+		if len(exprIndexList) > cap(b.tempPreFilters) {
+			b.tempPreFilters = make([]interface{}, len(exprIndexList))
+			b.tempPreFilterResult = make([]bool, len(exprIndexList))
+		} else {
+			b.tempPreFilters = b.tempPreFilters[:len(exprIndexList)]
+			b.tempPreFilterResult = b.tempPreFilterResult[:len(exprIndexList)]
+		}
+		for j := range exprIndexList {
+			b.tempPreFilters[j] = b.preFilterState[exprIndexList[j]]
+		}
+		return b.preFilterer.PreFilter(enc, b.tempPreFilters, b.tempPreFilterResult)
 	}
+	return true, nil
+}
+
+func (b *batchedInvertedExprEvaluator) addIndexRow(
+	_ invertedexpr.EncInvertedVal, keyIndex KeyIndex,
+) error {
+	i := b.routingIndex
+	if b.canPreFilter {
+		exprIndexes := b.fragmentedSpans[i].exprIndexList
+		exprSetIndexes := b.fragmentedSpans[i].exprAndSetIndexList
+		if len(exprIndexes) != len(b.tempPreFilterResult) {
+			return errors.Errorf("non-matching lengths of tempPreFilterResult and exprIndexes")
+		}
+		// Coordinated iteration over exprIndexes and exprSetIndexes.
+		j := 0
+		for k := range exprSetIndexes {
+			elem := exprSetIndexes[k]
+			if elem.exprIndex > exprIndexes[j] {
+				j++
+				if exprIndexes[j] != elem.exprIndex {
+					return errors.Errorf("non-matching expr indexes")
+				}
+			}
+			if b.tempPreFilterResult[j] {
+				b.exprEvals[elem.exprIndex].addIndexRow(elem.setIndex, keyIndex)
+			}
+		}
+	} else {
+		for _, elem := range b.fragmentedSpans[i].exprAndSetIndexList {
+			b.exprEvals[elem.exprIndex].addIndexRow(elem.setIndex, keyIndex)
+		}
+	}
+	return nil
 }
 
 func (b *batchedInvertedExprEvaluator) evaluate() [][]KeyIndex {
@@ -463,6 +545,7 @@ func (b *batchedInvertedExprEvaluator) evaluate() [][]KeyIndex {
 
 func (b *batchedInvertedExprEvaluator) reset() {
 	b.exprs = b.exprs[:0]
+	b.preFilterState = b.preFilterState[:0]
 	b.exprEvals = b.exprEvals[:0]
 	b.fragmentedSpans = b.fragmentedSpans[:0]
 	b.routingSpans = b.routingSpans[:0]

--- a/pkg/sql/rowexec/inverted_expr_evaluator_test.go
+++ b/pkg/sql/rowexec/inverted_expr_evaluator_test.go
@@ -248,7 +248,9 @@ func TestInvertedExpressionEvaluator(t *testing.T) {
 		indexRows[i], indexRows[j] = indexRows[j], indexRows[i]
 	})
 	for _, elem := range indexRows {
+		batchEvalUnion.prepareAddIndexRow(invertedexpr.EncInvertedVal(elem.key))
 		batchEvalUnion.addIndexRow(invertedexpr.EncInvertedVal(elem.key), elem.index)
+		batchEvalIntersection.prepareAddIndexRow(invertedexpr.EncInvertedVal(elem.key))
 		batchEvalIntersection.addIndexRow(invertedexpr.EncInvertedVal(elem.key), elem.index)
 	}
 	require.Equal(t, expectedUnion, keyIndexesToString(batchEvalUnion.evaluate()))
@@ -260,6 +262,7 @@ func TestInvertedExpressionEvaluator(t *testing.T) {
 	batchBoth.exprs = append(batchBoth.exprs, &protoUnion, &protoIntersection)
 	batchBoth.init()
 	for _, elem := range indexRows {
+		batchBoth.prepareAddIndexRow(invertedexpr.EncInvertedVal(elem.key))
 		batchBoth.addIndexRow(invertedexpr.EncInvertedVal(elem.key), elem.index)
 	}
 	require.Equal(t, "0: 0 3 4 5 6 7 8 \n1: 0 4 6 8 \n",
@@ -304,7 +307,7 @@ func TestFragmentedSpans(t *testing.T) {
 	require.Equal(t,
 		"span: [a, d)  indexes (expr, set): (0, 0) \n"+
 			"span: [d, e)  indexes (expr, set): (0, 0) (1, 0) \n"+
-			"span: [e, f)  indexes (expr, set): (2, 0) (0, 0) (1, 0) \n"+
+			"span: [e, f)  indexes (expr, set): (0, 0) (1, 0) (2, 0) \n"+
 			"span: [f, g)  indexes (expr, set): (0, 0) (1, 0) \n"+
 			"span: [g, i)  indexes (expr, set): (1, 0) \n"+
 			"span: [i, j)  indexes (expr, set): (1, 0) (2, 0) \n"+

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -41,6 +41,8 @@ const (
 	ifrEmittingRows
 )
 
+// TODO(sumeer): support pre-filtering, akin to the invertedJoiner, by passing
+// relationship info and parameters in the spec.
 type invertedFilterer struct {
 	execinfra.ProcessorBase
 	runningState   invertedFiltererState
@@ -205,7 +207,14 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 		return ifrStateUnknown, ifr.DrainHelper()
 	}
 	// Add to the evaluator.
-	ifr.invertedEval.addIndexRow(row[ifr.invertedColIdx].EncodedBytes(), keyIndex)
+	if _, err = ifr.invertedEval.prepareAddIndexRow(row[ifr.invertedColIdx].EncodedBytes()); err != nil {
+		ifr.MoveToDraining(err)
+		return ifrStateUnknown, ifr.DrainHelper()
+	}
+	if err = ifr.invertedEval.addIndexRow(row[ifr.invertedColIdx].EncodedBytes(), keyIndex); err != nil {
+		ifr.MoveToDraining(err)
+		return ifrStateUnknown, ifr.DrainHelper()
+	}
 	return ifrReadingInput, nil
 }
 

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -76,6 +76,24 @@ func (arrayIntersectionExpr) Convert(
 	return expr.(*invertedexpr.SpanExpression).ToProto(), nil
 }
 
+// TODO(sumeer): test with pre-filtering
+func (arrayIntersectionExpr) CanPreFilter() bool {
+	return false
+}
+func (arrayIntersectionExpr) GetPreFilterStateForLastConvert(
+	ctx context.Context,
+) (interface{}, error) {
+	return nil, errors.Errorf("unsupported")
+}
+func (arrayIntersectionExpr) PreFilter(
+	enc invertedexpr.EncInvertedVal, preFilters []interface{}, result []bool,
+) (bool, error) {
+	return false, errors.Errorf("unsupported")
+}
+func (arrayIntersectionExpr) PreFilterStats() (int, int) {
+	return 0, 0
+}
+
 // This expression converter is similar to the arrayIntersectionExpr, but for
 // JSON. Since the keys "c1" and "c2" distinguish the application of the / and
 // % operator here (unlike the array case), a left side integer d will only
@@ -109,6 +127,24 @@ func (jsonIntersectionExpr) Convert(
 	return expr.(*invertedexpr.SpanExpression).ToProto(), nil
 }
 
+// TODO(sumeer): test with pre-filtering
+func (jsonIntersectionExpr) CanPreFilter() bool {
+	return false
+}
+func (jsonIntersectionExpr) GetPreFilterStateForLastConvert(
+	ctx context.Context,
+) (interface{}, error) {
+	return nil, errors.Errorf("unsupported")
+}
+func (jsonIntersectionExpr) PreFilter(
+	enc invertedexpr.EncInvertedVal, preFilters []interface{}, result []bool,
+) (bool, error) {
+	return false, errors.Errorf("unsupported")
+}
+func (jsonIntersectionExpr) PreFilterStats() (int, int) {
+	return 0, 0
+}
+
 // For each integer d provided by the left side, this expression converter
 // constructs a union of {"c1": d/10} and {"c2": d%10}. So if d = 5, we will
 // find all right side rows containing {"c1": 0} or {"c2": 5}, which is
@@ -140,6 +176,22 @@ func (jsonUnionExpr) Convert(
 	expr := invertedexpr.Or(invertedexpr.ExprForInvertedSpan(d1Span, true),
 		invertedexpr.ExprForInvertedSpan(d2Span, true))
 	return expr.(*invertedexpr.SpanExpression).ToProto(), nil
+}
+
+// TODO(sumeer): test with pre-filtering
+func (jsonUnionExpr) CanPreFilter() bool {
+	return false
+}
+func (jsonUnionExpr) GetPreFilterStateForLastConvert(ctx context.Context) (interface{}, error) {
+	return nil, errors.Errorf("unsupported")
+}
+func (jsonUnionExpr) PreFilter(
+	enc invertedexpr.EncInvertedVal, preFilters []interface{}, result []bool,
+) (bool, error) {
+	return false, errors.Errorf("unsupported")
+}
+func (jsonUnionExpr) PreFilterStats() (int, int) {
+	return 0, 0
 }
 
 func TestInvertedJoiner(t *testing.T) {


### PR DESCRIPTION
The bounding box is encoded after the cellid, and used to perform
"pre-filtering", i.e., filtering after the inverted row is fetched
but before it is added to various set expressions.

The fundamental weakness with the cell covering
approach is that the coverings for convex shapes are typically
worse than a bounding box and we pay significant cost in doing
a lookup join to eliminate the false positives. This attempts
to reduce those false positives for the lookup join, and part
of the inverted join (the invertedJoiner can avoid adding a
row to the RowContainer).

The code is incomplete in that it lacks new tests and doesn't
do this pre-filtering for Geography and the invertedFilterer.
There is also a question of whether this information should be
part of the inverted column or placed in an additional column
(latter would require generalizing the structure of inverted
indexes).

For the canonical nyc st_intersects and st_dwithin queries
the joinReader would see a much higher input row count than
the output due to false positives. Specifically,
- st_intersects: input 3110, output 490
- st_dwithin: input 23183, output 8606

With this change the input counts are 1064 and 11177. There
is the additional cost of reading extra bytes and applying
the bounding box filter, but it is more than offset by the
gains (see comparison numbers below).

This is a format change for the index, so we will need to
support both formats. Also, the encoding here is
trivial, and consumes 32 bytes. We can do better wrt bytes
but will need to measure how that affects decoding cost.

Fuller comparison numbers (old is master):
```
name                                   old ms     new ms     delta
Test/nyc/nyc-intersects                80.0 ±23%  69.0 ±30%  -13.76%  (p=0.000 n=49+48)
Test/nyc/nyc-dwithin                    225 ±13%   169 ± 8%  -24.88%  (p=0.000 n=46+45)
Test/nyc/nyc-coveredby                 84.1 ±11%  69.0 ±14%  -17.96%  (p=0.000 n=50+49)
Test/nyc/nyc-expand-blocks             85.7 ± 6%  84.6 ± 8%   -1.22%  (p=0.030 n=45+47)
Test/nyc/nyc-dwithin-and-dfullywithin   195 ± 7%   195 ± 6%     ~     (p=1.000 n=46+49)
Test/postgis_geometry_tutorial/11.2b   1.66 ±24%  1.53 ±45%   -7.87%  (p=0.006 n=50+50)
Test/postgis_geometry_tutorial/11.6    1.61 ±19%  1.66 ±32%     ~     (p=0.329 n=46+50)
Test/postgis_geometry_tutorial/12.1.2  0.89 ±26%  0.91 ±26%     ~     (p=0.532 n=46+50)
Test/postgis_geometry_tutorial/12.2.3  1.33 ±20%  1.38 ±36%     ~     (p=0.308 n=49+49)
Test/postgis_geometry_tutorial/12.2.4  1.30 ±27%  1.29 ±18%     ~     (p=0.746 n=49+45)
Test/postgis_geometry_tutorial/13.0    1.49 ±36%  1.55 ±33%     ~     (p=0.141 n=49+50)
Test/postgis_geometry_tutorial/13.1a    233 ± 7%   197 ± 7%  -15.45%  (p=0.000 n=48+47)
Test/postgis_geometry_tutorial/13.1c   24.9 ±15%  19.4 ±18%  -22.17%  (p=0.000 n=50+48)
Test/postgis_geometry_tutorial/13.2     309 ± 4%   257 ± 7%  -16.92%  (p=0.000 n=43+47)
Test/postgis_geometry_tutorial/14.1a   1.51 ±15%  1.70 ±16%  +12.93%  (p=0.000 n=48+44)
Test/postgis_geometry_tutorial/14.2b   6.28 ±22%  6.07 ±19%     ~     (p=0.050 n=50+45)
Test/postgis_geometry_tutorial/14.2c   3.70 ±14%  3.47 ±10%   -5.98%  (p=0.000 n=48+46)
Test/postgis_geometry_tutorial/14.3c   31.9 ±11%  25.9 ±12%  -18.60%  (p=0.000 n=48+49)
Test/postgis_geometry_tutorial/15.0    1.50 ±20%  1.50 ±20%     ~     (p=0.860 n=48+49)
```

Release justification: probably not for this release
Release note: None