### PR TITLE
cloudimpl: improve unsupported storage scheme error

### DIFF
--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -212,7 +212,9 @@ func ExternalStorageConfFromURI(path, user string) (roachpb.ExternalStorage, err
 		conf.FileTableConfig.QualifiedTableName = qualifiedTableName
 		conf.FileTableConfig.Path = uri.Path
 	default:
-		return conf, errors.Errorf("unsupported storage scheme: %q", uri.Scheme)
+		// TODO(adityamaru): Link dedicated ExternalStorage scheme docs once ready.
+		return conf, errors.Errorf("unsupported storage scheme: %q - refer to docs to find supported"+
+			" storage schemes", uri.Scheme)
 	}
 	return conf, nil
 }


### PR DESCRIPTION
Informs: #29038

Release justification: low risk, high benefit changes to existing functionality