### PR TITLE
opt: build FD keys for partial index scans, not for tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1126,3 +1126,24 @@ statement ok
 SELECT * FROM t52702@t52702_false WHERE 1 = 2;
 SELECT * FROM t52702@t52702_false WHERE 's' = 't';
 SELECT * FROM t52702@t52702_false WHERE false;
+
+# Regression test for #53922. Do not build function dependency keys from partial
+# indexes. This causes incorrect results. For example, the optimizer could
+# incorrectly remove distinct operators if it thinks the column is a strict key.
+subtest regression_53922
+
+statement ok
+CREATE TABLE t53922 (
+    a INT NOT NULL,
+    UNIQUE INDEX (a) WHERE a > 10
+)
+
+statement ok
+INSERT INTO t53922 VALUES (1), (2), (3), (3)
+
+query I rowsort
+SELECT distinct(a) FROM t53922
+----
+1
+2
+3

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -323,3 +323,77 @@ project
       ├── fd: ()-->(3), (1)-->(2,4)
       ├── prune: (1-4)
       └── interesting orderings: (+1) (+3,+2,+1)
+
+# Test partial index scan functional dependencies.
+
+exec-ddl
+CREATE TABLE c (
+    k INT PRIMARY KEY,
+    x INT NOT NULL,
+    y INT,
+    s STRING,
+    UNIQUE (x) WHERE s = 'foo',
+    UNIQUE (y) WHERE s = 'bar'
+)
+----
+
+# Do not build table function dependency keys from partial index columns.
+build
+SELECT k FROM c
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── prune: (1)
+ ├── interesting orderings: (+1)
+ └── scan c
+      ├── columns: k:1(int!null) x:2(int!null) y:3(int) s:4(string) crdb_internal_mvcc_timestamp:5(decimal)
+      ├── partial index predicates
+      │    ├── secondary: filters
+      │    │    └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      │    │         ├── variable: s:4 [type=string]
+      │    │         └── const: 'foo' [type=string]
+      │    └── secondary: filters
+      │         └── eq [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
+      │              ├── variable: s:4 [type=string]
+      │              └── const: 'bar' [type=string]
+      ├── key: (1)
+      ├── fd: (1)-->(2-5)
+      ├── prune: (1-5)
+      └── interesting orderings: (+1) (+2) (+3,+1)
+
+# Add a strict key for partial index scan functional dependencies. (x)-->(k)
+# should be in the fds.
+opt
+SELECT * FROM c WHERE s = 'foo'
+----
+index-join c
+ ├── columns: k:1(int!null) x:2(int!null) y:3(int) s:4(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── prune: (1-3)
+ ├── interesting orderings: (+1) (+2) (+3,+1)
+ └── scan c@secondary,partial
+      ├── columns: k:1(int!null) x:2(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(1)
+      ├── prune: (1,2)
+      └── interesting orderings: (+1) (+2)
+
+# Add a lax key for partial index scan functional dependencies when the key can
+# be null. (y)~~>(k) should be in the fds.
+opt
+SELECT * FROM c WHERE s = 'bar'
+----
+index-join c
+ ├── columns: k:1(int!null) x:2(int!null) y:3(int) s:4(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── prune: (1-3)
+ ├── interesting orderings: (+1) (+2) (+3,+1)
+ └── scan c@secondary,partial
+      ├── columns: k:1(int!null) y:3(int)
+      ├── key: (1)
+      ├── fd: (1)-->(3), (3)~~>(1)
+      ├── prune: (1,3)
+      └── interesting orderings: (+1) (+3,+1)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -680,8 +680,8 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	// TODO(andyk): do we need to do more here?
 	mb.outScope.ordering = nil
 
-	// Loop again over each UNIQUE index, potentially creating a left join +
-	// filter for each one.
+	// Loop over each arbiter index, potentially creating a left join + filter
+	// for each one.
 	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 		// Skip non-arbiter indexes.
 		if !arbiterIndexes.Contains(idx) {

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2387,17 +2387,17 @@ insert unique_partial_indexes
       ├── columns: column13:13!null column14:14!null column15:15!null column1:5!null column2:6!null column3:7!null
       ├── select
       │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9
-      │    ├── left-join (cross)
+      │    ├── right-join (cross)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9
-      │    │    ├── values
-      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    │    │    └── (1, 1, 'bar')
       │    │    ├── select
       │    │    │    ├── columns: a:8!null b:9!null
       │    │    │    ├── scan unique_partial_indexes@u4,partial
       │    │    │    │    └── columns: a:8!null b:9
       │    │    │    └── filters
       │    │    │         └── b:9 = 1
+      │    │    ├── values
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    └── (1, 1, 'bar')
       │    │    └── filters (true)
       │    └── filters
       │         └── a:8 IS NULL


### PR DESCRIPTION
Previously, partial index columns were used to derive table-level
functional dependency keys, leading to correctness bugs. Because partial
indexes only index a subset of rows, they cannot be used to derive
functional dependencies for the entire table. This commit builds
functional dependency keys from partial indexes only for scans over the
partial index.

Consider the example from the added logictest:

    CREATE TABLE t (
        a INT NOT NULL,
        UNIQUE INDEX (a) WHERE a > 10
    )

    SELECT distinct(a) FROM t

The query plan must apply a distinct operator over a scan to ensure
there are no duplicate values in the result, like:

    distinct-on
     ├── columns: a:1
     ├── grouping columns: a:1
     ├── key: (1)
     └── scan t
          ├── columns: a:1
          ├── prune: (1)
          └── interesting orderings: (+1)

However, when the unique partial index is used to derive functional
dependencies for the table, the optimizer believes it is unique across
the entire table. As a result, the optimizer eliminates the distinct
operator, producing a query plan that returns incorrect results:

    scan t
     ├── columns: a:1
     ├── key: (1)
     └── prune: (1)

Fixes #53922

Release justification: This is a low-risk and critical bug fix for new
functionality, partial indexes.

Release note: None
