### PR TITLE
sql: check permissions before creating a schema

### DIFF
--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -48,6 +49,10 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	// Users cannot create schemas within the system database.
 	if db.ID == keys.SystemDatabaseID {
 		return pgerror.New(pgcode.InvalidObjectDefinition, "cannot create schemas in the system database")
+	}
+
+	if err := p.CheckPrivilege(params.ctx, db, privilege.CREATE); err != nil {
+		return err
 	}
 
 	schemaName := n.Schema

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_owner
@@ -24,6 +24,9 @@ GRANT testuser TO root
 statement ok
 ALTER TABLE t OWNER TO testuser
 
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
 user testuser
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_type_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type_owner
@@ -24,6 +24,9 @@ GRANT testuser TO root
 statement ok
 ALTER TYPE typ OWNER TO testuser
 
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
 user testuser
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -57,6 +57,9 @@ query I
 SELECT * FROM a
 ----
 
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
 user testuser
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -382,3 +382,33 @@ WHERE
 ----
 user1         user1
 user1_schema  user1
+
+# Ensure that we need CREATE on a database to create a schema.
+statement ok
+CREATE DATABASE perms
+
+user testuser
+
+statement ok
+USE perms
+
+statement error pq: user testuser does not have CREATE privilege on database perms
+CREATE SCHEMA test
+
+user root
+
+statement ok
+GRANT CREATE ON DATABASE perms TO testuser
+
+user testuser
+
+statement ok
+USE perms
+
+statement ok
+CREATE SCHEMA test
+
+user root
+
+statement ok
+USE defaultdb


### PR DESCRIPTION
Check that the user has `CREATE` on the target database before allowing
creation of a schema.

Release justification: bug fix for new functionality
Release note (bug fix): Properly check that a user has CREATE privilege
on the target database before allowing them to create a schema.