### PR TITLE
release-20.1: sql: prohibit new data types from usage in arrays during upgrades

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -119,6 +119,12 @@ var minimumTypeUsageVersions = map[types.Family]clusterversion.VersionKey{
 
 // isTypeSupportedInVersion returns whether a given type is supported in the given version.
 func isTypeSupportedInVersion(v clusterversion.ClusterVersion, t *types.T) (bool, error) {
+	// For these checks, if we have an array, we only want to find whether
+	// we support the array contents.
+	if t.Family() == types.ArrayFamily {
+		t = t.ArrayContents()
+	}
+
 	switch t.Family() {
 	case types.TimeFamily, types.TimestampFamily, types.TimestampTZFamily, types.TimeTZFamily:
 		if t.Precision() != 6 && !v.IsActive(clusterversion.VersionTimePrecision) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -193,6 +193,9 @@ CREATE TABLE regression_47110_interval_ok(interval_ok INTERVAL)
 statement error type TIMESTAMP\(3\) is not supported until version upgrade is finalized
 CREATE TABLE regression_47110_not_ok(tt_not_ok TIMESTAMP(3))
 
+statement error type TIMESTAMPTZ\(3\)\[\] is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(a TIMESTAMPTZ(3)[])
+
 statement error type TIMESTAMPTZ\(3\) is not supported until version upgrade is finalized
 CREATE TABLE regression_47110_not_ok(ttz_not_ok TIMESTAMPTZ(3))
 


### PR DESCRIPTION
Backport 1/1 commits from #53961.

/cc @cockroachdb/release

---

Fixed a bug where array types containing new types were not considered
during a version upgrade.

Resolves #53952 
Resolves #53014 

Release justification: low risk update to new functionality

Release note (bug fix): Fix a bug where we allowed new types to be used
in an array type during a version upgrade.


