### PR TITLE
geomfn: fix panic in ST_SetPoint when given empty point

### DIFF
--- a/pkg/geo/geomfn/linestring.go
+++ b/pkg/geo/geomfn/linestring.go
@@ -52,6 +52,9 @@ func setPoint(lineString *geom.LineString, index int, point *geom.Point) (*geom.
 	if lineString.Layout() != point.Layout() {
 		return nil, geom.ErrLayoutMismatch{Got: point.Layout(), Want: lineString.Layout()}
 	}
+	if point.Empty() {
+		point = geom.NewPointFlat(point.Layout(), make([]float64, point.Stride()))
+	}
 
 	coords := lineString.Coords()
 	hasNegIndex := index < 0

--- a/pkg/geo/geomfn/linestring_test.go
+++ b/pkg/geo/geomfn/linestring_test.go
@@ -50,6 +50,12 @@ func TestSetPoint(t *testing.T) {
 			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
 			expected:   geom.NewLineStringFlat(geom.XY, []float64{0, 0, 2, 2}),
 		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			index:      0,
+			point:      geom.NewPointEmpty(geom.XY),
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{0, 0, 2, 2}),
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new functionality

Release note (bug fix): fix panic in `ST_SetPoint` when given empty
point

Resolves #53855.