### PR TITLE
sql: improve error message for search_path with commas

### DIFF
--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -843,8 +843,10 @@ var varGen = map[string]sessionVar{
 					// TODO(knz): if/when we want to support this, we'll need to change
 					// the interface between GetStringVal() and Set() to take string
 					// arrays instead of a single string.
-					return "", unimplemented.Newf("schema names containing commas in search_path",
-						"schema name %q not supported in search_path", s)
+					return "",
+						errors.WithHintf(unimplemented.NewWithIssuef(53971,
+							`schema name %q has commas so is not supported in search_path.`, s),
+							`Did you mean to omit quotes? SET search_path = %s`, s)
 				}
 				buf.WriteString(comma)
 				buf.WriteString(s)


### PR DESCRIPTION
It's easy to accidentally surround your search path with quotes when
setting it, because you'd think that most things in `SET` syntax are
quoted. But you are not supposed to quote things in set search_path, and
it can lead to confusing scenarios. Now, if you try to set search_path
to a string containing a comma, which we don't support anyway, the error
message will be a bit friendlier.

Release note (sql change): improve error message when people use set
search_path incorrectly, or with a schema that legitimately has a comma
in its name

Release justification: error-message-only change