### PR TITLE
opt: clarify partial index consideration for interesting orderings

### DIFF
--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -61,6 +61,13 @@ func DeriveInterestingOrderings(e memo.RelExpr) opt.OrderingSet {
 	return res
 }
 
+// interestingOrderingsForScan calculates interesting orderings of a scan based
+// on the indexes on underlying table.
+//
+// Note that partial indexes are considered here, even though they don't provide
+// an interesting ordering for all values in the column. This is required in
+// order to consider partial indexes for certain optimization rules, such as
+// GenerateMergeJoins.
 func interestingOrderingsForScan(scan *memo.ScanExpr) opt.OrderingSet {
 	md := scan.Memo().Metadata()
 	tab := md.Table(scan.Table)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2090,6 +2090,32 @@ left-join (merge)
  │    └── filters (true)
  └── filters (true)
 
+# Generate a merge join with two partial indexes.
+
+exec-ddl
+CREATE TABLE partial_a (a INT, INDEX (a) WHERE a > 0)
+----
+
+exec-ddl
+CREATE TABLE partial_b (b INT, INDEX (b) WHERE b > 0)
+----
+
+opt
+SELECT a, b FROM partial_a JOIN partial_b ON a = b WHERE a > 0 AND b > 0
+----
+inner-join (merge)
+ ├── columns: a:1!null b:4!null
+ ├── left ordering: +1
+ ├── right ordering: +4
+ ├── fd: (1)==(4), (4)==(1)
+ ├── scan partial_a@secondary,partial
+ │    ├── columns: a:1!null
+ │    └── ordering: +1
+ ├── scan partial_b@secondary,partial
+ │    ├── columns: b:4!null
+ │    └── ordering: +4
+ └── filters (true)
+
 # --------------------------------------------------
 # GenerateLookupJoins
 # --------------------------------------------------


### PR DESCRIPTION
This commit adds clarification on why partial indexes are considered
when calculating interesting orderings of a scan. It also adds a test
for GenerateMergeJoins to ensure that the behavior does not regress.

Release justification: This is a non-production code change.

Release note: None