### PR TITLE
backupccl: enum/schemas integration with privileges in BACKUP/RESTORE

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -567,7 +567,6 @@ func backupPlanHook(
 
 		var tables []catalog.TableDescriptor
 		statsFiles := make(map[descpb.ID]string)
-		// TODO(pbardea): Let's check the privs for UDTs and UDSs here.
 		for _, desc := range targetDescs {
 			switch desc := desc.(type) {
 			case catalog.DatabaseDescriptor:
@@ -583,6 +582,10 @@ func backupPlanHook(
 				// TODO (anzo): look into the tradeoffs of having all objects in the array to be in the same file,
 				// vs having each object in a separate file, or somewhere in between.
 				statsFiles[desc.GetID()] = backupStatisticsFileName
+			case catalog.TypeDescriptor, catalog.SchemaDescriptor:
+				if err := p.CheckPrivilege(ctx, desc, privilege.USAGE); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -391,6 +391,9 @@ func showPrivileges(descriptor *descpb.Descriptor) string {
 	} else if table := descpb.TableFromDescriptor(descriptor, hlc.Timestamp{}); table != nil {
 		privDesc = table.GetPrivileges()
 		objectType = privilege.Table
+	} else if schema := descriptor.GetSchema(); schema != nil {
+		privDesc = schema.GetPrivileges()
+		objectType = privilege.Schema
 	}
 	if privDesc == nil {
 		return ""
@@ -398,10 +401,10 @@ func showPrivileges(descriptor *descpb.Descriptor) string {
 	for _, userPriv := range privDesc.Show(objectType) {
 		user := userPriv.User
 		privs := userPriv.Privileges
-		privStringBuilder.WriteString("GRANT ")
 		if len(privs) == 0 {
 			continue
 		}
+		privStringBuilder.WriteString("GRANT ")
 
 		for j, priv := range privs {
 			if j != 0 {


### PR DESCRIPTION
This commit has a few parts:
- Check for the required privileges on enums and schemas during backup
- Ensure that the privileges on these object types are displayed in SHOW
BACKUP
- Ensure that the descriptor privileges on enums and types are wipes
when performing a non-cluster restore

Fixes #53548.

Release justification: bug fix
Release note: None