### PR TITLE
sql: fix interleaved join with filters

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -112,7 +112,7 @@ func (dsp *DistSQLPlanner) createPlanForInterleavedJoin(
 			return nil, err
 		}
 		if filter != nil {
-			if err := plans[i].AddFilter(filter, planCtx, plan.PlanToStreamColMap); err != nil {
+			if err := plans[i].AddFilter(filter, planCtx, plans[i].PlanToStreamColMap); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -369,3 +369,27 @@ rows affected: 10
 
 statement ok
 DROP TABLE c; DROP TABLE b; DROP TABLE a
+
+# Regression test for interleaved join with filters.
+statement ok
+CREATE TABLE table0 (c0 INT, PRIMARY KEY (c0));
+CREATE TABLE table1 (c0 INT, c1 INT, PRIMARY KEY (c0, c1)) INTERLEAVE IN PARENT table0 (c0);
+CREATE TABLE table2 (c0 INT, c1 INT, c2 INT, PRIMARY KEY (c0, c1, c2)) INTERLEAVE IN PARENT table1 (c0, c1);
+INSERT INTO table0 SELECT i FROM generate_series(1, 10) AS i;
+INSERT INTO table1 SELECT (i-1)//10+1, i FROM generate_series(1, 100) AS i;
+INSERT INTO table2 SELECT (i-1)//100+1, (i-1)//10+1, i FROM generate_series(1, 1000) AS i;
+
+query TTT
+EXPLAIN SELECT count(*) FROM table1 INNER MERGE JOIN table2 USING(c0, c1) WHERE c1 >= 25 AND c1 < 75
+----
+·                      distribution  local
+·                      vectorized    true
+group (scalar)         ·             ·
+ └── interleaved join  ·             ·
+·                      left table    table1@primary
+·                      left spans    FULL SCAN
+·                      left filter   (c1 >= 25) AND (c1 < 75)
+·                      right table   table2@primary
+·                      right spans   FULL SCAN
+·                      right filter  (c1 >= 25) AND (c1 < 75)
+·                      ancestor      left


### PR DESCRIPTION
Release justification: bug fix.

Release note (bug fix): CockroachDB could previously crash when
performing an interleaved join in some cases. The bug has only been
present on 20.2 testing releases.