### PR TITLE
server: add health endpoint for tenant

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -692,6 +692,13 @@ func StartTenant(
 		mux := http.NewServeMux()
 		debugServer := debug.NewServer(args.Settings, s.pgServer.HBADebugFn())
 		mux.Handle("/", debugServer)
+		mux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
+			// Return Bad Request if called with arguments.
+			if err := req.ParseForm(); err != nil || len(req.Form) != 0 {
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+		})
 		f := varsHandler{metricSource: args.recorder}.handleVars
 		mux.Handle(statusVars, http.HandlerFunc(f))
 		_ = http.Serve(httpL, mux)


### PR DESCRIPTION
There isn't a /health endpoint for SQL tenants.
We need to be able to do a simple health check for SQL tenant process.
This adds a simple /health endpoint that returns 200.

Release justification: trivial change that has significant impact.

Release note: None