### PR TITLE
geos: do not set 3D on EWKB writer

### DIFF
--- a/pkg/geo/geos/geos.cc
+++ b/pkg/geo/geos/geos.cc
@@ -384,12 +384,8 @@ CR_GEOS_Geometry CR_GEOS_GeometryFromSlice(CR_GEOS* lib, CR_GEOS_Handle handle,
 
 void CR_GEOS_writeGeomToEWKB(CR_GEOS* lib, CR_GEOS_Handle handle, CR_GEOS_Geometry geom,
                              CR_GEOS_String* ewkb, int srid) {
-  auto hasZ = lib->GEOSHasZ_r(handle, geom);
   auto wkbWriter = lib->GEOSWKBWriter_create_r(handle);
   lib->GEOSWKBWriter_setByteOrder_r(handle, wkbWriter, 1);
-  if (hasZ) {
-    lib->GEOSWKBWriter_setOutputDimension_r(handle, wkbWriter, 3);
-  }
   if (srid != 0) {
     lib->GEOSSetSRID_r(handle, geom, srid);
   }

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -240,23 +240,6 @@ func TestParseEWKT(t *testing.T) {
 			require.Equal(t, tc.expected, ret)
 		})
 	}
-
-	errorTestCases := []struct {
-		wkt         geopb.EWKT
-		expectedErr string
-	}{
-		{"POINT Z (1 2 3)", "unimplemented: dimension XYZ is not currently supported"},
-		// GEOS assumes all M coordinates as Z coordinates, so the error message is not great here.
-		{"POINT M (1 2 3)", "unimplemented: dimension XYZ is not currently supported"},
-		{"POINT ZM (1 2 3 4)", "unimplemented: dimension XYZ is not currently supported"},
-	}
-	for _, tc := range errorTestCases {
-		t.Run(string(tc.wkt), func(t *testing.T) {
-			_, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.wkt, 0, false)
-			require.Error(t, err)
-			require.EqualError(t, err, tc.expectedErr)
-		})
-	}
 }
 
 func TestParseGeometry(t *testing.T) {

--- a/pkg/sql/testdata/telemetry/geospatial
+++ b/pkg/sql/testdata/telemetry/geospatial
@@ -15,8 +15,15 @@ error: pq: at or near ",": syntax error: unimplemented: this syntax
 unimplemented.#53091.XYZ_type
 unimplemented.syntax.#53091.XYZ_type
 
+# POINTZ 1 2 3
 feature-usage
-SELECT 'POINT Z (1 2 3)'::geometry
+SELECT '0101000080000000000000F03F00000000000000400000000000000840'::geometry
 ----
 error: pq: could not parse geometry: unimplemented: dimension XYZ is not currently supported
 unimplemented.#53091.XYZ_datum
+
+feature-usage
+SELECT '01010000C0000000000000F03F000000000000004000000000000008400000000000001040'::geometry
+----
+error: pq: could not parse geometry: unimplemented: dimension XYZM is not currently supported
+unimplemented.#53091.XYZM_datum


### PR DESCRIPTION
geos: do not set 3D on EWKB writer

This seems to do weird things on certain systems if a GEOMETRYCOLLECTION
contains an EMPTY element.

The corollary of this is WKTs which are given 3D/4D "lose" their 3D/4D
component. I think this will have to be a docs limitation.

Since we don't support 3D/4D properly anyway, added a note to #53091.

Release justification: low risk update to new functionality

Release note: None

