### PR TITLE
util/quotapool: skip TestRateLimiterBasic

### DIFF
--- a/pkg/util/quotapool/int_rate_test.go
+++ b/pkg/util/quotapool/int_rate_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -25,6 +26,7 @@ import (
 
 func TestRateLimiterBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 53795, "flaky test")
 
 	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 	mt := timeutil.NewManualTime(t0)


### PR DESCRIPTION
Refs: #53795

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None