### PR TITLE
release-20.1: backupccl: fix database resolution for revision_history cluster backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -529,7 +529,7 @@ func backupPlanHook(
 		var revs []BackupManifest_DescriptorRevision
 		if mvccFilter == MVCCFilter_All {
 			priorIDs = make(map[sqlbase.ID]sqlbase.ID)
-			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs)
+			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.DescriptorCoverage)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -303,6 +303,7 @@ func getRelevantDescChanges(
 	descs []sqlbase.Descriptor,
 	expanded []sqlbase.ID,
 	priorIDs map[sqlbase.ID]sqlbase.ID,
+	descriptorCoverage tree.DescriptorCoverage,
 ) ([]BackupManifest_DescriptorRevision, error) {
 
 	allChanges, err := getAllDescChanges(ctx, db, startTime, endTime, priorIDs)
@@ -373,13 +374,26 @@ func getRelevantDescChanges(
 		}
 	}
 
+	isInterestingID := func(id sqlbase.ID) bool {
+		// We're interested in changes to all descriptors if we're targeting all
+		// descriptors except for the system database itself.
+		if descriptorCoverage == tree.AllDescriptors && id != keys.SystemDatabaseID {
+			return true
+		}
+		// A change to an ID that we're interested in is obviously interesting.
+		if _, ok := interestingIDs[id]; ok {
+			return true
+		}
+		return false
+	}
+
 	for _, change := range allChanges {
 		// A change to an ID that we are interested in is obviously interesting --
 		// a change is also interesting if it is to a table that has a parent that
 		// we are interested and thereafter it also becomes an ID in which we are
 		// interested in changes (since, as mentioned above, to decide if deletes
 		// are interesting).
-		if _, ok := interestingIDs[change.ID]; ok {
+		if isInterestingID(change.ID) {
 			interestingChanges = append(interestingChanges, change)
 		} else if change.Desc != nil {
 			if table := change.Desc.Table(hlc.Timestamp{}); table != nil {


### PR DESCRIPTION
Backport 1/1 commits from #53667.

/cc @cockroachdb/release

---

Previously database descriptor changes were not tracked when performing
cluster backups with revision history.

Fixes https://github.com/cockroachdb/cockroach/issues/52392.

Release justification: bug fix
Release note (bug fix): Database creation/deletion was previously not
correctly tracked by revision_history cluster backups. This is now
fixed.
