### PR TITLE
cli: productionize start-sql

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -89,9 +89,9 @@ func setServerContextDefaults() {
 
 	serverCfg.ClockDevicePath = ""
 	serverCfg.ExternalIODirConfig = base.ExternalIODirConfig{}
+	serverCfg.GoroutineDumpDirName = ""
+	serverCfg.HeapProfileDirName = ""
 
-	serverCfg.KVConfig.GoroutineDumpDirName = ""
-	serverCfg.KVConfig.HeapProfileDirName = ""
 	serverCfg.AutoInitializeCluster = false
 	serverCfg.KVConfig.ReadyFn = nil
 	serverCfg.KVConfig.DelayedBootstrapFn = nil

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -815,6 +815,7 @@ func init() {
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
 
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
+		varFlag(f, &startCtx.logDir, cliflags.LogDir)
 	}
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1001,7 +1001,7 @@ func logOutputDirectory() string {
 // setupAndInitializeLoggingAndProfiling does what it says on the label.
 // Prior to this however it determines suitable defaults for the
 // logging output directory and the verbosity level of stderr logging.
-// We only do this for the "start" command which is why this work
+// We only do this for the "start" and "start-sql" commands which is why this work
 // occurs here and not in an OnInitialize function.
 func setupAndInitializeLoggingAndProfiling(
 	ctx context.Context, cmd *cobra.Command,
@@ -1031,6 +1031,7 @@ func setupAndInitializeLoggingAndProfiling(
 			}
 			newDir = filepath.Join(spec.Path, "logs")
 		}
+
 		if err := startCtx.logDir.Set(newDir); err != nil {
 			return nil, err
 		}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -54,7 +54,7 @@ const (
 	defaultScanMinIdleTime   = 10 * time.Millisecond
 	defaultScanMaxIdleTime   = 1 * time.Second
 
-	defaultStorePath = "cockroach-data"
+	DefaultStorePath = "cockroach-data"
 	// TempDirPrefix is the filename prefix of any temporary subdirectory
 	// created.
 	TempDirPrefix = "cockroach-temp"
@@ -384,7 +384,7 @@ func SetOpenFileLimitForOneStore() (uint64, error) {
 
 // MakeConfig returns a Config for the system tenant with default values.
 func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
-	storeSpec, err := base.NewStoreSpec(defaultStorePath)
+	storeSpec, err := base.NewStoreSpec(DefaultStorePath)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -122,6 +122,14 @@ type BaseConfig struct {
 	// ReadWithinUncertaintyIntervalError.
 	MaxOffset MaxOffsetType
 
+	// GoroutineDumpDirName is the directory name for goroutine dumps using
+	// goroutinedumper.
+	GoroutineDumpDirName string
+
+	// HeapProfileDirName is the directory name for heap profiles using
+	// heapprofiler. If empty, no heap profiles will be collected.
+	HeapProfileDirName string
+
 	// DefaultZoneConfig is used to set the default zone config inside the server.
 	// It can be overridden during tests by setting the DefaultZoneConfigOverride
 	// server testing knob.
@@ -194,14 +202,6 @@ type KVConfig struct {
 	// TimeSeriesServerConfig contains configuration specific to the time series
 	// server.
 	TimeSeriesServerConfig ts.ServerConfig
-
-	// GoroutineDumpDirName is the directory name for goroutine dumps using
-	// goroutinedumper.
-	GoroutineDumpDirName string
-
-	// HeapProfileDirName is the directory name for heap profiles using
-	// heapprofiler. If empty, no heap profiles will be collected.
-	HeapProfileDirName string
 
 	// Parsed values.
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -140,9 +140,8 @@ type sqlServerArgs struct {
 	// other things.
 	clock *hlc.Clock
 
-	// DistSQLCfg holds on to this to check for node CPU utilization in
-	// samplerProcessor.
-	runtime execinfra.RuntimeStats
+	// The RuntimeStatSampler provides metrics data to the recorder.
+	runtime *status.RuntimeStatSampler
 
 	// DistSQL uses rpcContext to set up flows. Less centrally, the executor
 	// also uses rpcContext in a number of places to learn whether the server

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -705,6 +705,19 @@ func StartTenant(
 	)
 	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
 
+	// TODO(tbg): the log dir is not configurable at this point
+	// since it is integrated too tightly with the `./cockroach start` command.
+	if err := startSampleEnvironment(ctx, sampleEnvironmentCfg{
+		st:                   args.Settings,
+		stopper:              args.stopper,
+		minSampleInterval:    base.DefaultMetricsSampleInterval,
+		goroutineDumpDirName: args.GoroutineDumpDirName,
+		heapProfileDirName:   args.HeapProfileDirName,
+		runtime:              args.runtime,
+	}); err != nil {
+		return "", "", err
+	}
+
 	if err := s.start(ctx,
 		args.stopper,
 		args.TestingKnobs,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -544,6 +544,9 @@ func makeSQLServerArgs(
 	const sqlInstanceID = base.SQLInstanceID(10001)
 	idContainer := base.NewSQLIDContainer(sqlInstanceID, &c, false /* exposed */)
 
+	runtime := status.NewRuntimeStatSampler(context.Background(), clock)
+	registry.AddMetricStruct(runtime)
+
 	// We don't need this for anything except some services that want a gRPC
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
@@ -573,7 +576,7 @@ func makeSQLServerArgs(
 		BaseConfig:               &baseCfg,
 		stopper:                  stopper,
 		clock:                    clock,
-		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
+		runtime:                  runtime,
 		rpcContext:               rpcContext,
 		nodeDescs:                tenantConnect,
 		systemConfigProvider:     tenantConnect,


### PR DESCRIPTION
Fixes #51138.

- server: prepare startSampleEnvironment for reuse
- cli: set up logging for start-sql
- server: sample environment on standalone SQL node

Release justification: see individual commits.
Release note: None
