### PR TITLE
 backupccl: fix NPE during restore rollback

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -526,6 +526,29 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("after offline tables", func(t *testing.T) {
+		_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
+			t, singleNode, tempDir, InitNone,
+		)
+		defer cleanupEmptyCluster()
+
+		// Bugger the backup by injecting a failure while restoring the system data.
+		for _, server := range tcRestore.Servers {
+			registry := server.JobRegistry().(*jobs.Registry)
+			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+					r := raw.(*restoreResumer)
+					r.testingKnobs.afterOfflineTableCreation = func() error {
+						return errors.New("injected error")
+					}
+					return r
+				},
+			}
+		}
+
+		sqlDBRestore.ExpectErr(t, "injected error", `RESTORE FROM $1`, LocalFoo)
+	})
 }
 
 // TestClusterRevisionHistory tests that cluster backups can be taken with


### PR DESCRIPTION
This commit fixes an NPE that happens during the rollback if the RESTORE
fails or is canceled before the execCfg is set on the resumer. The
execCfg should be removed from the resumer, but that change should be
left for a separate commit.

Fixes #52383.

Release justification: bug fix
Release note (bug fix): RESTOREs that have been cancelled may have
crashed a node. This is now fixed.