### PR TITLE
roachtest: re-skip two bank tests

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -31,7 +31,7 @@ func registerAcceptance(r *testRegistry) {
 			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
 				" various errors during its rebalances, see IsExpectedRelocateError)",
 		},
-		{name: "bank/zerosum-restart", fn: runBankZeroSumRestart},
+		// {"bank/zerosum-restart", runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},
 		{name: "cli/node-status", fn: runCLINodeStatus},

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -26,7 +26,11 @@ func registerAcceptance(r *testRegistry) {
 		// Sorted. Please keep it that way.
 		{name: "bank/cluster-recovery", fn: runBankClusterRecovery},
 		{name: "bank/node-restart", fn: runBankNodeRestart},
-		{name: "bank/zerosum-splits", fn: runBankNodeZeroSum},
+		{
+			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
+			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
+				" various errors during its rebalances, see IsExpectedRelocateError)",
+		},
 		{name: "bank/zerosum-restart", fn: runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},


### PR DESCRIPTION
- Revert "roachtest: re-enable acceptance/bank/zerosum-splits"
- Revert "roachtest: re-enable acceptance/bank/zerosum-restart"

They hit flakes: https://github.com/cockroachdb/cockroach/issues/53829

In particular, there seems to be a fatal on an untracked goroutine, which causes roachtest to terminate prematurely.

Release justification: testing
Release note: None