### PR TITLE
opt: add missing Copy() in buildInvertedFilterProps

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -295,7 +295,7 @@ func (b *logicalPropsBuilder) buildInvertedFilterProps(
 	// Output Columns
 	// --------------
 	// Inherit output columns from input, but remove the inverted column.
-	rel.OutputCols = inputProps.OutputCols
+	rel.OutputCols = inputProps.OutputCols.Copy()
 	rel.OutputCols.Remove(invFilter.InvertedColumn)
 
 	// Not Null Columns


### PR DESCRIPTION
We are modifying `input.OutputCols` in place, which leads to problems
when large ColumnIDs are involved.

Fixes #53933.

Release justification: bug fix for new functionality

Release note: None