### PR TITLE
opt: switch up const iota definitions to not confuse tooling

### DIFF
--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -1381,11 +1381,11 @@ type lookupTableEntry uint8
 const (
 	// never indicates that the transformation represented by the table entry is
 	// unconditionally incorrect.
-	never lookupTableEntry = 0
+	never lookupTableEntry = (1 << iota) / 2
 
 	// always indicates that the transformation represented by the table entry is
 	// unconditionally correct.
-	always lookupTableEntry = 1 << (iota - 1)
+	always
 
 	// filterA indicates that the filters of the "A" join operator must reject
 	// nulls for the set of vertexes specified by rejectsOnLeftA, rejectsOnRightA,


### PR DESCRIPTION
Kept seeing the following "compiler error" in Goland, it wasn't smart
enough to realize iota is non-zero where declared:

  Invalid operation: 1 << (iota - 1) (negative shift count)

This patch just side steps that problem.

Release justification: simple, tiny clean up
Release note: None