### PR TITLE
importccl: fix sqlbase refactor rebase issue with IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -754,7 +754,7 @@ func (m *pgDumpReader) readFile(
 						if s == nil {
 							conv.Datums[idx] = tree.DNull
 						} else {
-							conv.Datums[idx], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[i], *s, conv.EvalCtx)
+							conv.Datums[idx], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[idx], *s, conv.EvalCtx)
 							if err != nil {
 								col := conv.VisibleCols[idx]
 								return wrapRowErr(err, "", count, pgcode.Syntax,


### PR DESCRIPTION
Looks like 8e5e54f9270d7281184282d5946bd6e2ce6e9485 incorrectly modified
the `idx` back to `i` causing a bug. This was not caught
as `TestImportData` is skipped (I will fix this separately) -- I
tested this with it unskipped (by hand) beforehand.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None