### PR TITLE
sql: add typecasts to expressions shown in pg_catalog

### DIFF
--- a/pkg/sql/catalog/descpb/structured.pb.go
+++ b/pkg/sql/catalog/descpb/structured.pb.go
@@ -76,7 +76,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{0}
 }
 
 // SystemColumnKind is an enum representing the different kind of system
@@ -121,7 +121,7 @@ func (x *SystemColumnKind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SystemColumnKind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{1}
 }
 
 // State indicates whether a descriptor is public (i.e., normally visible,
@@ -173,7 +173,7 @@ func (x *DescriptorState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{2}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{2}
 }
 
 type ForeignKeyReference_Action int32
@@ -218,7 +218,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{0, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -258,7 +258,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{0, 1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -295,7 +295,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{7, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{7, 0}
 }
 
 // The type of the index.
@@ -332,7 +332,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{7, 1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{7, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -375,7 +375,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{8, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{8, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -440,7 +440,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{12, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{12, 0}
 }
 
 // Direction of mutation.
@@ -483,7 +483,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{12, 1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{12, 1}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -520,7 +520,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 0}
 }
 
 // Represents the kind of type that this type descriptor represents.
@@ -560,7 +560,7 @@ func (x *TypeDescriptor_Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_Kind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{16, 0}
 }
 
 // Represents what operations are allowed on this ENUM member.
@@ -601,7 +601,7 @@ func (x *TypeDescriptor_EnumMember_Capability) UnmarshalJSON(data []byte) error 
 	return nil
 }
 func (TypeDescriptor_EnumMember_Capability) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{16, 0, 0}
 }
 
 // ForeignKeyReference is deprecated, replaced by ForeignKeyConstraint in v19.2
@@ -631,7 +631,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -679,7 +679,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -712,8 +712,8 @@ type ColumnDescriptor struct {
 	// Default expression to use to populate the column on insert if no
 	// value is provided. Note that it is not correct to use DefaultExpr
 	// as output to display to a user. User defined types within DefaultExpr
-	// have been serialized in a internal format. Instead, format the result
-	// of DeserializeTableDescExpr.
+	// have been serialized in a internal format. Instead, use one of the
+	// schemaexpr.FormatExpr* functions.
 	DefaultExpr *string `protobuf:"bytes,5,opt,name=default_expr,json=defaultExpr" json:"default_expr,omitempty"`
 	Hidden      bool    `protobuf:"varint,6,opt,name=hidden" json:"hidden"`
 	// Ids of sequences used in this column's DEFAULT expression, in calls to nextval().
@@ -723,8 +723,8 @@ type ColumnDescriptor struct {
 	// Expression to use to compute the value of this column if this is a
 	// computed column. Note that it is not correct to use ComputeExpr
 	// as output to display to a user. User defined types within ComputeExpr
-	// have been serialized in a internal format. Instead, format the result
-	// of DeserializeTableDescExpr.
+	// have been serialized in a internal format. Instead, use one of the
+	// schemaexpr.FormatExpr* functions.
 	ComputeExpr *string `protobuf:"bytes,11,opt,name=compute_expr,json=computeExpr" json:"compute_expr,omitempty"`
 	// PGAttributeNum must be accessed through the accessor, since it is set
 	// lazily, it is incorrect to access it directly.
@@ -744,7 +744,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{2}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -800,7 +800,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{3}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -846,7 +846,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{4}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -890,7 +890,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{4, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -945,7 +945,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{5}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{5}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -990,7 +990,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{6}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{6}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1033,7 +1033,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{6, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{6, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1078,7 +1078,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{6, 1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{6, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1242,7 +1242,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{7}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{7}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1293,7 +1293,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{8}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{8}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1336,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{9}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{9}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1376,7 +1376,7 @@ func (m *ComputedColumnSwap) Reset()         { *m = ComputedColumnSwap{} }
 func (m *ComputedColumnSwap) String() string { return proto.CompactTextString(m) }
 func (*ComputedColumnSwap) ProtoMessage()    {}
 func (*ComputedColumnSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{10}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{10}
 }
 func (m *ComputedColumnSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1424,7 +1424,7 @@ func (m *MaterializedViewRefresh) Reset()         { *m = MaterializedViewRefresh
 func (m *MaterializedViewRefresh) String() string { return proto.CompactTextString(m) }
 func (*MaterializedViewRefresh) ProtoMessage()    {}
 func (*MaterializedViewRefresh) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{11}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{11}
 }
 func (m *MaterializedViewRefresh) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1481,7 +1481,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{12}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{12}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1819,7 +1819,7 @@ func (m *NameInfo) Reset()         { *m = NameInfo{} }
 func (m *NameInfo) String() string { return proto.CompactTextString(m) }
 func (*NameInfo) ProtoMessage()    {}
 func (*NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{13}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{13}
 }
 func (m *NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2001,7 +2001,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2308,7 +2308,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2337,9 +2337,8 @@ type TableDescriptor_CheckConstraint struct {
 	// Expr is the expression that this check constraint represents.
 	// Note that it is not correct to use Expr as output to display
 	// to a user. User defined types within Expr have been serialized
-	// in a internal format. Instead, format the result of
-	// DeserializeTableDescExpr.
-	// todo: old comment
+	// in a internal format. Instead, use one of the schemaexpr.FormatExpr*
+	// functions.
 	Expr     string             `protobuf:"bytes,1,opt,name=expr" json:"expr"`
 	Name     string             `protobuf:"bytes,2,opt,name=name" json:"name"`
 	Validity ConstraintValidity `protobuf:"varint,3,opt,name=validity,enum=cockroach.sql.sqlbase.ConstraintValidity" json:"validity"`
@@ -2355,7 +2354,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 1}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2395,7 +2394,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 2}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 2}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2432,7 +2431,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 3}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 3}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2475,7 +2474,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 4}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 4}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2515,7 +2514,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 4, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 4, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2555,7 +2554,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 5}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 5}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2592,7 +2591,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{14, 6}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{14, 6}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2640,7 +2639,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{15}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{15}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2734,7 +2733,7 @@ func (m *DatabaseDescriptor_SchemaInfo) Reset()         { *m = DatabaseDescripto
 func (m *DatabaseDescriptor_SchemaInfo) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_SchemaInfo) ProtoMessage()    {}
 func (*DatabaseDescriptor_SchemaInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{15, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{15, 0}
 }
 func (m *DatabaseDescriptor_SchemaInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2795,7 +2794,7 @@ func (m *TypeDescriptor) Reset()         { *m = TypeDescriptor{} }
 func (m *TypeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor) ProtoMessage()    {}
 func (*TypeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{16}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{16}
 }
 func (m *TypeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2929,7 +2928,7 @@ func (m *TypeDescriptor_EnumMember) Reset()         { *m = TypeDescriptor_EnumMe
 func (m *TypeDescriptor_EnumMember) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_EnumMember) ProtoMessage()    {}
 func (*TypeDescriptor_EnumMember) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{16, 0}
 }
 func (m *TypeDescriptor_EnumMember) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2976,7 +2975,7 @@ func (m *SchemaDescriptor) Reset()         { *m = SchemaDescriptor{} }
 func (m *SchemaDescriptor) String() string { return proto.CompactTextString(m) }
 func (*SchemaDescriptor) ProtoMessage()    {}
 func (*SchemaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{17}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{17}
 }
 func (m *SchemaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3072,7 +3071,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_b9707080b03e0326, []int{18}
+	return fileDescriptor_structured_c622cbb63d3d8ca4, []int{18}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -15596,10 +15595,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_b9707080b03e0326)
+	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_c622cbb63d3d8ca4)
 }
 
-var fileDescriptor_structured_b9707080b03e0326 = []byte{
+var fileDescriptor_structured_c622cbb63d3d8ca4 = []byte{
 	// 4598 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x3b, 0x49, 0x70, 0x1b, 0x57,
 	0x76, 0xc4, 0x0e, 0x3c, 0x2c, 0x6c, 0x7e, 0x51, 0x12, 0x44, 0xdb, 0x24, 0x05, 0x59, 0x36, 0x6d,

--- a/pkg/sql/catalog/descpb/structured.pb.go
+++ b/pkg/sql/catalog/descpb/structured.pb.go
@@ -76,7 +76,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{0}
 }
 
 // SystemColumnKind is an enum representing the different kind of system
@@ -121,7 +121,7 @@ func (x *SystemColumnKind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SystemColumnKind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{1}
 }
 
 // State indicates whether a descriptor is public (i.e., normally visible,
@@ -173,7 +173,7 @@ func (x *DescriptorState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{2}
+	return fileDescriptor_structured_b9707080b03e0326, []int{2}
 }
 
 type ForeignKeyReference_Action int32
@@ -218,7 +218,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{0, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -258,7 +258,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{0, 1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -295,7 +295,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{7, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{7, 0}
 }
 
 // The type of the index.
@@ -332,7 +332,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{7, 1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{7, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -375,7 +375,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{8, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{8, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -440,7 +440,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{12, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{12, 0}
 }
 
 // Direction of mutation.
@@ -483,7 +483,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{12, 1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{12, 1}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -520,7 +520,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 0}
 }
 
 // Represents the kind of type that this type descriptor represents.
@@ -560,7 +560,7 @@ func (x *TypeDescriptor_Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_Kind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{16, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0}
 }
 
 // Represents what operations are allowed on this ENUM member.
@@ -601,7 +601,7 @@ func (x *TypeDescriptor_EnumMember_Capability) UnmarshalJSON(data []byte) error 
 	return nil
 }
 func (TypeDescriptor_EnumMember_Capability) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{16, 0, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0, 0}
 }
 
 // ForeignKeyReference is deprecated, replaced by ForeignKeyConstraint in v19.2
@@ -631,7 +631,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -679,7 +679,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -744,7 +744,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{2}
+	return fileDescriptor_structured_b9707080b03e0326, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -800,7 +800,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{3}
+	return fileDescriptor_structured_b9707080b03e0326, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -846,7 +846,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{4}
+	return fileDescriptor_structured_b9707080b03e0326, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -890,7 +890,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{4, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -945,7 +945,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{5}
+	return fileDescriptor_structured_b9707080b03e0326, []int{5}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -990,7 +990,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{6}
+	return fileDescriptor_structured_b9707080b03e0326, []int{6}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1033,7 +1033,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{6, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{6, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1078,7 +1078,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{6, 1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{6, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1242,7 +1242,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{7}
+	return fileDescriptor_structured_b9707080b03e0326, []int{7}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1293,7 +1293,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{8}
+	return fileDescriptor_structured_b9707080b03e0326, []int{8}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1336,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{9}
+	return fileDescriptor_structured_b9707080b03e0326, []int{9}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1376,7 +1376,7 @@ func (m *ComputedColumnSwap) Reset()         { *m = ComputedColumnSwap{} }
 func (m *ComputedColumnSwap) String() string { return proto.CompactTextString(m) }
 func (*ComputedColumnSwap) ProtoMessage()    {}
 func (*ComputedColumnSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{10}
+	return fileDescriptor_structured_b9707080b03e0326, []int{10}
 }
 func (m *ComputedColumnSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1424,7 +1424,7 @@ func (m *MaterializedViewRefresh) Reset()         { *m = MaterializedViewRefresh
 func (m *MaterializedViewRefresh) String() string { return proto.CompactTextString(m) }
 func (*MaterializedViewRefresh) ProtoMessage()    {}
 func (*MaterializedViewRefresh) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{11}
+	return fileDescriptor_structured_b9707080b03e0326, []int{11}
 }
 func (m *MaterializedViewRefresh) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1481,7 +1481,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{12}
+	return fileDescriptor_structured_b9707080b03e0326, []int{12}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1819,7 +1819,7 @@ func (m *NameInfo) Reset()         { *m = NameInfo{} }
 func (m *NameInfo) String() string { return proto.CompactTextString(m) }
 func (*NameInfo) ProtoMessage()    {}
 func (*NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{13}
+	return fileDescriptor_structured_b9707080b03e0326, []int{13}
 }
 func (m *NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2001,7 +2001,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2308,7 +2308,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2339,6 +2339,7 @@ type TableDescriptor_CheckConstraint struct {
 	// to a user. User defined types within Expr have been serialized
 	// in a internal format. Instead, format the result of
 	// DeserializeTableDescExpr.
+	// todo: old comment
 	Expr     string             `protobuf:"bytes,1,opt,name=expr" json:"expr"`
 	Name     string             `protobuf:"bytes,2,opt,name=name" json:"name"`
 	Validity ConstraintValidity `protobuf:"varint,3,opt,name=validity,enum=cockroach.sql.sqlbase.ConstraintValidity" json:"validity"`
@@ -2354,7 +2355,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 1}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2394,7 +2395,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 2}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 2}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2431,7 +2432,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 3}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 3}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2474,7 +2475,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 4}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 4}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2514,7 +2515,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 4, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 4, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2554,7 +2555,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 5}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 5}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2591,7 +2592,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{14, 6}
+	return fileDescriptor_structured_b9707080b03e0326, []int{14, 6}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2639,7 +2640,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{15}
+	return fileDescriptor_structured_b9707080b03e0326, []int{15}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2733,7 +2734,7 @@ func (m *DatabaseDescriptor_SchemaInfo) Reset()         { *m = DatabaseDescripto
 func (m *DatabaseDescriptor_SchemaInfo) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_SchemaInfo) ProtoMessage()    {}
 func (*DatabaseDescriptor_SchemaInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{15, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{15, 0}
 }
 func (m *DatabaseDescriptor_SchemaInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2794,7 +2795,7 @@ func (m *TypeDescriptor) Reset()         { *m = TypeDescriptor{} }
 func (m *TypeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor) ProtoMessage()    {}
 func (*TypeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{16}
+	return fileDescriptor_structured_b9707080b03e0326, []int{16}
 }
 func (m *TypeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2928,7 +2929,7 @@ func (m *TypeDescriptor_EnumMember) Reset()         { *m = TypeDescriptor_EnumMe
 func (m *TypeDescriptor_EnumMember) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_EnumMember) ProtoMessage()    {}
 func (*TypeDescriptor_EnumMember) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{16, 0}
+	return fileDescriptor_structured_b9707080b03e0326, []int{16, 0}
 }
 func (m *TypeDescriptor_EnumMember) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2975,7 +2976,7 @@ func (m *SchemaDescriptor) Reset()         { *m = SchemaDescriptor{} }
 func (m *SchemaDescriptor) String() string { return proto.CompactTextString(m) }
 func (*SchemaDescriptor) ProtoMessage()    {}
 func (*SchemaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{17}
+	return fileDescriptor_structured_b9707080b03e0326, []int{17}
 }
 func (m *SchemaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3071,7 +3072,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_37e988af7300de18, []int{18}
+	return fileDescriptor_structured_b9707080b03e0326, []int{18}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -15595,10 +15596,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_37e988af7300de18)
+	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_b9707080b03e0326)
 }
 
-var fileDescriptor_structured_37e988af7300de18 = []byte{
+var fileDescriptor_structured_b9707080b03e0326 = []byte{
 	// 4598 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x3b, 0x49, 0x70, 0x1b, 0x57,
 	0x76, 0xc4, 0x0e, 0x3c, 0x2c, 0x6c, 0x7e, 0x51, 0x12, 0x44, 0xdb, 0x24, 0x05, 0x59, 0x36, 0x6d,

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -853,6 +853,7 @@ message TableDescriptor {
     // to a user. User defined types within Expr have been serialized
     // in a internal format. Instead, format the result of
     // DeserializeTableDescExpr.
+    // todo: old comment
     optional string expr = 1 [(gogoproto.nullable) = false];
     optional string name = 2 [(gogoproto.nullable) = false];
     optional ConstraintValidity validity = 3 [(gogoproto.nullable) = false];

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -113,8 +113,8 @@ message ColumnDescriptor {
   // Default expression to use to populate the column on insert if no
   // value is provided. Note that it is not correct to use DefaultExpr
   // as output to display to a user. User defined types within DefaultExpr
-  // have been serialized in a internal format. Instead, format the result
-  // of DeserializeTableDescExpr.
+  // have been serialized in a internal format. Instead, use one of the
+  // schemaexpr.FormatExpr* functions.
   optional string default_expr = 5;
   reserved 9;
   optional bool hidden = 6 [(gogoproto.nullable) = false];
@@ -126,8 +126,8 @@ message ColumnDescriptor {
   // Expression to use to compute the value of this column if this is a
   // computed column. Note that it is not correct to use ComputeExpr
   // as output to display to a user. User defined types within ComputeExpr
-  // have been serialized in a internal format. Instead, format the result
-  // of DeserializeTableDescExpr.
+  // have been serialized in a internal format. Instead, use one of the
+  // schemaexpr.FormatExpr* functions.
   optional string compute_expr = 11;
   // PGAttributeNum must be accessed through the accessor, since it is set
   // lazily, it is incorrect to access it directly.
@@ -851,9 +851,8 @@ message TableDescriptor {
     // Expr is the expression that this check constraint represents.
     // Note that it is not correct to use Expr as output to display
     // to a user. User defined types within Expr have been serialized
-    // in a internal format. Instead, format the result of
-    // DeserializeTableDescExpr.
-    // todo: old comment
+    // in a internal format. Instead, use one of the schemaexpr.FormatExpr*
+    // functions.
     optional string expr = 1 [(gogoproto.nullable) = false];
     optional string name = 2 [(gogoproto.nullable) = false];
     optional ConstraintValidity validity = 3 [(gogoproto.nullable) = false];

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -44,7 +44,7 @@ func validateCheckExpr(
 	ie *InternalExecutor,
 	txn *kv.Txn,
 ) error {
-	expr, err := schemaexpr.FormatExprForDisplay(ctx, tableDesc, exprStr, semaCtx)
+	expr, err := schemaexpr.FormatExprForDisplay(ctx, tableDesc, exprStr, semaCtx, tree.FmtParsable)
 	if err != nil {
 		return err
 	}
@@ -357,7 +357,7 @@ func checkMutationInput(
 		} else if !res && checkVals[colIdx] != tree.DNull {
 			// Failed to satisfy CHECK constraint, so unwrap the serialized
 			// check expression to display to the user.
-			expr, err := schemaexpr.FormatExprForDisplay(ctx, tabDesc, checks[i].Expr, semaCtx)
+			expr, err := schemaexpr.FormatExprForDisplay(ctx, tabDesc, checks[i].Expr, semaCtx, tree.FmtParsable)
 			if err != nil {
 				// If we ran into an error trying to read the check constraint, wrap it
 				// and return.

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -260,14 +260,7 @@ func NewMergeJoinOp(
 	actualRightOrdering := make([]execinfrapb.Ordering_Column, len(rightOrdering))
 	copy(actualLeftOrdering, leftOrdering)
 	copy(actualRightOrdering, rightOrdering)
-	isNumeric := func(t *types.T) bool {
-		switch t.Family() {
-		case types.IntFamily, types.FloatFamily, types.DecimalFamily:
-			return true
-		default:
-			return false
-		}
-	}
+
 	// Iterate over each equality column and check whether a cast is needed. If
 	// it is needed for some column, then a cast operator is planned on top of
 	// the input from the corresponding side and the types and ordering are
@@ -280,7 +273,7 @@ func NewMergeJoinOp(
 		rightColIdx := rightOrdering[i].ColIdx
 		leftType := leftTypes[leftColIdx]
 		rightType := rightTypes[rightColIdx]
-		if !leftType.Identical(rightType) && isNumeric(leftType) && isNumeric(rightType) {
+		if !leftType.Identical(rightType) && leftType.IsNumeric() && rightType.IsNumeric() {
 			// The types are different and both are numeric, so we need to plan
 			// a cast. There is a hierarchy of valid casts:
 			//   INT2 -> INT4 -> INT8 -> FLOAT -> DECIMAL

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1810,7 +1810,7 @@ CREATE TABLE crdb_internal.table_columns (
 						col := &columns[i]
 						defStr := tree.DNull
 						if col.DefaultExpr != nil {
-							defExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *col.DefaultExpr, &p.semaCtx)
+							defExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *col.DefaultExpr, &p.semaCtx, tree.FmtParsable)
 							if err != nil {
 								return err
 							}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -391,7 +391,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				}
 				colDefault := tree.DNull
 				if column.DefaultExpr != nil {
-					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *column.DefaultExpr, &p.semaCtx)
+					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *column.DefaultExpr, &p.semaCtx, tree.FmtParsable)
 					if err != nil {
 						return err
 					}
@@ -399,7 +399,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				}
 				colComputed := emptyString
 				if column.ComputeExpr != nil {
-					colExpr, err := schemaexpr.FormatExprForDisplayWithoutTypeAnnotations(ctx, table, *column.ComputeExpr, &p.semaCtx)
+					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *column.ComputeExpr, &p.semaCtx, tree.FmtSimple)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -465,6 +465,22 @@ SELECT * FROM enum_default
 1 hello true
 2 hello true
 
+query T
+SELECT
+  pg_get_expr(d.adbin, d.adrelid)
+FROM
+  pg_attribute AS a
+  LEFT JOIN pg_attrdef AS d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+  LEFT JOIN pg_type AS t ON a.atttypid = t.oid
+  LEFT JOIN pg_collation AS c ON
+    a.attcollation = c.oid AND a.attcollation != t.typcollation
+WHERE
+  a.attrelid = 'enum_default'::REGCLASS
+  AND NOT a.attisdropped
+  AND attname = 'y'
+----
+'hello'::public.greeting
+
 # Test that enum default values are formatted in human readable ways.
 query TT
 SHOW CREATE enum_default

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -620,7 +620,7 @@ WHERE n.nspname = 'public'
 oid         relname  adrelid  adnum  adbin           adsrc           pg_get_expr
 1666782879  t1       55       4      12              12              12
 841178406   t2       56       2      unique_rowid()  unique_rowid()  unique_rowid()
-2186255414  t3       57       3      'FOO'           'FOO'           'FOO'
+2186255414  t3       57       3      'FOO'::STRING   'FOO'::STRING   'FOO'::STRING
 2186255409  t3       57       4      unique_rowid()  unique_rowid()  unique_rowid()
 581442133   mv1      59       2      unique_rowid()  unique_rowid()  unique_rowid()
 
@@ -839,7 +839,7 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 oid         conname    connamespace  contype  condef
-370295511   check_c    2332901747    c        CHECK ((c != ''))
+370295511   check_c    2332901747    c        CHECK ((c != ''::STRING))
 2143281868  fk         2332901747    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
 2792001267  check_b    2332901747    c        CHECK ((b > 11))
 3572320190  primary    2332901747    p        PRIMARY KEY (p ASC)
@@ -919,12 +919,12 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
-conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin     consrc     condef
-check_c    NULL     NULL       NULL       NULL       NULL       (c != '')  (c != '')  CHECK ((c != ''))
-check_b    NULL     NULL       NULL       NULL       NULL       (b > 11)   (b > 11)   CHECK ((b > 11))
-primary    NULL     NULL       NULL       NULL       NULL       NULL       NULL       PRIMARY KEY (p ASC)
-t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL       NULL       UNIQUE (a ASC)
-index_key  NULL     NULL       NULL       NULL       NULL       NULL       NULL       UNIQUE (b ASC, c ASC)
+conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin             consrc             condef
+check_c    NULL     NULL       NULL       NULL       NULL       (c != ''::STRING)  (c != ''::STRING)  CHECK ((c != ''::STRING))
+check_b    NULL     NULL       NULL       NULL       NULL       (b > 11)           (b > 11)           CHECK ((b > 11))
+primary    NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (p ASC)
+t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (a ASC)
+index_key  NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (b ASC, c ASC)
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc
@@ -2079,7 +2079,7 @@ WHERE n.nspname = 'public'
 ----
 1666782879  t1   12
 841178406   t2   unique_rowid()
-2186255414  t3   'FOO'
+2186255414  t3   'FOO'::STRING
 2186255409  t3   unique_rowid()
 581442133   mv1  unique_rowid()
 
@@ -2698,7 +2698,7 @@ WHERE
   AND NOT a.attisdropped
   AND attname = 'x'
 ----
-'howdy'
+'howdy'::STRING
 
 # Regression test for limits on virtual index scans. (#53522)
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
@@ -414,19 +413,11 @@ CREATE TABLE pg_catalog.pg_attrdef (
 				// pg_attrdef only expects rows for columns with default values.
 				return nil
 			}
-			var defSrc *tree.DString
-			expr, err := parser.ParseExpr(*column.DefaultExpr)
+			displayExpr, err := schemaexpr.FormatExprForDisplayInPGCatalog(ctx, table, *column.DefaultExpr, &p.semaCtx)
 			if err != nil {
-				defSrc = tree.NewDString(*column.DefaultExpr)
-			} else {
-				expr, err := expr.TypeCheck(ctx, &p.semaCtx, column.Type)
-				if err != nil {
-					return err
-				}
-				ctx := tree.NewFmtCtx(tree.FmtPGAttrdefAdbin)
-				ctx.FormatNode(expr)
-				defSrc = tree.NewDString(ctx.String())
+				return err
 			}
+			defSrc := tree.NewDString(displayExpr)
 			return addRow(
 				h.ColumnOid(table.GetID(), column.ID),               // oid
 				tableOid(table.GetID()),                             // adrelid
@@ -978,7 +969,7 @@ func populateTableConstraints(
 			if conkey, err = colIDArrayToDatum(con.CheckConstraint.ColumnIDs); err != nil {
 				return err
 			}
-			displayExpr, err := schemaexpr.FormatExprForDisplayWithoutTypeAnnotations(ctx, table, con.Details, &p.semaCtx)
+			displayExpr, err := schemaexpr.FormatExprForDisplayInPGCatalog(ctx, table, con.Details, &p.semaCtx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -413,7 +413,7 @@ CREATE TABLE pg_catalog.pg_attrdef (
 				// pg_attrdef only expects rows for columns with default values.
 				return nil
 			}
-			displayExpr, err := schemaexpr.FormatExprForDisplayInPGCatalog(ctx, table, *column.DefaultExpr, &p.semaCtx)
+			displayExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *column.DefaultExpr, &p.semaCtx, tree.FmtPGCatalog)
 			if err != nil {
 				return err
 			}
@@ -969,7 +969,7 @@ func populateTableConstraints(
 			if conkey, err = colIDArrayToDatum(con.CheckConstraint.ColumnIDs); err != nil {
 				return err
 			}
-			displayExpr, err := schemaexpr.FormatExprForDisplayInPGCatalog(ctx, table, con.Details, &p.semaCtx)
+			displayExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, con.Details, &p.semaCtx, tree.FmtPGCatalog)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/schemaexpr/column.go
+++ b/pkg/sql/schemaexpr/column.go
@@ -94,7 +94,7 @@ func FormatColumnForDisplay(
 	}
 	if desc.DefaultExpr != nil {
 		f.WriteString(" DEFAULT ")
-		defExpr, err := FormatExprForDisplay(ctx, tbl, *desc.DefaultExpr, semaCtx)
+		defExpr, err := FormatExprForDisplay(ctx, tbl, *desc.DefaultExpr, semaCtx, tree.FmtParsable)
 		if err != nil {
 			return "", err
 		}
@@ -102,7 +102,7 @@ func FormatColumnForDisplay(
 	}
 	if desc.IsComputed() {
 		f.WriteString(" AS (")
-		compExpr, err := FormatExprForDisplay(ctx, tbl, *desc.ComputeExpr, semaCtx)
+		compExpr, err := FormatExprForDisplay(ctx, tbl, *desc.ComputeExpr, semaCtx, tree.FmtParsable)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -111,44 +111,21 @@ func ExtractColumnIDs(desc catalog.TableDescriptor, rootExpr tree.Expr) (TableCo
 	return colIDs, err
 }
 
-// FormatExprForDisplay formats a schema expression string for display by adding
-// type annotations and resolving user defined types.
+// FormatExprForDisplay formats a schema expression string for display. It
+// accepts formatting flags to control things like showing type annotations or
+// type casts.
 func FormatExprForDisplay(
-	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
+	ctx context.Context,
+	desc catalog.TableDescriptor,
+	exprStr string,
+	semaCtx *tree.SemaContext,
+	fmtFlags tree.FmtFlags,
 ) (string, error) {
 	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx)
 	if err != nil {
 		return "", err
 	}
-	return tree.SerializeForDisplay(expr), nil
-}
-
-// FormatExprForDisplayWithoutTypeAnnotations formats a schema expression string
-// for display, similar to FormatExprForDisplay, but does not add type
-// annotations.
-func FormatExprForDisplayWithoutTypeAnnotations(
-	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
-) (string, error) {
-	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx)
-	if err != nil {
-		return "", err
-	}
-	return tree.AsString(expr), nil
-}
-
-// FormatExprForDisplayInPGCatalog formats a schema expression string for
-// display, similar to FormatExprForDisplay, but does not add type annotations
-// and does add typecasts for non-numeric constants. This is the format that
-// should be used for displaying expressions in pg_catalog, in order to achieve
-// compatibility with the pg_catalog from PostgreSQL.
-func FormatExprForDisplayInPGCatalog(
-	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
-) (string, error) {
-	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx)
-	if err != nil {
-		return "", err
-	}
-	return tree.AsStringWithFlags(expr, tree.FmtPGCatalog), nil
+	return tree.AsStringWithFlags(expr, fmtFlags), nil
 }
 
 func deserializeExprForFormatting(

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -136,6 +136,21 @@ func FormatExprForDisplayWithoutTypeAnnotations(
 	return tree.AsString(expr), nil
 }
 
+// FormatExprForDisplayInPGCatalog formats a schema expression string for
+// display, similar to FormatExprForDisplay, but does not add type annotations
+// and does add typecasts for non-numeric constants. This is the format that
+// should be used for displaying expressions in pg_catalog, in order to achieve
+// compatibility with the pg_catalog from PostgreSQL.
+func FormatExprForDisplayInPGCatalog(
+	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
+) (string, error) {
+	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx)
+	if err != nil {
+		return "", err
+	}
+	return tree.AsStringWithFlags(expr, tree.FmtPGCatalog), nil
+}
+
 func deserializeExprForFormatting(
 	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
 ) (tree.Expr, error) {

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -215,7 +215,7 @@ func FormatIndexForDisplay(
 
 	if index.IsPartial() {
 		f.WriteString(" WHERE ")
-		pred, err := FormatExprForDisplay(ctx, table, index.Predicate, semaCtx)
+		pred, err := FormatExprForDisplay(ctx, table, index.Predicate, semaCtx, tree.FmtParsable)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1646,18 +1646,6 @@ type AnnotateTypeExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
-	if ctx.HasFlags(FmtPGAttrdefAdbin) {
-		ctx.FormatNode(node.Expr)
-		if typ, ok := GetStaticallyKnownType(node.Type); ok {
-			switch typ.Family() {
-			case types.StringFamily, types.CollatedStringFamily:
-				// Postgres formats strings using a cast afterward. Let's do the same.
-				ctx.WriteString("::")
-				ctx.WriteString(typ.SQLString())
-			}
-		}
-		return
-	}
 	switch node.SyntaxMode {
 	case AnnotateShort:
 		exprFmtWithParen(ctx, node.Expr)

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -29,6 +29,11 @@ func (f FmtFlags) HasFlags(subset FmtFlags) bool {
 	return f&subset == subset
 }
 
+// HasAnyFlags tests whether any of the given flags are all set.
+func (f FmtFlags) HasAnyFlags(subset FmtFlags) bool {
+	return f&subset != 0
+}
+
 // EncodeFlags returns the subset of the flags that are also lex encode flags.
 func (f FmtFlags) EncodeFlags() lex.EncodeFlags {
 	return lex.EncodeFlags(f) & (lex.EncFirstFreeFlagBit - 1)
@@ -366,7 +371,7 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 			ctx.WriteByte(')')
 		}
 	}
-	if f.HasFlags(fmtDisambiguateDatumTypes) || f.HasFlags(FmtPGCatalog) {
+	if f.HasAnyFlags(fmtDisambiguateDatumTypes | FmtPGCatalog) {
 		var typ *types.T
 		if d, isDatum := n.(Datum); isDatum {
 			if p, isPlaceholder := d.(*Placeholder); isPlaceholder {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -418,7 +418,7 @@ func showConstraintClause(
 			f.WriteString(" ")
 		}
 		f.WriteString("CHECK (")
-		expr, err := schemaexpr.FormatExprForDisplay(ctx, desc, e.Expr, semaCtx)
+		expr, err := schemaexpr.FormatExprForDisplay(ctx, desc, e.Expr, semaCtx, tree.FmtParsable)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2316,6 +2316,16 @@ func (t *T) IsAmbiguous() bool {
 	return false
 }
 
+// IsNumeric returns true iff this type is an integer, float, or decimal.
+func (t *T) IsNumeric() bool {
+	switch t.Family() {
+	case IntFamily, FloatFamily, DecimalFamily:
+		return true
+	default:
+		return false
+	}
+}
+
 // EnumGetIdxOfPhysical returns the index within the TypeMeta's slice of
 // enum physical representations that matches the input byte slice.
 func (t *T) EnumGetIdxOfPhysical(phys []byte) (int, error) {


### PR DESCRIPTION
fixes #53942 

also includes three small cleanup commits:
colexec: reduce code duplication in mergejoiner
descpb: fix comment about formatting expressions
sql: consolidate FormatExprForDisplay functions

pg_attrdef.adbin (column defaults) and pg_constraint.condef (column
constraints) are supposed to format the expression using typecasts for
non-numeric constants. This was previously being done for string
constants in pg_attrdef, but a recent change broke that functionality.

Release note (sql change): SQL expressions that are shown in pg_catalog
columns and related functions now will be formatted with a typecast for
non-numeric constants.

Release justification: low-risk change that improves compatibility, and
also fixes a regression that started in this release.