### PR TITLE
backupccl: name which descriptors are blocking cluster restore

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -320,8 +320,8 @@ func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
 	sqlDBRestore.Exec(t, `CREATE DATABASE foo`)
-	sqlDBRestore.ExpectErr(
-		t, "pq: full cluster restore can only be run on a cluster with no tables or databases but found 1 descriptors",
+	sqlDBRestore.ExpectErr(t,
+		"pq: full cluster restore can only be run on a cluster with no tables or databases but found 1 descriptors: \\[foo\\]",
 		`RESTORE FROM $1`, LocalFoo,
 	)
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1019,6 +1019,24 @@ func errOnMissingRange(span covering.Range, start, end hlc.Timestamp) error {
 	)
 }
 
+func getUserDescriptorNames(
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
+) ([]string, error) {
+	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, codec)
+	if err != nil {
+		return nil, err
+	}
+
+	var allNames = make([]string, 0, len(allDescs))
+	for _, desc := range allDescs {
+		if !catalogkeys.IsDefaultCreatedDescriptor(desc.GetID()) {
+			allNames = append(allNames, desc.GetName())
+		}
+	}
+
+	return allNames, nil
+}
+
 func resolveOptionsForRestoreJobDescription(
 	opts tree.RestoreOptions, intoDB string, kmsURIs []string,
 ) (tree.RestoreOptions, error) {
@@ -1299,9 +1317,16 @@ func doRestorePlan(
 		return errors.Wrap(err, "looking up user descriptors during restore")
 	}
 	if descCount != 0 && restoreStmt.DescriptorCoverage == tree.AllDescriptors {
+		var userDescriptorNames []string
+		userDescriptorNames, err := getUserDescriptorNames(ctx, txn, p.ExecCfg().Codec)
+		if err != nil {
+			// We're already returning an error, and we're just trying to make the
+			// error message more helpful. If we fail to do that, let's just log.
+			log.Errorf(ctx, "fetching user descriptor names: %+v", err)
+		}
 		return errors.Errorf(
-			"full cluster restore can only be run on a cluster with no tables or databases but found %d descriptors",
-			descCount,
+			"full cluster restore can only be run on a cluster with no tables or databases but found %d descriptors: %s",
+			descCount, userDescriptorNames,
 		)
 	}
 


### PR DESCRIPTION
This commit updates the error message returned when there are user
descriptors which are preventing a cluster restore from being run.

Fixes #50336.

Release justification: low risk, high benefit changes to existing
functionality.
Release note: None