### PR TITLE
sql: prohibit new data types from usage in arrays during upgrades

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -178,6 +178,12 @@ var minimumTypeUsageVersions = map[types.Family]clusterversion.VersionKey{
 
 // isTypeSupportedInVersion returns whether a given type is supported in the given version.
 func isTypeSupportedInVersion(v clusterversion.ClusterVersion, t *types.T) (bool, error) {
+	// For these checks, if we have an array, we only want to find whether
+	// we support the array contents.
+	if t.Family() == types.ArrayFamily {
+		t = t.ArrayContents()
+	}
+
 	switch t.Family() {
 	case types.TimeFamily, types.TimestampFamily, types.TimestampTZFamily, types.TimeTZFamily:
 		if t.Precision() != 6 && !v.IsActive(clusterversion.VersionTimePrecision) {

--- a/pkg/sql/logictest/testdata/logic_test/new_type_mixed_20.1_20.2
+++ b/pkg/sql/logictest/testdata/logic_test/new_type_mixed_20.1_20.2
@@ -1,0 +1,40 @@
+# LogicTest: local-mixed-20.1-20.2
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+statement error type GEOMETRY is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOMETRY)
+
+statement error type GEOMETRY\[\] is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOMETRY[])
+
+statement error type GEOGRAPHY.* is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOGRAPHY)
+
+statement error type GEOGRAPHY\[\] is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOGRAPHY[])
+
+statement error type GEOMETRY is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOMETRY
+
+statement error type GEOGRAPHY.* is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOGRAPHY
+
+statement error type GEOMETRY\[\] is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOMETRY[]
+
+statement error type GEOGRAPHY\[\].* is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOGRAPHY[]
+
+statement error type BOX2D is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a BOX2D)
+
+statement error type BOX2D\[\] is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a BOX2D[])
+
+statement error type BOX2D.* is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo BOX2D
+
+statement error type BOX2D\[\].* is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo BOX2D[]


### PR DESCRIPTION
Fixed a bug where array types containing new types were not considered
during a version upgrade.

Resolves #53952 
Resolves #53014 

Release justification: low risk update to new functionality

Release note (bug fix): Fix a bug where we allowed new types to be used
in an array type during a version upgrade.

