### PR TITLE
release-20.1: physicalplan: fix row estimates when merging plans

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2937,6 +2937,7 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 	}
 
 	var p PhysicalPlan
+	p.SetRowEstimates(&leftPlan.PhysicalPlan, &rightPlan.PhysicalPlan)
 
 	// Merge the plans' PlanToStreamColMap, which we know are equivalent.
 	p.PlanToStreamColMap = planToStreamColMap

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -132,3 +132,26 @@ group      ·            ·
  └── scan  ·            ·
 ·          table        large@primary
 ·          spans        FULL SCAN
+
+statement ok
+SET vectorize_row_count_threshold = 1000
+
+# Check that we estimate the row count correctly when multiple tables are
+# scanned.
+query TTT
+EXPLAIN SELECT * FROM small INNER MERGE JOIN large ON small.a = large.a
+----
+·           distributed         true
+·           vectorized          true
+merge-join  ·                   ·
+ │          type                inner
+ │          equality            (a) = (a)
+ │          left cols are key   ·
+ │          right cols are key  ·
+ │          mergeJoinOrder      +"(a=a)"
+ ├── scan   ·                   ·
+ │          table               small@primary
+ │          spans               FULL SCAN
+ └── scan   ·                   ·
+·           table               large@primary
+·           spans               FULL SCAN

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -873,6 +873,16 @@ func (p *PhysicalPlan) GenerateFlowSpecs(
 	return flows
 }
 
+// SetRowEstimates updates p according to the row estimates of left and right
+// plans.
+func (p *PhysicalPlan) SetRowEstimates(left, right *PhysicalPlan) {
+	p.TotalEstimatedScannedRows = left.TotalEstimatedScannedRows + right.TotalEstimatedScannedRows
+	p.MaxEstimatedRowCount = left.MaxEstimatedRowCount
+	if right.MaxEstimatedRowCount > p.MaxEstimatedRowCount {
+		p.MaxEstimatedRowCount = right.MaxEstimatedRowCount
+	}
+}
+
 // MergePlans merges the processors and streams of two plan into a new plan.
 // The result routers for each side are also returned (they point at processors
 // in the merged plan).
@@ -913,13 +923,7 @@ func MergePlans(
 		rightRouters[i] += rightProcStart
 	}
 
-	mergedPlan.TotalEstimatedScannedRows = left.TotalEstimatedScannedRows + right.TotalEstimatedScannedRows
-	// NB(dt): AFAIK no one looks at the MaxEstimatedRowCount of the overall plan
-	// but it is maintained here too just for completeness.
-	mergedPlan.MaxEstimatedRowCount = left.MaxEstimatedRowCount
-	if right.MaxEstimatedRowCount > left.MaxEstimatedRowCount {
-		mergedPlan.MaxEstimatedRowCount = left.MaxEstimatedRowCount
-	}
+	mergedPlan.SetRowEstimates(left, right)
 
 	return mergedPlan, leftRouters, rightRouters
 }


### PR DESCRIPTION
Backport 1/1 commits from #53862.

/cc @cockroachdb/release

---

Previously, there was a mistake when merging two physical plans in the
way we computed the max estimated row count (we always use the value
from the left). This error could result in us thinking that the
vectorized threshold wasn't met when, in fact, it was (e.g. we're
reading 100 rows on the left and 10000 rows on the right of a join - we
would think we don't meet 1000 row threshold). This is now fixed.

Additionally, it fixes the propagation of the estimates when planning
set-operation joins.

Release justification: bug fix.

Release note: None
