### PR TITLE
opt: remove xfunc references and clean up EnsureKey

### DIFF
--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -67,9 +67,7 @@ type Factory struct {
 	mem *memo.Memo
 
 	// funcs is the struct used to call all custom match and replace functions
-	// used by the normalization rules. It wraps an unnamed xfunc.CustomFuncs,
-	// so it provides a clean interface for calling functions from both the norm
-	// and xfunc packages using the same prefix.
+	// used by the normalization rules.
 	funcs CustomFuncs
 
 	// matchedRule is the callback function that is invoked each time a normalize

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -33,10 +33,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// CustomFuncs contains all the custom match and replace functions used by
-// the exploration rules. The unnamed xfunc.CustomFuncs allows
-// CustomFuncs to provide a clean interface for calling functions from both the
-// xform and xfunc packages using the same struct.
+// CustomFuncs contains all the custom match and replace functions used by the
+// exploration rules. The unnamed norm.CustomFuncs allows CustomFuncs to provide
+// a clean interface for calling functions from both the xform and norm packages
+// using the same struct.
 type CustomFuncs struct {
 	norm.CustomFuncs
 	e  *explorer

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -86,9 +86,9 @@ type explorer struct {
 	mem     *memo.Memo
 
 	// funcs is the struct used to call all custom match and replace functions
-	// used by the exploration rules. It wraps an unnamed xfunc.CustomFuncs,
-	// so it provides a clean interface for calling functions from both the xform
-	// and xfunc packages using the same prefix.
+	// used by the exploration rules. It wraps an unnamed norm.CustomFuncs, so
+	// it provides a clean interface for calling functions from both the xform
+	// and norm packages using the same prefix.
 	funcs CustomFuncs
 }
 


### PR DESCRIPTION
#### norm: clean up EnsureKey decorrelation function

This commit replaces a single-case type switch statement in EnsureKey
with an `if` with a type assertion. It also adds clariying comments.

Release justification: This is a low-risk change to new and minor
changes to existing functionality.

Release note: None

#### opt: fix comment in xform custom_funcs.go

This commit removes references to the non-existent `xfunc` package.

Release justification: This is a non-production code-change.

Release note: None
