### PR TITLE
release-19.2: use redirect server for Github links to track clicks

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3200,17 +3200,17 @@ func TestUnimplementedSyntax(t *testing.T) {
 					t.Errorf("%s: expected %q in telemetry keys, got %+v", d.sql, exp, tkeys)
 				}
 
-				exp2 := fmt.Sprintf("issue/%d", d.issue)
+				exp2 := fmt.Sprintf("issue-v/%d", d.issue)
 				found = false
 				hints := errors.GetAllHints(err)
 				for _, h := range hints {
-					if strings.HasSuffix(h, exp2) {
+					if strings.Contains(h, exp2) {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("%s: expected %q at end of hint, got %+v", d.sql, exp2, hints)
+					t.Errorf("%s: expected %q at in hint, got %+v", d.sql, exp2, hints)
 				}
 			}
 		})

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3200,7 +3200,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 					t.Errorf("%s: expected %q in telemetry keys, got %+v", d.sql, exp, tkeys)
 				}
 
-				exp2 := fmt.Sprintf("issues/%d", d.issue)
+				exp2 := fmt.Sprintf("issue/%d", d.issue)
 				found = false
 				hints := errors.GetAllHints(err)
 				for _, h := range hints {

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -13,6 +13,7 @@ package unimplemented
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/errors"
 )
 
@@ -109,5 +110,5 @@ func unimplementedInternal(
 }
 
 func makeURL(issue int) string {
-	return fmt.Sprintf("https://go.crdb.dev/issue/%d", issue)
+	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, build.VersionPrefix())
 }

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -109,5 +109,5 @@ func unimplementedInternal(
 }
 
 func makeURL(issue int) string {
-	return fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", issue)
+	return fmt.Sprintf("https://go.crdb.dev/issue/%d", issue)
 }

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -24,12 +24,14 @@ func TestDepWhitelist(t *testing.T) {
 	// set of deps, run it by danhhz first.
 	buildutil.VerifyTransitiveWhitelist(t, "github.com/cockroachdb/cockroach/pkg/workload",
 		[]string{
+			`github.com/cockroachdb/cockroach/pkg/build`,
 			`github.com/cockroachdb/cockroach/pkg/col/coldata`,
 			`github.com/cockroachdb/cockroach/pkg/col/coltypes`,
 			`github.com/cockroachdb/cockroach/pkg/util/bufalloc`,
 			`github.com/cockroachdb/cockroach/pkg/util/encoding/csv`,
 			`github.com/cockroachdb/cockroach/pkg/util/syncutil`,
 			`github.com/cockroachdb/cockroach/pkg/util/timeutil`,
+			`github.com/cockroachdb/cockroach/pkg/util/version`,
 			`github.com/cockroachdb/cockroach/pkg/workload/histogram`,
 		},
 	)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "errorutil/unimplemented: use redirect server for Github links" (#49836)
  * 1/1 commits from "unimplemented: track version number in issue redirect links" (#53917)

Please see individual PRs for details.

/cc @cockroachdb/release
