### PR TITLE
cli/zip: avoid mistakenly suffixing non-pprof data with `.pprof`

### DIFF
--- a/pkg/server/heapprofiler/cgoprofiler.go
+++ b/pkg/server/heapprofiler/cgoprofiler.go
@@ -32,7 +32,11 @@ type NonGoAllocProfiler struct {
 	profiler
 }
 
-const jemallocFileNamePrefix = "jeprof"
+// JemallocFileNamePrefix is the prefix of jemalloc profile dumps.
+const JemallocFileNamePrefix = "jeprof"
+
+// JemallocFileNameSuffix is the file name extension of jemalloc profile dumps.
+const JemallocFileNameSuffix = ".jeprof"
 
 // NewNonGoAllocProfiler creates a NonGoAllocProfiler. dir is the
 // directory in which profiles are to be stored.
@@ -53,7 +57,7 @@ func NewNonGoAllocProfiler(
 
 	hp := &NonGoAllocProfiler{
 		profiler{
-			store: newProfileStore(dumpStore, jemallocFileNamePrefix, st),
+			store: newProfileStore(dumpStore, JemallocFileNamePrefix, JemallocFileNameSuffix, st),
 		},
 	}
 	return hp, nil

--- a/pkg/server/heapprofiler/heapprofiler.go
+++ b/pkg/server/heapprofiler/heapprofiler.go
@@ -33,7 +33,11 @@ type HeapProfiler struct {
 	profiler
 }
 
-const heapFileNamePrefix = "memprof"
+// HeapFileNamePrefix is the prefix of files containing pprof data.
+const HeapFileNamePrefix = "memprof"
+
+// HeapFileNameSuffix is the suffix of files containing pprof data.
+const HeapFileNameSuffix = ".pprof"
 
 // NewHeapProfiler creates a HeapProfiler. dir is the directory in which
 // profiles are to be stored.
@@ -48,7 +52,7 @@ func NewHeapProfiler(ctx context.Context, dir string, st *cluster.Settings) (*He
 
 	hp := &HeapProfiler{
 		profiler{
-			store: newProfileStore(dumpStore, heapFileNamePrefix, st),
+			store: newProfileStore(dumpStore, HeapFileNamePrefix, HeapFileNameSuffix, st),
 		},
 	}
 	return hp, nil

--- a/pkg/server/heapprofiler/profilestore_test.go
+++ b/pkg/server/heapprofiler/profilestore_test.go
@@ -27,9 +27,9 @@ func TestMakeFileName(t *testing.T) {
 	ts := time.Date(2020, 6, 15, 13, 19, 19, 543000000, time.UTC)
 
 	store := dumpstore.NewStore("mydir", nil, nil)
-	joy := newProfileStore(store, heapFileNamePrefix, nil)
+	joy := newProfileStore(store, HeapFileNamePrefix, ".test", nil)
 	assert.Equal(t,
-		filepath.Join("mydir", "memprof.2020-06-15T13_19_19.543.123456"),
+		filepath.Join("mydir", "memprof.2020-06-15T13_19_19.543.123456.test"),
 		joy.makeNewFileName(ts, 123456))
 }
 
@@ -52,7 +52,7 @@ func TestParseFileName(t *testing.T) {
 		{"memprof.2020-06-15T13_19_19.543.123456", time.Date(2020, 6, 15, 13, 19, 19, 543000000, time.UTC), 123456, false},
 	}
 
-	s := profileStore{prefix: heapFileNamePrefix}
+	s := profileStore{prefix: HeapFileNamePrefix}
 	for _, tc := range testData {
 		ok, ts, heapUsage := s.parseFileName(context.Background(), tc.f)
 		if ok != !tc.expError {
@@ -182,7 +182,7 @@ func TestCleanupLastRampup(t *testing.T) {
 		},
 	}
 
-	s := profileStore{prefix: heapFileNamePrefix}
+	s := profileStore{prefix: HeapFileNamePrefix}
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			path, err := ioutil.TempDir("", "cleanup")

--- a/pkg/server/heapprofiler/statsprofiler.go
+++ b/pkg/server/heapprofiler/statsprofiler.go
@@ -36,7 +36,11 @@ type StatsProfiler struct {
 	profiler
 }
 
-const statsFileNamePrefix = "memstats"
+// StatsFileNamePrefix is the prefix of memory stats dumps.
+const StatsFileNamePrefix = "memstats"
+
+// StatsFileNameSuffix is the suffix of memory stats dumps.
+const StatsFileNameSuffix = ".txt"
 
 // NewStatsProfiler creates a StatsProfiler. dir is the
 // directory in which profiles are to be stored.
@@ -53,7 +57,7 @@ func NewStatsProfiler(
 
 	hp := &StatsProfiler{
 		profiler{
-			store: newProfileStore(dumpStore, statsFileNamePrefix, st),
+			store: newProfileStore(dumpStore, StatsFileNamePrefix, StatsFileNameSuffix, st),
 		},
 	}
 	return hp, nil


### PR DESCRIPTION
Found while troubleshooting #50988.
The non-pprof files were newly added in 20.2.

Release justification: low risk, high benefit changes to existing functionality

Release note: None