### PR TITLE
sql,tree: move flags from Object to Common LookupFlags

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -281,8 +281,7 @@ func (r fkResolver) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 // Implements the sql.SchemaResolver interface.
 func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.ObjectLookupFlags {
 	return tree.ObjectLookupFlags{
-		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
-		RequireMutable:    requireMutable,
+		CommonLookupFlags: tree.CommonLookupFlags{Required: required, RequireMutable: requireMutable},
 	}
 }
 

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -110,8 +110,7 @@ func ResolveMutableExistingTableObject(
 	requiredType tree.RequiredTableKind,
 ) (res *tabledesc.Mutable, err error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags:    tree.CommonLookupFlags{Required: required},
-		RequireMutable:       true,
+		CommonLookupFlags:    tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		DesiredObjectKind:    tree.TableObject,
 		DesiredTableDescKind: requiredType,
 	}
@@ -133,8 +132,7 @@ func ResolveMutableType(
 	ctx context.Context, sc SchemaResolver, un *tree.UnresolvedObjectName, required bool,
 ) (*tree.TypeName, *typedesc.Mutable, error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
-		RequireMutable:    true,
+		CommonLookupFlags: tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		DesiredObjectKind: tree.TypeObject,
 	}
 	desc, prefix, err := ResolveExistingObject(ctx, sc, un, lookupFlags)

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -73,9 +73,11 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			tree.ObjectLookupFlags{
 				// Note we set required to be false here in order to not error out
 				// if we don't find the object.
-				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
-				RequireMutable:    true,
-				IncludeOffline:    true,
+				CommonLookupFlags: tree.CommonLookupFlags{
+					Required:       false,
+					IncludeOffline: true,
+					RequireMutable: true,
+				},
 				DesiredObjectKind: tree.TableObject,
 			},
 			objName.Catalog(),
@@ -116,9 +118,11 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			found, desc, err := p.LookupObject(
 				ctx,
 				tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-					RequireMutable:    true,
-					IncludeOffline:    true,
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required:       true,
+						RequireMutable: true,
+						IncludeOffline: true,
+					},
 					DesiredObjectKind: tree.TypeObject,
 				},
 				objName.Catalog(),

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -140,9 +140,11 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 			tree.ObjectLookupFlags{
 				// Note we set required to be false here in order to not error out
 				// if we don't find the object.
-				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
-				RequireMutable:    true,
-				IncludeOffline:    true,
+				CommonLookupFlags: tree.CommonLookupFlags{
+					Required:       false,
+					RequireMutable: true,
+					IncludeOffline: true,
+				},
 				DesiredObjectKind: tree.TableObject,
 			},
 			objName.Catalog(),
@@ -204,9 +206,11 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 			found, desc, err := p.LookupObject(
 				ctx,
 				tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-					RequireMutable:    true,
-					IncludeOffline:    true,
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required:       true,
+						RequireMutable: true,
+						IncludeOffline: true,
+					},
 					DesiredObjectKind: tree.TypeObject,
 				},
 				objName.Catalog(),

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -248,9 +248,8 @@ func (p *planner) ResolveType(
 	ctx context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags: tree.CommonLookupFlags{Required: true},
+		CommonLookupFlags: tree.CommonLookupFlags{Required: true, RequireMutable: false},
 		DesiredObjectKind: tree.TypeObject,
-		RequireMutable:    false,
 	}
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, p, name, lookupFlags)
 	if err != nil {
@@ -291,10 +290,9 @@ func (p *planner) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, 
 
 // ObjectLookupFlags is part of the resolver.SchemaResolver interface.
 func (p *planner) ObjectLookupFlags(required, requireMutable bool) tree.ObjectLookupFlags {
-	return tree.ObjectLookupFlags{
-		CommonLookupFlags: p.CommonLookupFlags(required),
-		RequireMutable:    requireMutable,
-	}
+	flags := p.CommonLookupFlags(required)
+	flags.RequireMutable = requireMutable
+	return tree.ObjectLookupFlags{CommonLookupFlags: flags}
 }
 
 // getDescriptorsFromTargetListForPrivilegeChange fetches the descriptors for the targets.
@@ -866,8 +864,7 @@ func (p *planner) ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 	requiredType tree.RequiredTableKind,
 ) (*tabledesc.Mutable, error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags:      tree.CommonLookupFlags{Required: required},
-		RequireMutable:         true,
+		CommonLookupFlags:      tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		AllowWithoutPrimaryKey: true,
 		DesiredObjectKind:      tree.TableObject,
 		DesiredTableDescKind:   requiredType,

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -572,8 +572,14 @@ func newSourceNotFoundError(fmt string, args ...interface{}) error {
 type CommonLookupFlags struct {
 	// if required is set, lookup will return an error if the item is not found.
 	Required bool
+	// return a MutableTableDescriptor
+	RequireMutable bool
 	// if AvoidCached is set, lookup will avoid the cache (if any).
 	AvoidCached bool
+	// IncludeOffline specifies if offline descriptors should be visible.
+	IncludeOffline bool
+	// IncludeOffline specifies if dropped descriptors should be visible.
+	IncludeDropped bool
 }
 
 // SchemaLookupFlags is the flag struct suitable for GetSchema().
@@ -650,10 +656,6 @@ func (r RequiredTableKind) String() string {
 // ObjectLookupFlags is the flag struct suitable for GetObjectDesc().
 type ObjectLookupFlags struct {
 	CommonLookupFlags
-	// return a MutableTableDescriptor
-	RequireMutable         bool
-	IncludeOffline         bool
-	IncludeDropped         bool
 	AllowWithoutPrimaryKey bool
 	// Control what type of object is being requested.
 	DesiredObjectKind DesiredObjectKind


### PR DESCRIPTION
This commit moves Include{Offline,Dropped} and RequireMutable flags from
the ObjectLookupFlags to the CommonLookupFlags.

These flags are applicable to all descriptors and should be included in
CommonLookupFlags rather than ObjectLookupFlags.

Release justification: low-risk, high impact change
Release note: None