### PR TITLE
bulkio: Drop `EXPERIMENTAL` modifier for schedules.

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1287,8 +1287,8 @@ opt_full_backup_clause ::=
 	| 
 
 opt_with_schedule_options ::=
-	'WITH' 'EXPERIMENTAL' 'SCHEDULE' 'OPTIONS' kv_option_list
-	| 'WITH' 'EXPERIMENTAL' 'SCHEDULE' 'OPTIONS' '(' kv_option_list ')'
+	'WITH' 'SCHEDULE' 'OPTIONS' kv_option_list
+	| 'WITH' 'SCHEDULE' 'OPTIONS' '(' kv_option_list ')'
 	| 
 
 with_clause ::=

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -341,7 +341,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		WITH revision_history
     RECURRING '1 2 * * *'
     FULL BACKUP ALWAYS
-		WITH EXPERIMENTAL SCHEDULE OPTIONS first_run=$1
+		WITH SCHEDULE OPTIONS first_run=$1
 		`,
 			queryArgs: []interface{}{th.env.Now().Add(time.Minute)},
 			expectedSchedules: []expectedSchedule{
@@ -606,7 +606,7 @@ func TestCreateBackupScheduleCollectionOverwrite(t *testing.T) {
 	// Expect that we can override this option with the ignore_existing_backups
 	// flag.
 	th.sqlDB.Exec(t, "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/collection' "+
-		"RECURRING '@daily' WITH EXPERIMENTAL SCHEDULE OPTIONS ignore_existing_backups;")
+		"RECURRING '@daily' WITH SCHEDULE OPTIONS ignore_existing_backups;")
 }
 
 func TestCreateBackupScheduleInExplicitTxnRollback(t *testing.T) {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1550,7 +1550,7 @@ func TestParse(t *testing.T) {
 		{`CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP ALWAYS`},
 		{`CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP '@weekly'`},
 		{`CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly'`},
-		{`CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly' WITH EXPERIMENTAL SCHEDULE OPTIONS foo = 'bar'`},
+		{`CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS foo = 'bar'`},
 		{`EXPLAIN BACKUP TABLE foo TO 'bar'`},
 		{`BACKUP TABLE foo.foo, baz.baz TO 'bar'`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2280,12 +2280,6 @@ backup_options:
 //     "@daily": run daily, at midnight
 //   See https://en.wikipedia.org/wiki/Cron
 //
-//   RECURRING NEVER indicates that the schedule is non recurring.
-//   If, in addition to 'NEVER', the 'first_run' schedule option is specified,
-//   then the schedule will execute once at that time (that is: it's a one-off execution).
-//   If the 'first_run' is not specified, then the created scheduled will be in 'PAUSED' state,
-//   and will need to be unpaused before it can execute.
-//
 // FULL BACKUP <crontab|ALWAYS>:
 //   The optional FULL BACKUP '<cron expr>' clause specifies when we'll start a new full backup,
 //   which becomes the "current" backup when complete.
@@ -2297,7 +2291,7 @@ backup_options:
 //      * RECURRING <= 1 day:  we default to FULL BACKUP '@weekly';
 //      * Otherwise: we default to FULL BACKUP ALWAYS.
 //
-// EXPERIMENTAL SCHEDULE OPTIONS:
+//  SCHEDULE OPTIONS:
 //   The schedule can be modified by specifying the following options (which are considered
 //   to be experimental at this time):
 //   * first_run=TIMESTAMPTZ:
@@ -2384,13 +2378,13 @@ opt_full_backup_clause:
   }
 
 opt_with_schedule_options:
-  WITH EXPERIMENTAL SCHEDULE OPTIONS kv_option_list
+  WITH SCHEDULE OPTIONS kv_option_list
+  {
+    $$.val = $4.kvOptions()
+  }
+| WITH SCHEDULE OPTIONS '(' kv_option_list ')'
   {
     $$.val = $5.kvOptions()
-  }
-| WITH EXPERIMENTAL SCHEDULE OPTIONS '(' kv_option_list ')'
-  {
-    $$.val = $6.kvOptions()
   }
 | /* EMPTY */
   {

--- a/pkg/sql/sem/tree/schedule.go
+++ b/pkg/sql/sem/tree/schedule.go
@@ -70,7 +70,7 @@ func (node *ScheduledBackup) Format(ctx *FmtCtx) {
 	}
 
 	if node.ScheduleOptions != nil {
-		ctx.WriteString(" WITH EXPERIMENTAL SCHEDULE OPTIONS ")
+		ctx.WriteString(" WITH SCHEDULE OPTIONS ")
 		node.ScheduleOptions.Format(ctx)
 	}
 }


### PR DESCRIPTION
Drop `EXPERIMENTAL` modifier from `WITH SCHEDULE OPTIONS`.

In addition, fix `CREATE SCHEDULE FOR BACKUP`
comment to remove `RECURRING NEVER` option.

Release Notes: None

Release Justification: Low impact change; remove EXPERIMENTAL from grammar since
the use of experimental keyword is discouraged; update create schedule help message
to be more accurate.