### PR TITLE
roachtest: Unskip disk-full roachtest

### DIFF
--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -22,9 +22,8 @@ import (
 func registerDiskFull(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "disk-full",
-		Owner:      OwnerKV,
-		MinVersion: `v2.1.0`,
-		Skip:       "https://github.com/cockroachdb/cockroach/issues/35328#issuecomment-478540195",
+		Owner:      OwnerStorage,
+		MinVersion: `v20.2.0`,
 		Cluster:    makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if c.isLocal() {


### PR DESCRIPTION
The disk-full roachtest no longer fails now that Pebble is the
default storage engine. Remove the skipped marker.

Fixes #35328.

Release justification: Roachtest-only change.
Release note: None.