### PR TITLE
sql: Remove type annotations from pg_get_constraintdef

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -90,7 +90,7 @@ query TTTTB colnames
 SHOW CONSTRAINTS FROM t
 ----
 table_name  constraint_name  constraint_type  details                              validated
-t           check_a          CHECK            CHECK ((a > 0:::INT8))               true
+t           check_a          CHECK            CHECK ((a > 0))                      true
 t           fk_f_ref_other   FOREIGN KEY      FOREIGN KEY (f) REFERENCES other(b)  true
 t           foo              UNIQUE           UNIQUE (b ASC)                       true
 t           primary          PRIMARY KEY      PRIMARY KEY (a ASC)                  true
@@ -119,7 +119,7 @@ INSERT INTO t (a) VALUES (-3)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a         CHECK        CHECK ((a > 0))                      true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -137,8 +137,8 @@ ALTER TABLE t ADD CHECK (a > 0)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
-t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a         CHECK        CHECK ((a > 0))                      true
+t  check_a1        CHECK        CHECK ((a > 0))                      true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -159,8 +159,8 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
-t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a         CHECK        CHECK ((a > 0))                      true
+t  check_a1        CHECK        CHECK ((a > 0))                      true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -381,12 +381,12 @@ ALTER TABLE t ADD i INT AS (g - 1) STORED CHECK (i > 0)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_f   CHECK        CHECK ((f > 1:::INT8))  true
-t  check_g   CHECK        CHECK ((g > 0:::INT8))  true
-t  check_h   CHECK        CHECK ((h > 0:::INT8))  true
-t  check_h1  CHECK        CHECK ((h < 10:::INT8)) true
-t  primary   PRIMARY KEY  PRIMARY KEY (a ASC)     true
-t  t_h_key   UNIQUE       UNIQUE (h ASC)          true
+t  check_f   CHECK        CHECK ((f > 1))      true
+t  check_g   CHECK        CHECK ((g > 0))      true
+t  check_h   CHECK        CHECK ((h > 0))      true
+t  check_h1  CHECK        CHECK ((h < 10))     true
+t  primary   PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_h_key   UNIQUE       UNIQUE (h ASC)       true
 
 statement ok
 DROP TABLE t
@@ -419,13 +419,13 @@ ALTER TABLE t ADD COLUMN u INT UNIQUE, ADD COLUMN v INT UNIQUE, ADD CONSTRAINT c
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_c_b  CHECK        CHECK ((c > b))         true
-t  ck         CHECK        CHECK ((a > 0:::INT8))  true
-t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)     true
-t  t_d_key    UNIQUE       UNIQUE (d ASC)          true
-t  t_e_key    UNIQUE       UNIQUE (e ASC)          true
-t  t_u_key    UNIQUE       UNIQUE (u ASC)          true
-t  t_v_key    UNIQUE       UNIQUE (v ASC)          true
+t  check_c_b  CHECK        CHECK ((c > b))      true
+t  ck         CHECK        CHECK ((a > 0))      true
+t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_d_key    UNIQUE       UNIQUE (d ASC)       true
+t  t_e_key    UNIQUE       UNIQUE (e ASC)       true
+t  t_u_key    UNIQUE       UNIQUE (u ASC)       true
+t  t_v_key    UNIQUE       UNIQUE (v ASC)       true
 
 statement ok
 DROP TABLE t
@@ -978,8 +978,8 @@ ALTER TABLE t ADD CHECK (a < 16) NOT VALID
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK  ((a < 100:::INT8))  true
-t  check_a1  CHECK  CHECK  ((a < 16:::INT8))   false
+t  check_a   CHECK  CHECK ((a < 100))  true
+t  check_a1  CHECK  CHECK ((a < 16))   false
 
 query error pq: failed to satisfy CHECK constraint \(a < 16:::INT8\)
 INSERT INTO t VALUES (20)
@@ -996,8 +996,8 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a1
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK  ((a < 100:::INT8))  true
-t  check_a1  CHECK  CHECK  ((a < 16:::INT8))   true
+t  check_a   CHECK  CHECK ((a < 100))  true
+t  check_a1  CHECK  CHECK ((a < 16))   true
 
 subtest regression_42858
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -215,7 +215,7 @@ statement ok
 CREATE TABLE constraint_db.t3 (
     a INT,
     b INT CHECK (b > 11),
-    c STRING DEFAULT 'FOO',
+    c STRING DEFAULT 'FOO' CHECK (c != ''),
     CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES constraint_db.t1(b, c),
     INDEX (a, b DESC) STORING (c)
 )
@@ -381,7 +381,7 @@ index_key     false      i        2         0          false       false
 t2            false      r        2         0          false       true
 primary       false      i        1         0          false       false
 t2_t1_id_idx  false      i        1         0          false       false
-t3            false      r        4         1          false       true
+t3            false      r        4         2          false       true
 primary       false      i        1         0          false       false
 t3_a_b_idx    false      i        2         0          false       false
 v1            false      v        4         0          false       false
@@ -610,19 +610,19 @@ oid         amname    amstrategies  amsupport  amcanorder  amcanorderbyop  amcan
 
 ## pg_catalog.pg_attrdef
 
-query OTOITT colnames
-SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc
+query OTOITTT colnames
+SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc, pg_get_expr(ad.adbin, ad.adrelid)
 FROM pg_catalog.pg_attrdef ad
 JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-oid         relname  adrelid  adnum  adbin           adsrc
-1666782879  t1       55       4      12              12
-841178406   t2       56       2      unique_rowid()  unique_rowid()
-2186255414  t3       57       3      'FOO'           'FOO'
-2186255409  t3       57       4      unique_rowid()  unique_rowid()
-581442133   mv1      59       2      unique_rowid()  unique_rowid()
+oid         relname  adrelid  adnum  adbin           adsrc           pg_get_expr
+1666782879  t1       55       4      12              12              12
+841178406   t2       56       2      unique_rowid()  unique_rowid()  unique_rowid()
+2186255414  t3       57       3      'FOO'           'FOO'           'FOO'
+2186255409  t3       57       4      unique_rowid()  unique_rowid()  unique_rowid()
+581442133   mv1      59       2      unique_rowid()  unique_rowid()  unique_rowid()
 
 ## pg_catalog.pg_indexes
 
@@ -839,8 +839,9 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 oid         conname    connamespace  contype  condef
+370295511   check_c    2332901747    c        CHECK ((c != ''))
 2143281868  fk         2332901747    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
-2792001267  check_b    2332901747    c        CHECK ((b > 11:::INT8))
+2792001267  check_b    2332901747    c        CHECK ((b > 11))
 3572320190  primary    2332901747    p        PRIMARY KEY (p ASC)
 4089604113  fk         2332901747    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
 4243354484  t1_a_key   2332901747    u        UNIQUE (a ASC)
@@ -854,6 +855,7 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 conname    contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
+check_c    c        false          false        true          57        0         0
 fk         f        false          false        true          57        0         450499961
 check_b    c        false          false        true          57        0         0
 primary    p        false          false        true          55        0         450499963
@@ -877,6 +879,7 @@ WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
 conname    confrelid  confupdtype  confdeltype  confmatchtype
+check_c    0          NULL         NULL         NULL
 check_b    0          NULL         NULL         NULL
 primary    0          NULL         NULL         NULL
 t1_a_key   0          NULL         NULL         NULL
@@ -901,6 +904,7 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 conname    conislocal  coninhcount  connoinherit  conkey
+check_c    true        0            true          {3}
 fk         true        0            true          {1,2}
 check_b    true        0            true          {2}
 primary    true        0            true          {1}
@@ -908,18 +912,19 @@ fk         true        0            true          {1}
 t1_a_key   true        0            true          {2}
 index_key  true        0            true          {3,4}
 
-query TTTTTTTT colnames
-SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc
+query TTTTTTTTT colnames
+SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc, pg_get_constraintdef(con.oid) as condef
 FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
-conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin           consrc
-check_b    NULL     NULL       NULL       NULL       NULL       (b > 11:::INT8)  (b > 11:::INT8)
-primary    NULL     NULL       NULL       NULL       NULL       NULL             NULL
-t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL             NULL
-index_key  NULL     NULL       NULL       NULL       NULL       NULL             NULL
+conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin     consrc     condef
+check_c    NULL     NULL       NULL       NULL       NULL       (c != '')  (c != '')  CHECK ((c != ''))
+check_b    NULL     NULL       NULL       NULL       NULL       (b > 11)   (b > 11)   CHECK ((b > 11))
+primary    NULL     NULL       NULL       NULL       NULL       NULL       NULL       PRIMARY KEY (p ASC)
+t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL       NULL       UNIQUE (a ASC)
+index_key  NULL     NULL       NULL       NULL       NULL       NULL       NULL       UNIQUE (b ASC, c ASC)
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+ # LogicTest: !3node-tenant(49854)
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
@@ -924,9 +924,9 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0:::INT8))  false
-check_table  d_0      CHECK        CHECK ((d > 0:::INT8))  true
-check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)     true
+check_table  c_0      CHECK        CHECK ((c > 0))      false
+check_table  d_0      CHECK        CHECK ((d > 0))      true
+check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
 statement ok
 BEGIN
@@ -957,9 +957,9 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0:::INT8))  false
-check_table  d_0      CHECK        CHECK ((d > 0:::INT8))  true
-check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)     true
+check_table  c_0      CHECK        CHECK ((c > 0))      false
+check_table  d_0      CHECK        CHECK ((d > 0))      true
+check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
 # Adding column e was rolled back
 query TTBTTTB
@@ -1142,8 +1142,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  ck_a  CHECK  CHECK ((a = 0:::INT8))  true
-check_table  ck_b  CHECK  CHECK ((b > 0:::INT8))  true
+check_table  ck_a  CHECK  CHECK ((a = 0))  true
+check_table  ck_b  CHECK  CHECK ((b > 0))  true
 check_table  ck_c  CHECK  CHECK ((c > b))  true
 
 # Also test insert/update to ensure constraint was added in a valid state (with correct column IDs, etc.)

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -238,10 +238,10 @@ query TTTTB colnames
 SHOW CONSTRAINTS FROM test.dupe_generated
 ----
 table_name      constraint_name  constraint_type  details             validated
-dupe_generated  check_bar        CHECK            CHECK ((bar > 2:::INT8))   true
-dupe_generated  check_foo        CHECK            CHECK ((foo > 2:::INT8))   true
-dupe_generated  check_foo1       CHECK            CHECK ((foo < 10:::INT8))  true
-dupe_generated  check_foo2       CHECK            CHECK ((foo > 1:::INT8))   true
+dupe_generated  check_bar        CHECK            CHECK ((bar > 2))   true
+dupe_generated  check_foo        CHECK            CHECK ((foo > 2))   true
+dupe_generated  check_foo1       CHECK            CHECK ((foo < 10))  true
+dupe_generated  check_foo2       CHECK            CHECK ((foo > 1))   true
 
 statement ok
 CREATE TABLE test.named_constraints (
@@ -289,7 +289,7 @@ SHOW CONSTRAINTS FROM test.named_constraints
 ----
 table_name         constraint_name  constraint_type  details                                    validated
 named_constraints  bar              UNIQUE           UNIQUE (id ASC, name ASC)                  true
-named_constraints  ck1              CHECK            CHECK ((length(nickname) < 10:::INT8))     true
+named_constraints  ck1              CHECK            CHECK ((length(nickname) < 10))            true
 named_constraints  ck2              CHECK            CHECK ((length(nickname) < length(name)))  true
 named_constraints  pk               PRIMARY KEY      PRIMARY KEY (id ASC)                       true
 named_constraints  uq               UNIQUE           UNIQUE (email ASC)                         true


### PR DESCRIPTION
Some ORMs rely on the output of this function to inspect constraint
definitions. They should not contain type annotations in the output,
since that is not standard SQL.

Release justification: low-risk change that increases compatibility with
ORMs.
Releaes note: The pg_get_constraintdef function used to return a result that
included type annotations, which is a CockroachDB-specific syntax. Now
they do not.