### PR TITLE
workload/tpcc: optimize statements using batching and vectorized prepared statements

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -63,36 +63,10 @@ type tpccOptions struct {
 }
 
 // tpccFixturesCmd generates the command string to load tpcc data for the
-// specified warehouse count into a cluster using either `fixtures import`
-// or `fixtures load` depending on the cloud.
-func tpccFixturesCmd(t *test, cloud string, warehouses int, extraArgs string) string {
-	var command string
-	switch cloud {
-	case gce:
-		// TODO(nvanbenschoten): We could switch to import for both clouds.
-		// At the moment, import is still a little unstable and load is still
-		// marginally faster.
-		command = "./workload fixtures load"
-		fixtureWarehouses := -1
-		for _, w := range []int{1, 10, 100, 1000, 2000, 5000, 10000} {
-			if w >= warehouses {
-				fixtureWarehouses = w
-				break
-			}
-		}
-		if fixtureWarehouses == -1 {
-			t.Fatalf("could not find fixture big enough for %d warehouses", warehouses)
-		}
-		warehouses = fixtureWarehouses
-	case aws, azure:
-		// For fixtures import, use the version built into the cockroach binary
-		// so the tpcc workload-versions match on release branches.
-		command = "./cockroach workload fixtures import"
-	default:
-		t.Fatalf("unknown cloud: %q", cloud)
-	}
-	return fmt.Sprintf("%s tpcc --warehouses=%d %s {pgurl:1}",
-		command, warehouses, extraArgs)
+// specified warehouse count into a cluster.
+func tpccFixturesCmd(t *test, warehouses int, extraArgs string) string {
+	return fmt.Sprintf("./workload fixtures import tpcc --warehouses=%d %s {pgurl:1}",
+		warehouses, extraArgs)
 }
 
 func setupTPCC(
@@ -144,7 +118,7 @@ func setupTPCC(
 		switch opts.SetupType {
 		case usingFixture:
 			t.Status("loading fixture")
-			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, opts.Warehouses, opts.ExtraSetupArgs))
+			c.Run(ctx, workloadNode, tpccFixturesCmd(t, opts.Warehouses, opts.ExtraSetupArgs))
 		case usingInit:
 			t.Status("initializing tables")
 			cmd := fmt.Sprintf("./workload init tpcc --warehouses=%d %s {pgurl:1}",
@@ -680,7 +654,7 @@ func loadTPCCBench(
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
 	waitForFullReplication(t, db)
-	cmd := tpccFixturesCmd(t, cloud, b.LoadWarehouses, loadArgs)
+	cmd := tpccFixturesCmd(t, b.LoadWarehouses, loadArgs)
 	if err := c.RunE(ctx, loadNode, cmd); err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -379,7 +379,7 @@ func registerTPCC(r *testRegistry) {
 		CPUs:  4,
 
 		LoadWarehouses: 1000,
-		EstimatedMax:   gceOrAws(cloud, 400, 600),
+		EstimatedMax:   gceOrAws(cloud, 650, 800),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 3,

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -90,7 +90,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_03
 SELECT i_price, i_name, i_data
 FROM item
-WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+WHERE i_id = ANY ('{125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300}')
 ORDER BY i_id
 ----
 ----
@@ -133,54 +133,55 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 
 stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_04 ignore-tables=1
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
-FROM stock
-WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+FROM (SELECT unnest('{1000, 900, 1100, 1500, 1400}':::INT[]) AS i_id, 
+             unnest('{4, 4, 4, 4, 4}':::INT[])               AS w_id)
+INNER LOOKUP JOIN stock ON s_i_id = i_id AND s_w_id = w_id
 ORDER BY s_i_id
 ----
 ----
-project
- ├── save-table-name: new_order_04_project_1
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
+sort
+ ├── save-table-name: new_order_04_sort_1
+ ├── columns: s_quantity:5(int) s_ytd:16(int) s_order_cnt:17(int) s_remote_cnt:18(int) s_data:19(varchar) s_dist_05:10(char)  [hidden: s_i_id:3(int!null)]
  ├── cardinality: [0 - 5]
- ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(3)=4.86513081, null(3)=0, distinct(8)=4.8037108, null(8)=0, distinct(14)=0.993262137, null(14)=0, distinct(15)=0.993262137, null(15)=0, distinct(16)=0.993262137, null(16)=0, distinct(17)=4.99972957, null(17)=0]
- ├── key: (1)
- ├── fd: (1)-->(3,8,14-17)
- ├── ordering: +1
- └── scan stock
-      ├── save-table-name: new_order_04_scan_2
-      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
-      ├── constraint: /2/1
-      │    ├── [/4/900 - /4/900]
-      │    ├── [/4/1000 - /4/1000]
-      │    ├── [/4/1100 - /4/1100]
-      │    ├── [/4/1400 - /4/1400]
-      │    └── [/4/1500 - /4/1500]
+ ├── stats: [rows=5, distinct(3)=5, null(3)=0, distinct(5)=4.88136116, null(5)=0, distinct(10)=4.81952865, null(10)=0, distinct(16)=0.993376698, null(16)=0, distinct(17)=0.993376698, null(17)=0, distinct(18)=0.993376698, null(18)=0, distinct(19)=5, null(19)=0]
+ ├── ordering: +3
+ └── project
+      ├── save-table-name: new_order_04_project_2
+      ├── columns: s_i_id:3(int!null) s_quantity:5(int) s_dist_05:10(char) s_ytd:16(int) s_order_cnt:17(int) s_remote_cnt:18(int) s_data:19(varchar)
       ├── cardinality: [0 - 5]
-      ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.86513081, null(3)=0, distinct(8)=4.8037108, null(8)=0, distinct(14)=0.993262137, null(14)=0, distinct(15)=0.993262137, null(15)=0, distinct(16)=0.993262137, null(16)=0, distinct(17)=4.99972957, null(17)=0, distinct(1,2)=5, null(1,2)=0]
-      ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      └── ordering: +1 opt(2) [actual: +1]
+      ├── stats: [rows=5, distinct(3)=5, null(3)=0, distinct(5)=4.88136116, null(5)=0, distinct(10)=4.81952865, null(10)=0, distinct(16)=0.993376698, null(16)=0, distinct(17)=0.993376698, null(17)=0, distinct(18)=0.993376698, null(18)=0, distinct(19)=5, null(19)=0]
+      └── inner-join (lookup stock)
+           ├── save-table-name: new_order_04_lookup_join_3
+           ├── columns: unnest:1(int!null) unnest:2(int!null) s_i_id:3(int!null) s_w_id:4(int!null) s_quantity:5(int) s_dist_05:10(char) s_ytd:16(int) s_order_cnt:17(int) s_remote_cnt:18(int) s_data:19(varchar)
+           ├── flags: force lookup join (into right side)
+           ├── key columns: [2 1] = [4 3]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 5]
+           ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=5, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=4.88136116, null(5)=0, distinct(10)=4.81952865, null(10)=0, distinct(16)=0.993376698, null(16)=0, distinct(17)=0.993376698, null(17)=0, distinct(18)=0.993376698, null(18)=0, distinct(19)=5, null(19)=0]
+           ├── fd: (3,4)-->(5,10,16-19), (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+           ├── values
+           │    ├── save-table-name: new_order_04_values_4
+           │    ├── columns: unnest:1(int!null) unnest:2(int!null)
+           │    ├── cardinality: [5 - 5]
+           │    ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0]
+           │    ├── (1000, 4) [type=tuple{int, int}]
+           │    ├── (900, 4) [type=tuple{int, int}]
+           │    ├── (1100, 4) [type=tuple{int, int}]
+           │    ├── (1500, 4) [type=tuple{int, int}]
+           │    └── (1400, 4) [type=tuple{int, int}]
+           └── filters (true)
 
-----Stats for new_order_04_scan_2----
-column_names    row_count  distinct_count  null_count
-{s_data}        5          5               0
-{s_dist_05}     5          5               0
-{s_i_id}        5          5               0
-{s_order_cnt}   5          1               0
-{s_quantity}    5          4               0
-{s_remote_cnt}  5          1               0
-{s_w_id}        5          1               0
-{s_ytd}         5          1               0
-~~~~
-column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{s_data}        5.00           1.00           5.00                1.00                0.00            1.00
-{s_dist_05}     5.00           1.00           5.00                1.00                0.00            1.00
-{s_i_id}        5.00           1.00           5.00                1.00                0.00            1.00
-{s_order_cnt}   5.00           1.00           1.00                1.00                0.00            1.00
-{s_quantity}    5.00           1.00           5.00                1.25                0.00            1.00
-{s_remote_cnt}  5.00           1.00           1.00                1.00                0.00            1.00
-{s_w_id}        5.00           1.00           1.00                1.00                0.00            1.00
-{s_ytd}         5.00           1.00           1.00                1.00                0.00            1.00
+----Stats for new_order_04_project_2----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for new_order_04_lookup_join_3----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for new_order_04_values_4----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
 ----
 ----
 

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -465,90 +465,397 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 # recorded into a result file.
 # --------------------------------------------------
 stats-quality format=hide-qual database=tpcc stats-quality-prefix=delivery_01 ignore-tables=1
-SELECT no_o_id
-FROM new_order
-WHERE no_w_id = 7 AND no_d_id = 6
-ORDER BY no_o_id ASC
-LIMIT 1
+SELECT no_d_id, no_o_id, sum(ol_amount)
+FROM (
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 1  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 2  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 3  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 4  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 5  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 6  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 7  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 8  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 9  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 7 AND no_d_id = 10 ORDER BY no_o_id ASC LIMIT 1)
+)
+INNER LOOKUP JOIN order_line
+ON ol_d_id = no_d_id AND ol_o_id = no_o_id
+WHERE ol_w_id = 7
+GROUP BY no_d_id, no_o_id
 ----
 ----
-project
- ├── save-table-name: delivery_01_project_1
- ├── columns: no_o_id:1(int!null)
- ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=0.99967821, null(1)=0]
- ├── key: ()
- ├── fd: ()-->(1)
- └── scan new_order
-      ├── save-table-name: delivery_01_scan_2
-      ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
-      ├── constraint: /3/2/1: [/7/6 - /7/6]
-      ├── limit: 1
-      ├── stats: [rows=1, distinct(1)=0.99967821, null(1)=0, distinct(2)=0.632320605, null(2)=0, distinct(3)=0.632320605, null(3)=0]
-      ├── key: ()
-      └── fd: ()-->(1-3)
-
-----Stats for delivery_01_scan_2----
-column_names  row_count  distinct_count  null_count
-{no_d_id}     1          1               0
-{no_o_id}     1          1               0
-{no_w_id}     1          1               0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{no_d_id}     1.00           1.00           1.00                1.00                0.00            1.00
-{no_o_id}     1.00           1.00           1.00                1.00                0.00            1.00
-{no_w_id}     1.00           1.00           1.00                1.00                0.00            1.00
-----
-----
-
-stats-quality format=hide-qual database=tpcc stats-quality-prefix=delivery_02
-SELECT sum(ol_amount)
-FROM order_line
-WHERE ol_w_id = 8 AND ol_d_id = 6 AND ol_o_id = 1000
-----
-----
-scalar-group-by
- ├── save-table-name: delivery_02_scalar_group_by_1
- ├── columns: sum:12(decimal)
- ├── cardinality: [1 - 1]
- ├── stats: [rows=1, distinct(12)=1, null(12)=0]
- ├── key: ()
- ├── fd: ()-->(12)
- ├── scan order_line
- │    ├── save-table-name: delivery_02_scan_2
- │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_amount:9(decimal)
- │    ├── constraint: /3/2/-1/4: [/8/6/1000 - /8/6/1000]
- │    ├── stats: [rows=10.2098768, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(9)=10.2098057, null(9)=0, distinct(1-3)=1, null(1-3)=0]
- │    │   histogram(1)=  0 10.21
- │    │                <--- 1000
- │    │   histogram(2)=  0 10.21
- │    │                <---- 6 -
- │    │   histogram(3)=  0 10.21
- │    │                <---- 8 -
- │    └── fd: ()-->(1-3)
+group-by
+ ├── save-table-name: delivery_01_group_by_1
+ ├── columns: no_d_id:57(int!null) no_o_id:58(int!null) sum:70(decimal)
+ ├── grouping columns: no_d_id:57(int!null) no_o_id:58(int!null)
+ ├── stats: [rows=9.99678837, distinct(57)=6.32323565, null(57)=0, distinct(58)=9.99678837, null(58)=0, distinct(70)=9.99678837, null(70)=0, distinct(57,58)=9.99678837, null(57,58)=0]
+ ├── key: (57,58)
+ ├── fd: (57,58)-->(70)
+ ├── inner-join (lookup order_line)
+ │    ├── save-table-name: delivery_01_lookup_join_2
+ │    ├── columns: no_d_id:57(int!null) no_o_id:58(int!null) ol_o_id:59(int!null) ol_d_id:60(int!null) ol_w_id:61(int!null) ol_amount:67(decimal)
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [71 57 58] = [61 60 59]
+ │    ├── stats: [rows=100.474292, distinct(57)=6.32323565, null(57)=0, distinct(58)=9.99678837, null(58)=0, distinct(59)=9.99678837, null(59)=0, distinct(60)=6.32323565, null(60)=0, distinct(61)=1, null(61)=0, distinct(67)=100.455405, null(67)=0, distinct(57,58)=9.99678837, null(57,58)=0]
+ │    ├── fd: ()-->(61), (57)==(60), (60)==(57), (58)==(59), (59)==(58)
+ │    ├── project
+ │    │    ├── save-table-name: delivery_01_project_3
+ │    │    ├── columns: "project_const_col_@61":71(int!null) no_d_id:57(int!null) no_o_id:58(int!null)
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── stats: [rows=10, distinct(57)=6.32323565, null(57)=0, distinct(58)=9.99678837, null(58)=0, distinct(71)=1, null(71)=0]
+ │    │    ├── fd: ()-->(71)
+ │    │    ├── union-all
+ │    │    │    ├── save-table-name: delivery_01_union_all_4
+ │    │    │    ├── columns: no_d_id:57(int!null) no_o_id:58(int!null)
+ │    │    │    ├── left columns: no_d_id:51(int) no_o_id:52(int)
+ │    │    │    ├── right columns: new_order.no_d_id:54(int) new_order.no_o_id:53(int)
+ │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    ├── stats: [rows=10, distinct(57)=6.32323565, null(57)=0, distinct(58)=9.99678837, null(58)=0, distinct(57,58)=9.99678837, null(57,58)=0]
+ │    │    │    ├── union-all
+ │    │    │    │    ├── save-table-name: delivery_01_union_all_5
+ │    │    │    │    ├── columns: no_d_id:51(int!null) no_o_id:52(int!null)
+ │    │    │    │    ├── left columns: no_d_id:45(int) no_o_id:46(int)
+ │    │    │    │    ├── right columns: new_order.no_d_id:48(int) new_order.no_o_id:47(int)
+ │    │    │    │    ├── cardinality: [0 - 9]
+ │    │    │    │    ├── stats: [rows=9, distinct(51)=5.69091816, null(51)=0, distinct(52)=8.99711087, null(52)=0, distinct(51,52)=8.99711087, null(51,52)=0]
+ │    │    │    │    ├── union-all
+ │    │    │    │    │    ├── save-table-name: delivery_01_union_all_6
+ │    │    │    │    │    ├── columns: no_d_id:45(int!null) no_o_id:46(int!null)
+ │    │    │    │    │    ├── left columns: no_d_id:39(int) no_o_id:40(int)
+ │    │    │    │    │    ├── right columns: new_order.no_d_id:42(int) new_order.no_o_id:41(int)
+ │    │    │    │    │    ├── cardinality: [0 - 8]
+ │    │    │    │    │    ├── stats: [rows=8, distinct(45)=5.05859656, null(45)=0, distinct(46)=7.99743244, null(46)=0, distinct(45,46)=7.99743244, null(45,46)=0]
+ │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_7
+ │    │    │    │    │    │    ├── columns: no_d_id:39(int!null) no_o_id:40(int!null)
+ │    │    │    │    │    │    ├── left columns: no_d_id:33(int) no_o_id:34(int)
+ │    │    │    │    │    │    ├── right columns: new_order.no_d_id:36(int) new_order.no_o_id:35(int)
+ │    │    │    │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    │    │    │    ├── stats: [rows=7, distinct(39)=4.42627456, null(39)=0, distinct(40)=6.99775391, null(40)=0, distinct(39,40)=6.99775391, null(39,40)=0]
+ │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_8
+ │    │    │    │    │    │    │    ├── columns: no_d_id:33(int!null) no_o_id:34(int!null)
+ │    │    │    │    │    │    │    ├── left columns: no_d_id:27(int) no_o_id:28(int)
+ │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:30(int) new_order.no_o_id:29(int)
+ │    │    │    │    │    │    │    ├── cardinality: [0 - 6]
+ │    │    │    │    │    │    │    ├── stats: [rows=6, distinct(33)=3.79395745, null(33)=0, distinct(34)=5.99807651, null(34)=0, distinct(33,34)=5.99807651, null(33,34)=0]
+ │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_9
+ │    │    │    │    │    │    │    │    ├── columns: no_d_id:27(int!null) no_o_id:28(int!null)
+ │    │    │    │    │    │    │    │    ├── left columns: no_d_id:21(int) no_o_id:22(int)
+ │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:24(int) new_order.no_o_id:23(int)
+ │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5]
+ │    │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(27)=3.16163684, null(27)=0, distinct(28)=4.9983983, null(28)=0, distinct(27,28)=4.9983983, null(27,28)=0]
+ │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_10
+ │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:21(int!null) no_o_id:22(int!null)
+ │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:15(int) no_o_id:16(int)
+ │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:18(int) new_order.no_o_id:17(int)
+ │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    │    │    │    │    │    │    ├── stats: [rows=4, distinct(21)=2.52931838, null(21)=0, distinct(22)=3.99872058, null(22)=0, distinct(21,22)=3.99872058, null(21,22)=0]
+ │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_11
+ │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:15(int!null) no_o_id:16(int!null)
+ │    │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:9(int) no_o_id:10(int)
+ │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:12(int) new_order.no_o_id:11(int)
+ │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=3, distinct(15)=1.89698913, null(15)=0, distinct(16)=2.99904049, null(16)=0, distinct(15,16)=2.99904049, null(15,16)=0]
+ │    │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    │    ├── save-table-name: delivery_01_union_all_12
+ │    │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:9(int!null) no_o_id:10(int!null)
+ │    │    │    │    │    │    │    │    │    │    │    ├── left columns: new_order.no_d_id:2(int) new_order.no_o_id:1(int)
+ │    │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:6(int) new_order.no_o_id:5(int)
+ │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 2]
+ │    │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=2, distinct(9)=1.26466221, null(9)=0, distinct(10)=1.9993609, null(10)=0, distinct(9,10)=1.9993609, null(9,10)=0]
+ │    │    │    │    │    │    │    │    │    │    │    ├── project
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── save-table-name: delivery_01_project_13
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null)
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=1, distinct(1)=0.999679417, null(1)=0, distinct(2)=0.63232608, null(2)=0, distinct(1,2)=0.999679417, null(1,2)=0]
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    │    │    │    │    │    └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── save-table-name: delivery_01_scan_14
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) no_w_id:3(int!null)
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── constraint: /3/2/1: [/7/1 - /7/1]
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(1)=0.999679417, null(1)=0, distinct(2)=0.63232608, null(2)=0, distinct(3)=0.63232608, null(3)=0, distinct(1,2)=0.999679417, null(1,2)=0]
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │         └── fd: ()-->(1-3)
+ │    │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │    │         ├── save-table-name: delivery_01_project_15
+ │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:5(int!null) new_order.no_d_id:6(int!null)
+ │    │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(5)=0.999681479, null(5)=0, distinct(6)=0.632336132, null(6)=0, distinct(5,6)=0.999681479, null(5,6)=0]
+ │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(5,6)
+ │    │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_16
+ │    │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:5(int!null) new_order.no_d_id:6(int!null) no_w_id:7(int!null)
+ │    │    │    │    │    │    │    │    │    │    │              ├── constraint: /7/6/5: [/7/2 - /7/2]
+ │    │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │              ├── stats: [rows=1, distinct(5)=0.999681479, null(5)=0, distinct(6)=0.632336132, null(6)=0, distinct(7)=0.632336132, null(7)=0, distinct(5,6)=0.999681479, null(5,6)=0]
+ │    │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(5-7)
+ │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │         ├── save-table-name: delivery_01_project_17
+ │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:11(int!null) new_order.no_d_id:12(int!null)
+ │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(11)=0.999679596, null(11)=0, distinct(12)=0.632326917, null(12)=0, distinct(11,12)=0.999679596, null(11,12)=0]
+ │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(11,12)
+ │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_18
+ │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:11(int!null) new_order.no_d_id:12(int!null) no_w_id:13(int!null)
+ │    │    │    │    │    │    │    │    │    │              ├── constraint: /13/12/11: [/7/3 - /7/3]
+ │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │              ├── stats: [rows=1, distinct(11)=0.999679596, null(11)=0, distinct(12)=0.632326917, null(12)=0, distinct(13)=0.632326917, null(13)=0, distinct(11,12)=0.999679596, null(11,12)=0]
+ │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(11-13)
+ │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │         ├── save-table-name: delivery_01_project_19
+ │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:17(int!null) new_order.no_d_id:18(int!null)
+ │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(17)=0.999680088, null(17)=0, distinct(18)=0.632329254, null(18)=0, distinct(17,18)=0.999680088, null(17,18)=0]
+ │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │         ├── fd: ()-->(17,18)
+ │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_20
+ │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:17(int!null) new_order.no_d_id:18(int!null) no_w_id:19(int!null)
+ │    │    │    │    │    │    │    │    │              ├── constraint: /19/18/17: [/7/4 - /7/4]
+ │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │              ├── stats: [rows=1, distinct(17)=0.999680088, null(17)=0, distinct(18)=0.632329254, null(18)=0, distinct(19)=0.632329254, null(19)=0, distinct(17,18)=0.999680088, null(17,18)=0]
+ │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │              └── fd: ()-->(17-19)
+ │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │         ├── save-table-name: delivery_01_project_21
+ │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:23(int!null) new_order.no_d_id:24(int!null)
+ │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(23)=0.999677719, null(23)=0, distinct(24)=0.632318458, null(24)=0, distinct(23,24)=0.999677719, null(23,24)=0]
+ │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │         ├── fd: ()-->(23,24)
+ │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_22
+ │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:23(int!null) new_order.no_d_id:24(int!null) no_w_id:25(int!null)
+ │    │    │    │    │    │    │    │              ├── constraint: /25/24/23: [/7/5 - /7/5]
+ │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │              ├── stats: [rows=1, distinct(23)=0.999677719, null(23)=0, distinct(24)=0.632318458, null(24)=0, distinct(25)=0.632318458, null(25)=0, distinct(23,24)=0.999677719, null(23,24)=0]
+ │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │              └── fd: ()-->(23-25)
+ │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │         ├── save-table-name: delivery_01_project_23
+ │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:29(int!null) new_order.no_d_id:30(int!null)
+ │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │         ├── stats: [rows=1, distinct(29)=0.99967821, null(29)=0, distinct(30)=0.632320605, null(30)=0, distinct(29,30)=0.99967821, null(29,30)=0]
+ │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │         ├── fd: ()-->(29,30)
+ │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_24
+ │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:29(int!null) new_order.no_d_id:30(int!null) no_w_id:31(int!null)
+ │    │    │    │    │    │    │              ├── constraint: /31/30/29: [/7/6 - /7/6]
+ │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │              ├── stats: [rows=1, distinct(29)=0.99967821, null(29)=0, distinct(30)=0.632320605, null(30)=0, distinct(31)=0.632320605, null(31)=0, distinct(29,30)=0.99967821, null(29,30)=0]
+ │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │              └── fd: ()-->(29-31)
+ │    │    │    │    │    │    └── project
+ │    │    │    │    │    │         ├── save-table-name: delivery_01_project_25
+ │    │    │    │    │    │         ├── columns: new_order.no_o_id:35(int!null) new_order.no_d_id:36(int!null)
+ │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │         ├── stats: [rows=1, distinct(35)=0.999677407, null(35)=0, distinct(36)=0.632317115, null(36)=0, distinct(35,36)=0.999677407, null(35,36)=0]
+ │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │         ├── fd: ()-->(35,36)
+ │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │              ├── save-table-name: delivery_01_scan_26
+ │    │    │    │    │    │              ├── columns: new_order.no_o_id:35(int!null) new_order.no_d_id:36(int!null) no_w_id:37(int!null)
+ │    │    │    │    │    │              ├── constraint: /37/36/35: [/7/7 - /7/7]
+ │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │              ├── stats: [rows=1, distinct(35)=0.999677407, null(35)=0, distinct(36)=0.632317115, null(36)=0, distinct(37)=0.632317115, null(37)=0, distinct(35,36)=0.999677407, null(35,36)=0]
+ │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │              └── fd: ()-->(35-37)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── save-table-name: delivery_01_project_27
+ │    │    │    │    │         ├── columns: new_order.no_o_id:41(int!null) new_order.no_d_id:42(int!null)
+ │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │         ├── stats: [rows=1, distinct(41)=0.999678522, null(41)=0, distinct(42)=0.632321997, null(42)=0, distinct(41,42)=0.999678522, null(41,42)=0]
+ │    │    │    │    │         ├── key: ()
+ │    │    │    │    │         ├── fd: ()-->(41,42)
+ │    │    │    │    │         └── scan new_order
+ │    │    │    │    │              ├── save-table-name: delivery_01_scan_28
+ │    │    │    │    │              ├── columns: new_order.no_o_id:41(int!null) new_order.no_d_id:42(int!null) no_w_id:43(int!null)
+ │    │    │    │    │              ├── constraint: /43/42/41: [/7/8 - /7/8]
+ │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │              ├── stats: [rows=1, distinct(41)=0.999678522, null(41)=0, distinct(42)=0.632321997, null(42)=0, distinct(43)=0.632321997, null(43)=0, distinct(41,42)=0.999678522, null(41,42)=0]
+ │    │    │    │    │              ├── key: ()
+ │    │    │    │    │              └── fd: ()-->(41-43)
+ │    │    │    │    └── project
+ │    │    │    │         ├── save-table-name: delivery_01_project_29
+ │    │    │    │         ├── columns: new_order.no_o_id:47(int!null) new_order.no_d_id:48(int!null)
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── stats: [rows=1, distinct(47)=0.999678433, null(47)=0, distinct(48)=0.632321597, null(48)=0, distinct(47,48)=0.999678433, null(47,48)=0]
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(47,48)
+ │    │    │    │         └── scan new_order
+ │    │    │    │              ├── save-table-name: delivery_01_scan_30
+ │    │    │    │              ├── columns: new_order.no_o_id:47(int!null) new_order.no_d_id:48(int!null) no_w_id:49(int!null)
+ │    │    │    │              ├── constraint: /49/48/47: [/7/9 - /7/9]
+ │    │    │    │              ├── limit: 1
+ │    │    │    │              ├── stats: [rows=1, distinct(47)=0.999678433, null(47)=0, distinct(48)=0.632321597, null(48)=0, distinct(49)=0.632321597, null(49)=0, distinct(47,48)=0.999678433, null(47,48)=0]
+ │    │    │    │              ├── key: ()
+ │    │    │    │              └── fd: ()-->(47-49)
+ │    │    │    └── project
+ │    │    │         ├── save-table-name: delivery_01_project_31
+ │    │    │         ├── columns: new_order.no_o_id:53(int!null) new_order.no_d_id:54(int!null)
+ │    │    │         ├── cardinality: [0 - 1]
+ │    │    │         ├── stats: [rows=1, distinct(53)=0.999677496, null(53)=0, distinct(54)=0.632317497, null(54)=0, distinct(53,54)=0.999677496, null(53,54)=0]
+ │    │    │         ├── key: ()
+ │    │    │         ├── fd: ()-->(53,54)
+ │    │    │         └── scan new_order
+ │    │    │              ├── save-table-name: delivery_01_scan_32
+ │    │    │              ├── columns: new_order.no_o_id:53(int!null) new_order.no_d_id:54(int!null) no_w_id:55(int!null)
+ │    │    │              ├── constraint: /55/54/53: [/7/10 - /7/10]
+ │    │    │              ├── limit: 1
+ │    │    │              ├── stats: [rows=1, distinct(53)=0.999677496, null(53)=0, distinct(54)=0.632317497, null(54)=0, distinct(55)=0.632317497, null(55)=0, distinct(53,54)=0.999677496, null(53,54)=0]
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(53-55)
+ │    │    └── projections
+ │    │         └── 7 [as="project_const_col_@61":71, type=int]
+ │    └── filters (true)
  └── aggregations
-      └── sum [as=sum:12, type=decimal, outer=(9)]
-           └── ol_amount:9 [type=decimal]
+      └── sum [as=sum:70, type=decimal, outer=(67)]
+           └── ol_amount:67 [type=decimal]
 
-----Stats for delivery_02_scalar_group_by_1----
-column_names  row_count  distinct_count  null_count
-{sum}         1          1               0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+----Stats for delivery_01_lookup_join_2----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
 
-----Stats for delivery_02_scan_2----
-column_names  row_count  distinct_count  null_count
-{ol_amount}   7          1               0
-{ol_d_id}     7          1               0
-{ol_o_id}     7          1               0
-{ol_w_id}     7          1               0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{ol_amount}   10.00          1.43           10.00               10.00 <==           0.00            1.00
-{ol_d_id}     10.00          1.43           1.00                1.00                0.00            1.00
-{ol_o_id}     10.00          1.43           1.00                1.00                0.00            1.00
-{ol_w_id}     10.00          1.43           1.00                1.00                0.00            1.00
+----Stats for delivery_01_project_3----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_4----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_5----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_6----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_7----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_8----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_9----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_10----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_11----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_union_all_12----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_13----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_14----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_15----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_16----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_17----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_18----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_19----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_20----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_21----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_22----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_23----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_24----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_25----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_26----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_27----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_28----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_29----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_30----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_project_31----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
+
+----Stats for delivery_01_scan_32----
+WARNING: No previous statistics output was found. To collect actual statistics,
+run with the rewrite-actual-stats flag set to true.
 ----
 ----
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -748,41 +748,208 @@ project
 # recorded into a result file.
 # --------------------------------------------------
 opt format=hide-qual
-SELECT no_o_id
-FROM new_order
-WHERE no_w_id = 10 AND no_d_id = 100
-ORDER BY no_o_id ASC
-LIMIT 1
+SELECT no_d_id, no_o_id, sum(ol_amount)
+FROM (
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 1  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 2  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 3  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 4  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 5  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 6  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 7  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 8  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 9  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 10 ORDER BY no_o_id ASC LIMIT 1)
+)
+INNER LOOKUP JOIN order_line
+ON ol_d_id = no_d_id AND ol_o_id = no_o_id
+WHERE ol_w_id = 10
+GROUP BY no_d_id, no_o_id
 ----
-project
- ├── columns: no_o_id:1!null
- ├── cardinality: [0 - 1]
- ├── key: ()
- ├── fd: ()-->(1)
- └── scan new_order
-      ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
-      ├── constraint: /3/2/1: [/10/100 - /10/100]
-      ├── limit: 1
-      ├── key: ()
-      └── fd: ()-->(1-3)
-
-opt format=hide-qual
-SELECT sum(ol_amount)
-FROM order_line
-WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
-----
-scalar-group-by
- ├── columns: sum:12
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(12)
- ├── scan order_line
- │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_amount:9
- │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    └── fd: ()-->(1-3)
+group-by
+ ├── columns: no_d_id:57!null no_o_id:58!null sum:70
+ ├── grouping columns: no_d_id:57!null no_o_id:58!null
+ ├── key: (57,58)
+ ├── fd: (57,58)-->(70)
+ ├── inner-join (lookup order_line)
+ │    ├── columns: no_d_id:57!null no_o_id:58!null ol_o_id:59!null ol_d_id:60!null ol_w_id:61!null ol_amount:67
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [71 57 58] = [61 60 59]
+ │    ├── fd: ()-->(61), (57)==(60), (60)==(57), (58)==(59), (59)==(58)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@61":71!null no_d_id:57!null no_o_id:58!null
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── fd: ()-->(71)
+ │    │    ├── union-all
+ │    │    │    ├── columns: no_d_id:57!null no_o_id:58!null
+ │    │    │    ├── left columns: no_d_id:51 no_o_id:52
+ │    │    │    ├── right columns: new_order.no_d_id:54 new_order.no_o_id:53
+ │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    ├── union-all
+ │    │    │    │    ├── columns: no_d_id:51!null no_o_id:52!null
+ │    │    │    │    ├── left columns: no_d_id:45 no_o_id:46
+ │    │    │    │    ├── right columns: new_order.no_d_id:48 new_order.no_o_id:47
+ │    │    │    │    ├── cardinality: [0 - 9]
+ │    │    │    │    ├── union-all
+ │    │    │    │    │    ├── columns: no_d_id:45!null no_o_id:46!null
+ │    │    │    │    │    ├── left columns: no_d_id:39 no_o_id:40
+ │    │    │    │    │    ├── right columns: new_order.no_d_id:42 new_order.no_o_id:41
+ │    │    │    │    │    ├── cardinality: [0 - 8]
+ │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    ├── columns: no_d_id:39!null no_o_id:40!null
+ │    │    │    │    │    │    ├── left columns: no_d_id:33 no_o_id:34
+ │    │    │    │    │    │    ├── right columns: new_order.no_d_id:36 new_order.no_o_id:35
+ │    │    │    │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    ├── columns: no_d_id:33!null no_o_id:34!null
+ │    │    │    │    │    │    │    ├── left columns: no_d_id:27 no_o_id:28
+ │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:30 new_order.no_o_id:29
+ │    │    │    │    │    │    │    ├── cardinality: [0 - 6]
+ │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    ├── columns: no_d_id:27!null no_o_id:28!null
+ │    │    │    │    │    │    │    │    ├── left columns: no_d_id:21 no_o_id:22
+ │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:24 new_order.no_o_id:23
+ │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5]
+ │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:21!null no_o_id:22!null
+ │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:15 no_o_id:16
+ │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:18 new_order.no_o_id:17
+ │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:15!null no_o_id:16!null
+ │    │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:9 no_o_id:10
+ │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:12 new_order.no_o_id:11
+ │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:9!null no_o_id:10!null
+ │    │    │    │    │    │    │    │    │    │    │    ├── left columns: new_order.no_d_id:2 new_order.no_o_id:1
+ │    │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:6 new_order.no_o_id:5
+ │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 2]
+ │    │    │    │    │    │    │    │    │    │    │    ├── project
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    │    │    │    │    │    └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null no_w_id:3!null
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── constraint: /3/2/1: [/10/1 - /10/1]
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │         └── fd: ()-->(1-3)
+ │    │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null
+ │    │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(5,6)
+ │    │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null no_w_id:7!null
+ │    │    │    │    │    │    │    │    │    │    │              ├── constraint: /7/6/5: [/10/2 - /10/2]
+ │    │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(5-7)
+ │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null
+ │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(11,12)
+ │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null no_w_id:13!null
+ │    │    │    │    │    │    │    │    │    │              ├── constraint: /13/12/11: [/10/3 - /10/3]
+ │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(11-13)
+ │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null
+ │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │         ├── fd: ()-->(17,18)
+ │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null no_w_id:19!null
+ │    │    │    │    │    │    │    │    │              ├── constraint: /19/18/17: [/10/4 - /10/4]
+ │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │              └── fd: ()-->(17-19)
+ │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null
+ │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │         ├── fd: ()-->(23,24)
+ │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null no_w_id:25!null
+ │    │    │    │    │    │    │    │              ├── constraint: /25/24/23: [/10/5 - /10/5]
+ │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │              └── fd: ()-->(23-25)
+ │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null
+ │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │         ├── fd: ()-->(29,30)
+ │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null no_w_id:31!null
+ │    │    │    │    │    │    │              ├── constraint: /31/30/29: [/10/6 - /10/6]
+ │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │              └── fd: ()-->(29-31)
+ │    │    │    │    │    │    └── project
+ │    │    │    │    │    │         ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null
+ │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │         ├── fd: ()-->(35,36)
+ │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │              ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null no_w_id:37!null
+ │    │    │    │    │    │              ├── constraint: /37/36/35: [/10/7 - /10/7]
+ │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │              └── fd: ()-->(35-37)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null
+ │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │         ├── key: ()
+ │    │    │    │    │         ├── fd: ()-->(41,42)
+ │    │    │    │    │         └── scan new_order
+ │    │    │    │    │              ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null no_w_id:43!null
+ │    │    │    │    │              ├── constraint: /43/42/41: [/10/8 - /10/8]
+ │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │              ├── key: ()
+ │    │    │    │    │              └── fd: ()-->(41-43)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(47,48)
+ │    │    │    │         └── scan new_order
+ │    │    │    │              ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null no_w_id:49!null
+ │    │    │    │              ├── constraint: /49/48/47: [/10/9 - /10/9]
+ │    │    │    │              ├── limit: 1
+ │    │    │    │              ├── key: ()
+ │    │    │    │              └── fd: ()-->(47-49)
+ │    │    │    └── project
+ │    │    │         ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null
+ │    │    │         ├── cardinality: [0 - 1]
+ │    │    │         ├── key: ()
+ │    │    │         ├── fd: ()-->(53,54)
+ │    │    │         └── scan new_order
+ │    │    │              ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null no_w_id:55!null
+ │    │    │              ├── constraint: /55/54/53: [/10/10 - /10/10]
+ │    │    │              ├── limit: 1
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(53-55)
+ │    │    └── projections
+ │    │         └── 10 [as="project_const_col_@61":71]
+ │    └── filters (true)
  └── aggregations
-      └── sum [as=sum:12, outer=(9)]
-           └── ol_amount:9
+      └── sum [as=sum:70, outer=(67)]
+           └── ol_amount:67
 
 opt format=hide-qual
 UPDATE "order"

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -86,7 +86,7 @@ project
 opt format=hide-qual
 SELECT i_price, i_name, i_data
 FROM item
-WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+WHERE i_id = ANY ('{125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300}')
 ORDER BY i_id
 ----
 scan item
@@ -111,28 +111,34 @@ scan item
 
 opt format=hide-qual
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
-FROM stock
-WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+FROM (SELECT unnest('{1000, 900, 1100, 1500, 1400}':::INT[]) AS i_id, 
+             unnest('{4, 4, 4, 4, 4}':::INT[])               AS w_id)
+INNER LOOKUP JOIN stock ON s_i_id = i_id AND s_w_id = w_id
 ORDER BY s_i_id
 ----
-project
- ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null]
+sort
+ ├── columns: s_quantity:5 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19 s_dist_05:10  [hidden: s_i_id:3!null]
  ├── cardinality: [0 - 5]
- ├── key: (1)
- ├── fd: (1)-->(3,8,14-17)
- ├── ordering: +1
- └── scan stock
-      ├── columns: s_i_id:1!null s_w_id:2!null s_quantity:3 s_dist_05:8 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17
-      ├── constraint: /2/1
-      │    ├── [/4/900 - /4/900]
-      │    ├── [/4/1000 - /4/1000]
-      │    ├── [/4/1100 - /4/1100]
-      │    ├── [/4/1400 - /4/1400]
-      │    └── [/4/1500 - /4/1500]
+ ├── ordering: +3
+ └── project
+      ├── columns: s_i_id:3!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
       ├── cardinality: [0 - 5]
-      ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      └── ordering: +1 opt(2) [actual: +1]
+      └── inner-join (lookup stock)
+           ├── columns: unnest:1!null unnest:2!null s_i_id:3!null s_w_id:4!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
+           ├── flags: force lookup join (into right side)
+           ├── key columns: [2 1] = [4 3]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 5]
+           ├── fd: (3,4)-->(5,10,16-19), (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+           ├── values
+           │    ├── columns: unnest:1!null unnest:2!null
+           │    ├── cardinality: [5 - 5]
+           │    ├── (1000, 4)
+           │    ├── (900, 4)
+           │    ├── (1100, 4)
+           │    ├── (1500, 4)
+           │    └── (1400, 4)
+           └── filters (true)
 
 opt format=hide-qual
 INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
@@ -217,203 +223,192 @@ insert new_order
                 └── filters (true)
 
 opt format=hide-qual
-UPDATE
-  stock
-SET
-  s_quantity
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 26
-    WHEN (7853, 0) THEN 10
-    WHEN (8497, 0) THEN 62
-    WHEN (10904, 0) THEN 54
-    WHEN (16152, 0) THEN 80
-    WHEN (41382, 0) THEN 18
-    WHEN (55952, 0) THEN 56
-    WHEN (64817, 0) THEN 26
-    WHEN (66335, 0) THEN 30
-    WHEN (76567, 0) THEN 71
-    WHEN (81680, 0) THEN 51
-    WHEN (89641, 0) THEN 51
-    WHEN (89905, 0) THEN 77
-    ELSE crdb_internal.force_error('', 'unknown case')
-    END,
-  s_ytd
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 6
-    WHEN (7853, 0) THEN 9
-    WHEN (8497, 0) THEN 13
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 2
-    WHEN (41382, 0) THEN 3
-    WHEN (55952, 0) THEN 10
-    WHEN (64817, 0) THEN 31
-    WHEN (66335, 0) THEN 9
-    WHEN (76567, 0) THEN 7
-    WHEN (81680, 0) THEN 4
-    WHEN (89641, 0) THEN 13
-    WHEN (89905, 0) THEN 20
-    END,
-  s_order_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 1
-    WHEN (7853, 0) THEN 1
-    WHEN (8497, 0) THEN 2
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 1
-    WHEN (41382, 0) THEN 1
-    WHEN (55952, 0) THEN 1
-    WHEN (64817, 0) THEN 4
-    WHEN (66335, 0) THEN 2
-    WHEN (76567, 0) THEN 1
-    WHEN (81680, 0) THEN 1
-    WHEN (89641, 0) THEN 2
-    WHEN (89905, 0) THEN 4
-    END,
-  s_remote_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 0
-    WHEN (7853, 0) THEN 0
-    WHEN (8497, 0) THEN 0
-    WHEN (10904, 0) THEN 0
-    WHEN (16152, 0) THEN 0
-    WHEN (41382, 0) THEN 0
-    WHEN (55952, 0) THEN 0
-    WHEN (64817, 0) THEN 0
-    WHEN (66335, 0) THEN 0
-    WHEN (76567, 0) THEN 0
-    WHEN (81680, 0) THEN 0
-    WHEN (89641, 0) THEN 0
-    WHEN (89905, 0) THEN 0
-    END
-WHERE
-  (s_i_id, s_w_id)
-  IN (
-      (6823, 0),
-      (7853, 0),
-      (8497, 0),
-      (10904, 0),
-      (16152, 0),
-      (41382, 0),
-      (55952, 0),
-      (64817, 0),
-      (66335, 0),
-      (76567, 0),
-      (81680, 0),
-      (89641, 0),
-      (89905, 0)
-    )
+UPDATE stock
+SET s_quantity   = new_s_quantity,
+	s_ytd        = new_s_ytd,
+	s_order_cnt  = new_s_order_cnt,
+	s_remote_cnt = new_s_remote_cnt
+FROM (SELECT 
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS i_id,
+	unnest('{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}':::INT[]) AS w_id,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_quantity,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_ytd,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_order_cnt,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_remote_cnt)
+WHERE s_i_id = i_id AND s_w_id = w_id
 ----
 update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:19 s_w_id:20 s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
  ├── update-mapping:
- │    ├── s_quantity_new:37 => s_quantity:3
- │    ├── s_ytd_new:38 => s_ytd:14
- │    ├── s_order_cnt_new:39 => s_order_cnt:15
- │    └── s_remote_cnt_new:40 => s_remote_cnt:16
+ │    ├── unnest:39 => s_quantity:3
+ │    ├── unnest:40 => s_ytd:14
+ │    ├── unnest:41 => s_order_cnt:15
+ │    └── unnest:42 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── project
-      ├── columns: s_quantity_new:37 s_ytd_new:38 s_order_cnt_new:39 s_remote_cnt_new:40 s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
+ └── distinct-on
+      ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      ├── grouping columns: s_i_id:19!null s_w_id:20!null
       ├── cardinality: [0 - 13]
-      ├── volatile
-      ├── key: (19)
-      ├── fd: ()-->(20), (19)-->(21-35,37-40)
-      ├── scan stock
-      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
-      │    ├── constraint: /20/19
-      │    │    ├── [/0/6823 - /0/6823]
-      │    │    ├── [/0/7853 - /0/7853]
-      │    │    ├── [/0/8497 - /0/8497]
-      │    │    ├── [/0/10904 - /0/10904]
-      │    │    ├── [/0/16152 - /0/16152]
-      │    │    ├── [/0/41382 - /0/41382]
-      │    │    ├── [/0/55952 - /0/55952]
-      │    │    ├── [/0/64817 - /0/64817]
-      │    │    ├── [/0/66335 - /0/66335]
-      │    │    ├── [/0/76567 - /0/76567]
-      │    │    ├── [/0/81680 - /0/81680]
-      │    │    ├── [/0/89641 - /0/89641]
-      │    │    └── [/0/89905 - /0/89905]
+      ├── key: (19,20)
+      ├── fd: (19,20)-->(21-35,37-42), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      ├── inner-join (lookup stock)
+      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    ├── key columns: [38 37] = [20 19]
+      │    ├── lookup columns are key
       │    ├── cardinality: [0 - 13]
-      │    ├── key: (19)
-      │    └── fd: ()-->(20), (19)-->(21-35)
-      └── projections
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:37, outer=(19,20), volatile]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 ELSE CAST(NULL AS INT8) END [as=s_ytd_new:38, outer=(19,20)]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 ELSE CAST(NULL AS INT8) END [as=s_order_cnt_new:39, outer=(19,20)]
-           └── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 ELSE CAST(NULL AS INT8) END [as=s_remote_cnt_new:40, outer=(19,20)]
+      │    ├── fd: (19,20)-->(21-35), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      │    ├── values
+      │    │    ├── columns: unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    │    ├── cardinality: [13 - 13]
+      │    │    ├── (6823, 0, 6823, 6823, 6823, 6823)
+      │    │    ├── (7853, 0, 7853, 7853, 7853, 7853)
+      │    │    ├── (8497, 0, 8497, 8497, 8497, 8497)
+      │    │    ├── (10904, 0, 10904, 10904, 10904, 10904)
+      │    │    ├── (16152, 0, 16152, 16152, 16152, 16152)
+      │    │    ├── (41382, 0, 41382, 41382, 41382, 41382)
+      │    │    ├── (55952, 0, 55952, 55952, 55952, 55952)
+      │    │    ├── (64817, 0, 64817, 64817, 64817, 64817)
+      │    │    ├── (66335, 0, 66335, 66335, 66335, 66335)
+      │    │    ├── (76567, 0, 76567, 76567, 76567, 76567)
+      │    │    ├── (81680, 0, 81680, 81680, 81680, 81680)
+      │    │    ├── (89641, 0, 89641, 89641, 89641, 89641)
+      │    │    └── (89905, 0, 89905, 89905, 89905, 89905)
+      │    └── filters (true)
+      └── aggregations
+           ├── first-agg [as=s_quantity:21, outer=(21)]
+           │    └── s_quantity:21
+           ├── first-agg [as=s_dist_01:22, outer=(22)]
+           │    └── s_dist_01:22
+           ├── first-agg [as=s_dist_02:23, outer=(23)]
+           │    └── s_dist_02:23
+           ├── first-agg [as=s_dist_03:24, outer=(24)]
+           │    └── s_dist_03:24
+           ├── first-agg [as=s_dist_04:25, outer=(25)]
+           │    └── s_dist_04:25
+           ├── first-agg [as=s_dist_05:26, outer=(26)]
+           │    └── s_dist_05:26
+           ├── first-agg [as=s_dist_06:27, outer=(27)]
+           │    └── s_dist_06:27
+           ├── first-agg [as=s_dist_07:28, outer=(28)]
+           │    └── s_dist_07:28
+           ├── first-agg [as=s_dist_08:29, outer=(29)]
+           │    └── s_dist_08:29
+           ├── first-agg [as=s_dist_09:30, outer=(30)]
+           │    └── s_dist_09:30
+           ├── first-agg [as=s_dist_10:31, outer=(31)]
+           │    └── s_dist_10:31
+           ├── first-agg [as=s_ytd:32, outer=(32)]
+           │    └── s_ytd:32
+           ├── first-agg [as=s_order_cnt:33, outer=(33)]
+           │    └── s_order_cnt:33
+           ├── first-agg [as=s_remote_cnt:34, outer=(34)]
+           │    └── s_remote_cnt:34
+           ├── first-agg [as=s_data:35, outer=(35)]
+           │    └── s_data:35
+           ├── first-agg [as=unnest:37, outer=(37)]
+           │    └── unnest:37
+           ├── first-agg [as=unnest:38, outer=(38)]
+           │    └── unnest:38
+           ├── first-agg [as=unnest:39, outer=(39)]
+           │    └── unnest:39
+           ├── first-agg [as=unnest:40, outer=(40)]
+           │    └── unnest:40
+           ├── first-agg [as=unnest:41, outer=(41)]
+           │    └── unnest:41
+           └── first-agg [as=unnest:42, outer=(42)]
+                └── unnest:42
 
 opt format=hide-qual
 INSERT INTO order_line
-  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity,  ol_amount,  ol_dist_info)
-VALUES
-  (3045,    2,       10,      3,         648,     0,              9,            394.470000, 'YhgLRrwsmd68P2bElAgrnp8u'),
-  (3045,    2,       10,      5,       25393,     0,             10,            830.600000, 'dLXe0YhgLRrwsmd68P2bElAg'),
-  (3045,    2,       10,      1,       47887,     0,              9,            204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn'),
-  (3045,    2,       10,      2,       52000,     0,              6,            561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo'),
-  (3045,    2,       10,      4,       56624,     0,              6,            273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh'),
-  (3045,    2,       10,      6,       92966,     0,              4,            366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+(
+     ol_o_id,
+     ol_d_id,
+     ol_w_id,
+     ol_i_id,
+     ol_supply_w_id,
+     ol_number,
+     ol_quantity,
+     ol_amount,
+     ol_dist_info
+)
+(
+     SELECT 3045,
+            2,
+            10,
+            unnest('{3, 5, 1, 2, 4, 6}':::INT[]),
+            unnest('{648, 25393, 47887, 52000, 56624, 92966}':::INT[]),
+            unnest('{0, 0, 0, 0, 0, 0}':::INT[]),
+            unnest('{9, 10, 9, 6, 6, 4}':::INT[]),
+            unnest('{394.470000, 830.600000, 204.390000, 561.660000, 273.360000, 366.760000}':::DECIMAL[]),
+            unnest('{YhgLRrwsmd68P2bElAgrnp8u, dLXe0YhgLRrwsmd68P2bElAg, Xe0YhgLRrwsmd68P2bElAgrn, ElAgrnp8ueWNXJpBB0ObpVWo, RsaCXoEzmssaF9m9cdLXe0Yh, saCXoEzmssaF9m9cdLXe0Yhg}':::STRING[])
+)
 ----
 insert order_line
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:12 => ol_o_id:1
- │    ├── column2:13 => ol_d_id:2
- │    ├── column3:14 => ol_w_id:3
- │    ├── column4:15 => ol_number:4
- │    ├── column5:16 => ol_i_id:5
- │    ├── column6:17 => ol_supply_w_id:6
+ │    ├── "?column?":18 => ol_o_id:1
+ │    ├── "?column?":19 => ol_d_id:2
+ │    ├── "?column?":20 => ol_w_id:3
+ │    ├── unnest:14 => ol_number:4
+ │    ├── unnest:12 => ol_i_id:5
+ │    ├── unnest:13 => ol_supply_w_id:6
  │    ├── column21:21 => ol_delivery_d:7
- │    ├── column7:18 => ol_quantity:8
+ │    ├── unnest:15 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
- │    └── column9:20 => ol_dist_info:10
+ │    └── unnest:17 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 column21:21 "?column?":18!null "?column?":19!null "?column?":20!null unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:17!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
- │    ├── fd: ()-->(21)
+ │    ├── fd: ()-->(18-21)
  │    ├── values
- │    │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column8:19!null column9:20!null
+ │    │    ├── columns: unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:16!null unnest:17!null
  │    │    ├── cardinality: [6 - 6]
- │    │    ├── (3045, 2, 10, 3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
- │    │    ├── (3045, 2, 10, 5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
- │    │    ├── (3045, 2, 10, 1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
- │    │    ├── (3045, 2, 10, 2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
- │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
- │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+ │    │    ├── (3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
+ │    │    ├── (5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
+ │    │    ├── (1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
+ │    │    ├── (2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
+ │    │    ├── (4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
+ │    │    └── (6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── crdb_internal.round_decimal_values(unnest:16, 2) [as=ol_amount:22, outer=(16), immutable]
+ │         ├── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── 3045 [as="?column?":18]
+ │         ├── 2 [as="?column?":19]
+ │         └── 10 [as="?column?":20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:23!null column2:24!null column1:25!null
+      │         ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         ├── key columns: [23 24 25] = [28 27 26]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
+      │         ├── fd: ()-->(23-25)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:23!null column2:24!null column1:25!null
+      │         │    ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => column3:23
-      │         │    │    ├──  column2:13 => column2:24
-      │         │    │    └──  column1:12 => column1:25
-      │         │    └── cardinality: [6 - 6]
+      │         │    │    ├──  "?column?":20 => "?column?":23
+      │         │    │    ├──  "?column?":19 => "?column?":24
+      │         │    │    └──  "?column?":18 => "?column?":25
+      │         │    ├── cardinality: [6 - 6]
+      │         │    └── fd: ()-->(23-25)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:35!null column5:36!null
+                ├── columns: unnest:35!null unnest:36!null
                 ├── key columns: [36 35] = [37 38]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── with-scan &1
-                │    ├── columns: column6:35!null column5:36!null
+                │    ├── columns: unnest:35!null unnest:36!null
                 │    ├── mapping:
-                │    │    ├──  column6:17 => column6:35
-                │    │    └──  column5:16 => column5:36
+                │    │    ├──  unnest:13 => unnest:35
+                │    │    └──  unnest:12 => unnest:36
                 │    └── cardinality: [6 - 6]
                 └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -89,7 +89,7 @@ project
 opt format=hide-qual
 SELECT i_price, i_name, i_data
 FROM item
-WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+WHERE i_id = ANY ('{125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300}')
 ORDER BY i_id
 ----
 scan item
@@ -114,28 +114,34 @@ scan item
 
 opt format=hide-qual
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
-FROM stock
-WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+FROM (SELECT unnest('{1000, 900, 1100, 1500, 1400}':::INT[]) AS i_id, 
+             unnest('{4, 4, 4, 4, 4}':::INT[])               AS w_id)
+INNER LOOKUP JOIN stock ON s_i_id = i_id AND s_w_id = w_id
 ORDER BY s_i_id
 ----
-project
- ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null]
+sort
+ ├── columns: s_quantity:5 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19 s_dist_05:10  [hidden: s_i_id:3!null]
  ├── cardinality: [0 - 5]
- ├── key: (1)
- ├── fd: (1)-->(3,8,14-17)
- ├── ordering: +1
- └── scan stock
-      ├── columns: s_i_id:1!null s_w_id:2!null s_quantity:3 s_dist_05:8 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17
-      ├── constraint: /2/1
-      │    ├── [/4/900 - /4/900]
-      │    ├── [/4/1000 - /4/1000]
-      │    ├── [/4/1100 - /4/1100]
-      │    ├── [/4/1400 - /4/1400]
-      │    └── [/4/1500 - /4/1500]
+ ├── ordering: +3
+ └── project
+      ├── columns: s_i_id:3!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
       ├── cardinality: [0 - 5]
-      ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      └── ordering: +1 opt(2) [actual: +1]
+      └── inner-join (lookup stock)
+           ├── columns: unnest:1!null unnest:2!null s_i_id:3!null s_w_id:4!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
+           ├── flags: force lookup join (into right side)
+           ├── key columns: [2 1] = [4 3]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 5]
+           ├── fd: (3,4)-->(5,10,16-19), (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+           ├── values
+           │    ├── columns: unnest:1!null unnest:2!null
+           │    ├── cardinality: [5 - 5]
+           │    ├── (1000, 4)
+           │    ├── (900, 4)
+           │    ├── (1100, 4)
+           │    ├── (1500, 4)
+           │    └── (1400, 4)
+           └── filters (true)
 
 opt format=hide-qual
 INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
@@ -220,203 +226,192 @@ insert new_order
                 └── filters (true)
 
 opt format=hide-qual
-UPDATE
-  stock
-SET
-  s_quantity
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 26
-    WHEN (7853, 0) THEN 10
-    WHEN (8497, 0) THEN 62
-    WHEN (10904, 0) THEN 54
-    WHEN (16152, 0) THEN 80
-    WHEN (41382, 0) THEN 18
-    WHEN (55952, 0) THEN 56
-    WHEN (64817, 0) THEN 26
-    WHEN (66335, 0) THEN 30
-    WHEN (76567, 0) THEN 71
-    WHEN (81680, 0) THEN 51
-    WHEN (89641, 0) THEN 51
-    WHEN (89905, 0) THEN 77
-    ELSE crdb_internal.force_error('', 'unknown case')
-    END,
-  s_ytd
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 6
-    WHEN (7853, 0) THEN 9
-    WHEN (8497, 0) THEN 13
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 2
-    WHEN (41382, 0) THEN 3
-    WHEN (55952, 0) THEN 10
-    WHEN (64817, 0) THEN 31
-    WHEN (66335, 0) THEN 9
-    WHEN (76567, 0) THEN 7
-    WHEN (81680, 0) THEN 4
-    WHEN (89641, 0) THEN 13
-    WHEN (89905, 0) THEN 20
-    END,
-  s_order_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 1
-    WHEN (7853, 0) THEN 1
-    WHEN (8497, 0) THEN 2
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 1
-    WHEN (41382, 0) THEN 1
-    WHEN (55952, 0) THEN 1
-    WHEN (64817, 0) THEN 4
-    WHEN (66335, 0) THEN 2
-    WHEN (76567, 0) THEN 1
-    WHEN (81680, 0) THEN 1
-    WHEN (89641, 0) THEN 2
-    WHEN (89905, 0) THEN 4
-    END,
-  s_remote_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 0
-    WHEN (7853, 0) THEN 0
-    WHEN (8497, 0) THEN 0
-    WHEN (10904, 0) THEN 0
-    WHEN (16152, 0) THEN 0
-    WHEN (41382, 0) THEN 0
-    WHEN (55952, 0) THEN 0
-    WHEN (64817, 0) THEN 0
-    WHEN (66335, 0) THEN 0
-    WHEN (76567, 0) THEN 0
-    WHEN (81680, 0) THEN 0
-    WHEN (89641, 0) THEN 0
-    WHEN (89905, 0) THEN 0
-    END
-WHERE
-  (s_i_id, s_w_id)
-  IN (
-      (6823, 0),
-      (7853, 0),
-      (8497, 0),
-      (10904, 0),
-      (16152, 0),
-      (41382, 0),
-      (55952, 0),
-      (64817, 0),
-      (66335, 0),
-      (76567, 0),
-      (81680, 0),
-      (89641, 0),
-      (89905, 0)
-    )
+UPDATE stock
+SET s_quantity   = new_s_quantity,
+	s_ytd        = new_s_ytd,
+	s_order_cnt  = new_s_order_cnt,
+	s_remote_cnt = new_s_remote_cnt
+FROM (SELECT 
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS i_id,
+	unnest('{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}':::INT[]) AS w_id,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_quantity,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_ytd,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_order_cnt,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_remote_cnt)
+WHERE s_i_id = i_id AND s_w_id = w_id
 ----
 update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:19 s_w_id:20 s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
  ├── update-mapping:
- │    ├── s_quantity_new:37 => s_quantity:3
- │    ├── s_ytd_new:38 => s_ytd:14
- │    ├── s_order_cnt_new:39 => s_order_cnt:15
- │    └── s_remote_cnt_new:40 => s_remote_cnt:16
+ │    ├── unnest:39 => s_quantity:3
+ │    ├── unnest:40 => s_ytd:14
+ │    ├── unnest:41 => s_order_cnt:15
+ │    └── unnest:42 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── project
-      ├── columns: s_quantity_new:37 s_ytd_new:38 s_order_cnt_new:39 s_remote_cnt_new:40 s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
+ └── distinct-on
+      ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      ├── grouping columns: s_i_id:19!null s_w_id:20!null
       ├── cardinality: [0 - 13]
-      ├── volatile
-      ├── key: (19)
-      ├── fd: ()-->(20), (19)-->(21-35,37-40)
-      ├── scan stock
-      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
-      │    ├── constraint: /20/19
-      │    │    ├── [/0/6823 - /0/6823]
-      │    │    ├── [/0/7853 - /0/7853]
-      │    │    ├── [/0/8497 - /0/8497]
-      │    │    ├── [/0/10904 - /0/10904]
-      │    │    ├── [/0/16152 - /0/16152]
-      │    │    ├── [/0/41382 - /0/41382]
-      │    │    ├── [/0/55952 - /0/55952]
-      │    │    ├── [/0/64817 - /0/64817]
-      │    │    ├── [/0/66335 - /0/66335]
-      │    │    ├── [/0/76567 - /0/76567]
-      │    │    ├── [/0/81680 - /0/81680]
-      │    │    ├── [/0/89641 - /0/89641]
-      │    │    └── [/0/89905 - /0/89905]
+      ├── key: (19,20)
+      ├── fd: (19,20)-->(21-35,37-42), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      ├── inner-join (lookup stock)
+      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    ├── key columns: [38 37] = [20 19]
+      │    ├── lookup columns are key
       │    ├── cardinality: [0 - 13]
-      │    ├── key: (19)
-      │    └── fd: ()-->(20), (19)-->(21-35)
-      └── projections
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:37, outer=(19,20), volatile]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 ELSE CAST(NULL AS INT8) END [as=s_ytd_new:38, outer=(19,20)]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 ELSE CAST(NULL AS INT8) END [as=s_order_cnt_new:39, outer=(19,20)]
-           └── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 ELSE CAST(NULL AS INT8) END [as=s_remote_cnt_new:40, outer=(19,20)]
+      │    ├── fd: (19,20)-->(21-35), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      │    ├── values
+      │    │    ├── columns: unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    │    ├── cardinality: [13 - 13]
+      │    │    ├── (6823, 0, 6823, 6823, 6823, 6823)
+      │    │    ├── (7853, 0, 7853, 7853, 7853, 7853)
+      │    │    ├── (8497, 0, 8497, 8497, 8497, 8497)
+      │    │    ├── (10904, 0, 10904, 10904, 10904, 10904)
+      │    │    ├── (16152, 0, 16152, 16152, 16152, 16152)
+      │    │    ├── (41382, 0, 41382, 41382, 41382, 41382)
+      │    │    ├── (55952, 0, 55952, 55952, 55952, 55952)
+      │    │    ├── (64817, 0, 64817, 64817, 64817, 64817)
+      │    │    ├── (66335, 0, 66335, 66335, 66335, 66335)
+      │    │    ├── (76567, 0, 76567, 76567, 76567, 76567)
+      │    │    ├── (81680, 0, 81680, 81680, 81680, 81680)
+      │    │    ├── (89641, 0, 89641, 89641, 89641, 89641)
+      │    │    └── (89905, 0, 89905, 89905, 89905, 89905)
+      │    └── filters (true)
+      └── aggregations
+           ├── first-agg [as=s_quantity:21, outer=(21)]
+           │    └── s_quantity:21
+           ├── first-agg [as=s_dist_01:22, outer=(22)]
+           │    └── s_dist_01:22
+           ├── first-agg [as=s_dist_02:23, outer=(23)]
+           │    └── s_dist_02:23
+           ├── first-agg [as=s_dist_03:24, outer=(24)]
+           │    └── s_dist_03:24
+           ├── first-agg [as=s_dist_04:25, outer=(25)]
+           │    └── s_dist_04:25
+           ├── first-agg [as=s_dist_05:26, outer=(26)]
+           │    └── s_dist_05:26
+           ├── first-agg [as=s_dist_06:27, outer=(27)]
+           │    └── s_dist_06:27
+           ├── first-agg [as=s_dist_07:28, outer=(28)]
+           │    └── s_dist_07:28
+           ├── first-agg [as=s_dist_08:29, outer=(29)]
+           │    └── s_dist_08:29
+           ├── first-agg [as=s_dist_09:30, outer=(30)]
+           │    └── s_dist_09:30
+           ├── first-agg [as=s_dist_10:31, outer=(31)]
+           │    └── s_dist_10:31
+           ├── first-agg [as=s_ytd:32, outer=(32)]
+           │    └── s_ytd:32
+           ├── first-agg [as=s_order_cnt:33, outer=(33)]
+           │    └── s_order_cnt:33
+           ├── first-agg [as=s_remote_cnt:34, outer=(34)]
+           │    └── s_remote_cnt:34
+           ├── first-agg [as=s_data:35, outer=(35)]
+           │    └── s_data:35
+           ├── first-agg [as=unnest:37, outer=(37)]
+           │    └── unnest:37
+           ├── first-agg [as=unnest:38, outer=(38)]
+           │    └── unnest:38
+           ├── first-agg [as=unnest:39, outer=(39)]
+           │    └── unnest:39
+           ├── first-agg [as=unnest:40, outer=(40)]
+           │    └── unnest:40
+           ├── first-agg [as=unnest:41, outer=(41)]
+           │    └── unnest:41
+           └── first-agg [as=unnest:42, outer=(42)]
+                └── unnest:42
 
 opt format=hide-qual
 INSERT INTO order_line
-  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity,  ol_amount,  ol_dist_info)
-VALUES
-  (3045,    2,       10,      3,         648,     0,              9,            394.470000, 'YhgLRrwsmd68P2bElAgrnp8u'),
-  (3045,    2,       10,      5,       25393,     0,             10,            830.600000, 'dLXe0YhgLRrwsmd68P2bElAg'),
-  (3045,    2,       10,      1,       47887,     0,              9,            204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn'),
-  (3045,    2,       10,      2,       52000,     0,              6,            561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo'),
-  (3045,    2,       10,      4,       56624,     0,              6,            273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh'),
-  (3045,    2,       10,      6,       92966,     0,              4,            366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+(
+     ol_o_id,
+     ol_d_id,
+     ol_w_id,
+     ol_i_id,
+     ol_supply_w_id,
+     ol_number,
+     ol_quantity,
+     ol_amount,
+     ol_dist_info
+)
+(
+     SELECT 3045,
+            2,
+            10,
+            unnest('{3, 5, 1, 2, 4, 6}':::INT[]),
+            unnest('{648, 25393, 47887, 52000, 56624, 92966}':::INT[]),
+            unnest('{0, 0, 0, 0, 0, 0}':::INT[]),
+            unnest('{9, 10, 9, 6, 6, 4}':::INT[]),
+            unnest('{394.470000, 830.600000, 204.390000, 561.660000, 273.360000, 366.760000}':::DECIMAL[]),
+            unnest('{YhgLRrwsmd68P2bElAgrnp8u, dLXe0YhgLRrwsmd68P2bElAg, Xe0YhgLRrwsmd68P2bElAgrn, ElAgrnp8ueWNXJpBB0ObpVWo, RsaCXoEzmssaF9m9cdLXe0Yh, saCXoEzmssaF9m9cdLXe0Yhg}':::STRING[])
+)
 ----
 insert order_line
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:12 => ol_o_id:1
- │    ├── column2:13 => ol_d_id:2
- │    ├── column3:14 => ol_w_id:3
- │    ├── column4:15 => ol_number:4
- │    ├── column5:16 => ol_i_id:5
- │    ├── column6:17 => ol_supply_w_id:6
+ │    ├── "?column?":18 => ol_o_id:1
+ │    ├── "?column?":19 => ol_d_id:2
+ │    ├── "?column?":20 => ol_w_id:3
+ │    ├── unnest:14 => ol_number:4
+ │    ├── unnest:12 => ol_i_id:5
+ │    ├── unnest:13 => ol_supply_w_id:6
  │    ├── column21:21 => ol_delivery_d:7
- │    ├── column7:18 => ol_quantity:8
+ │    ├── unnest:15 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
- │    └── column9:20 => ol_dist_info:10
+ │    └── unnest:17 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 column21:21 "?column?":18!null "?column?":19!null "?column?":20!null unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:17!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
- │    ├── fd: ()-->(21)
+ │    ├── fd: ()-->(18-21)
  │    ├── values
- │    │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column8:19!null column9:20!null
+ │    │    ├── columns: unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:16!null unnest:17!null
  │    │    ├── cardinality: [6 - 6]
- │    │    ├── (3045, 2, 10, 3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
- │    │    ├── (3045, 2, 10, 5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
- │    │    ├── (3045, 2, 10, 1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
- │    │    ├── (3045, 2, 10, 2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
- │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
- │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+ │    │    ├── (3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
+ │    │    ├── (5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
+ │    │    ├── (1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
+ │    │    ├── (2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
+ │    │    ├── (4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
+ │    │    └── (6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── crdb_internal.round_decimal_values(unnest:16, 2) [as=ol_amount:22, outer=(16), immutable]
+ │         ├── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── 3045 [as="?column?":18]
+ │         ├── 2 [as="?column?":19]
+ │         └── 10 [as="?column?":20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:23!null column2:24!null column1:25!null
+      │         ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         ├── key columns: [23 24 25] = [28 27 26]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
+      │         ├── fd: ()-->(23-25)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:23!null column2:24!null column1:25!null
+      │         │    ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => column3:23
-      │         │    │    ├──  column2:13 => column2:24
-      │         │    │    └──  column1:12 => column1:25
-      │         │    └── cardinality: [6 - 6]
+      │         │    │    ├──  "?column?":20 => "?column?":23
+      │         │    │    ├──  "?column?":19 => "?column?":24
+      │         │    │    └──  "?column?":18 => "?column?":25
+      │         │    ├── cardinality: [6 - 6]
+      │         │    └── fd: ()-->(23-25)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:35!null column5:36!null
+                ├── columns: unnest:35!null unnest:36!null
                 ├── key columns: [36 35] = [37 38]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── with-scan &1
-                │    ├── columns: column6:35!null column5:36!null
+                │    ├── columns: unnest:35!null unnest:36!null
                 │    ├── mapping:
-                │    │    ├──  column6:17 => column6:35
-                │    │    └──  column5:16 => column5:36
+                │    │    ├──  unnest:13 => unnest:35
+                │    │    └──  unnest:12 => unnest:36
                 │    └── cardinality: [6 - 6]
                 └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -751,41 +751,208 @@ project
 # recorded into a result file.
 # --------------------------------------------------
 opt format=hide-qual
-SELECT no_o_id
-FROM new_order
-WHERE no_w_id = 10 AND no_d_id = 100
-ORDER BY no_o_id ASC
-LIMIT 1
+SELECT no_d_id, no_o_id, sum(ol_amount)
+FROM (
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 1  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 2  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 3  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 4  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 5  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 6  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 7  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 8  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 9  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 10 ORDER BY no_o_id ASC LIMIT 1)
+)
+INNER LOOKUP JOIN order_line
+ON ol_d_id = no_d_id AND ol_o_id = no_o_id
+WHERE ol_w_id = 10
+GROUP BY no_d_id, no_o_id
 ----
-project
- ├── columns: no_o_id:1!null
- ├── cardinality: [0 - 1]
- ├── key: ()
- ├── fd: ()-->(1)
- └── scan new_order
-      ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
-      ├── constraint: /3/2/1: [/10/100 - /10/100]
-      ├── limit: 1
-      ├── key: ()
-      └── fd: ()-->(1-3)
-
-opt format=hide-qual
-SELECT sum(ol_amount)
-FROM order_line
-WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
-----
-scalar-group-by
- ├── columns: sum:12
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(12)
- ├── scan order_line
- │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_amount:9
- │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    └── fd: ()-->(1-3)
+group-by
+ ├── columns: no_d_id:57!null no_o_id:58!null sum:70
+ ├── grouping columns: no_d_id:57!null no_o_id:58!null
+ ├── key: (57,58)
+ ├── fd: (57,58)-->(70)
+ ├── inner-join (lookup order_line)
+ │    ├── columns: no_d_id:57!null no_o_id:58!null ol_o_id:59!null ol_d_id:60!null ol_w_id:61!null ol_amount:67
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [71 57 58] = [61 60 59]
+ │    ├── fd: ()-->(61), (57)==(60), (60)==(57), (58)==(59), (59)==(58)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@61":71!null no_d_id:57!null no_o_id:58!null
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── fd: ()-->(71)
+ │    │    ├── union-all
+ │    │    │    ├── columns: no_d_id:57!null no_o_id:58!null
+ │    │    │    ├── left columns: no_d_id:51 no_o_id:52
+ │    │    │    ├── right columns: new_order.no_d_id:54 new_order.no_o_id:53
+ │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    ├── union-all
+ │    │    │    │    ├── columns: no_d_id:51!null no_o_id:52!null
+ │    │    │    │    ├── left columns: no_d_id:45 no_o_id:46
+ │    │    │    │    ├── right columns: new_order.no_d_id:48 new_order.no_o_id:47
+ │    │    │    │    ├── cardinality: [0 - 9]
+ │    │    │    │    ├── union-all
+ │    │    │    │    │    ├── columns: no_d_id:45!null no_o_id:46!null
+ │    │    │    │    │    ├── left columns: no_d_id:39 no_o_id:40
+ │    │    │    │    │    ├── right columns: new_order.no_d_id:42 new_order.no_o_id:41
+ │    │    │    │    │    ├── cardinality: [0 - 8]
+ │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    ├── columns: no_d_id:39!null no_o_id:40!null
+ │    │    │    │    │    │    ├── left columns: no_d_id:33 no_o_id:34
+ │    │    │    │    │    │    ├── right columns: new_order.no_d_id:36 new_order.no_o_id:35
+ │    │    │    │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    ├── columns: no_d_id:33!null no_o_id:34!null
+ │    │    │    │    │    │    │    ├── left columns: no_d_id:27 no_o_id:28
+ │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:30 new_order.no_o_id:29
+ │    │    │    │    │    │    │    ├── cardinality: [0 - 6]
+ │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    ├── columns: no_d_id:27!null no_o_id:28!null
+ │    │    │    │    │    │    │    │    ├── left columns: no_d_id:21 no_o_id:22
+ │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:24 new_order.no_o_id:23
+ │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5]
+ │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:21!null no_o_id:22!null
+ │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:15 no_o_id:16
+ │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:18 new_order.no_o_id:17
+ │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:15!null no_o_id:16!null
+ │    │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:9 no_o_id:10
+ │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:12 new_order.no_o_id:11
+ │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:9!null no_o_id:10!null
+ │    │    │    │    │    │    │    │    │    │    │    ├── left columns: new_order.no_d_id:2 new_order.no_o_id:1
+ │    │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:6 new_order.no_o_id:5
+ │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 2]
+ │    │    │    │    │    │    │    │    │    │    │    ├── project
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    │    │    │    │    │    └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null no_w_id:3!null
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── constraint: /3/2/1: [/10/1 - /10/1]
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │         └── fd: ()-->(1-3)
+ │    │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null
+ │    │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(5,6)
+ │    │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null no_w_id:7!null
+ │    │    │    │    │    │    │    │    │    │    │              ├── constraint: /7/6/5: [/10/2 - /10/2]
+ │    │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(5-7)
+ │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null
+ │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(11,12)
+ │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null no_w_id:13!null
+ │    │    │    │    │    │    │    │    │    │              ├── constraint: /13/12/11: [/10/3 - /10/3]
+ │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(11-13)
+ │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null
+ │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │         ├── fd: ()-->(17,18)
+ │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null no_w_id:19!null
+ │    │    │    │    │    │    │    │    │              ├── constraint: /19/18/17: [/10/4 - /10/4]
+ │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │              └── fd: ()-->(17-19)
+ │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null
+ │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │         ├── fd: ()-->(23,24)
+ │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null no_w_id:25!null
+ │    │    │    │    │    │    │    │              ├── constraint: /25/24/23: [/10/5 - /10/5]
+ │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │              └── fd: ()-->(23-25)
+ │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null
+ │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │         ├── fd: ()-->(29,30)
+ │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null no_w_id:31!null
+ │    │    │    │    │    │    │              ├── constraint: /31/30/29: [/10/6 - /10/6]
+ │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │              └── fd: ()-->(29-31)
+ │    │    │    │    │    │    └── project
+ │    │    │    │    │    │         ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null
+ │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │         ├── fd: ()-->(35,36)
+ │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │              ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null no_w_id:37!null
+ │    │    │    │    │    │              ├── constraint: /37/36/35: [/10/7 - /10/7]
+ │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │              └── fd: ()-->(35-37)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null
+ │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │         ├── key: ()
+ │    │    │    │    │         ├── fd: ()-->(41,42)
+ │    │    │    │    │         └── scan new_order
+ │    │    │    │    │              ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null no_w_id:43!null
+ │    │    │    │    │              ├── constraint: /43/42/41: [/10/8 - /10/8]
+ │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │              ├── key: ()
+ │    │    │    │    │              └── fd: ()-->(41-43)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(47,48)
+ │    │    │    │         └── scan new_order
+ │    │    │    │              ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null no_w_id:49!null
+ │    │    │    │              ├── constraint: /49/48/47: [/10/9 - /10/9]
+ │    │    │    │              ├── limit: 1
+ │    │    │    │              ├── key: ()
+ │    │    │    │              └── fd: ()-->(47-49)
+ │    │    │    └── project
+ │    │    │         ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null
+ │    │    │         ├── cardinality: [0 - 1]
+ │    │    │         ├── key: ()
+ │    │    │         ├── fd: ()-->(53,54)
+ │    │    │         └── scan new_order
+ │    │    │              ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null no_w_id:55!null
+ │    │    │              ├── constraint: /55/54/53: [/10/10 - /10/10]
+ │    │    │              ├── limit: 1
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(53-55)
+ │    │    └── projections
+ │    │         └── 10 [as="project_const_col_@61":71]
+ │    └── filters (true)
  └── aggregations
-      └── sum [as=sum:12, outer=(9)]
-           └── ol_amount:9
+      └── sum [as=sum:70, outer=(67)]
+           └── ol_amount:67
 
 opt format=hide-qual
 UPDATE "order"

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -83,7 +83,7 @@ project
 opt format=hide-qual
 SELECT i_price, i_name, i_data
 FROM item
-WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+WHERE i_id = ANY ('{125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300}')
 ORDER BY i_id
 ----
 scan item
@@ -108,28 +108,34 @@ scan item
 
 opt format=hide-qual
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
-FROM stock
-WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+FROM (SELECT unnest('{1000, 900, 1100, 1500, 1400}':::INT[]) AS i_id, 
+             unnest('{4, 4, 4, 4, 4}':::INT[])               AS w_id)
+INNER LOOKUP JOIN stock ON s_i_id = i_id AND s_w_id = w_id
 ORDER BY s_i_id
 ----
-project
- ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null]
+sort
+ ├── columns: s_quantity:5 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19 s_dist_05:10  [hidden: s_i_id:3!null]
  ├── cardinality: [0 - 5]
- ├── key: (1)
- ├── fd: (1)-->(3,8,14-17)
- ├── ordering: +1
- └── scan stock
-      ├── columns: s_i_id:1!null s_w_id:2!null s_quantity:3 s_dist_05:8 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17
-      ├── constraint: /2/1
-      │    ├── [/4/900 - /4/900]
-      │    ├── [/4/1000 - /4/1000]
-      │    ├── [/4/1100 - /4/1100]
-      │    ├── [/4/1400 - /4/1400]
-      │    └── [/4/1500 - /4/1500]
+ ├── ordering: +3
+ └── project
+      ├── columns: s_i_id:3!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
       ├── cardinality: [0 - 5]
-      ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      └── ordering: +1 opt(2) [actual: +1]
+      └── inner-join (lookup stock)
+           ├── columns: unnest:1!null unnest:2!null s_i_id:3!null s_w_id:4!null s_quantity:5 s_dist_05:10 s_ytd:16 s_order_cnt:17 s_remote_cnt:18 s_data:19
+           ├── flags: force lookup join (into right side)
+           ├── key columns: [2 1] = [4 3]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 5]
+           ├── fd: (3,4)-->(5,10,16-19), (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+           ├── values
+           │    ├── columns: unnest:1!null unnest:2!null
+           │    ├── cardinality: [5 - 5]
+           │    ├── (1000, 4)
+           │    ├── (900, 4)
+           │    ├── (1100, 4)
+           │    ├── (1500, 4)
+           │    └── (1400, 4)
+           └── filters (true)
 
 opt format=hide-qual
 INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
@@ -214,203 +220,192 @@ insert new_order
                 └── filters (true)
 
 opt format=hide-qual
-UPDATE
-  stock
-SET
-  s_quantity
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 26
-    WHEN (7853, 0) THEN 10
-    WHEN (8497, 0) THEN 62
-    WHEN (10904, 0) THEN 54
-    WHEN (16152, 0) THEN 80
-    WHEN (41382, 0) THEN 18
-    WHEN (55952, 0) THEN 56
-    WHEN (64817, 0) THEN 26
-    WHEN (66335, 0) THEN 30
-    WHEN (76567, 0) THEN 71
-    WHEN (81680, 0) THEN 51
-    WHEN (89641, 0) THEN 51
-    WHEN (89905, 0) THEN 77
-    ELSE crdb_internal.force_error('', 'unknown case')
-    END,
-  s_ytd
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 6
-    WHEN (7853, 0) THEN 9
-    WHEN (8497, 0) THEN 13
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 2
-    WHEN (41382, 0) THEN 3
-    WHEN (55952, 0) THEN 10
-    WHEN (64817, 0) THEN 31
-    WHEN (66335, 0) THEN 9
-    WHEN (76567, 0) THEN 7
-    WHEN (81680, 0) THEN 4
-    WHEN (89641, 0) THEN 13
-    WHEN (89905, 0) THEN 20
-    END,
-  s_order_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 1
-    WHEN (7853, 0) THEN 1
-    WHEN (8497, 0) THEN 2
-    WHEN (10904, 0) THEN 1
-    WHEN (16152, 0) THEN 1
-    WHEN (41382, 0) THEN 1
-    WHEN (55952, 0) THEN 1
-    WHEN (64817, 0) THEN 4
-    WHEN (66335, 0) THEN 2
-    WHEN (76567, 0) THEN 1
-    WHEN (81680, 0) THEN 1
-    WHEN (89641, 0) THEN 2
-    WHEN (89905, 0) THEN 4
-    END,
-  s_remote_cnt
-    = CASE (s_i_id, s_w_id)
-    WHEN (6823, 0) THEN 0
-    WHEN (7853, 0) THEN 0
-    WHEN (8497, 0) THEN 0
-    WHEN (10904, 0) THEN 0
-    WHEN (16152, 0) THEN 0
-    WHEN (41382, 0) THEN 0
-    WHEN (55952, 0) THEN 0
-    WHEN (64817, 0) THEN 0
-    WHEN (66335, 0) THEN 0
-    WHEN (76567, 0) THEN 0
-    WHEN (81680, 0) THEN 0
-    WHEN (89641, 0) THEN 0
-    WHEN (89905, 0) THEN 0
-    END
-WHERE
-  (s_i_id, s_w_id)
-  IN (
-      (6823, 0),
-      (7853, 0),
-      (8497, 0),
-      (10904, 0),
-      (16152, 0),
-      (41382, 0),
-      (55952, 0),
-      (64817, 0),
-      (66335, 0),
-      (76567, 0),
-      (81680, 0),
-      (89641, 0),
-      (89905, 0)
-    )
+UPDATE stock
+SET s_quantity   = new_s_quantity,
+	s_ytd        = new_s_ytd,
+	s_order_cnt  = new_s_order_cnt,
+	s_remote_cnt = new_s_remote_cnt
+FROM (SELECT 
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS i_id,
+	unnest('{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}':::INT[]) AS w_id,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_quantity,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_ytd,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_order_cnt,
+	unnest('{6823, 7853, 8497, 10904, 16152, 41382, 55952, 64817, 66335, 76567, 81680, 89641, 89905}':::INT[]) AS new_s_remote_cnt)
+WHERE s_i_id = i_id AND s_w_id = w_id
 ----
 update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:19 s_w_id:20 s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
  ├── update-mapping:
- │    ├── s_quantity_new:37 => s_quantity:3
- │    ├── s_ytd_new:38 => s_ytd:14
- │    ├── s_order_cnt_new:39 => s_order_cnt:15
- │    └── s_remote_cnt_new:40 => s_remote_cnt:16
+ │    ├── unnest:39 => s_quantity:3
+ │    ├── unnest:40 => s_ytd:14
+ │    ├── unnest:41 => s_order_cnt:15
+ │    └── unnest:42 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── project
-      ├── columns: s_quantity_new:37 s_ytd_new:38 s_order_cnt_new:39 s_remote_cnt_new:40 s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
+ └── distinct-on
+      ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      ├── grouping columns: s_i_id:19!null s_w_id:20!null
       ├── cardinality: [0 - 13]
-      ├── volatile
-      ├── key: (19)
-      ├── fd: ()-->(20), (19)-->(21-35,37-40)
-      ├── scan stock
-      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35
-      │    ├── constraint: /20/19
-      │    │    ├── [/0/6823 - /0/6823]
-      │    │    ├── [/0/7853 - /0/7853]
-      │    │    ├── [/0/8497 - /0/8497]
-      │    │    ├── [/0/10904 - /0/10904]
-      │    │    ├── [/0/16152 - /0/16152]
-      │    │    ├── [/0/41382 - /0/41382]
-      │    │    ├── [/0/55952 - /0/55952]
-      │    │    ├── [/0/64817 - /0/64817]
-      │    │    ├── [/0/66335 - /0/66335]
-      │    │    ├── [/0/76567 - /0/76567]
-      │    │    ├── [/0/81680 - /0/81680]
-      │    │    ├── [/0/89641 - /0/89641]
-      │    │    └── [/0/89905 - /0/89905]
+      ├── key: (19,20)
+      ├── fd: (19,20)-->(21-35,37-42), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      ├── inner-join (lookup stock)
+      │    ├── columns: s_i_id:19!null s_w_id:20!null s_quantity:21 s_dist_01:22 s_dist_02:23 s_dist_03:24 s_dist_04:25 s_dist_05:26 s_dist_06:27 s_dist_07:28 s_dist_08:29 s_dist_09:30 s_dist_10:31 s_ytd:32 s_order_cnt:33 s_remote_cnt:34 s_data:35 unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    ├── key columns: [38 37] = [20 19]
+      │    ├── lookup columns are key
       │    ├── cardinality: [0 - 13]
-      │    ├── key: (19)
-      │    └── fd: ()-->(20), (19)-->(21-35)
-      └── projections
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:37, outer=(19,20), volatile]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 ELSE CAST(NULL AS INT8) END [as=s_ytd_new:38, outer=(19,20)]
-           ├── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 ELSE CAST(NULL AS INT8) END [as=s_order_cnt_new:39, outer=(19,20)]
-           └── CASE (s_i_id:19, s_w_id:20) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 ELSE CAST(NULL AS INT8) END [as=s_remote_cnt_new:40, outer=(19,20)]
+      │    ├── fd: (19,20)-->(21-35), (19)==(37), (37)==(19), (20)==(38), (38)==(20)
+      │    ├── values
+      │    │    ├── columns: unnest:37!null unnest:38!null unnest:39!null unnest:40!null unnest:41!null unnest:42!null
+      │    │    ├── cardinality: [13 - 13]
+      │    │    ├── (6823, 0, 6823, 6823, 6823, 6823)
+      │    │    ├── (7853, 0, 7853, 7853, 7853, 7853)
+      │    │    ├── (8497, 0, 8497, 8497, 8497, 8497)
+      │    │    ├── (10904, 0, 10904, 10904, 10904, 10904)
+      │    │    ├── (16152, 0, 16152, 16152, 16152, 16152)
+      │    │    ├── (41382, 0, 41382, 41382, 41382, 41382)
+      │    │    ├── (55952, 0, 55952, 55952, 55952, 55952)
+      │    │    ├── (64817, 0, 64817, 64817, 64817, 64817)
+      │    │    ├── (66335, 0, 66335, 66335, 66335, 66335)
+      │    │    ├── (76567, 0, 76567, 76567, 76567, 76567)
+      │    │    ├── (81680, 0, 81680, 81680, 81680, 81680)
+      │    │    ├── (89641, 0, 89641, 89641, 89641, 89641)
+      │    │    └── (89905, 0, 89905, 89905, 89905, 89905)
+      │    └── filters (true)
+      └── aggregations
+           ├── first-agg [as=s_quantity:21, outer=(21)]
+           │    └── s_quantity:21
+           ├── first-agg [as=s_dist_01:22, outer=(22)]
+           │    └── s_dist_01:22
+           ├── first-agg [as=s_dist_02:23, outer=(23)]
+           │    └── s_dist_02:23
+           ├── first-agg [as=s_dist_03:24, outer=(24)]
+           │    └── s_dist_03:24
+           ├── first-agg [as=s_dist_04:25, outer=(25)]
+           │    └── s_dist_04:25
+           ├── first-agg [as=s_dist_05:26, outer=(26)]
+           │    └── s_dist_05:26
+           ├── first-agg [as=s_dist_06:27, outer=(27)]
+           │    └── s_dist_06:27
+           ├── first-agg [as=s_dist_07:28, outer=(28)]
+           │    └── s_dist_07:28
+           ├── first-agg [as=s_dist_08:29, outer=(29)]
+           │    └── s_dist_08:29
+           ├── first-agg [as=s_dist_09:30, outer=(30)]
+           │    └── s_dist_09:30
+           ├── first-agg [as=s_dist_10:31, outer=(31)]
+           │    └── s_dist_10:31
+           ├── first-agg [as=s_ytd:32, outer=(32)]
+           │    └── s_ytd:32
+           ├── first-agg [as=s_order_cnt:33, outer=(33)]
+           │    └── s_order_cnt:33
+           ├── first-agg [as=s_remote_cnt:34, outer=(34)]
+           │    └── s_remote_cnt:34
+           ├── first-agg [as=s_data:35, outer=(35)]
+           │    └── s_data:35
+           ├── first-agg [as=unnest:37, outer=(37)]
+           │    └── unnest:37
+           ├── first-agg [as=unnest:38, outer=(38)]
+           │    └── unnest:38
+           ├── first-agg [as=unnest:39, outer=(39)]
+           │    └── unnest:39
+           ├── first-agg [as=unnest:40, outer=(40)]
+           │    └── unnest:40
+           ├── first-agg [as=unnest:41, outer=(41)]
+           │    └── unnest:41
+           └── first-agg [as=unnest:42, outer=(42)]
+                └── unnest:42
 
 opt format=hide-qual
 INSERT INTO order_line
-  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity,  ol_amount,  ol_dist_info)
-VALUES
-  (3045,    2,       10,      3,         648,     0,              9,            394.470000, 'YhgLRrwsmd68P2bElAgrnp8u'),
-  (3045,    2,       10,      5,       25393,     0,             10,            830.600000, 'dLXe0YhgLRrwsmd68P2bElAg'),
-  (3045,    2,       10,      1,       47887,     0,              9,            204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn'),
-  (3045,    2,       10,      2,       52000,     0,              6,            561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo'),
-  (3045,    2,       10,      4,       56624,     0,              6,            273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh'),
-  (3045,    2,       10,      6,       92966,     0,              4,            366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+(
+     ol_o_id,
+     ol_d_id,
+     ol_w_id,
+     ol_i_id,
+     ol_supply_w_id,
+     ol_number,
+     ol_quantity,
+     ol_amount,
+     ol_dist_info
+)
+(
+     SELECT 3045,
+            2,
+            10,
+            unnest('{3, 5, 1, 2, 4, 6}':::INT[]),
+            unnest('{648, 25393, 47887, 52000, 56624, 92966}':::INT[]),
+            unnest('{0, 0, 0, 0, 0, 0}':::INT[]),
+            unnest('{9, 10, 9, 6, 6, 4}':::INT[]),
+            unnest('{394.470000, 830.600000, 204.390000, 561.660000, 273.360000, 366.760000}':::DECIMAL[]),
+            unnest('{YhgLRrwsmd68P2bElAgrnp8u, dLXe0YhgLRrwsmd68P2bElAg, Xe0YhgLRrwsmd68P2bElAgrn, ElAgrnp8ueWNXJpBB0ObpVWo, RsaCXoEzmssaF9m9cdLXe0Yh, saCXoEzmssaF9m9cdLXe0Yhg}':::STRING[])
+)
 ----
 insert order_line
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:12 => ol_o_id:1
- │    ├── column2:13 => ol_d_id:2
- │    ├── column3:14 => ol_w_id:3
- │    ├── column4:15 => ol_number:4
- │    ├── column5:16 => ol_i_id:5
- │    ├── column6:17 => ol_supply_w_id:6
+ │    ├── "?column?":18 => ol_o_id:1
+ │    ├── "?column?":19 => ol_d_id:2
+ │    ├── "?column?":20 => ol_w_id:3
+ │    ├── unnest:14 => ol_number:4
+ │    ├── unnest:12 => ol_i_id:5
+ │    ├── unnest:13 => ol_supply_w_id:6
  │    ├── column21:21 => ol_delivery_d:7
- │    ├── column7:18 => ol_quantity:8
+ │    ├── unnest:15 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
- │    └── column9:20 => ol_dist_info:10
+ │    └── unnest:17 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 column21:21 "?column?":18!null "?column?":19!null "?column?":20!null unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:17!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
- │    ├── fd: ()-->(21)
+ │    ├── fd: ()-->(18-21)
  │    ├── values
- │    │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column8:19!null column9:20!null
+ │    │    ├── columns: unnest:12!null unnest:13!null unnest:14!null unnest:15!null unnest:16!null unnest:17!null
  │    │    ├── cardinality: [6 - 6]
- │    │    ├── (3045, 2, 10, 3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
- │    │    ├── (3045, 2, 10, 5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
- │    │    ├── (3045, 2, 10, 1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
- │    │    ├── (3045, 2, 10, 2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
- │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
- │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+ │    │    ├── (3, 648, 0, 9, 394.470000, 'YhgLRrwsmd68P2bElAgrnp8u')
+ │    │    ├── (5, 25393, 0, 10, 830.600000, 'dLXe0YhgLRrwsmd68P2bElAg')
+ │    │    ├── (1, 47887, 0, 9, 204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn')
+ │    │    ├── (2, 52000, 0, 6, 561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo')
+ │    │    ├── (4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
+ │    │    └── (6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── crdb_internal.round_decimal_values(unnest:16, 2) [as=ol_amount:22, outer=(16), immutable]
+ │         ├── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         ├── 3045 [as="?column?":18]
+ │         ├── 2 [as="?column?":19]
+ │         └── 10 [as="?column?":20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:23!null column2:24!null column1:25!null
+      │         ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         ├── key columns: [23 24 25] = [28 27 26]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
+      │         ├── fd: ()-->(23-25)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:23!null column2:24!null column1:25!null
+      │         │    ├── columns: "?column?":23!null "?column?":24!null "?column?":25!null
       │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => column3:23
-      │         │    │    ├──  column2:13 => column2:24
-      │         │    │    └──  column1:12 => column1:25
-      │         │    └── cardinality: [6 - 6]
+      │         │    │    ├──  "?column?":20 => "?column?":23
+      │         │    │    ├──  "?column?":19 => "?column?":24
+      │         │    │    └──  "?column?":18 => "?column?":25
+      │         │    ├── cardinality: [6 - 6]
+      │         │    └── fd: ()-->(23-25)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:35!null column5:36!null
+                ├── columns: unnest:35!null unnest:36!null
                 ├── key columns: [36 35] = [37 38]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── with-scan &1
-                │    ├── columns: column6:35!null column5:36!null
+                │    ├── columns: unnest:35!null unnest:36!null
                 │    ├── mapping:
-                │    │    ├──  column6:17 => column6:35
-                │    │    └──  column5:16 => column5:36
+                │    │    ├──  unnest:13 => unnest:35
+                │    │    └──  unnest:12 => unnest:36
                 │    └── cardinality: [6 - 6]
                 └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -749,41 +749,208 @@ project
 # recorded into a result file.
 # --------------------------------------------------
 opt format=hide-qual
-SELECT no_o_id
-FROM new_order
-WHERE no_w_id = 10 AND no_d_id = 100
-ORDER BY no_o_id ASC
-LIMIT 1
+SELECT no_d_id, no_o_id, sum(ol_amount)
+FROM (
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 1  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 2  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 3  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 4  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 5  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 6  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 7  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 8  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 9  ORDER BY no_o_id ASC LIMIT 1)
+UNION ALL
+     (SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = 10 AND no_d_id = 10 ORDER BY no_o_id ASC LIMIT 1)
+)
+INNER LOOKUP JOIN order_line
+ON ol_d_id = no_d_id AND ol_o_id = no_o_id
+WHERE ol_w_id = 10
+GROUP BY no_d_id, no_o_id
 ----
-project
- ├── columns: no_o_id:1!null
- ├── cardinality: [0 - 1]
- ├── key: ()
- ├── fd: ()-->(1)
- └── scan new_order
-      ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
-      ├── constraint: /3/2/1: [/10/100 - /10/100]
-      ├── limit: 1
-      ├── key: ()
-      └── fd: ()-->(1-3)
-
-opt format=hide-qual
-SELECT sum(ol_amount)
-FROM order_line
-WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
-----
-scalar-group-by
- ├── columns: sum:12
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(12)
- ├── scan order_line
- │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_amount:9
- │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    └── fd: ()-->(1-3)
+group-by
+ ├── columns: no_d_id:57!null no_o_id:58!null sum:70
+ ├── grouping columns: no_d_id:57!null no_o_id:58!null
+ ├── key: (57,58)
+ ├── fd: (57,58)-->(70)
+ ├── inner-join (lookup order_line)
+ │    ├── columns: no_d_id:57!null no_o_id:58!null ol_o_id:59!null ol_d_id:60!null ol_w_id:61!null ol_amount:67
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [71 57 58] = [61 60 59]
+ │    ├── fd: ()-->(61), (57)==(60), (60)==(57), (58)==(59), (59)==(58)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@61":71!null no_d_id:57!null no_o_id:58!null
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── fd: ()-->(71)
+ │    │    ├── union-all
+ │    │    │    ├── columns: no_d_id:57!null no_o_id:58!null
+ │    │    │    ├── left columns: no_d_id:51 no_o_id:52
+ │    │    │    ├── right columns: new_order.no_d_id:54 new_order.no_o_id:53
+ │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    ├── union-all
+ │    │    │    │    ├── columns: no_d_id:51!null no_o_id:52!null
+ │    │    │    │    ├── left columns: no_d_id:45 no_o_id:46
+ │    │    │    │    ├── right columns: new_order.no_d_id:48 new_order.no_o_id:47
+ │    │    │    │    ├── cardinality: [0 - 9]
+ │    │    │    │    ├── union-all
+ │    │    │    │    │    ├── columns: no_d_id:45!null no_o_id:46!null
+ │    │    │    │    │    ├── left columns: no_d_id:39 no_o_id:40
+ │    │    │    │    │    ├── right columns: new_order.no_d_id:42 new_order.no_o_id:41
+ │    │    │    │    │    ├── cardinality: [0 - 8]
+ │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    ├── columns: no_d_id:39!null no_o_id:40!null
+ │    │    │    │    │    │    ├── left columns: no_d_id:33 no_o_id:34
+ │    │    │    │    │    │    ├── right columns: new_order.no_d_id:36 new_order.no_o_id:35
+ │    │    │    │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    ├── columns: no_d_id:33!null no_o_id:34!null
+ │    │    │    │    │    │    │    ├── left columns: no_d_id:27 no_o_id:28
+ │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:30 new_order.no_o_id:29
+ │    │    │    │    │    │    │    ├── cardinality: [0 - 6]
+ │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    ├── columns: no_d_id:27!null no_o_id:28!null
+ │    │    │    │    │    │    │    │    ├── left columns: no_d_id:21 no_o_id:22
+ │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:24 new_order.no_o_id:23
+ │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5]
+ │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:21!null no_o_id:22!null
+ │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:15 no_o_id:16
+ │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:18 new_order.no_o_id:17
+ │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:15!null no_o_id:16!null
+ │    │    │    │    │    │    │    │    │    │    ├── left columns: no_d_id:9 no_o_id:10
+ │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:12 new_order.no_o_id:11
+ │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    │    │    │    │    │    │    │    ├── union-all
+ │    │    │    │    │    │    │    │    │    │    │    ├── columns: no_d_id:9!null no_o_id:10!null
+ │    │    │    │    │    │    │    │    │    │    │    ├── left columns: new_order.no_d_id:2 new_order.no_o_id:1
+ │    │    │    │    │    │    │    │    │    │    │    ├── right columns: new_order.no_d_id:6 new_order.no_o_id:5
+ │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 2]
+ │    │    │    │    │    │    │    │    │    │    │    ├── project
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    │    │    │    │    │    └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:1!null new_order.no_d_id:2!null no_w_id:3!null
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── constraint: /3/2/1: [/10/1 - /10/1]
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │    │         └── fd: ()-->(1-3)
+ │    │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null
+ │    │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(5,6)
+ │    │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:5!null new_order.no_d_id:6!null no_w_id:7!null
+ │    │    │    │    │    │    │    │    │    │    │              ├── constraint: /7/6/5: [/10/2 - /10/2]
+ │    │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(5-7)
+ │    │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null
+ │    │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │    │         ├── fd: ()-->(11,12)
+ │    │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:11!null new_order.no_d_id:12!null no_w_id:13!null
+ │    │    │    │    │    │    │    │    │    │              ├── constraint: /13/12/11: [/10/3 - /10/3]
+ │    │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │    │              └── fd: ()-->(11-13)
+ │    │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null
+ │    │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │    │         ├── fd: ()-->(17,18)
+ │    │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:17!null new_order.no_d_id:18!null no_w_id:19!null
+ │    │    │    │    │    │    │    │    │              ├── constraint: /19/18/17: [/10/4 - /10/4]
+ │    │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │    │              └── fd: ()-->(17-19)
+ │    │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null
+ │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │    │         ├── fd: ()-->(23,24)
+ │    │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:23!null new_order.no_d_id:24!null no_w_id:25!null
+ │    │    │    │    │    │    │    │              ├── constraint: /25/24/23: [/10/5 - /10/5]
+ │    │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │    │              └── fd: ()-->(23-25)
+ │    │    │    │    │    │    │    └── project
+ │    │    │    │    │    │    │         ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null
+ │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │    │         ├── fd: ()-->(29,30)
+ │    │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │    │              ├── columns: new_order.no_o_id:29!null new_order.no_d_id:30!null no_w_id:31!null
+ │    │    │    │    │    │    │              ├── constraint: /31/30/29: [/10/6 - /10/6]
+ │    │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │    │              └── fd: ()-->(29-31)
+ │    │    │    │    │    │    └── project
+ │    │    │    │    │    │         ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null
+ │    │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │    │         ├── key: ()
+ │    │    │    │    │    │         ├── fd: ()-->(35,36)
+ │    │    │    │    │    │         └── scan new_order
+ │    │    │    │    │    │              ├── columns: new_order.no_o_id:35!null new_order.no_d_id:36!null no_w_id:37!null
+ │    │    │    │    │    │              ├── constraint: /37/36/35: [/10/7 - /10/7]
+ │    │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │    │              ├── key: ()
+ │    │    │    │    │    │              └── fd: ()-->(35-37)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null
+ │    │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │    │         ├── key: ()
+ │    │    │    │    │         ├── fd: ()-->(41,42)
+ │    │    │    │    │         └── scan new_order
+ │    │    │    │    │              ├── columns: new_order.no_o_id:41!null new_order.no_d_id:42!null no_w_id:43!null
+ │    │    │    │    │              ├── constraint: /43/42/41: [/10/8 - /10/8]
+ │    │    │    │    │              ├── limit: 1
+ │    │    │    │    │              ├── key: ()
+ │    │    │    │    │              └── fd: ()-->(41-43)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(47,48)
+ │    │    │    │         └── scan new_order
+ │    │    │    │              ├── columns: new_order.no_o_id:47!null new_order.no_d_id:48!null no_w_id:49!null
+ │    │    │    │              ├── constraint: /49/48/47: [/10/9 - /10/9]
+ │    │    │    │              ├── limit: 1
+ │    │    │    │              ├── key: ()
+ │    │    │    │              └── fd: ()-->(47-49)
+ │    │    │    └── project
+ │    │    │         ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null
+ │    │    │         ├── cardinality: [0 - 1]
+ │    │    │         ├── key: ()
+ │    │    │         ├── fd: ()-->(53,54)
+ │    │    │         └── scan new_order
+ │    │    │              ├── columns: new_order.no_o_id:53!null new_order.no_d_id:54!null no_w_id:55!null
+ │    │    │              ├── constraint: /55/54/53: [/10/10 - /10/10]
+ │    │    │              ├── limit: 1
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(53-55)
+ │    │    └── projections
+ │    │         └── 10 [as="project_const_col_@61":71]
+ │    └── filters (true)
  └── aggregations
-      └── sum [as=sum:12, outer=(9)]
-           └── ol_amount:9
+      └── sum [as=sum:70, outer=(67)]
+           └── ol_amount:67
 
 opt format=hide-qual
 UPDATE "order"

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -44,8 +44,7 @@ type delivery struct {
 	mcp    *workload.MultiConnPool
 	sr     workload.SQLRunner
 
-	selectNewOrder workload.StmtHandle
-	sumAmount      workload.StmtHandle
+	selectNewOrders workload.StmtHandle
 }
 
 var _ tpccTx = &delivery{}
@@ -58,17 +57,33 @@ func createDelivery(
 		mcp:    mcp,
 	}
 
-	del.selectNewOrder = del.sr.Define(`
-		SELECT no_o_id
-		FROM new_order
-		WHERE no_w_id = $1 AND no_d_id = $2
-		ORDER BY no_o_id ASC
-		LIMIT 1`,
-	)
-
-	del.sumAmount = del.sr.Define(`
-		SELECT sum(ol_amount) FROM order_line
-		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+	del.selectNewOrders = del.sr.Define(`
+		SELECT no_d_id, no_o_id, sum(ol_amount)
+		FROM (
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 1  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 2  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 3  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 4  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 5  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 6  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 7  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 8  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 9  ORDER BY no_o_id ASC LIMIT 1)
+		UNION ALL
+			(SELECT no_d_id, no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = 10 ORDER BY no_o_id ASC LIMIT 1)
+		)
+		INNER LOOKUP JOIN order_line
+		ON ol_d_id = no_d_id AND ol_o_id = no_o_id
+		WHERE ol_w_id = $1
+		GROUP BY no_d_id, no_o_id`,
 	)
 
 	if err := del.sr.Init(ctx, "delivery", mcp, config.connFlags); err != nil {
@@ -93,32 +108,65 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 	err = crdb.ExecuteInTx(
 		ctx, (*workload.PgxTx)(tx),
 		func() error {
-			// 2.7.4.2. For each district:
-			dIDoIDPairs := make(map[int]int)
-			dIDolTotalPairs := make(map[int]float64)
-			for dID := 1; dID <= 10; dID++ {
-				var oID int
-				if err := del.selectNewOrder.QueryRowTx(ctx, tx, wID, dID).Scan(&oID); err != nil {
-					// If no matching order is found, the delivery of this order is skipped.
-					if !errors.Is(err, gosql.ErrNoRows) {
-						atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)
-						return err
-					}
-					continue
-				}
-				dIDoIDPairs[dID] = oID
-
+			// 2.7.4.2. For each district, the row in the NEW-ORDER table with
+			// matching NO_W_ID (equals W_ID) and NO_D_ID (equals D_ID) and with
+			// the lowest NO_O_ID value is selected. This is the oldest
+			// undelivered order of that district. NO_O_ID, the order number, is
+			// retrieved. If no matching row is found, then the delivery of an
+			// order for this district is skipped. The condition in which no
+			// outstandin g order is present at a given district must be handled
+			// by skipping the delivery of an order for that district only and
+			// resuming the delivery of an order from all remaining districts of
+			// the selected warehouse.
+			rows, err := del.selectNewOrders.QueryTx(ctx, tx, wID)
+			if err != nil {
+				return err
+			}
+			dIDoIDPairs := make(map[int]int, 10)
+			dIDolTotalPairs := make(map[int]float64, 10)
+			for rows.Next() {
+				var dID, oID int
 				var olTotal float64
-				if err := del.sumAmount.QueryRowTx(
-					ctx, tx, wID, dID, oID,
-				).Scan(&olTotal); err != nil {
+				if err := rows.Scan(&dID, &oID, &olTotal); err != nil {
+					rows.Close()
 					return err
 				}
+				if _, ok := dIDoIDPairs[dID]; ok {
+					return errors.Wrap(err, "duplicate district")
+				}
+				dIDoIDPairs[dID] = oID
 				dIDolTotalPairs[dID] = olTotal
 			}
-			dIDoIDPairsStr := makeInTuples(dIDoIDPairs)
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
 
-			rows, err := tx.QueryEx(
+			// Handle skipped deliveries.
+			atomic.AddUint64(&del.config.auditor.skippedDelivieries, uint64(10-len(dIDoIDPairs)))
+			if len(dIDoIDPairs) == 0 {
+				return nil
+			}
+
+			// The selected rows in the NEW-ORDER table are deleted.
+			dIDoIDPairsStr := makeInTuples(dIDoIDPairs)
+			if _, err := tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					DELETE FROM new_order
+					WHERE no_w_id = %d AND (no_d_id, no_o_id) IN (%s)`,
+					wID, dIDoIDPairsStr,
+				),
+				nil, /* options */
+			); err != nil {
+				return err
+			}
+
+			// The rows in the ORDER table with matching O_W_ID (equals W_ ID),
+			// O_D_ID (equals D_ID), and O_ID (equals NO_O_ID) are selected,
+			// O_C_ID, the customer number, is retrieved, and O_CARRIER_ID is
+			// updated.
+			rows, err = tx.QueryEx(
 				ctx,
 				fmt.Sprintf(`
 					UPDATE "order"
@@ -152,6 +200,11 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 			dIDcIDPairsStr := makeInTuples(dIDcIDPairs)
 			dIDToOlTotalStr := makeWhereCases(dIDolTotalPairs)
 
+			// The row in the CUSTOMER table with matching C_W_ID (equals W_ID),
+			// C_D_ID (equals D_ID), and C_ID (equals O_C_ID) is selected and
+			// C_BALANCE is increased by the sum of all order-line amounts
+			// (OL_AMOUNT) previously retrieved. C_DELIVERY_CNT is incremented
+			// by 1.
 			if _, err := tx.ExecEx(
 				ctx,
 				fmt.Sprintf(`
@@ -165,18 +218,12 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 			); err != nil {
 				return err
 			}
-			if _, err := tx.ExecEx(
-				ctx,
-				fmt.Sprintf(`
-					DELETE FROM new_order
-					WHERE no_w_id = %d AND (no_d_id, no_o_id) IN (%s)`,
-					wID, dIDoIDPairsStr,
-				),
-				nil, /* options */
-			); err != nil {
-				return err
-			}
 
+			// All rows in the ORDER-LINE table with matching OL_W_ID (equals
+			// O_W_ID), OL_D_ID (equals O_D_ID), and OL_O_ID (equals O_ID) are
+			// selected. All OL_DELIVERY_D, the delivery dates, are updated to
+			// the current system time as returned by the operating system and
+			// the sum of all OL_AMOUNT is retrieved.
 			_, err = tx.ExecEx(
 				ctx,
 				fmt.Sprintf(`

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -78,8 +78,12 @@ type newOrder struct {
 	updateDistrict     workload.StmtHandle
 	selectWarehouseTax workload.StmtHandle
 	selectCustomerInfo workload.StmtHandle
+	selectItemInfos    workload.StmtHandle
+	selectStockInfo    [10]workload.StmtHandle // 0-indexed, by district ID
+	updateStock        workload.StmtHandle
 	insertOrder        workload.StmtHandle
 	insertNewOrder     workload.StmtHandle
+	insertOrderLine    workload.StmtHandle
 }
 
 var _ tpccTx = &newOrder{}
@@ -105,11 +109,48 @@ func createNewOrder(
 		SELECT w_tax FROM warehouse WHERE w_id = $1`,
 	)
 
-	// Select the customer's discount, last name and credit.
+	// Select the customer's discount, last name, and credit.
 	n.selectCustomerInfo = n.sr.Define(`
 		SELECT c_discount, c_last, c_credit
 		FROM customer
 		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+	)
+
+	// For each o_ol_cnt item in the order, query the relevant item row.
+	n.selectItemInfos = n.sr.Define(`
+		SELECT i_price, i_name, i_data
+		FROM item
+		WHERE i_id = ANY ($1)
+		ORDER BY i_id`,
+	)
+
+	// The row in the STOCK table with matching S_I_ID (equals OL_I_ID) and
+	// S_W_ID (equals OL_SUPPLY_W_ID) is selected. S_QUANTITY, the quantity in
+	// stock, S_DIST_xx, where xx represents the district number, and S_DATA are
+	// retrieved.
+	for i := range n.selectStockInfo {
+		n.selectStockInfo[i] = n.sr.Define(fmt.Sprintf(`
+			SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
+			FROM (SELECT unnest($1:::INT[]) AS i_id, unnest($2:::INT[]) AS w_id)
+			INNER LOOKUP JOIN stock ON s_i_id = i_id AND s_w_id = w_id
+			ORDER BY s_i_id`, i+1,
+		))
+	}
+
+	n.updateStock = n.sr.Define(`
+		UPDATE stock
+		SET s_quantity   = new_s_quantity,
+			s_ytd        = new_s_ytd,
+			s_order_cnt  = new_s_order_cnt,
+			s_remote_cnt = new_s_remote_cnt
+		FROM (SELECT 
+			unnest($1:::INT[]) AS i_id,
+			unnest($2:::INT[]) AS w_id,
+			unnest($3:::INT[]) AS new_s_quantity,
+			unnest($4:::INT[]) AS new_s_ytd,
+			unnest($5:::INT[]) AS new_s_order_cnt,
+			unnest($6:::INT[]) AS new_s_remote_cnt)
+		WHERE s_i_id = i_id AND s_w_id = w_id`,
 	)
 
 	n.insertOrder = n.sr.Define(`
@@ -120,6 +161,32 @@ func createNewOrder(
 	n.insertNewOrder = n.sr.Define(`
 		INSERT INTO new_order (no_o_id, no_d_id, no_w_id)
 		VALUES ($1, $2, $3)`,
+	)
+
+	n.insertOrderLine = n.sr.Define(`
+		INSERT INTO order_line
+		(
+			ol_o_id,
+			ol_d_id,
+			ol_w_id,
+			ol_i_id,
+			ol_supply_w_id,
+			ol_number,
+			ol_quantity,
+			ol_amount,
+			ol_dist_info
+		)
+		(
+		 SELECT $1,
+				$2,
+				$3,
+				unnest($4:::INT[]),
+				unnest($5:::INT[]),
+				unnest($6:::INT[]),
+				unnest($7:::INT[]),
+				unnest($8:::DECIMAL[]),
+				unnest($9:::STRING[])
+		)`,
 	)
 
 	if err := n.sr.Init(ctx, "new-order", mcp, config.connFlags); err != nil {
@@ -229,7 +296,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 				return err
 			}
 
-			// Select the customer's discount, last name and credit.
+			// Select the customer's discount, last name, and credit.
 			if err := n.selectCustomerInfo.QueryRowTx(
 				ctx, tx, d.wID, d.dID, d.cID,
 			).Scan(&d.cDiscount, &d.cLast, &d.cCredit); err != nil {
@@ -239,21 +306,11 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			// 2.4.2.2: For each o_ol_cnt item in the order, query the relevant item
 			// row, update the stock row to account for the order, and insert a new
 			// line into the order_line table to reflect the item on the order.
-			itemIDs := make([]string, d.oOlCnt)
+			itemIDs := make([]int64, d.oOlCnt)
 			for i, item := range d.items {
-				itemIDs[i] = fmt.Sprint(item.olIID)
+				itemIDs[i] = int64(item.olIID)
 			}
-			rows, err := tx.QueryEx(
-				ctx,
-				fmt.Sprintf(`
-					SELECT i_price, i_name, i_data
-					FROM item
-					WHERE i_id IN (%[1]s)
-					ORDER BY i_id`,
-					strings.Join(itemIDs, ", "),
-				),
-				nil, /* options */
-			)
+			rows, err := n.selectItemInfos.QueryTx(ctx, tx, itemIDs)
 			if err != nil {
 				return err
 			}
@@ -292,29 +349,29 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 			rows.Close()
 
-			stockIDs := make([]string, d.oOlCnt)
+			// The row in the STOCK table with matching S_I_ID (equals OL_I_ID)
+			// and S_W_ID (equals OL_SUPPLY_W_ID) is selected. S_QUANTITY, the
+			// quantity in stock, S_DIST_xx, where xx represents the district
+			// number, and S_DATA are retrieved.
+			supplyWIDs := make([]int64, d.oOlCnt)
 			for i, item := range d.items {
-				stockIDs[i] = fmt.Sprintf("(%d, %d)", item.olIID, item.olSupplyWID)
+				supplyWIDs[i] = int64(item.olSupplyWID)
 			}
-			rows, err = tx.QueryEx(
-				ctx,
-				fmt.Sprintf(`
-					SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
-					FROM stock
-					WHERE (s_i_id, s_w_id) IN (%[2]s)
-					ORDER BY s_i_id`,
-					d.dID, strings.Join(stockIDs, ", "),
-				),
-				nil, /* options */
-			)
+			rows, err = n.selectStockInfo[d.dID-1].QueryTx(ctx, tx, itemIDs, supplyWIDs)
 			if err != nil {
 				return err
 			}
+
+			// If the retrieved value for S_QUANTITY exceeds OL_QUANTITY by 10
+			// or more, then S_QUANTITY is decreased by OL_QUANTITY; otherwise
+			// S_QUANTITY is updated to (S_QUANTITY - OL_QUANTITY)+91. S_YTD is
+			// increased by OL_QUANTITY and S_ORDER_CNT is incremented by 1. If
+			// the ord er-line is remote, then S_REMOTE_CNT is incremented by 1.
+			newStockQuantities := make([]int64, d.oOlCnt)
+			newStockYtds := make([]int64, d.oOlCnt)
+			newStockOrderCounts := make([]int64, d.oOlCnt)
+			newStockRemoteCounts := make([]int64, d.oOlCnt)
 			distInfos := make([]string, d.oOlCnt)
-			sQuantityUpdateCases := make([]string, d.oOlCnt)
-			sYtdUpdateCases := make([]string, d.oOlCnt)
-			sOrderCntUpdateCases := make([]string, d.oOlCnt)
-			sRemoteCntUpdateCases := make([]string, d.oOlCnt)
 			for i := range d.items {
 				item := &d.items[i]
 
@@ -349,10 +406,10 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 					newSRemoteCnt++
 				}
 
-				sQuantityUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], newSQuantity)
-				sYtdUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], sYtd+item.olQuantity)
-				sOrderCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], sOrderCnt+1)
-				sRemoteCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], newSRemoteCnt)
+				newStockQuantities[i] = int64(newSQuantity)
+				newStockYtds[i] = int64(sYtd + item.olQuantity)
+				newStockOrderCounts[i] = int64(sOrderCnt + 1)
+				newStockRemoteCounts[i] = int64(newSRemoteCnt)
 			}
 			if rows.Next() {
 				return errors.New("extra stock row")
@@ -362,68 +419,45 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 			rows.Close()
 
-			// Insert row into the orders and new orders table.
+			// Update the stock table for each item.
+			if _, err := n.updateStock.ExecTx(
+				ctx, tx, itemIDs, supplyWIDs, newStockQuantities,
+				newStockYtds, newStockOrderCounts, newStockRemoteCounts,
+			); err != nil {
+				return err
+			}
+
+			// Insert row into the orders table.
 			if _, err := n.insertOrder.ExecTx(
 				ctx, tx,
 				d.oID, d.dID, d.wID, d.cID, d.oEntryD.Format("2006-01-02 15:04:05"), d.oOlCnt, allLocal,
 			); err != nil {
 				return err
 			}
+
+			// Insert row into the new orders table.
 			if _, err := n.insertNewOrder.ExecTx(
 				ctx, tx, d.oID, d.dID, d.wID,
 			); err != nil {
 				return err
 			}
 
-			// Update the stock table for each item.
-			if _, err := tx.ExecEx(
-				ctx,
-				fmt.Sprintf(`
-					UPDATE stock
-					SET
-						s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE crdb_internal.force_error('', 'unknown case') END,
-						s_ytd = CASE (s_i_id, s_w_id) %[2]s END,
-						s_order_cnt = CASE (s_i_id, s_w_id) %[3]s END,
-						s_remote_cnt = CASE (s_i_id, s_w_id) %[4]s END
-					WHERE (s_i_id, s_w_id) IN (%[5]s)`,
-					strings.Join(sQuantityUpdateCases, " "),
-					strings.Join(sYtdUpdateCases, " "),
-					strings.Join(sOrderCntUpdateCases, " "),
-					strings.Join(sRemoteCntUpdateCases, " "),
-					strings.Join(stockIDs, ", "),
-				),
-				nil, /* options */
-			); err != nil {
-				return err
-			}
-
 			// Insert a new order line for each item in the order.
-			olValsStrings := make([]string, d.oOlCnt)
+			olNumbers := make([]int64, d.oOlCnt)
+			olQuantities := make([]int64, d.oOlCnt)
+			olAmounts := make([]float64, d.oOlCnt)
 			for i := range d.items {
 				item := &d.items[i]
 				item.olAmount = float64(item.olQuantity) * item.iPrice
 				d.totalAmount += item.olAmount
 
-				olValsStrings[i] = fmt.Sprintf("(%d,%d,%d,%d,%d,%d,%d,%f,'%s')",
-					d.oID,            // ol_o_id
-					d.dID,            // ol_d_id
-					d.wID,            // ol_w_id
-					item.olNumber,    // ol_number
-					item.olIID,       // ol_i_id
-					item.olSupplyWID, // ol_supply_w_id
-					item.olQuantity,  // ol_quantity
-					item.olAmount,    // ol_amount
-					distInfos[i],     // ol_dist_info
-				)
+				olNumbers[i] = int64(item.olNumber)
+				olQuantities[i] = int64(item.olQuantity)
+				olAmounts[i] = item.olAmount
 			}
-			if _, err := tx.ExecEx(
-				ctx,
-				fmt.Sprintf(`
-					INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-					VALUES %s`,
-					strings.Join(olValsStrings, ", "),
-				),
-				nil, /* options */
+			if _, err := n.insertOrderLine.ExecTx(
+				ctx, tx, d.oID, d.dID, d.wID, itemIDs, supplyWIDs,
+				olNumbers, olQuantities, olAmounts, distInfos,
 			); err != nil {
 				return err
 			}

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -135,7 +135,6 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 	)
 
 	// Insert history line.
-
 	p.insertHistory = p.sr.Define(`
 		INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
@@ -244,7 +243,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
 				&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
 			); err != nil {
-				return errors.Wrap(err, "select by customer idfail")
+				return errors.Wrap(err, "update customer fail")
 			}
 
 			hData := fmt.Sprintf("%s    %s", wName, dName)

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -67,19 +67,15 @@ func createStockLevel(
 
 	// Count the number of recently sold items that have a stock level below
 	// the threshold.
-	// TODO(radu): we use count(DISTINCT s_i_id) because DISTINCT inside
-	// aggregates was not supported by the optimizer. This can be cleaned up.
 	s.countRecentlySold = s.sr.Define(`
-		SELECT count(*) FROM (
-			SELECT DISTINCT s_i_id
-			FROM order_line
-			JOIN stock
-			ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-			WHERE ol_w_id = $1
-				AND ol_d_id = $2
-				AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
-				AND s_quantity < $4
-		)`,
+		SELECT count(DISTINCT s_i_id)
+		FROM order_line
+		JOIN stock
+		ON s_w_id = $1 AND s_i_id = ol_i_id
+		WHERE ol_w_id = $1
+		  AND ol_d_id = $2
+		  AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
+		  AND s_quantity < $4`,
 	)
 
 	if err := s.sr.Init(ctx, "stock-level", mcp, config.connFlags); err != nil {

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -86,6 +86,8 @@ type tpcc struct {
 		values [][]int
 	}
 	localsPool *sync.Pool
+
+	deliveryQueue deliveryQueue
 }
 
 type waitSetter struct {
@@ -292,6 +294,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 			}
 
 			w.auditor = newAuditor(w.warehouses)
+			w.deliveryQueue = newDeliveryQueue(w.warehouses)
 
 			// Create a partitioner to help us partition the warehouses. The base-case is
 			// where w.warehouses == w.activeWarehouses and w.partitions == 1.


### PR DESCRIPTION
This PR contains a series of optimizations to TPC-C that I'm hoping to land before our next large-scale TPC-C test. The optimizations build off some of the insights gained while optimizing TPC-E, like using array placeholders and `unnest` to support "vectorized" prepared statements and to batch small statements into larger statements whenever possible. It also implements spec-compliant mutual exclusion for Delivery transactions operating on the same warehouse, which is mostly useless with wait times enabled, but was critical to keep tail latencies under control in a test like the one discussed in https://github.com/cockroachdb/cockroach/pull/30624#issuecomment-687469115.

See the individual commit messages for more detail.

When combined with https://github.com/cockroachdb/cockroach/pull/30624, this gives the following speedup:
```
name                     old warehouses  new warehouses  delta
tpccbench/nodes=3/cpu=4        753 ± 3%        809 ± 2%  +7.44%  (p=0.000 n=9+7)
```

Release justification: testing only