### PR TITLE
sql,tree: move descriptor-specific flags to CommonLookupFlags

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -281,8 +281,7 @@ func (r fkResolver) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 // Implements the sql.SchemaResolver interface.
 func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.ObjectLookupFlags {
 	return tree.ObjectLookupFlags{
-		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
-		RequireMutable:    requireMutable,
+		CommonLookupFlags: tree.CommonLookupFlags{Required: required, RequireMutable: requireMutable},
 	}
 }
 

--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -141,8 +141,7 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	scName string,
 	flags tree.DatabaseListFlags,
 ) (tree.TableNames, error) {
-	ok, schema, err := a.GetSchema(ctx, txn, codec, dbDesc.GetID(), scName,
-		tree.SchemaLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+	ok, schema, err := a.GetSchema(ctx, txn, codec, dbDesc.GetID(), scName, flags.CommonLookupFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +242,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	}
 
 	ok, schema, err := a.GetSchema(ctx, txn, codec, dbID, scName,
-		tree.SchemaLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+		tree.SchemaLookupFlags{Required: flags.Required, AvoidCached: flags.AvoidCached})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/catalogkv/test_utils.go
+++ b/pkg/sql/catalog/catalogkv/test_utils.go
@@ -89,7 +89,7 @@ func TestingGetDatabaseDescriptor(
 	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		desc, err := UncachedPhysicalAccessor{}.GetDatabaseDesc(
 			ctx, txn, codec, database, tree.DatabaseLookupFlags{
-				CommonLookupFlags: tree.CommonLookupFlags{Required: true, AvoidCached: true},
+				Required: true, AvoidCached: true,
 			})
 		if err != nil {
 			return err

--- a/pkg/sql/catalog/database/database.go
+++ b/pkg/sql/catalog/database/database.go
@@ -144,7 +144,7 @@ func (dc *Cache) GetDatabaseDesc(
 			}
 			a := catalogkv.UncachedPhysicalAccessor{}
 			descI, err := a.GetDatabaseDesc(ctx, txn, dc.codec, name,
-				tree.DatabaseLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{Required: required}})
+				tree.DatabaseLookupFlags{Required: required})
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -393,7 +393,7 @@ func (tc *Collection) getMutableObjectDescriptor(
 
 	// Resolve the database.
 	db, err := tc.GetDatabaseVersion(ctx, txn, name.Catalog(),
-		tree.DatabaseLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+		tree.DatabaseLookupFlags{Required: flags.Required, AvoidCached: flags.AvoidCached})
 	if err != nil || db == nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (tc *Collection) getMutableObjectDescriptor(
 
 	// Resolve the schema to the ID of the schema.
 	foundSchema, resolvedSchema, err := tc.ResolveSchema(ctx, txn, dbID, name.Schema(),
-		tree.SchemaLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+		tree.SchemaLookupFlags{Required: flags.Required, AvoidCached: flags.AvoidCached})
 	if err != nil || !foundSchema {
 		return nil, err
 	}
@@ -508,8 +508,7 @@ func (tc *Collection) getUserDefinedSchemaVersion(
 	// descriptor here, since we'll already have done this lookup when we're
 	// resolving the schema by name. Arguably we should be doing this at a higher
 	// level.
-	dbDesc, err := tc.GetDatabaseVersionByID(ctx, txn, dbID,
-		tree.DatabaseLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{Required: true}})
+	dbDesc, err := tc.GetDatabaseVersionByID(ctx, txn, dbID, tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +535,7 @@ func (tc *Collection) getUserDefinedSchemaVersion(
 	// the database which doesn't reflect the changes to the schema. But this
 	// isn't a problem for correctness; it can only happen on other sessions
 	// before the schema change has returned results.
-	desc, err := tc.getDescriptorVersionByID(ctx, txn, schemaInfo.ID, flags.CommonLookupFlags, true /* setTxnDeadline */)
+	desc, err := tc.getDescriptorVersionByID(ctx, txn, schemaInfo.ID, flags, true /* setTxnDeadline */)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, sqlerrors.NewUndefinedSchemaError(schemaName)
@@ -786,7 +785,7 @@ func (tc *Collection) getObjectVersion(
 
 	// Resolve the database.
 	db, err := tc.GetDatabaseVersion(ctx, txn, name.Catalog(),
-		tree.DatabaseLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+		tree.DatabaseLookupFlags{Required: flags.Required, AvoidCached: flags.Required})
 	if err != nil || db == nil {
 		return nil, err
 	}
@@ -794,7 +793,7 @@ func (tc *Collection) getObjectVersion(
 
 	// Resolve the schema to the ID of the schema.
 	foundSchema, resolvedSchema, err := tc.ResolveSchema(ctx, txn, dbID, name.Schema(),
-		tree.SchemaLookupFlags{CommonLookupFlags: flags.CommonLookupFlags})
+		tree.SchemaLookupFlags{Required: flags.Required, AvoidCached: flags.Required})
 	if err != nil || !foundSchema {
 		return nil, err
 	}
@@ -853,7 +852,7 @@ func (tc *Collection) GetDatabaseVersionByID(
 		return tc.deprecatedDatabaseCache().GetDatabaseDescByID(ctx, txn, dbID)
 	}
 
-	desc, err := tc.getDescriptorVersionByID(ctx, txn, dbID, flags.CommonLookupFlags, true /* setTxnDeadline */)
+	desc, err := tc.getDescriptorVersionByID(ctx, txn, dbID, flags, true /* setTxnDeadline */)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
@@ -1054,7 +1053,7 @@ func (tc *Collection) hydrateTypesInTableDesc(
 				return tree.TypeName{}, nil, err
 			}
 			dbDesc, err := tc.GetDatabaseVersionByID(ctx, txn, desc.ParentID,
-				tree.DatabaseLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{Required: true}})
+				tree.DatabaseLookupFlags{Required: true})
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
@@ -1083,7 +1082,7 @@ func (tc *Collection) hydrateTypesInTableDesc(
 				return tree.TypeName{}, nil, err
 			}
 			dbDesc, err := tc.GetDatabaseVersionByID(ctx, txn, desc.ParentID,
-				tree.DatabaseLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{Required: true}})
+				tree.DatabaseLookupFlags{Required: true})
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -110,8 +110,7 @@ func ResolveMutableExistingTableObject(
 	requiredType tree.RequiredTableKind,
 ) (res *tabledesc.Mutable, err error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags:    tree.CommonLookupFlags{Required: required},
-		RequireMutable:       true,
+		CommonLookupFlags:    tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		DesiredObjectKind:    tree.TableObject,
 		DesiredTableDescKind: requiredType,
 	}
@@ -133,8 +132,7 @@ func ResolveMutableType(
 	ctx context.Context, sc SchemaResolver, un *tree.UnresolvedObjectName, required bool,
 ) (*tree.TypeName, *typedesc.Mutable, error) {
 	lookupFlags := tree.ObjectLookupFlags{
-		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
-		RequireMutable:    true,
+		CommonLookupFlags: tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		DesiredObjectKind: tree.TypeObject,
 	}
 	desc, prefix, err := ResolveExistingObject(ctx, sc, un, lookupFlags)

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -73,9 +73,11 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			tree.ObjectLookupFlags{
 				// Note we set required to be false here in order to not error out
 				// if we don't find the object.
-				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
-				RequireMutable:    true,
-				IncludeOffline:    true,
+				CommonLookupFlags: tree.CommonLookupFlags{
+					Required:       false,
+					RequireMutable: true,
+					IncludeOffline: true,
+				},
 				DesiredObjectKind: tree.TableObject,
 			},
 			objName.Catalog(),
@@ -116,9 +118,11 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			found, desc, err := p.LookupObject(
 				ctx,
 				tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-					RequireMutable:    true,
-					IncludeOffline:    true,
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required:       true,
+						RequireMutable: true,
+						IncludeOffline: true,
+					},
 					DesiredObjectKind: tree.TypeObject,
 				},
 				objName.Catalog(),

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -147,9 +147,11 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 			tree.ObjectLookupFlags{
 				// Note we set required to be false here in order to not error out
 				// if we don't find the object.
-				CommonLookupFlags: tree.CommonLookupFlags{Required: false},
-				RequireMutable:    true,
-				IncludeOffline:    true,
+				CommonLookupFlags: tree.CommonLookupFlags{
+					Required:       false,
+					RequireMutable: true,
+					IncludeOffline: true,
+				},
 				DesiredObjectKind: tree.TableObject,
 			},
 			objName.Catalog(),
@@ -211,9 +213,11 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 			found, desc, err := p.LookupObject(
 				ctx,
 				tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-					RequireMutable:    true,
-					IncludeOffline:    true,
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required:       true,
+						RequireMutable: true,
+						IncludeOffline: true,
+					},
 					DesiredObjectKind: tree.TypeObject,
 				},
 				objName.Catalog(),

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -568,25 +568,24 @@ func newSourceNotFoundError(fmt string, args ...interface{}) error {
 }
 
 // CommonLookupFlags is the common set of flags for the various accessor interfaces.
-// TODO (lucy): Extract RequireMutable into the common flags.
 type CommonLookupFlags struct {
 	// if required is set, lookup will return an error if the item is not found.
 	Required bool
+	// RequireMutable specifies whether to return a mutable descriptor.
+	RequireMutable bool
 	// if AvoidCached is set, lookup will avoid the cache (if any).
 	AvoidCached bool
+	// IncludeOffline specifies if offline descriptors should be visible.
+	IncludeOffline bool
+	// IncludeOffline specifies if dropped descriptors should be visible.
+	IncludeDropped bool
 }
 
 // SchemaLookupFlags is the flag struct suitable for GetSchema().
-type SchemaLookupFlags struct {
-	CommonLookupFlags
-	RequireMutable bool
-}
+type SchemaLookupFlags = CommonLookupFlags
 
 // DatabaseLookupFlags is the flag struct suitable for GetDatabaseDesc().
-type DatabaseLookupFlags struct {
-	CommonLookupFlags
-	RequireMutable bool
-}
+type DatabaseLookupFlags = CommonLookupFlags
 
 // DatabaseListFlags is the flag struct suitable for GetObjectNames().
 type DatabaseListFlags struct {
@@ -650,10 +649,6 @@ func (r RequiredTableKind) String() string {
 // ObjectLookupFlags is the flag struct suitable for GetObjectDesc().
 type ObjectLookupFlags struct {
 	CommonLookupFlags
-	// return a MutableTableDescriptor
-	RequireMutable         bool
-	IncludeOffline         bool
-	IncludeDropped         bool
 	AllowWithoutPrimaryKey bool
 	// Control what type of object is being requested.
 	DesiredObjectKind DesiredObjectKind

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -241,9 +241,7 @@ var varGen = map[string]sessionVar{
 			if len(dbName) != 0 {
 				// Verify database descriptor exists.
 				if _, err := evalCtx.schemaAccessors.logical.GetDatabaseDesc(
-					ctx, evalCtx.Txn, evalCtx.Codec, dbName, tree.DatabaseLookupFlags{
-						CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-					},
+					ctx, evalCtx.Txn, evalCtx.Codec, dbName, tree.DatabaseLookupFlags{Required: true},
 				); err != nil {
 					return "", err
 				}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -460,9 +460,7 @@ func (e virtualDefEntry) getPlanInfo(
 		if dbName != "" {
 			dbDescI, err := p.LogicalSchemaAccessor().GetDatabaseDesc(ctx, p.txn, p.ExecCfg().Codec,
 				dbName, tree.DatabaseLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{
-						Required: true, AvoidCached: p.avoidCachedDescriptors,
-					},
+					Required: true, AvoidCached: p.avoidCachedDescriptors,
 				})
 			if err != nil {
 				return nil, err

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -253,9 +253,7 @@ func (v *vTableLookupJoinNode) startExec(params runParams) error {
 		params.p.ExecCfg().Codec,
 		v.dbName,
 		tree.DatabaseLookupFlags{
-			CommonLookupFlags: tree.CommonLookupFlags{
-				Required: true, AvoidCached: params.p.avoidCachedDescriptors,
-			},
+			Required: true, AvoidCached: params.p.avoidCachedDescriptors,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This commit moves `Include{Offline,Dropped}` and `RequireMutable` flags
from `{Object,Schema,Database}LookupFlags` to the `CommonLookupFlags`.

These flags are applicable to all descriptors and should be included in
CommonLookupFlags.

Schema and database resolution will start reading the `Include` flags in
a later change.

Release justification: low-risk, high impact change
Release note: None