### PR TITLE
kvserver: unskip TestStoreRangeMergeConcurrentRequests

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1635,9 +1634,6 @@ func TestStoreRangeMergeCheckConsistencyAfterSubsumption(t *testing.T) {
 func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// Skipping as part of test-infra-team flaky test cleanup.
-	skip.WithIssue(t, 50795)
 
 	ctx := context.Background()
 	storeCfg := kvserver.TestStoreConfig(nil)


### PR DESCRIPTION
I `stressrace`ed it for ~4K runs and couldn't repro.

```
4456 runs so far, 0 failures, over 28m5s
```

In all likelihood, this test was fixed by @andreimatei's changes around
the range descriptor cache. In particular, #51437 and/or #51395.

Fixes #50795

Release justification: Non production code change
Release note: None