### PR TITLE
sql: fix SET CLUSTER SETTING for enums in prepared statement

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/cluster_setting
+++ b/pkg/sql/pgwire/testdata/pgtest/cluster_setting
@@ -1,0 +1,51 @@
+# Start of test.
+
+send crdb_only
+Query {"String": "SET CLUSTER SETTING sql.defaults.serial_normalization = 'rowid'"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET CLUSTER SETTING"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 83 = ASCII 'S' for Statement
+# [114, 111, 119, 105, 100] = 'rowid'
+send crdb_only
+Parse {"Name": "s1", "Query": "SET CLUSTER SETTING sql.defaults.serial_normalization = $1"}
+Describe {"ObjectType": 83, "Name": "s1"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1", "ParameterFormatCodes": [1], "Parameters": [[114, 111, 119, 105, 100]]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[25]}
+{"Type":"NoData"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SET CLUSTER SETTING"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 83 = ASCII 'S' for Statement
+# [48] = '0'
+send crdb_only
+Parse {"Name": "s2", "Query": "SET CLUSTER SETTING sql.defaults.serial_normalization = $1"}
+Describe {"ObjectType": 83, "Name": "s2"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2", "ParameterFormatCodes": [1], "Parameters": [[48]]}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[25]}
+{"Type":"NoData"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SET CLUSTER SETTING"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -97,7 +97,7 @@ func (p *planner) SetClusterSetting(
 			case *settings.FloatSetting:
 				requiredType = types.Float
 			case *settings.EnumSetting:
-				requiredType = types.Any
+				requiredType = types.String
 			case *settings.DurationSetting:
 				requiredType = types.Interval
 			case *settings.DurationSettingWithExplicitUnit:


### PR DESCRIPTION
fixes #53925 

Release note (bug fix): Previously, SET CLUSTER SETTING could not be
used in the extended protocol if the setting was an enum, since the
placeholder argument could not be resolved. Now, these types of
statements can be used in the extended protocol.

Release note (backwards-incompatible change): An unquoted integer can no
longer be used to set an enum setting. You must now use
`SET CLUSTER SETTING enum.setting = '1'` instead of
`SET CLUSTER SETTING enum.setting = 1`. Or you can keep using
`SET CLUSTER SETTING enum.setting = 'name_of_setting'`.

Release justification: Low risk bug fix to existing functionality.