### PR TITLE
sql: ensure auto-retrying transactions respect the statement_timeout

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -279,11 +279,34 @@ func (ex *connExecutor) execStmtInOpenState(
 		// in that jungle, we just overwrite them all here with an error that's
 		// nicer to look at for the client.
 		if res != nil && ctx.Err() != nil && res.Err() != nil {
-			if queryTimedOut {
-				res.SetError(sqlerrors.QueryTimeoutError)
-			} else {
-				res.SetError(cancelchecker.QueryCanceledError)
+			// Even in the cases where the error is a retryable error, we want to
+			// intercept the event and payload returned here to ensure that the query
+			// is not retried.
+			retEv = eventNonRetriableErr{
+				IsCommit: fsm.FromBool(isCommit(stmt.AST)),
 			}
+			res.SetError(cancelchecker.QueryCanceledError)
+			retPayload = eventNonRetriableErrPayload{err: cancelchecker.QueryCanceledError}
+		}
+
+		// If the query timed out, we intercept the error, payload, and event here
+		// for the same reasons we intercept them for canceled queries above.
+		// Overriding queries with a QueryTimedOut error needs to happen after
+		// we've checked for canceled queries as some queries may be canceled
+		// because of a timeout, in which case the appropriate error to return to
+		// the client is one that indicates the timeout, rather than the more general
+		// query canceled error. It's important to note that a timed out query may
+		// not have been canceled (eg. We never even start executing a query
+		// because the timeout has already expired), and therefore this check needs
+		// to happen outside the canceled query check above.
+		if queryTimedOut {
+			// A timed out query should never produce retryable errors/events/payloads
+			// so we intercept and overwrite them all here.
+			retEv = eventNonRetriableErr{
+				IsCommit: fsm.FromBool(isCommit(stmt.AST)),
+			}
+			res.SetError(sqlerrors.QueryTimeoutError)
+			retPayload = eventNonRetriableErrPayload{err: sqlerrors.QueryTimeoutError}
 		}
 	}
 	// Generally we want to unregister after the auto-commit below. However, in
@@ -375,9 +398,20 @@ func (ex *connExecutor) execStmtInOpenState(
 		}()
 	}
 
+	makeErrEvent := func(err error) (fsm.Event, fsm.EventPayload, error) {
+		ev, payload := ex.makeErrEvent(err, stmt.AST)
+		return ev, payload, nil
+	}
+
 	if ex.sessionData.StmtTimeout > 0 {
+		timerDuration := ex.sessionData.StmtTimeout - timeutil.Since(ex.phaseTimes[sessionQueryReceived])
+		// There's no need to proceed with execution if the timer has already expired.
+		if timerDuration < 0 {
+			queryTimedOut = true
+			return makeErrEvent(sqlerrors.QueryTimeoutError)
+		}
 		timeoutTicker = time.AfterFunc(
-			ex.sessionData.StmtTimeout-timeutil.Since(ex.phaseTimes[sessionQueryReceived]),
+			timerDuration,
 			func() {
 				ex.cancelQuery(stmt.queryID)
 				queryTimedOut = true
@@ -403,11 +437,6 @@ func (ex *connExecutor) execStmtInOpenState(
 			return
 		}
 	}()
-
-	makeErrEvent := func(err error) (fsm.Event, fsm.EventPayload, error) {
-		ev, payload := ex.makeErrEvent(err, stmt.AST)
-		return ev, payload, nil
-	}
 
 	switch s := stmt.AST.(type) {
 	case *tree.BeginTransaction:

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -663,7 +663,6 @@ func TestIdleInSessionTimeout(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	var err error
 	conn, err := tc.ServerConn(0).Conn(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -902,6 +901,42 @@ func TestIdleInTransactionSessionTimeoutCommitWaitState(t *testing.T) {
 		t.Fatal("expected the connection to be killed " +
 			"but the connection is still alive")
 	}
+}
+
+func TestStatementTimeoutRetryableErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	numNodes := 1
+	tc := serverutils.StartNewTestCluster(t, numNodes,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		})
+	defer tc.Stopper().Stop(ctx)
+
+	conn, err := tc.ServerConn(0).Conn(ctx)
+	require.NoError(t, err)
+
+	_, err = conn.QueryContext(ctx,
+		`SET statement_timeout = '0.1s'`)
+	require.NoError(t, err)
+
+	testutils.RunTrueAndFalse(t, "test statement timeout with explicit txn",
+		func(t *testing.T, explicitTxn bool) {
+			query := `SELECT crdb_internal.force_retry('2s');`
+			if explicitTxn {
+				query = `BEGIN; ` + query + ` COMMIT;`
+			}
+			startTime := timeutil.Now()
+			_, err = conn.QueryContext(ctx, query)
+			require.Regexp(t, "pq: query execution canceled due to statement timeout", err)
+
+			// The query timeout should be triggered and therefore the force retry
+			// should not last for 2 seconds as specified.
+			if timeutil.Since(startTime) >= 2*time.Second {
+				t.Fatal("expected the query to error out due to the statement_timeout.")
+			}
+		})
 }
 
 func getUserConn(t *testing.T, username string, server serverutils.TestServerInterface) *gosql.DB {


### PR DESCRIPTION
Previously, if a statement exceeded the statement_timnout in the
conn_executor, but failed with a retryable error, we would still retry
it. This was because even though we overrode the error, we didn't
override the `fms.Event` and `fsm.EventPayload` which actually dictates
the next transition. This patch overrides them, thereby ensuring that
even if a timed out query/cancelled query encountered a retryable
error, we do not transition into retrying it.

Fixes #52845

Release justification: low risk, high benefit changes to existing functionality

Release note (bug fix): queries that can be automatically retried did
not respect the `statement_timeout` earlier, which is now fixed.