### PR TITLE
sql: clean up tenant node id

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -155,18 +155,6 @@ func (c *SQLIDContainer) SQLInstanceID() SQLInstanceID {
 	return c.sqlInstanceID
 }
 
-// Get is a temporary method to aid refactoring.
-//
-// TODO(tbg): remove.
-func (c *SQLIDContainer) Get() roachpb.NodeID {
-	// Silence staticcheck.
-	var _ = (*SQLIDContainer)(nil).OptionalNodeID
-	var _ = (*SQLIDContainer)(nil).OptionalNodeIDErr
-	var _ = (*SQLIDContainer)(nil).SQLInstanceID
-	return c.DeprecatedNodeID(-12131415)
-
-}
-
 // TestingIDContainer is an SQLIDContainer with hard-coded SQLInstanceID of 10 and
 // NodeID of 1.
 var TestingIDContainer = func() *SQLIDContainer {

--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -100,21 +100,14 @@ type SQLIDContainer struct {
 	sqlInstanceID SQLInstanceID
 }
 
-// NewSQLIDContainer sets up an SQLIDContainer wrapping the (positive) SQLInstanceID
-// and a NodeID. See errorutil.TenantSQLDeprecatedWrapper for an explanation of
-// the nodeIDExposed parameter.
+// NewSQLIDContainer sets up an SQLIDContainer. It is handed either a positive SQLInstanceID
+// (on tenants) or a positive NodeID, but not both.
 //
-// As a special case, a zero sqlInstanceID in conjunction with
-// nodeIDExposed==true falls back to the NodeID in SQLInstanceID(). This is used
-// in single-tenant deployments.
-func NewSQLIDContainer(
-	sqlInstanceID SQLInstanceID, nodeID *NodeIDContainer, nodeIDExposed bool,
-) *SQLIDContainer {
-	if !nodeIDExposed && sqlInstanceID == 0 {
-		panic("sqlInstanceID must not be zero")
-	}
+// A zero sqlInstanceID falls back to the NodeID in SQLInstanceID().
+// This is used in single-tenant deployments.
+func NewSQLIDContainer(sqlInstanceID SQLInstanceID, nodeID *NodeIDContainer) *SQLIDContainer {
 	return &SQLIDContainer{
-		w:             errorutil.MakeTenantSQLDeprecatedWrapper(nodeID, nodeIDExposed),
+		w:             errorutil.MakeTenantSQLDeprecatedWrapper(nodeID, nodeID != nil),
 		sqlInstanceID: sqlInstanceID,
 	}
 }
@@ -139,14 +132,6 @@ func (c *SQLIDContainer) OptionalNodeIDErr(issueNos ...int) (roachpb.NodeID, err
 	return v.(*NodeIDContainer).Get(), nil
 }
 
-// DeprecatedNodeID returns the NodeID. This call is deprecated: removal of all
-// call sites is the goal, at which point this method will be removed. Calls to
-// this method reflect essential functionality which needs to be reworked in
-// order to enable multi-tenancy.
-func (c *SQLIDContainer) DeprecatedNodeID(issueNo int) roachpb.NodeID {
-	return c.w.Deprecated(issueNo).(*NodeIDContainer).Get()
-}
-
 // SQLInstanceID returns the wrapped SQLInstanceID.
 func (c *SQLIDContainer) SQLInstanceID() SQLInstanceID {
 	if n, ok := c.OptionalNodeID(); ok {
@@ -160,5 +145,5 @@ func (c *SQLIDContainer) SQLInstanceID() SQLInstanceID {
 var TestingIDContainer = func() *SQLIDContainer {
 	var c NodeIDContainer
 	c.Set(context.Background(), 1)
-	return NewSQLIDContainer(10, &c, true /* exposed */)
+	return NewSQLIDContainer(10, &c)
 }()

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -1,7 +1,11 @@
 # This file documents operations that are unsupported when running a SQL tenant
 # server.
-# TODO(tbg): file an issue detailing which ones are Phase 2 blockers.
 # LogicTest: 3node-tenant
+
+query I
+SELECT crdb_internal.node_id()
+----
+NULL
 
 statement ok
 CREATE TABLE kv (k STRING PRIMARY KEY, v STRING)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -50,9 +50,6 @@ import (
 
 const defaultLeniencySetting = 60 * time.Second
 
-// See https://github.com/cockroachdb/cockroach/issues/47892.
-const multiTenancyIssueNo = 47892
-
 var (
 	gcSetting = settings.RegisterPublicDurationSetting(
 		"jobs.retention_time",

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -96,7 +96,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	newRegistry := func(id roachpb.NodeID) *jobs.Registry {
 		var c base.NodeIDContainer
 		c.Set(ctx, id)
-		idContainer := base.NewSQLIDContainer(0, &c, true /* exposed */)
+		idContainer := base.NewSQLIDContainer(0, &c)
 		ac := log.AmbientContext{Tracer: tracing.NewTracer()}
 		sqlStorage := slstorage.NewStorage(
 			s.Stopper(), clock, db, s.InternalExecutor().(sqlutil.InternalExecutor), s.ClusterSettings(),

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -851,7 +851,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 		if nodeID != 0 {
 			c.Set(context.Background(), nodeID)
 		}
-		dbCtx.NodeID = base.NewSQLIDContainer(0, &c, true /* exposed */)
+		dbCtx.NodeID = base.NewSQLIDContainer(0, &c)
 
 		db := kv.NewDBWithContext(testutils.MakeAmbientCtx(), factory, clock, dbCtx)
 		return db

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -188,7 +188,7 @@ func DefaultDBContext(stopper *stop.Stopper) DBContext {
 	return DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		// TODO(tbg): this is ugly. Force callers to pass in an SQLIDContainer.
-		NodeID:  base.NewSQLIDContainer(0, &c, true /* exposed */),
+		NodeID:  base.NewSQLIDContainer(0, &c),
 		Stopper: stopper,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -273,7 +273,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	nodeIDContainer := &base.NodeIDContainer{}
 	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
 	const sqlInstanceID = base.SQLInstanceID(0)
-	idContainer := base.NewSQLIDContainer(sqlInstanceID, nodeIDContainer, true /* exposed */)
+	idContainer := base.NewSQLIDContainer(sqlInstanceID, nodeIDContainer)
 
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -401,8 +401,6 @@ func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record
 	return errors.New("fake protectedts.Provider")
 }
 
-const fakeNodeID = roachpb.NodeID(123456789)
-
 func makeSQLServerArgs(
 	stopper *stop.Stopper, kvClusterName string, baseCfg BaseConfig, sqlCfg SQLConfig,
 ) (sqlServerArgs, error) {
@@ -606,11 +604,9 @@ func StartTenant(
 		return "", "", err
 	}
 
-	// NB: this should no longer be necessary after #47902. Right now it keeps
-	// the tenant from crashing.
-	//
-	// NB: this NodeID is actually used by the DistSQL planner.
-	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: fakeNodeID})
+	// TODO(asubiotto): remove this. Right now it is needed to initialize the
+	// SpanResolver.
+	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: 0})
 
 	connManager := netutil.MakeServer(
 		args.stopper,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -505,10 +505,8 @@ func makeSQLServerArgs(
 
 	recorder := status.NewMetricsRecorder(clock, nil, rpcContext, nil, st)
 
-	var c base.NodeIDContainer
-	c.Set(context.Background(), fakeNodeID)
 	const sqlInstanceID = base.SQLInstanceID(10001)
-	idContainer := base.NewSQLIDContainer(sqlInstanceID, &c, false /* exposed */)
+	idContainer := base.NewSQLIDContainer(sqlInstanceID, nil /* nodeID */)
 
 	runtime := status.NewRuntimeStatSampler(context.Background(), clock)
 	registry.AddMetricStruct(runtime)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -211,7 +211,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 	if mgr == nil {
 		var c base.NodeIDContainer
 		c.Set(context.Background(), roachpb.NodeID(nodeID))
-		nc := base.NewSQLIDContainer(0, &c, true /* exposed*/)
+		nc := base.NewSQLIDContainer(0, &c)
 		// Hack the ExecutorConfig that we pass to the Manager to have a
 		// different node id.
 		cfgCpy := t.server.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -426,7 +426,8 @@ func (p *planner) preparePlannerForCopy(
 	stmtTs := txnOpt.stmtTimestamp
 	autoCommit := false
 	if txn == nil {
-		txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, p.execCfg.NodeID.Get())
+		nodeID, _ := p.execCfg.NodeID.OptionalNodeID()
+		txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID)
 		txnTs = p.execCfg.Clock.PhysicalTime()
 		stmtTs = txnTs
 		autoCommit = true

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -170,7 +170,10 @@ CREATE TABLE crdb_internal.node_runtime_info (
 
 		node := p.ExecCfg().NodeInfo
 
-		nodeID := tree.NewDInt(tree.DInt(int64(node.NodeID.Get())))
+		dNodeID := tree.DNull
+		if nodeID, ok := node.NodeID.OptionalNodeID(); ok {
+			dNodeID = tree.NewDInt(tree.DInt(nodeID))
+		}
 		dbURL, err := node.PGURL(url.User(security.RootUser))
 		if err != nil {
 			return err
@@ -200,7 +203,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
 			} {
 				k, v := kv[0], kv[1]
 				if err := addRow(
-					nodeID,
+					dNodeID,
 					tree.NewDString(item.component),
 					tree.NewDString(k),
 					tree.NewDString(v),
@@ -481,7 +484,10 @@ CREATE TABLE crdb_internal.leases (
 	populate: func(
 		ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error,
 	) (err error) {
-		nodeID := tree.NewDInt(tree.DInt(int64(p.execCfg.NodeID.Get())))
+		dNodeID := tree.DNull
+		if nodeID, ok := p.execCfg.NodeID.OptionalNodeID(); ok {
+			dNodeID = tree.NewDInt(tree.DInt(nodeID))
+		}
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, dropped bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
 			if p.CheckAnyPrivilege(ctx, desc) != nil {
 				// TODO(ajwerner): inspect what type of error got returned.
@@ -489,7 +495,7 @@ CREATE TABLE crdb_internal.leases (
 			}
 
 			err = addRow(
-				nodeID,
+				dNodeID,
 				tree.NewDInt(tree.DInt(int64(desc.GetID()))),
 				tree.NewDString(desc.GetName()),
 				tree.NewDInt(tree.DInt(int64(desc.GetParentID()))),

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3348,7 +3348,11 @@ may increase either contention or retry errors, or both.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDInt(tree.DInt(ctx.NodeID.Get())), nil
+				dNodeID := tree.DNull
+				if nodeID, ok := ctx.NodeID.OptionalNodeID(); ok {
+					dNodeID = tree.NewDInt(tree.DInt(nodeID))
+				}
+				return dNodeID, nil
 			},
 			Info:       "Returns the node ID.",
 			Volatility: tree.VolatilityStable,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -145,7 +145,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	ltc.dbContext = &kv.DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		Stopper:      ltc.stopper,
-		NodeID:       base.NewSQLIDContainer(0, &nodeIDContainer, true /* exposed */),
+		NodeID:       base.NewSQLIDContainer(0, &nodeIDContainer),
 	}
 	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.dbContext)
 	transport := kvserver.NewDummyRaftTransport(cfg.Settings)

--- a/pkg/util/errorutil/tenant_deprecated_wrapper.go
+++ b/pkg/util/errorutil/tenant_deprecated_wrapper.go
@@ -56,13 +56,6 @@ func MakeTenantSQLDeprecatedWrapper(v interface{}, exposed bool) TenantSQLDeprec
 	return TenantSQLDeprecatedWrapper{v: v, exposed: exposed}
 }
 
-// Deprecated returns the unwrapped object. It takes an issue number that should
-// contain a work item resulting in the removal of the Deprecated() call (i.e.
-// removes the dependency on the wrapped object).
-func (w TenantSQLDeprecatedWrapper) Deprecated(issueNo int) interface{} {
-	return w.v
-}
-
 // Optional returns the wrapped object if it is available (meaning that the
 // wrapper was set up to make it available). This should be called by
 // functionality that relies on the wrapped object but can be disabled when this


### PR DESCRIPTION
There was some detritus left that I never cleaned up. Since I wanted `crdb_internal.node_id()` to return NULL on tenants (as opposed to 123456789) this was a good moment to do some housekeeping.

- sql: remove (*SQLIDContainer).Get
- sql: remove DeprecatedNodeID
- sql: remove call to planner.SetNodeInfo on tenants

Release justification: low-risk cleanups
