### PR TITLE
backupccl: fix TestClientDisconnect/RESTORE

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5908,7 +5908,10 @@ func TestClientDisconnect(t *testing.T) {
 				close(allowResponse)
 				sqlDB.Exec(t, fmt.Sprintf("CREATE DATABASE %s", restoreDB))
 				sqlDB.Exec(t, "BACKUP TO $1", LocalFoo)
+				// Reset the channels. There will be a request on the gotRequest channel
+				// due to the backup.
 				allowResponse = make(chan struct{})
+				<-gotRequest
 			}
 
 			// Make credentials for the new connection.


### PR DESCRIPTION
The RESTORE portion of this test wasn't testing what it intended to.
Instead it tested the adoption logic for jobs. The test previously
took ~30s due to the job adoption loop and now takes ~4. The problem
was that we'd cancel the context for the startable job before it was
able to actually start the job because we'd immediately receive on the
channel.

Release justification: non-production code changes.

Release note: None