### PR TITLE
builtins: add ST_LineFromMultiPoint and ST_LineMerge

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1790,6 +1790,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 <p>Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
+<tr><td><a name="st_linefrommultipoint"></a><code>st_linefrommultipoint(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Creates a LineString from a MultiPoint geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_linefromtext"></a><code>st_linefromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not LineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_linefromtext"></a><code>st_linefromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not LineString, NULL is returned.</p>
@@ -1807,6 +1809,9 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_lineinterpolatepoints"></a><code>st_lineinterpolatepoints(geometry: geometry, fraction: <a href="float.html">float</a>, repeat: <a href="bool.html">bool</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns one or more points along the LineString which is at an integral multiples of given fraction of LineString’s total length. If repeat is false (default true) then it returns first point.</p>
 <p>Note If the result has zero or one points, it will be returned as a POINT. If it has two or more points, it will be returned as a MULTIPOINT.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_linemerge"></a><code>st_linemerge(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a LineString or MultiLineString by joining together constituents of a MultiLineString with matching endpoints. If the input is not a MultiLineString or LineString, an empty GeometryCollection is returned.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_linestringfromtext"></a><code>st_linestringfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not LineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -352,6 +352,19 @@ func Normalize(a geopb.EWKB) (geopb.EWKB, error) {
 	return cStringToSafeGoBytes(cEWKB), nil
 }
 
+// LineMerge merges multilinestring constituents.
+func LineMerge(a geopb.EWKB) (geopb.EWKB, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, err
+	}
+	var cEWKB C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_LineMerge(g, goToCSlice(a), &cEWKB)); err != nil {
+		return nil, err
+	}
+	return cStringToSafeGoBytes(cEWKB), nil
+}
+
 // IsSimple returns whether the EWKB is simple.
 func IsSimple(ewkb geopb.EWKB) (bool, error) {
 	g, err := ensureInitInternal()

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -85,6 +85,7 @@ CR_GEOS_Status CR_GEOS_MakeValid(CR_GEOS* lib, CR_GEOS_Slice g, CR_GEOS_String* 
 CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Normalize(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* normalizedEWKB);
+CR_GEOS_Status CR_GEOS_LineMerge(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* ewkb);
 
 //
 // Unary predicates.

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4685,6 +4685,36 @@ POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, -0.1 1,
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
 
+subtest linefrommultipoint_test
+
+query T
+SELECT
+  ST_AsText(ST_LineFromMultiPoint(mp::geometry))
+FROM ( VALUES
+  ('MULTIPOINT EMPTY'),
+  ('MULTIPOINT (1 1, 2 2, 3 3)')
+  )
+ t(mp) ;
+----
+LINESTRING EMPTY
+LINESTRING (1 1, 2 2, 3 3)
+
+subtest linemerge
+
+query T
+SELECT
+  ST_AsText(ST_LineMerge(g::geometry))
+FROM ( VALUES
+  ('MULTILINESTRING ((1 2, 3 4), (3 4, 5 6))'),
+  ('MULTILINESTRING ((1 2, 3 4), (5 6, 7 8)))'),
+  ('POINT (1 2)')
+  )
+ t(g) ;
+----
+LINESTRING (1 2, 3 4, 5 6)
+MULTILINESTRING ((1 2, 3 4), (5 6, 7 8))
+GEOMETRYCOLLECTION EMPTY
+
 subtest public_schema_resolution
 
 query T

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2430,6 +2430,43 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_linefrommultipoint": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				line, err := geomfn.LineStringFromMultiPoint(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeometry{Geometry: line}, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Creates a LineString from a MultiPoint geometry.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_linemerge": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				line, err := geomfn.LineMerge(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeometry{Geometry: line}, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Returns a LineString or MultiLineString by joining together constituents of a ` +
+					`MultiLineString with matching endpoints. If the input is not a MultiLineString or LineString, ` +
+					`an empty GeometryCollection is returned.`,
+				libraryUsage: usesGEOS,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 
 	//
 	// Unary predicates
@@ -4667,9 +4704,7 @@ Bottom Left.`,
 	"st_length2dspheroid":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48967}),
 	"st_lengthspheroid":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48968}),
 	"st_linecrossingdirection":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48969}),
-	"st_linefrommultipoint":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48970}),
 	"st_linelocatepoint":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48973}),
-	"st_linemerge":               makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48974}),
 	"st_linesubstring":           makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48975}),
 	"st_memsize":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48985}),
 	"st_minimumboundingcircle":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48987}),


### PR DESCRIPTION
One test case for `ST_LineFromMultiPoint` is commented out until #53997 is resolved - this may fail and need code changes.

Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): Implement the geometry builtins
`ST_LineFromMultiPoint` and `ST_LineMerge`.

Closes #48970.
Closes #48974.