### PR TITLE
release-20.1: unimplemented: track version number in issue redirect links

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,4 +1,4 @@
-statement error temporary tables are only supported experimentally\nHINT:.*46260\n.*\n.*SET experimental_enable_temp_tables = 'on'
+statement error temporary tables are only supported experimentally\nHINT:.*46260.*\n.*\n.*SET experimental_enable_temp_tables = 'on'
 CREATE TEMP TABLE a_temp(a INT PRIMARY KEY)
 
 statement ok

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3369,17 +3369,17 @@ func TestUnimplementedSyntax(t *testing.T) {
 					t.Errorf("%s: expected %q in telemetry keys, got %+v", d.sql, exp, tkeys)
 				}
 
-				exp2 := fmt.Sprintf("issue/%d", d.issue)
+				exp2 := fmt.Sprintf("issue-v/%d", d.issue)
 				found = false
 				hints := errors.GetAllHints(err)
 				for _, h := range hints {
-					if strings.HasSuffix(h, exp2) {
+					if strings.Contains(h, exp2) {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("%s: expected %q at end of hint, got %+v", d.sql, exp2, hints)
+					t.Errorf("%s: expected %q at in hint, got %+v", d.sql, exp2, hints)
 				}
 			}
 		})

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -13,6 +13,7 @@ package unimplemented
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/errors"
 )
 
@@ -109,5 +110,5 @@ func unimplementedInternal(
 
 // MakeURL produces a URL to a CockroachDB issue.
 func MakeURL(issue int) string {
-	return fmt.Sprintf("https://go.crdb.dev/issue/%d", issue)
+	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, build.VersionPrefix())
 }

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -24,6 +24,7 @@ func TestDepWhitelist(t *testing.T) {
 	// set of deps, run it by danhhz first.
 	buildutil.VerifyTransitiveWhitelist(t, "github.com/cockroachdb/cockroach/pkg/workload",
 		[]string{
+			`github.com/cockroachdb/cockroach/pkg/build`,
 			`github.com/cockroachdb/cockroach/pkg/col/coldata`,
 			`github.com/cockroachdb/cockroach/pkg/col/coltypes`,
 			`github.com/cockroachdb/cockroach/pkg/util/arith`,
@@ -33,6 +34,7 @@ func TestDepWhitelist(t *testing.T) {
 			`github.com/cockroachdb/cockroach/pkg/util/stacktrace`,
 			`github.com/cockroachdb/cockroach/pkg/util/syncutil`,
 			`github.com/cockroachdb/cockroach/pkg/util/timeutil`,
+			`github.com/cockroachdb/cockroach/pkg/util/version`,
 			`github.com/cockroachdb/cockroach/pkg/workload/histogram`,
 			// TODO(dan): These really shouldn't be used in util packages, but the
 			// payoff of fixing it is not worth it right now.


### PR DESCRIPTION
Backport 1/1 commits from #53917.

/cc @cockroachdb/release

---

The issue redirect link will now track the version number. It redirects
to a URL like:
https://github.com/cockroachdb/cockroach/issues/ISSUE?version=VERSION

For non-release versions, the version will be "dev"

Release justification: low-risk change to improve telemetry
Release note: None
