### PR TITLE
opt: don't allow the dummy PK key to be part of any FDs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2700,3 +2700,13 @@ query T
 SELECT attname FROM pg_attribute WHERE attrelid = $testid LIMIT 1
 ----
 x
+
+# Regression test for #53854.
+statement ok
+SELECT
+  t.typname, t.oid
+FROM
+  pg_catalog.pg_type AS t JOIN pg_catalog.pg_namespace AS n ON t.typnamespace = n.oid
+WHERE
+  n.nspname != 'pg_toast'
+  AND (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class AS c WHERE c.oid = t.typrelid))


### PR DESCRIPTION
The dummy PK column of virtual tables can't actually be scanned. We
don't expose it as a key, but we can still expose it as part of a
composite key, which can result in errors if that key is used by some
transformation.

Fixes #53854.

Release justification: regression fix

Release notes (bug fix): fixed "use of crdb_internal_vtable_pk column
not allowed" for some queries involving virtual tables.