### PR TITLE
roachtest: update tpcc init to check if deprecated indexes are needed

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -149,6 +149,9 @@ func setupTPCC(
 			t.Status("initializing tables")
 			cmd := fmt.Sprintf("./workload init tpcc --warehouses=%d %s {pgurl:1}",
 				opts.Warehouses, opts.ExtraSetupArgs)
+			if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
+				cmd += " --deprecated-fk-indexes"
+			}
 			c.Run(ctx, workloadNode, cmd)
 		default:
 			t.Fatal("unknown tpcc setup type")


### PR DESCRIPTION
Fixes #53733.

Release justification: non-production code change
Release note: None