### PR TITLE
storageccl: improve wrong encryption key error

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4110,7 +4110,7 @@ func TestEncryptedBackup(t *testing.T) {
 			if tc.useKMS {
 				expectedShowError = `one of the provided URIs was not used when encrypting the base BACKUP`
 			} else {
-				expectedShowError = `cipher: message authentication failed`
+				expectedShowError = `failed to decrypt — maybe incorrect key: cipher: message authentication failed`
 			}
 			sqlDB.ExpectErr(t, expectedShowError,
 				fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, incorrectEncryptionOption), backupLoc1)

--- a/pkg/ccl/storageccl/encryption.go
+++ b/pkg/ccl/storageccl/encryption.go
@@ -117,6 +117,9 @@ func DecryptFile(ciphertext, key []byte) ([]byte, error) {
 	iv := ciphertext[:ivSize]
 	ciphertext = ciphertext[ivSize:]
 	plaintext, err := gcm.Open(ciphertext[:0], iv, ciphertext, nil)
+	if err != nil {
+		err = errors.Wrap(err, "failed to decrypt — maybe incorrect key")
+	}
 	return plaintext, err
 }
 


### PR DESCRIPTION
Fixes: #46736

Release justification: low risk, high benefit changes to existing functionality