### PR TITLE
physicalplan: fix row estimates when merging plans

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3169,6 +3169,7 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 	}
 
 	p := MakePhysicalPlan(dsp.gatewayNodeID)
+	p.SetRowEstimates(&leftPlan.PhysicalPlan, &rightPlan.PhysicalPlan)
 
 	// Merge the plans' PlanToStreamColMap, which we know are equivalent.
 	p.PlanToStreamColMap = planToStreamColMap

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -126,3 +126,26 @@ group (scalar)  ·                    ·
 ·               estimated row count  100000
 ·               table                large@primary
 ·               spans                FULL SCAN
+
+statement ok
+SET vectorize_row_count_threshold = 1000
+
+# Check that we estimate the row count correctly when multiple tables are
+# scanned.
+query TTT
+EXPLAIN SELECT * FROM small INNER MERGE JOIN large ON small.a = large.a
+----
+·           distribution         full
+·           vectorized           true
+merge join  ·                    ·
+ │          equality             (a) = (a)
+ │          left cols are key    ·
+ │          right cols are key   ·
+ ├── scan   ·                    ·
+ │          estimated row count  100
+ │          table                small@primary
+ │          spans                FULL SCAN
+ └── scan   ·                    ·
+·           estimated row count  100000
+·           table                large@primary
+·           spans                FULL SCAN


### PR DESCRIPTION
Previously, there was a mistake when merging two physical plans in the
way we computed the max estimated row count (we always use the value
from the left). This error could result in us thinking that the
vectorized threshold wasn't met when, in fact, it was (e.g. we're
reading 100 rows on the left and 10000 rows on the right of a join - we
would think we don't meet 1000 row threshold). This is now fixed.

Additionally, it fixes the propagation of the estimates when planning
set-operation joins.

Release justification: bug fix.

Release note: None