### PR TITLE
importccl: partially unskip TestImportData

### DIFF
--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -754,7 +754,7 @@ func (m *pgDumpReader) readFile(
 						if s == nil {
 							conv.Datums[idx] = tree.DNull
 						} else {
-							conv.Datums[idx], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[i], *s, conv.EvalCtx)
+							conv.Datums[idx], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[idx], *s, conv.EvalCtx)
 							if err != nil {
 								col := conv.VisibleCols[idx]
 								return wrapRowErr(err, "", count, pgcode.Syntax,


### PR DESCRIPTION
second commit is what is important

Refs: #51811

----

TestImportData seems to have been skipped for a while. Not sure why, but
it has caused regressions to new tests. I've unskipped the ones that
look like they pass.

Release justification: non-production code changes.

Release note: None

