### PR TITLE
sql: add crdb_internal.invalid_tables

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -80,6 +80,7 @@ const (
 	CrdbInternalTablesTableLastStatsID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalZonesTableID
+	CrdbInternalInvalidDescriptorsTableID
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -151,7 +151,9 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		return err
 	}
 
-	lCtx := newInternalLookupCtx(params.ctx, descs, nil /*prefix - we want all descriptors */)
+	lCtx := newInternalLookupCtx(params.ctx, descs,
+		nil, /* prefix - we want all descriptors */
+		nil /* fallback */)
 	// TODO(richardjcai): Also need to add privilege checking for types and
 	// user defined schemas when they are added.
 	// privileges are added.

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1656,7 +1656,8 @@ func forEachTypeDesc(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
+		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 	for _, id := range lCtx.typIDs {
 		typ := lCtx.typDescs[id]
 		dbDesc, parentExists := lCtx.dbDescs[typ.ParentID]
@@ -1691,7 +1692,6 @@ func forEachTableDesc(
 	p *planner,
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	// TODO(ajwerner): Introduce TableDescriptor.
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
 	return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts, func(
@@ -1808,7 +1808,8 @@ func forEachTableDescWithTableLookupInternal(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
+		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 
 	if virtualOpts == virtualMany || virtualOpts == virtualOnce {
 		// Virtual descriptors first.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -634,6 +634,12 @@ func (r *fkSelfResolver) LookupObject(
 // aliased as tableLookupFn below.
 //
 // It only reveals physical descriptors (not virtual descriptors).
+// It also implements catalog.DescGetter for table validation. In this scenario
+// it may fall back to utilizing the fallback DescGetter to resolve references
+// outside of the dbContext in which it was initialized.
+//
+// TODO(ajwerner): remove in 21.2 or whenever cross-database references are
+// fully removed.
 type internalLookupCtx struct {
 	dbNames     map[descpb.ID]string
 	dbIDs       []descpb.ID
@@ -643,6 +649,42 @@ type internalLookupCtx struct {
 	tbIDs       []descpb.ID
 	typDescs    map[descpb.ID]*typedesc.Immutable
 	typIDs      []descpb.ID
+
+	// fallback is utilized in GetDesc
+	fallback catalog.DescGetter
+}
+
+func (l *internalLookupCtx) GetDesc(ctx context.Context, id descpb.ID) (catalog.Descriptor, error) {
+	if desc, ok := l.dbDescs[id]; ok {
+		return desc, nil
+	}
+	if desc, ok := l.schemaDescs[id]; ok {
+		return desc, nil
+	}
+	if desc, ok := l.typDescs[id]; ok {
+		return desc, nil
+	}
+	if desc, ok := l.tbDescs[id]; ok {
+		return desc, nil
+	}
+	if l.fallback != nil {
+		return l.fallback.GetDesc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (l *internalLookupCtx) GetDescs(
+	ctx context.Context, reqs []descpb.ID,
+) ([]catalog.Descriptor, error) {
+	ret := make([]catalog.Descriptor, len(reqs))
+	for i := 0; i < len(reqs); i++ {
+		var err error
+		ret[i], err = l.GetDesc(ctx, reqs[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
 }
 
 // tableLookupFn can be used to retrieve a table descriptor and its corresponding
@@ -670,15 +712,20 @@ func newInternalLookupCtxFromDescriptors(
 			descriptors[i] = schemadesc.NewImmutable(*t.Schema)
 		}
 	}
-	lCtx := newInternalLookupCtx(ctx, descriptors, prefix)
+	lCtx := newInternalLookupCtx(ctx, descriptors, prefix, nil /* fallback */)
 	if err := descs.HydrateGivenDescriptors(ctx, descriptors); err != nil {
 		return nil, err
 	}
 	return lCtx, nil
 }
 
+// newInternalLookupCtx provides cached access to a set of descriptors for use
+// in virtual tables.
 func newInternalLookupCtx(
-	ctx context.Context, descs []catalog.Descriptor, prefix *dbdesc.Immutable,
+	ctx context.Context,
+	descs []catalog.Descriptor,
+	prefix *dbdesc.Immutable,
+	fallback catalog.DescGetter,
 ) *internalLookupCtx {
 	dbNames := make(map[descpb.ID]string)
 	dbDescs := make(map[descpb.ID]*dbdesc.Immutable)
@@ -721,8 +768,11 @@ func newInternalLookupCtx(
 		tbIDs:       tbIDs,
 		dbIDs:       dbIDs,
 		typIDs:      typIDs,
+		fallback:    fallback,
 	}
 }
+
+var _ catalog.DescGetter = (*internalLookupCtx)(nil)
 
 func (l *internalLookupCtx) getDatabaseByID(id descpb.ID) (*dbdesc.Immutable, error) {
 	db, ok := l.dbDescs[id]


### PR DESCRIPTION
This commit adds a new crdb_internal table that pulls all of the descriptors
for a given db context and validates them all (including their cross-database
references). To use it one can do the following to validate all of the tables
in the current database:

```
SELECT * FROM crdb_internal.invalid_tables
```

To validate all tables in all database, one uses the special "" database
context like in all other crdb_internal tables. That looks like:

```
SELECT * FROM "".crdb_internal.invalid_tables
```

Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): Added a new virtual table
`crdb_internal.invalid_tables` which runs validations on tables in the
database context and reports any errors.