### PR TITLE
sql: skip TestCancelQueryPermissions

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -299,6 +300,7 @@ GRANT admin TO has_admin2;
 
 func TestCancelQueryPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 53791, "data race")
 	defer log.Scope(t).Close(t)
 
 	// getQueryIDs retrieves the IDs of any currently running queries for the


### PR DESCRIPTION
This test is exposing more data races. Skipping until we can fix them.

Refs: #53791

Release justification: non-production code changes

Release note: None