### PR TITLE
kvserver: check for in-progress merge before dropping latches

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -38,7 +38,7 @@ func (r *Replica) executeReadOnlyBatch(
 	defer r.readOnlyCmdMu.RUnlock()
 
 	// Verify that the batch can be executed.
-	if err := r.checkExecutionCanProceed(ctx, ba, g, &st); err != nil {
+	if _, err := r.checkExecutionCanProceed(ctx, ba, g, &st); err != nil {
 		return nil, g, roachpb.NewError(err)
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -557,7 +557,7 @@ func (r *Replica) executeAdminBatch(
 	// NB: we pass nil for the spanlatch guard because we haven't acquired
 	// latches yet. This is ok because each individual request that the admin
 	// request sends will acquire latches.
-	if err := r.checkExecutionCanProceed(ctx, ba, nil /* g */, &status); err != nil {
+	if _, err := r.checkExecutionCanProceed(ctx, ba, nil /* g */, &status); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -727,7 +727,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	st := &kvserverpb.LeaseStatus{Timestamp: repl1.Clock().Now()}
-	if err = repl1.checkExecutionCanProceed(ctx, &roachpb.BatchRequest{}, nil /* g */, st); !errors.Is(err, expErr) {
+	if _, err = repl1.checkExecutionCanProceed(ctx, &roachpb.BatchRequest{}, nil /* g */, st); !errors.Is(err, expErr) {
 		t.Fatalf("expected error %s, but got %v", expErr, err)
 	}
 }


### PR DESCRIPTION
When a request bumps the LeaseAppliedIndex of a range, we assert that
the range isn't currently subsumed. This is a correctness invariant for
range merges that if violated, can allow subsumed ranges to continue
(incorrectly) serving follower reads.

However, this assertion checks for a pending merge _after_ the write
request's latches are dropped. If the concerned range gets subsumed
between when these latches are dropped and when we call
`replica.mergeInProgress()`, the assertion will incorrectly fire.

This commit fixes this issue by checking for a pending merge before we
drop the write's latches.

Fixes #52115

Release justification: Fix race condition causing a fatal
Release note: None