### PR TITLE
sql: add prefer_lookup_joins_for_fk setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -195,6 +195,12 @@ var optDrivenFKCascadesClusterLimit = settings.RegisterNonNegativeIntSetting(
 	10000,
 )
 
+var preferLookupJoinsForFKs = settings.RegisterBoolSetting(
+	"sql.defaults.prefer_lookup_joins_for_fks.enabled",
+	"default value for prefer_lookup_joins_for_fks session setting; causes foreign key operations to use lookup joins when possible",
+	false,
+)
+
 // optUseHistogramsClusterMode controls the cluster default for whether
 // histograms are used by the optimizer for cardinality estimation.
 // Note that it does not control histogram collection; regardless of the
@@ -2119,6 +2125,10 @@ func (m *sessionDataMutator) SetSerialNormalizationMode(val sessiondata.SerialNo
 
 func (m *sessionDataMutator) SetSafeUpdates(val bool) {
 	m.data.SafeUpdates = val
+}
+
+func (m *sessionDataMutator) SetPreferLookupJoinsForFKs(val bool) {
+	m.data.PreferLookupJoinsForFKs = val
 }
 
 func (m *sessionDataMutator) UpdateSearchPath(paths []string) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1843,6 +1843,7 @@ max_index_keys                                 32                  NULL      NUL
 node_id                                        1                   NULL      NULL        NULL        string
 optimizer_use_histograms                       on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                   on                  NULL      NULL        NULL        string
+prefer_lookup_joins_for_fks                    off                 NULL      NULL        NULL        string
 reorder_joins_limit                            8                   NULL      NULL        NULL        string
 require_explicit_primary_keys                  off                 NULL      NULL        NULL        string
 results_buffer_size                            16384               NULL      NULL        NULL        string
@@ -1913,6 +1914,7 @@ max_index_keys                                 32                  NULL  user   
 node_id                                        1                   NULL  user     NULL      1                   1
 optimizer_use_histograms                       on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                   on                  NULL  user     NULL      on                  on
+prefer_lookup_joins_for_fks                    off                 NULL  user     NULL      off                 off
 reorder_joins_limit                            8                   NULL  user     NULL      8                   8
 require_explicit_primary_keys                  off                 NULL  user     NULL      off                 off
 results_buffer_size                            16384               NULL  user     NULL      16384               16384
@@ -1980,6 +1982,7 @@ node_id                                        NULL    NULL     NULL     NULL   
 optimizer                                      NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                       NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                   NULL    NULL     NULL     NULL        NULL
+prefer_lookup_joins_for_fks                    NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                            NULL    NULL     NULL     NULL        NULL
 require_explicit_primary_keys                  NULL    NULL     NULL     NULL        NULL
 results_buffer_size                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -63,6 +63,7 @@ max_index_keys                                 32
 node_id                                        1
 optimizer_use_histograms                       on
 optimizer_use_multicol_stats                   on
+prefer_lookup_joins_for_fks                    off
 reorder_joins_limit                            8
 require_explicit_primary_keys                  off
 results_buffer_size                            16384

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -845,11 +845,11 @@ func (b *Builder) presentationToResultColumns(pres physical.Presentation) colinf
 }
 
 func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
-	if f := join.Private().(*memo.JoinPrivate).Flags; !f.Has(memo.AllowHashJoinStoreRight) {
+	if f := join.Private().(*memo.JoinPrivate).Flags; f.Has(memo.DisallowHashJoinStoreRight) {
 		// We need to do a bit of reverse engineering here to determine what the
 		// hint was.
 		hint := tree.AstLookup
-		if f.Has(memo.AllowMergeJoin) {
+		if !f.Has(memo.DisallowMergeJoin) {
 			hint = tree.AstMerge
 		}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -894,3 +894,239 @@ tree    field         description
 ·       distribution  local
 ·       vectorized    true
 norows  ·             ·
+
+# Verify that prefer_lookup_joins_for_fks works as expected.
+statement ok
+CREATE TABLE p (p INT PRIMARY KEY);
+CREATE TABLE c (c INT PRIMARY KEY, p INT REFERENCES p(p), INDEX(p));
+
+statement ok
+ALTER TABLE p INJECT STATISTICS '[
+  {
+    "columns": ["p"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+statement ok
+ALTER TABLE c INJECT STATISTICS '[
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+# These queries should not be using lookup joins (we're inserting more rows
+# than exist in the tables).
+query TTT
+EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
+----
+·                                distribution         local
+·                                vectorized           false
+root                             ·                    ·
+ ├── insert                      ·                    ·
+ │    │                          into                 c(c, p)
+ │    └── buffer                 ·                    ·
+ │         │                     label                buffer 1
+ │         └── values            ·                    ·
+ │                               size                 2 columns, 3 rows
+ └── fk-check                    ·                    ·
+      └── error if rows          ·                    ·
+           └── hash join (anti)  ·                    ·
+                │                equality             (column2) = (p)
+                │                right cols are key   ·
+                ├── scan buffer  ·                    ·
+                │                label                buffer 1
+                └── scan         ·                    ·
+·                                estimated row count  1
+·                                table                p@primary
+·                                spans                FULL SCAN
+
+query TTT
+EXPLAIN UPDATE c SET p=p+c WHERE c > 0
+----
+·                                     distribution         local
+·                                     vectorized           false
+root                                  ·                    ·
+ ├── update                           ·                    ·
+ │    │                               table                c
+ │    │                               set                  p
+ │    └── buffer                      ·                    ·
+ │         │                          label                buffer 1
+ │         └── render                 ·                    ·
+ │              └── scan              ·                    ·
+ │                                    estimated row count  1
+ │                                    table                c@primary
+ │                                    spans                [/1 - ]
+ │                                    locking strength     for update
+ └── fk-check                         ·                    ·
+      └── error if rows               ·                    ·
+           └── hash join (anti)       ·                    ·
+                │                     equality             (p_new) = (p)
+                │                     right cols are key   ·
+                ├── filter            ·                    ·
+                │    │                filter               p_new IS NOT NULL
+                │    └── scan buffer  ·                    ·
+                │                     label                buffer 1
+                └── scan              ·                    ·
+·                                     estimated row count  1
+·                                     table                p@primary
+·                                     spans                FULL SCAN
+
+query TTT
+EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
+----
+·                                     distribution         local
+·                                     vectorized           false
+root                                  ·                    ·
+ ├── update                           ·                    ·
+ │    │                               table                p
+ │    │                               set                  p
+ │    └── buffer                      ·                    ·
+ │         │                          label                buffer 1
+ │         └── render                 ·                    ·
+ │              └── scan              ·                    ·
+ │                                    estimated row count  1
+ │                                    table                p@primary
+ │                                    spans                [/1 - ]
+ │                                    locking strength     for update
+ └── fk-check                         ·                    ·
+      └── error if rows               ·                    ·
+           └── hash join (semi)       ·                    ·
+                │                     equality             (p) = (p)
+                │                     left cols are key    ·
+                ├── except            ·                    ·
+                │    ├── scan buffer  ·                    ·
+                │    │                label                buffer 1
+                │    └── scan buffer  ·                    ·
+                │                     label                buffer 1
+                └── scan              ·                    ·
+·                                     estimated row count  1
+·                                     table                c@primary
+·                                     spans                FULL SCAN
+
+query TTT
+EXPLAIN DELETE FROM p WHERE p > 0
+----
+·                                distribution         local
+·                                vectorized           false
+root                             ·                    ·
+ ├── delete                      ·                    ·
+ │    │                          from                 p
+ │    └── buffer                 ·                    ·
+ │         │                     label                buffer 1
+ │         └── scan              ·                    ·
+ │                               estimated row count  1
+ │                               table                p@primary
+ │                               spans                [/1 - ]
+ └── fk-check                    ·                    ·
+      └── error if rows          ·                    ·
+           └── hash join (semi)  ·                    ·
+                │                equality             (p) = (p)
+                │                left cols are key    ·
+                ├── scan buffer  ·                    ·
+                │                label                buffer 1
+                └── scan         ·                    ·
+·                                estimated row count  1
+·                                table                c@primary
+·                                spans                FULL SCAN
+
+statement ok
+SET prefer_lookup_joins_for_fks = true
+
+# Now we should be using lookup joins.
+query TTT
+EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
+----
+·                 distribution  local
+·                 vectorized    false
+insert fast path  ·             ·
+·                 into          c(c, p)
+·                 auto commit   ·
+·                 FK check      p@primary
+·                 size          2 columns, 3 rows
+
+query TTT
+EXPLAIN UPDATE c SET p=p+c WHERE c > 0
+----
+·                                     distribution           local
+·                                     vectorized             false
+root                                  ·                      ·
+ ├── update                           ·                      ·
+ │    │                               table                  c
+ │    │                               set                    p
+ │    └── buffer                      ·                      ·
+ │         │                          label                  buffer 1
+ │         └── render                 ·                      ·
+ │              └── scan              ·                      ·
+ │                                    estimated row count    1
+ │                                    table                  c@primary
+ │                                    spans                  [/1 - ]
+ │                                    locking strength       for update
+ └── fk-check                         ·                      ·
+      └── error if rows               ·                      ·
+           └── lookup join (anti)     ·                      ·
+                │                     table                  p@primary
+                │                     equality               (p_new) = (p)
+                │                     equality cols are key  ·
+                └── filter            ·                      ·
+                     │                filter                 p_new IS NOT NULL
+                     └── scan buffer  ·                      ·
+·                                     label                  buffer 1
+
+query TTT
+EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
+----
+·                                     distribution         local
+·                                     vectorized           false
+root                                  ·                    ·
+ ├── update                           ·                    ·
+ │    │                               table                p
+ │    │                               set                  p
+ │    └── buffer                      ·                    ·
+ │         │                          label                buffer 1
+ │         └── render                 ·                    ·
+ │              └── scan              ·                    ·
+ │                                    estimated row count  1
+ │                                    table                p@primary
+ │                                    spans                [/1 - ]
+ │                                    locking strength     for update
+ └── fk-check                         ·                    ·
+      └── error if rows               ·                    ·
+           └── lookup join (semi)     ·                    ·
+                │                     table                c@c_p_idx
+                │                     equality             (p) = (p)
+                └── except            ·                    ·
+                     ├── scan buffer  ·                    ·
+                     │                label                buffer 1
+                     └── scan buffer  ·                    ·
+·                                     label                buffer 1
+
+query TTT
+EXPLAIN DELETE FROM p WHERE p > 0
+----
+·                                  distribution         local
+·                                  vectorized           false
+root                               ·                    ·
+ ├── delete                        ·                    ·
+ │    │                            from                 p
+ │    └── buffer                   ·                    ·
+ │         │                       label                buffer 1
+ │         └── scan                ·                    ·
+ │                                 estimated row count  1
+ │                                 table                p@primary
+ │                                 spans                [/1 - ]
+ └── fk-check                      ·                    ·
+      └── error if rows            ·                    ·
+           └── lookup join (semi)  ·                    ·
+                │                  table                c@c_p_idx
+                │                  equality             (p) = (p)
+                └── scan buffer    ·                    ·
+·                                  label                buffer 1
+
+statement ok
+SET prefer_lookup_joins_for_fks = false

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -360,8 +360,11 @@ func (sf *ScanFlags) Empty() bool {
 
 // JoinFlags stores restrictions on the join execution method, derived from
 // hints for a join specified in the query (see tree.JoinTableExpr).  It is a
-// bitfield where each bit indicates if a certain type of join is disallowed.
-// The zero value indicates that any join is allowed.
+// bitfield where each bit indicates if a certain type of join is disallowed or
+// preferred.
+//
+// The zero value indicates that any join is allowed and there are no special
+// preferences.
 type JoinFlags uint8
 
 // Each flag indicates if a certain type of join is disallowed.
@@ -386,6 +389,14 @@ const (
 	// DisallowLookupJoinIntoRight corresponds to a lookup join where the lookup
 	// table is on the right side.
 	DisallowLookupJoinIntoRight
+
+	// PreferLookupJoinIntoLeft reduces the cost of a lookup join where the lookup
+	// table is on the left side.
+	PreferLookupJoinIntoLeft
+
+	// PreferLookupJoinIntoRight reduces the cost of a lookup join where the
+	// lookup table is on the right side.
+	PreferLookupJoinIntoRight
 )
 
 const (
@@ -403,8 +414,7 @@ const (
 	// DisallowLookupJoinIntoRight.
 	AllowOnlyLookupJoinIntoRight JoinFlags = disallowAll ^ DisallowLookupJoinIntoRight
 
-	// AllowOnlyLookupJoinIntoRight has all "disallow" flags set except
-	// DisallowMergeJoin.
+	// AllowOnlyMergeJoin has all "disallow" flags set except DisallowMergeJoin.
 	AllowOnlyMergeJoin JoinFlags = disallowAll ^ DisallowMergeJoin
 )
 
@@ -414,6 +424,9 @@ var joinFlagStr = map[JoinFlags]string{
 	DisallowMergeJoin:           "merge join",
 	DisallowLookupJoinIntoLeft:  "lookup join (into left side)",
 	DisallowLookupJoinIntoRight: "lookup join (into right side)",
+
+	PreferLookupJoinIntoLeft:  "lookup join (into left side)",
+	PreferLookupJoinIntoRight: "lookup join (into right side)",
 }
 
 // Empty returns true if this is the default value (where all join types are
@@ -432,26 +445,40 @@ func (jf JoinFlags) String() string {
 		return "no flags"
 	}
 
-	// Special cases for prettier results in common cases.
-	switch jf {
+	prefer := jf & (PreferLookupJoinIntoLeft | PreferLookupJoinIntoRight)
+	disallow := jf ^ prefer
+
+	// Special cases with prettier results for common cases.
+	var b strings.Builder
+	switch disallow {
 	case AllowOnlyHashJoinStoreRight:
-		return "force hash join (store right side)"
+		b.WriteString("force hash join (store right side)")
 	case AllowOnlyLookupJoinIntoRight:
-		return "force lookup join (into right side)"
+		b.WriteString("force lookup join (into right side)")
 	case AllowOnlyMergeJoin:
-		return "force merge join"
+		b.WriteString("force merge join")
+
+	default:
+		for disallow != 0 {
+			flag := JoinFlags(1 << uint8(bits.TrailingZeros8(uint8(disallow))))
+			if b.Len() == 0 {
+				b.WriteString("disallow ")
+			} else {
+				b.WriteString(" and ")
+			}
+			b.WriteString(joinFlagStr[flag])
+			disallow ^= flag
+		}
 	}
 
-	var b strings.Builder
-	for jf != 0 {
-		flag := JoinFlags(1 << uint8(bits.TrailingZeros8(uint8(jf))))
-		if b.Len() == 0 {
-			b.WriteString("disallow ")
-		} else {
-			b.WriteString(" and ")
+	for prefer != 0 {
+		flag := JoinFlags(1 << uint8(bits.TrailingZeros8(uint8(prefer))))
+		if b.Len() > 0 {
+			b.WriteString("; ")
 		}
+		b.WriteString("prefer ")
 		b.WriteString(joinFlagStr[flag])
-		jf ^= flag
+		prefer ^= flag
 	}
 	return b.String()
 }

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -359,43 +359,61 @@ func (sf *ScanFlags) Empty() bool {
 }
 
 // JoinFlags stores restrictions on the join execution method, derived from
-// hints for a join specified in the query (see tree.JoinTableExpr).
-// It is a bitfield where a bit is 1 if a certain type of join is allowed. The
-// value 0 is special and indicates that any join is allowed.
+// hints for a join specified in the query (see tree.JoinTableExpr).  It is a
+// bitfield where each bit indicates if a certain type of join is disallowed.
+// The zero value indicates that any join is allowed.
 type JoinFlags uint8
 
-// Each flag indicates if a certain type of join is allowed. The JoinFlags are
-// an OR of these flags, with the special case that the value 0 means anything
-// is allowed.
+// Each flag indicates if a certain type of join is disallowed.
 const (
-	// AllowHashJoinStoreLeft corresponds to a hash join where the left side is
+	// DisallowHashJoinStoreLeft corresponds to a hash join where the left side is
 	// stored into the hashtable. Note that execution can override the stored side
 	// if it finds that the other side is smaller (up to a certain size).
-	AllowHashJoinStoreLeft JoinFlags = (1 << iota)
+	DisallowHashJoinStoreLeft JoinFlags = (1 << iota)
 
-	// AllowHashJoinStoreRight corresponds to a hash join where the right side is
-	// stored into the hashtable. Note that execution can override the stored side
-	// if it finds that the other side is smaller (up to a certain size).
-	AllowHashJoinStoreRight
+	// DisallowHashJoinStoreRight corresponds to a hash join where the right side
+	// is stored into the hashtable. Note that execution can override the stored
+	// side if it finds that the other side is smaller (up to a certain size).
+	DisallowHashJoinStoreRight
 
-	// AllowMergeJoin corresponds to a merge join.
-	AllowMergeJoin
+	// DisallowMergeJoin corresponds to a merge join.
+	DisallowMergeJoin
 
-	// AllowLookupJoinIntoLeft corresponds to a lookup join where the lookup
+	// DisallowLookupJoinIntoLeft corresponds to a lookup join where the lookup
 	// table is on the left side.
-	AllowLookupJoinIntoLeft
+	DisallowLookupJoinIntoLeft
 
-	// AllowLookupJoinIntoRight corresponds to a lookup join where the lookup
+	// DisallowLookupJoinIntoRight corresponds to a lookup join where the lookup
 	// table is on the right side.
-	AllowLookupJoinIntoRight
+	DisallowLookupJoinIntoRight
+)
+
+const (
+	disallowAll JoinFlags = (DisallowHashJoinStoreLeft |
+		DisallowHashJoinStoreRight |
+		DisallowMergeJoin |
+		DisallowLookupJoinIntoLeft |
+		DisallowLookupJoinIntoRight)
+
+	// AllowOnlyHashJoinStoreRight has all "disallow" flags set except
+	// DisallowHashJoinStoreRight.
+	AllowOnlyHashJoinStoreRight JoinFlags = disallowAll ^ DisallowHashJoinStoreRight
+
+	// AllowOnlyLookupJoinIntoRight has all "disallow" flags set except
+	// DisallowLookupJoinIntoRight.
+	AllowOnlyLookupJoinIntoRight JoinFlags = disallowAll ^ DisallowLookupJoinIntoRight
+
+	// AllowOnlyLookupJoinIntoRight has all "disallow" flags set except
+	// DisallowMergeJoin.
+	AllowOnlyMergeJoin JoinFlags = disallowAll ^ DisallowMergeJoin
 )
 
 var joinFlagStr = map[JoinFlags]string{
-	AllowHashJoinStoreLeft:   "hash join (store left side)",
-	AllowHashJoinStoreRight:  "hash join (store right side)",
-	AllowMergeJoin:           "merge join",
-	AllowLookupJoinIntoLeft:  "lookup join (into left side)",
-	AllowLookupJoinIntoRight: "lookup join (into right side)",
+	DisallowHashJoinStoreLeft:   "hash join (store left side)",
+	DisallowHashJoinStoreRight:  "hash join (store right side)",
+	DisallowMergeJoin:           "merge join",
+	DisallowLookupJoinIntoLeft:  "lookup join (into left side)",
+	DisallowLookupJoinIntoRight: "lookup join (into right side)",
 }
 
 // Empty returns true if this is the default value (where all join types are
@@ -406,7 +424,7 @@ func (jf JoinFlags) Empty() bool {
 
 // Has returns true if the given flag is set.
 func (jf JoinFlags) Has(flag JoinFlags) bool {
-	return jf.Empty() || jf&flag != 0
+	return jf&flag != 0
 }
 
 func (jf JoinFlags) String() string {
@@ -414,23 +432,24 @@ func (jf JoinFlags) String() string {
 		return "no flags"
 	}
 
-	// Special cases for prettier results.
+	// Special cases for prettier results in common cases.
 	switch jf {
-	case AllowHashJoinStoreLeft | AllowHashJoinStoreRight:
-		return "force hash join"
-	case AllowLookupJoinIntoLeft | AllowLookupJoinIntoRight:
-		return "force lookup join"
+	case AllowOnlyHashJoinStoreRight:
+		return "force hash join (store right side)"
+	case AllowOnlyLookupJoinIntoRight:
+		return "force lookup join (into right side)"
+	case AllowOnlyMergeJoin:
+		return "force merge join"
 	}
 
 	var b strings.Builder
-	b.WriteString("force ")
-	first := true
 	for jf != 0 {
 		flag := JoinFlags(1 << uint8(bits.TrailingZeros8(uint8(jf))))
-		if !first {
-			b.WriteString(" or ")
+		if b.Len() == 0 {
+			b.WriteString("disallow ")
+		} else {
+			b.WriteString(" and ")
 		}
-		first = false
 		b.WriteString(joinFlagStr[flag])
 		jf ^= flag
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -131,12 +131,13 @@ type Memo struct {
 
 	// The following are selected fields from SessionData which can affect
 	// planning. We need to cross-check these before reusing a cached memo.
-	reorderJoinsLimit int
-	zigzagJoinEnabled bool
-	useHistograms     bool
-	useMultiColStats  bool
-	safeUpdates       bool
-	saveTablesPrefix  string
+	reorderJoinsLimit       int
+	zigzagJoinEnabled       bool
+	useHistograms           bool
+	useMultiColStats        bool
+	safeUpdates             bool
+	preferLookupJoinsForFKs bool
+	saveTablesPrefix        string
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
@@ -168,6 +169,7 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.useHistograms = evalCtx.SessionData.OptimizerUseHistograms
 	m.useMultiColStats = evalCtx.SessionData.OptimizerUseMultiColStats
 	m.safeUpdates = evalCtx.SessionData.SafeUpdates
+	m.preferLookupJoinsForFKs = evalCtx.SessionData.PreferLookupJoinsForFKs
 	m.saveTablesPrefix = evalCtx.SessionData.SaveTablesPrefix
 
 	m.curID = 0
@@ -274,6 +276,7 @@ func (m *Memo) IsStale(
 		m.useHistograms != evalCtx.SessionData.OptimizerUseHistograms ||
 		m.useMultiColStats != evalCtx.SessionData.OptimizerUseMultiColStats ||
 		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
+		m.preferLookupJoinsForFKs != evalCtx.SessionData.PreferLookupJoinsForFKs ||
 		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -165,6 +165,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData.SafeUpdates = false
 	notStale()
 
+	// Stale prefer lookup joins for FKs.
+	evalCtx.SessionData.PreferLookupJoinsForFKs = true
+	stale()
+	evalCtx.SessionData.PreferLookupJoinsForFKs = false
+	notStale()
+
 	// Stale data sources and schema. Create new catalog so that data sources are
 	// recreated and can be modified independently.
 	catalog = testcat.New()

--- a/pkg/sql/opt/norm/general_funcs_test.go
+++ b/pkg/sql/opt/norm/general_funcs_test.go
@@ -23,23 +23,29 @@ func TestCommuteJoinFlags(t *testing.T) {
 	cases := [][2]memo.JoinFlags{
 		{0, 0},
 
-		{memo.AllowLookupJoinIntoLeft, memo.AllowLookupJoinIntoRight},
-
 		{
-			memo.AllowLookupJoinIntoLeft | memo.AllowLookupJoinIntoRight,
-			memo.AllowLookupJoinIntoLeft | memo.AllowLookupJoinIntoRight,
-		},
-
-		{memo.AllowHashJoinStoreLeft, memo.AllowHashJoinStoreRight},
-
-		{
-			memo.AllowHashJoinStoreLeft | memo.AllowHashJoinStoreRight,
-			memo.AllowHashJoinStoreLeft | memo.AllowHashJoinStoreRight,
+			memo.DisallowLookupJoinIntoLeft,
+			memo.DisallowLookupJoinIntoRight,
 		},
 
 		{
-			memo.AllowMergeJoin | memo.AllowHashJoinStoreLeft | memo.AllowLookupJoinIntoRight,
-			memo.AllowMergeJoin | memo.AllowHashJoinStoreRight | memo.AllowLookupJoinIntoLeft,
+			memo.AllowOnlyMergeJoin,
+			memo.AllowOnlyMergeJoin,
+		},
+
+		{
+			memo.DisallowHashJoinStoreLeft | memo.DisallowMergeJoin | memo.DisallowLookupJoinIntoLeft | memo.DisallowLookupJoinIntoRight,
+			memo.DisallowHashJoinStoreRight | memo.DisallowMergeJoin | memo.DisallowLookupJoinIntoLeft | memo.DisallowLookupJoinIntoRight,
+		},
+
+		{
+			memo.DisallowHashJoinStoreLeft | memo.DisallowHashJoinStoreRight | memo.DisallowMergeJoin | memo.DisallowLookupJoinIntoLeft,
+			memo.DisallowHashJoinStoreLeft | memo.DisallowHashJoinStoreRight | memo.DisallowMergeJoin | memo.DisallowLookupJoinIntoRight,
+		},
+
+		{
+			memo.DisallowMergeJoin | memo.DisallowHashJoinStoreLeft | memo.DisallowLookupJoinIntoRight,
+			memo.DisallowMergeJoin | memo.DisallowHashJoinStoreRight | memo.DisallowLookupJoinIntoLeft,
 		},
 	}
 

--- a/pkg/sql/opt/norm/general_funcs_test.go
+++ b/pkg/sql/opt/norm/general_funcs_test.go
@@ -29,6 +29,11 @@ func TestCommuteJoinFlags(t *testing.T) {
 		},
 
 		{
+			memo.PreferLookupJoinIntoLeft,
+			memo.PreferLookupJoinIntoRight,
+		},
+
+		{
 			memo.AllowOnlyMergeJoin,
 			memo.AllowOnlyMergeJoin,
 		},

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -567,8 +567,8 @@ func (c *CustomFuncs) CommuteJoinFlags(p *memo.JoinPrivate) *memo.JoinPrivate {
 		return f
 	}
 	f := p.Flags
-	f = swap(f, memo.AllowLookupJoinIntoLeft, memo.AllowLookupJoinIntoRight)
-	f = swap(f, memo.AllowHashJoinStoreLeft, memo.AllowHashJoinStoreRight)
+	f = swap(f, memo.DisallowLookupJoinIntoLeft, memo.DisallowLookupJoinIntoRight)
+	f = swap(f, memo.DisallowHashJoinStoreLeft, memo.DisallowHashJoinStoreRight)
 	if p.Flags == f {
 		return p
 	}

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -569,6 +569,7 @@ func (c *CustomFuncs) CommuteJoinFlags(p *memo.JoinPrivate) *memo.JoinPrivate {
 	f := p.Flags
 	f = swap(f, memo.DisallowLookupJoinIntoLeft, memo.DisallowLookupJoinIntoRight)
 	f = swap(f, memo.DisallowHashJoinStoreLeft, memo.DisallowHashJoinStoreRight)
+	f = swap(f, memo.PreferLookupJoinIntoLeft, memo.PreferLookupJoinIntoRight)
 	if p.Flags == f {
 		return p
 	}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -58,11 +58,11 @@ func (b *Builder) buildJoin(
 	case "":
 	case tree.AstHash:
 		telemetry.Inc(sqltelemetry.HashJoinHintUseCounter)
-		flags = memo.AllowHashJoinStoreRight
+		flags = memo.AllowOnlyHashJoinStoreRight
 
 	case tree.AstLookup:
 		telemetry.Inc(sqltelemetry.LookupJoinHintUseCounter)
-		flags = memo.AllowLookupJoinIntoRight
+		flags = memo.AllowOnlyLookupJoinIntoRight
 		if joinType != descpb.InnerJoin && joinType != descpb.LeftOuterJoin {
 			panic(pgerror.Newf(pgcode.Syntax,
 				"%s can only be used with INNER or LEFT joins", tree.AstLookup,
@@ -71,7 +71,7 @@ func (b *Builder) buildJoin(
 
 	case tree.AstMerge:
 		telemetry.Inc(sqltelemetry.MergeJoinHintUseCounter)
-		flags = memo.AllowMergeJoin
+		flags = memo.AllowOnlyMergeJoin
 
 	default:
 		panic(pgerror.Newf(

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -754,9 +754,11 @@ func (h *fkCheckHelper) buildInsertionCheck() memo.FKChecksItem {
 			),
 		)
 	}
-	antiJoin := f.ConstructAntiJoin(
-		fkInput, scanScope.expr, antiJoinFilters, &memo.JoinPrivate{},
-	)
+	var p memo.JoinPrivate
+	if h.mb.b.evalCtx.SessionData.PreferLookupJoinsForFKs {
+		p.Flags = memo.PreferLookupJoinIntoRight
+	}
+	antiJoin := f.ConstructAntiJoin(fkInput, scanScope.expr, antiJoinFilters, &p)
 
 	return f.ConstructFKChecksItem(antiJoin, &memo.FKChecksItemPrivate{
 		OriginTable:     h.mb.tabID,
@@ -794,9 +796,11 @@ func (h *fkCheckHelper) buildDeletionCheck(
 			),
 		)
 	}
-	semiJoin := f.ConstructSemiJoin(
-		deletedRows, scanScope.expr, semiJoinFilters, &memo.JoinPrivate{},
-	)
+	var p memo.JoinPrivate
+	if h.mb.b.evalCtx.SessionData.PreferLookupJoinsForFKs {
+		p.Flags = memo.PreferLookupJoinIntoRight
+	}
+	semiJoin := f.ConstructSemiJoin(deletedRows, scanScope.expr, semiJoinFilters, &p)
 
 	return f.ConstructFKChecksItem(semiJoin, &memo.FKChecksItemPrivate{
 		OriginTable:     origTabMeta.MetaID,

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -134,3 +134,43 @@ delete doublechild
       │    └── columns: c:5!null p1:6 p2:7 crdb_internal_mvcc_timestamp:8
       └── filters
            └── p1:6 = 10
+
+# Verify that the join hint is set.
+build prefer-lookup-joins-for-fks
+DELETE FROM parent WHERE p = 3
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: x:5 parent.p:6 parent.other:7
+ ├── input binding: &1
+ ├── select
+ │    ├── columns: x:5 parent.p:6!null parent.other:7 parent.crdb_internal_mvcc_timestamp:8
+ │    ├── scan parent
+ │    │    └── columns: x:5 parent.p:6!null parent.other:7 parent.crdb_internal_mvcc_timestamp:8
+ │    └── filters
+ │         └── parent.p:6 = 3
+ └── f-k-checks
+      ├── f-k-checks-item: child(p) -> parent(p)
+      │    └── semi-join (hash)
+      │         ├── columns: p:9!null
+      │         ├── flags: prefer lookup join (into right side)
+      │         ├── with-scan &1
+      │         │    ├── columns: p:9!null
+      │         │    └── mapping:
+      │         │         └──  parent.p:6 => p:9
+      │         ├── scan child
+      │         │    └── columns: child.p:11!null
+      │         └── filters
+      │              └── p:9 = child.p:11
+      └── f-k-checks-item: child2(p) -> parent(other)
+           └── semi-join (hash)
+                ├── columns: other:13
+                ├── flags: prefer lookup join (into right side)
+                ├── with-scan &1
+                │    ├── columns: other:13
+                │    └── mapping:
+                │         └──  parent.other:7 => other:13
+                ├── scan child2
+                │    └── columns: child2.p:15!null
+                └── filters
+                     └── other:13 = child2.p:15

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -637,3 +637,31 @@ insert multi_ref_child
  └── values
       ├── columns: column1:6!null column2:7 column3:8 column4:9
       └── (1, NULL::INT8, NULL::INT8, NULL::INT8)
+
+# Verify that the join hint is set.
+build prefer-lookup-joins-for-fks
+INSERT INTO child VALUES (100, 1), (200, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => c:1
+ │    └── column2:5 => child.p:2
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:4!null column2:5!null
+ │    ├── (100, 1)
+ │    └── (200, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: column2:6!null
+                ├── flags: prefer lookup join (into right side)
+                ├── with-scan &1
+                │    ├── columns: column2:6!null
+                │    └── mapping:
+                │         └──  column2:5 => column2:6
+                ├── scan parent
+                │    └── columns: parent.p:7!null
+                └── filters
+                     └── column2:6 = parent.p:7

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -526,3 +526,33 @@ update fam
                 └── filters
                      ├── c:16 = two.a:18
                      └── d_new:17 = two.b:19
+
+# Verify that the join hint is set.
+build prefer-lookup-joins-for-fks
+UPDATE child SET p = 4
+----
+update child
+ ├── columns: <none>
+ ├── fetch columns: c:4 child.p:5
+ ├── update-mapping:
+ │    └── p_new:7 => child.p:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: p_new:7!null c:4!null child.p:5!null child.crdb_internal_mvcc_timestamp:6
+ │    ├── scan child
+ │    │    └── columns: c:4!null child.p:5!null child.crdb_internal_mvcc_timestamp:6
+ │    └── projections
+ │         └── 4 [as=p_new:7]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p_new:8!null
+                ├── flags: prefer lookup join (into right side)
+                ├── with-scan &1
+                │    ├── columns: p_new:8!null
+                │    └── mapping:
+                │         └──  p_new:7 => p_new:8
+                ├── scan parent
+                │    └── columns: parent.p:10!null
+                └── filters
+                     └── p_new:8 = parent.p:10

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -160,6 +160,10 @@ type Flags struct {
 	// JoinLimit is the default value for SessionData.ReorderJoinsLimit.
 	JoinLimit int
 
+	// PreferLookupJoinsForFK is the default value for
+	// SessionData.PreferLookupJoinsForFKs.
+	PreferLookupJoinsForFKs bool
+
 	// Locality specifies the location of the planning node as a set of user-
 	// defined key/value pairs, ordered from most inclusive to least inclusive.
 	// If there are no tiers, then the node's location is not known. Examples:
@@ -392,10 +396,8 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		}
 	}
 
-	defer func(oldValue int) {
-		ot.evalCtx.SessionData.ReorderJoinsLimit = oldValue
-	}(ot.evalCtx.SessionData.ReorderJoinsLimit)
 	ot.evalCtx.SessionData.ReorderJoinsLimit = ot.Flags.JoinLimit
+	ot.evalCtx.SessionData.PreferLookupJoinsForFKs = ot.Flags.PreferLookupJoinsForFKs
 
 	ot.Flags.Verbose = datadriven.Verbose()
 	ot.evalCtx.TestingKnobs.OptimizerCostPerturbation = ot.Flags.PerturbCost
@@ -706,6 +708,9 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 			return errors.Wrap(err, "join-limit")
 		}
 		f.JoinLimit = int(limit)
+
+	case "prefer-lookup-joins-for-fks":
+		f.PreferLookupJoinsForFKs = true
 
 	case "rule":
 		if len(arg.Vals) != 1 {

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -609,7 +609,7 @@ func (c *coster) computeValuesCost(values *memo.ValuesExpr) memo.Cost {
 }
 
 func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
-	if !join.Private().(*memo.JoinPrivate).Flags.Has(memo.AllowHashJoinStoreRight) {
+	if join.Private().(*memo.JoinPrivate).Flags.Has(memo.DisallowHashJoinStoreRight) {
 		return hugeCost
 	}
 	leftRowCount := join.Child(0).(memo.RelExpr).Relational().Stats.RowCount

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1584,9 +1584,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	orders := DeriveInterestingOrderings(left).Copy()
 	orders.RestrictToCols(leftEq.ToSet())
 
-	if (!joinPrivate.Flags.Has(memo.AllowHashJoinStoreLeft) &&
-		!joinPrivate.Flags.Has(memo.AllowHashJoinStoreRight)) ||
-		c.e.evalCtx.SessionData.ReorderJoinsLimit == 0 {
+	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData.ReorderJoinsLimit == 0 {
 		// If we are using a hint, or the join limit is set to zero, the join won't
 		// be commuted. Add the orderings from the right side.
 		rightOrders := DeriveInterestingOrderings(right).Copy()

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1563,7 +1563,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	on memo.FiltersExpr,
 	joinPrivate *memo.JoinPrivate,
 ) {
-	if !joinPrivate.Flags.Has(memo.AllowMergeJoin) {
+	if joinPrivate.Flags.Has(memo.DisallowMergeJoin) {
 		return
 	}
 
@@ -1701,7 +1701,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	on memo.FiltersExpr,
 	joinPrivate *memo.JoinPrivate,
 ) {
-	if !joinPrivate.Flags.Has(memo.AllowLookupJoinIntoRight) {
+	if joinPrivate.Flags.Has(memo.DisallowLookupJoinIntoRight) {
 		return
 	}
 	md := c.e.mem.Metadata()
@@ -1916,7 +1916,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 	on memo.FiltersExpr,
 	joinPrivate *memo.JoinPrivate,
 ) {
-	if !joinPrivate.Flags.Has(memo.AllowLookupJoinIntoRight) {
+	if joinPrivate.Flags.Has(memo.DisallowLookupJoinIntoRight) {
 		return
 	}
 

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -696,3 +696,89 @@ project
       │         ├── w:1 = 'foo' [outer=(1), constraints=(/1: [/'foo' - /'foo']; tight), fd=()-->(1)]
       │         └── x:2 = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [outer=(2), constraints=(/2: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(2)]
       └── 10
+
+exec-ddl
+CREATE TABLE p (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE c (c INT PRIMARY KEY, c INT REFERENCES p(p));
+----
+
+opt
+INSERT INTO c VALUES (1,1), (2,2)
+----
+insert c
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => c:1
+ │    └── column2:5 => c:2
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 12.12
+ ├── values
+ │    ├── columns: column1:4!null column2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── stats: [rows=2, distinct(4)=2, null(4)=0]
+ │    ├── cost: 0.03
+ │    ├── (1, 1)
+ │    └── (2, 2)
+ └── f-k-checks
+      └── f-k-checks-item: c(c) -> p(p)
+           └── anti-join (lookup p)
+                ├── columns: column1:6!null
+                ├── key columns: [6] = [7]
+                ├── lookup columns are key
+                ├── cardinality: [0 - 2]
+                ├── stats: [rows=1e-10]
+                ├── cost: 12.08
+                ├── with-scan &1
+                │    ├── columns: column1:6!null
+                │    ├── mapping:
+                │    │    └──  column1:4 => column1:6
+                │    ├── cardinality: [2 - 2]
+                │    ├── stats: [rows=2, distinct(6)=2, null(6)=0]
+                │    └── cost: 0.01
+                └── filters (true)
+
+# The cost should be much smaller with this hint.
+opt prefer-lookup-joins-for-fks
+INSERT INTO c VALUES (1,1), (2,2)
+----
+insert c
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => c:1
+ │    └── column2:5 => c:2
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 0.06001206
+ ├── values
+ │    ├── columns: column1:4!null column2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── stats: [rows=2, distinct(4)=2, null(4)=0]
+ │    ├── cost: 0.03
+ │    ├── (1, 1)
+ │    └── (2, 2)
+ └── f-k-checks
+      └── f-k-checks-item: c(c) -> p(p)
+           └── anti-join (lookup p)
+                ├── columns: column1:6!null
+                ├── flags: prefer lookup join (into right side)
+                ├── key columns: [6] = [7]
+                ├── lookup columns are key
+                ├── cardinality: [0 - 2]
+                ├── stats: [rows=1e-10]
+                ├── cost: 0.02001206
+                ├── with-scan &1
+                │    ├── columns: column1:6!null
+                │    ├── mapping:
+                │    │    └──  column1:4 => column1:6
+                │    ├── cardinality: [2 - 2]
+                │    ├── stats: [rows=2, distinct(6)=2, null(6)=0]
+                │    └── cost: 0.01
+                └── filters (true)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -82,6 +82,9 @@ type SessionData struct {
 	// SafeUpdates causes errors when the client
 	// sends syntax that may have unwanted side effects.
 	SafeUpdates bool
+	// PreferLookupJoinsForFKs causes foreign key operations to prefer lookup
+	// joins.
+	PreferLookupJoinsForFKs bool
 	// RemoteAddr is used to generate logging events.
 	RemoteAddr net.Addr
 	// ZigzagJoinEnabled indicates whether the optimizer should try and plan a

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -813,6 +813,25 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: globalFalse,
 	},
 
+	// CockroachDB extension.
+	`prefer_lookup_joins_for_fks`: {
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.PreferLookupJoinsForFKs)
+		},
+		GetStringVal: makePostgresBoolGetStringValFn("prefer_lookup_joins_for_fks"),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parseBoolVar("prefer_lookup_joins_for_fks", s)
+			if err != nil {
+				return err
+			}
+			m.SetPreferLookupJoinsForFKs(b)
+			return nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(preferLookupJoinsForFKs.Get(sv))
+		},
+	},
+
 	// See https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH
 	// https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
 	`search_path`: {


### PR DESCRIPTION
#### opt: correct check for no join hints

Correcting a check in GenerateMergeJoins to use the same method (`NoJoinHints`)
used by the rules to determine if commuting is allowed instead of checking
specific flags.

Release note: None

#### opt: rework join hints

The join hints are a set of "allow" bits, with the special case that 0 means
that everything is allowed. This makes some things more convenient but makes it
hard to add other types of flags.

This change flips the meaning of the bits from "allow" to "disallow". Now the
zero value makes logical sense.

Release note: None

#### sql: add prefer_lookup_joins_for_fk setting

We have seen cases where the new FK incorrectly use merge joins instead of
lookup joins. Some cases were due to a bug; one known case which is still
problematic is when the parent table is interleaved and scanning the table is
much more costly than the optimizer accounts for.

In the previous release, we were able to disable the optimizer-driven FKs as a
workaround, but that is no longer available.

This change adds a `prefer_lookup_joins_for_fk` session setting and
corresponding cluster variable. This setting makes FK checks prefer use of
lookup joins.

To implement this, we extend the JoinFlags to support flags that indicate a
preference. We cannot use the regular join hints because they error out if we
can't build a lookup join, and we no longer force existence of indexes. Thew new
flag causes the coster to slash the cost of lookup joins.

Note that any join flags still prevent reordering and commutation. We would need
extra work to make the `PreferLookupJoinIntoLeft` flag work properly;
fortunately we only need the right variant.

Release justification: low-risk updates to new functionality

Release note (sql change): The prefer_lookup_joins_for_fk session setting (and
corresponding cluster setting) can be used to make foreign key checks use lookup
joins if they incorrectly use hash or merge join.
