### PR TITLE
sql: include err msg in a barrier

### DIFF
--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -176,7 +176,7 @@ func retrieveUserAndPassword(
 	if err != nil {
 		// Failed to retrieve the user account. Report in logs for later investigation.
 		log.Warningf(ctx, "user lookup for %q failed: %v", normalizedUsername, err)
-		err = errors.HandledWithMessage(err, "internal error while retrieving user account")
+		err = errors.Wrap(errors.Handled(err), "internal error while retrieving user account")
 	}
 	return exists, canLogin, hashedPassword, validUntil, err
 }


### PR DESCRIPTION
We were returning to a client a Handled error that didn't include the
message of its wrapped error, making it quite unactionable by a user.
The wrapped error was logged, but that's not useful enough -
in particular, this error was seen in a multi-tenant cluster where the
client doesn't get any logs.

Release note: None