### PR TITLE
sql: add crdb_internal.invalid_descriptors

### DIFF
--- a/output
+++ b/output
@@ -1,0 +1,192 @@
+=== RUN   TestInvalidObjects
+WARNING: DATA RACE
+Read at 0x00c001210000 by goroutine 36:
+
+  github.com/cockroachdb/pebble/internal/record.(*LogWriter).emitEOFTrailer()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/internal/record/log_writer.go:625 +0x5b
+
+  github.com/cockroachdb/pebble/internal/record.(*LogWriter).Close()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/internal/record/log_writer.go:540 +0x3e
+
+  github.com/cockroachdb/pebble.(*DB).Close()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/db.go:876 +0x38e
+
+  github.com/cockroachdb/cockroach/pkg/storage.(*Pebble).Close()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/storage/pebble.go:610 +0xe5
+
+  github.com/cockroachdb/cockroach/pkg/server.(*Engines).Close()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/server/config.go:452 +0x8d
+
+  github.com/cockroachdb/cockroach/pkg/util/stop.(*Stopper).Stop()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/stop/stopper.go:518 +0x540
+
+  github.com/cockroachdb/cockroach/pkg/sql_test.TestInvalidObjects()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/sql/crdb_internal_test.go:493 +0xf87
+
+  testing.tRunner()
+
+      /usr/local/go/src/testing/testing.go:909 +0x199
+
+
+Previous write at 0x00c001210000 by goroutine 474:
+
+  sync/atomic.StoreInt32()
+
+      /usr/local/go/src/runtime/race_amd64.s:229 +0xb
+
+  github.com/cockroachdb/pebble/internal/record.(*LogWriter).emitFragment()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/internal/record/log_writer.go:659 +0x56b
+
+  github.com/cockroachdb/pebble/internal/record.(*LogWriter).SyncRecord()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/internal/record/log_writer.go:593 +0x9e
+
+  github.com/cockroachdb/pebble.(*DB).commitWrite()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/db.go:650 +0x2bb
+
+  github.com/cockroachdb/pebble.(*DB).commitWrite-fm()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/db.go:601 +0x63
+
+  github.com/cockroachdb/pebble.(*commitPipeline).prepare()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/commit.go:377 +0x347
+
+  github.com/cockroachdb/pebble.(*commitPipeline).Commit()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/commit.go:253 +0xd0
+
+  github.com/cockroachdb/pebble.(*DB).Apply()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/db.go:556 +0x200
+
+  github.com/cockroachdb/cockroach/pkg/storage.(*pebbleBatch).Commit()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/batch.go:727 +0xcc
+
+  github.com/cockroachdb/cockroach/pkg/storage.WriteSyncNoop()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/storage/engine.go:652 +0xeb
+
+  github.com/cockroachdb/cockroach/pkg/kv/kvserver.Server.WaitForApplication.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/stores_server.go:114 +0x269
+
+  github.com/cockroachdb/cockroach/pkg/kv/kvserver.Server.execStoreCommand()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/stores_server.go:42 +0x93
+
+  github.com/cockroachdb/cockroach/pkg/kv/kvserver.Server.WaitForApplication()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/stores_server.go:88 +0xa9
+
+  github.com/cockroachdb/cockroach/pkg/kv/kvserver._PerReplica_WaitForApplication_Handler.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go:281 +0xa1
+
+  github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/server.go:44 +0xbd8
+
+  google.golang.org/grpc.getChainUnaryHandler.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:921 +0x146
+
+  github.com/cockroachdb/cockroach/pkg/rpc.NewServer.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/rpc/context.go:199 +0x135
+
+  google.golang.org/grpc.getChainUnaryHandler.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:921 +0x146
+
+  github.com/cockroachdb/cockroach/pkg/rpc.kvAuth.unaryInterceptor()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/rpc/auth.go:60 +0xbe
+
+  github.com/cockroachdb/cockroach/pkg/rpc.kvAuth.unaryInterceptor-fm()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/rpc/auth.go:47 +0x80
+
+  google.golang.org/grpc.chainUnaryServerInterceptors.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:907 +0x110
+
+  github.com/cockroachdb/cockroach/pkg/kv/kvserver._PerReplica_WaitForApplication_Handler()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go:283 +0x1d8
+
+  google.golang.org/grpc.(*Server).processUnaryRPC()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:1082 +0x954
+
+  google.golang.org/grpc.(*Server).handleStream()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:1405 +0x12bd
+
+  google.golang.org/grpc.(*Server).serveStreams.func1.1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:746 +0xc8
+
+
+Goroutine 36 (running) created at:
+
+  testing.(*T).Run()
+
+      /usr/local/go/src/testing/testing.go:960 +0x651
+
+  testing.runTests.func1()
+
+      /usr/local/go/src/testing/testing.go:1202 +0xa6
+
+  testing.tRunner()
+
+      /usr/local/go/src/testing/testing.go:909 +0x199
+
+  testing.runTests()
+
+      /usr/local/go/src/testing/testing.go:1200 +0x521
+
+  testing.(*M).Run()
+
+      /usr/local/go/src/testing/testing.go:1117 +0x2ff
+
+  github.com/cockroachdb/cockroach/pkg/sql_test.TestMain()
+
+      /go/src/github.com/cockroachdb/cockroach/pkg/sql/main_test.go:32 +0x15b
+
+  main.main()
+
+      _testmain.go:682 +0x223
+
+
+Goroutine 474 (finished) created at:
+
+  google.golang.org/grpc.(*Server).serveStreams.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:744 +0xb8
+
+  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/internal/transport/http2_server.go:442 +0x16a6
+
+  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/internal/transport/http2_server.go:483 +0x459
+
+  google.golang.org/grpc.(*Server).serveStreams()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:742 +0x19a
+
+  google.golang.org/grpc.(*Server).handleRawConn.func1()
+
+      /go/src/github.com/cockroachdb/cockroach/vendor/google.golang.org/grpc/server.go:703 +0x4c

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -783,7 +783,7 @@ func isDatabaseEmpty(
 	dbDesc catalog.DatabaseDescriptor,
 	ignoredChildren map[descpb.ID]struct{},
 ) (bool, error) {
-	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, keys.SystemSQLCodec)
+	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, keys.SystemSQLCodec, true /* validate */)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1049,7 +1049,7 @@ func errOnMissingRange(span covering.Range, start, end hlc.Timestamp) error {
 func getUserDescriptorNames(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 ) ([]string, error) {
-	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, codec)
+	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, codec, true /* validate */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -698,7 +698,7 @@ func loadAllDescs(
 		ctx,
 		func(ctx context.Context, txn *kv.Txn) (err error) {
 			txn.SetFixedTimestamp(ctx, asOf)
-			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, keys.SystemSQLCodec)
+			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, keys.SystemSQLCodec, true /* validate */)
 			return err
 		}); err != nil {
 		return nil, err

--- a/pkg/cli/testdata/doctor/testzipdir
+++ b/pkg/cli/testdata/doctor/testzipdir
@@ -2,12 +2,12 @@ doctor zipdir
 ----
 debug doctor zipdir testdata/doctor/debugzip
 Examining 38 descriptors and 43 namespace entries...
-   Table  53: ParentID  52, ParentSchemaID 29, Name 'users': parentID 52 does not exist
-   Table  54: ParentID  52, ParentSchemaID 29, Name 'vehicles': parentID 52 does not exist
-   Table  55: ParentID  52, ParentSchemaID 29, Name 'rides': parentID 52 does not exist
-   Table  56: ParentID  52, ParentSchemaID 29, Name 'vehicle_location_histories': parentID 52 does not exist
-   Table  57: ParentID  52, ParentSchemaID 29, Name 'promo_codes': parentID 52 does not exist
-   Table  58: ParentID  52, ParentSchemaID 29, Name 'user_promo_codes': parentID 52 does not exist
+   Table  53: ParentID  52, ParentSchemaID 29, Name 'users': desc 53: parentID 52 does not exist
+   Table  54: ParentID  52, ParentSchemaID 29, Name 'vehicles': desc 54: parentID 52 does not exist
+   Table  55: ParentID  52, ParentSchemaID 29, Name 'rides': desc 55: parentID 52 does not exist
+   Table  56: ParentID  52, ParentSchemaID 29, Name 'vehicle_location_histories': desc 56: parentID 52 does not exist
+   Table  57: ParentID  52, ParentSchemaID 29, Name 'promo_codes': desc 57: parentID 52 does not exist
+   Table  58: ParentID  52, ParentSchemaID 29, Name 'user_promo_codes': desc 58: parentID 52 does not exist
 Descriptor 52: has namespace row(s) [{ParentID:0 ParentSchemaID:0 Name:movr}] but no descriptor
 Examining 1 running jobs...
 job 587337426984566785: schema change GC refers to missing table descriptor(s) [59]

--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -24,6 +24,7 @@ retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_int
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -24,6 +24,7 @@ retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_int
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -24,6 +24,7 @@ retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_int
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -24,6 +24,7 @@ retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_int
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 requesting CPU profiles... ok

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -77,6 +77,7 @@ var debugZipTablesPerCluster = []string{
 	"crdb_internal.schema_changes",
 	"crdb_internal.partitions",
 	"crdb_internal.zones",
+	"crdb_internal.invalid_objects",
 }
 
 // Tables collected from each node in a debug zip.

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -74,6 +74,7 @@ const (
 	CrdbInternalTransactionStatsTableID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalZonesTableID
+	CrdbInternalInvalidDescriptorsTableID
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1443,7 +1443,7 @@ func (desc *Immutable) Validate(ctx context.Context, dg catalog.DescGetter) erro
 	if desc.Dropped() {
 		return nil
 	}
-	return desc.validateCrossReferences(ctx, dg)
+	return errors.Wrapf(desc.validateCrossReferences(ctx, dg), "desc %d", desc.GetID())
 }
 
 // validateTableIfTesting is similar to validateTable, except it is only invoked

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -146,12 +146,12 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	// the predefined forEachTableAll() function because we need to look
 	// at all _visible_ descriptors, not just those on which the current
 	// user has permission.
-	descs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn)
+	descs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn, true /* validate */)
 	if err != nil {
 		return err
 	}
 
-	lCtx := newInternalLookupCtx(params.ctx, descs, nil /*prefix - we want all descriptors */)
+	lCtx := newInternalLookupCtx(params.ctx, descs, nil /*prefix - we want all descriptors */, nil /* fallback */)
 	// privileges are added.
 	for _, tbID := range lCtx.tbIDs {
 		table := lCtx.tbDescs[tbID]

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1735,7 +1735,8 @@ func forEachTypeDesc(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
+		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 	for _, id := range lCtx.typIDs {
 		typ := lCtx.typDescs[id]
 		dbDesc, parentExists := lCtx.dbDescs[typ.ParentID]
@@ -1773,7 +1774,6 @@ func forEachTableDesc(
 	p *planner,
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	// TODO(ajwerner): Introduce TableDescriptor.
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
 	return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts, func(
@@ -1904,7 +1904,8 @@ func forEachTableDescWithTableLookupInternal(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(ctx, descs, dbContext)
+	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
+		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 
 	if virtualOpts == virtualMany || virtualOpts == virtualOnce {
 		// Virtual descriptors first.

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1605,7 +1605,7 @@ CREATE TABLE information_schema.views (
 func forEachSchema(
 	ctx context.Context, p *planner, db *dbdesc.Immutable, fn func(sc catalog.ResolvedSchema) error,
 ) error {
-	schemaNames, err := getSchemaNames(ctx, p, db)
+	schemaNames, err := getSchemaNames(ctx, p, db, false /* allowMissingDesc */)
 	if err != nil {
 		return err
 	}
@@ -1684,7 +1684,9 @@ func forEachDatabaseDesc(
 ) error {
 	var dbDescs []*dbdesc.Immutable
 	if dbContext == nil {
-		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
+		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(
+			ctx, p.txn, false, /* allowMissingDesc */
+		)
 		if err != nil {
 			return err
 		}
@@ -1692,7 +1694,9 @@ func forEachDatabaseDesc(
 	} else {
 		// We can't just use dbContext here because we need to fetch the descriptor
 		// with privileges from kv.
-		fetchedDbDesc, err := catalogkv.GetDatabaseDescriptorsFromIDs(ctx, p.txn, p.ExecCfg().Codec, []descpb.ID{dbContext.GetID()})
+		fetchedDbDesc, err := catalogkv.GetDatabaseDescriptorsFromIDs(
+			ctx, p.txn, p.ExecCfg().Codec, []descpb.ID{dbContext.GetID()}, false, /* allowMissingDesc */
+		)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				return pgerror.Newf(pgcode.UndefinedDatabase, "database %s does not exist", dbContext.GetName())
@@ -1723,11 +1727,11 @@ func forEachTypeDesc(
 	dbContext *dbdesc.Immutable,
 	fn func(db *dbdesc.Immutable, sc string, typ *typedesc.Immutable) error,
 ) error {
-	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn, true /* validate */)
 	if err != nil {
 		return err
 	}
-	schemaNames, err := getSchemaNames(ctx, p, dbContext)
+	schemaNames, err := getSchemaNames(ctx, p, dbContext, false /* allowMissingDesc */)
 	if err != nil {
 		return err
 	}
@@ -1803,7 +1807,7 @@ func forEachTableDescAll(
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
 	return forEachTableDescAllWithTableLookup(ctx,
-		p, dbContext, virtualOpts,
+		p, dbContext, virtualOpts, true, /* validate */
 		func(
 			db *dbdesc.Immutable,
 			scName string,
@@ -1815,16 +1819,19 @@ func forEachTableDescAll(
 }
 
 // forEachTableDescAllWithTableLookup is like forEachTableDescAll, but it also
-// provides a tableLookupFn like forEachTableDescWithTableLookup.
+// provides a tableLookupFn like forEachTableDescWithTableLookup. If validate is
+// set to false descriptors will not be validated for existence or consistency
+// hence fn should be able to handle nil-s.
 func forEachTableDescAllWithTableLookup(
 	ctx context.Context,
 	p *planner,
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
+	validate bool,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(ctx,
-		p, dbContext, virtualOpts, true /* allowAdding */, fn)
+		p, dbContext, virtualOpts, true /* allowAdding */, validate, fn)
 }
 
 // forEachTableDescWithTableLookup acts like forEachTableDesc, except it also provides a
@@ -1843,21 +1850,29 @@ func forEachTableDescWithTableLookup(
 	virtualOpts virtualOpts,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
-	return forEachTableDescWithTableLookupInternal(ctx, p, dbContext, virtualOpts, false /* allowAdding */, fn)
+	return forEachTableDescWithTableLookupInternal(
+		ctx, p, dbContext, virtualOpts, false /* allowAdding */, true, fn,
+	)
 }
 
 func getSchemaNames(
-	ctx context.Context, p *planner, dbContext *dbdesc.Immutable,
+	ctx context.Context, p *planner, dbContext *dbdesc.Immutable, allowMissingDesc bool,
 ) (map[descpb.ID]string, error) {
 	if dbContext != nil {
 		return p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbContext.GetID())
 	}
 	ret := make(map[descpb.ID]string)
-	dbs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
+	dbs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn, allowMissingDesc)
 	if err != nil {
 		return nil, err
 	}
 	for _, db := range dbs {
+		if db == nil {
+			if allowMissingDesc {
+				continue
+			}
+			return nil, catalog.ErrDescriptorNotFound
+		}
 		schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, db.GetID())
 		if err != nil {
 			return nil, err
@@ -1874,15 +1889,18 @@ func getSchemaNames(
 //
 // The allowAdding argument if true includes newly added tables that
 // are not yet public.
+// The validate argument if false turns off checking if the descriptor ids exist
+// and if they are valid.
 func forEachTableDescWithTableLookupInternal(
 	ctx context.Context,
 	p *planner,
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
 	allowAdding bool,
+	validate bool,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
-	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn, validate)
 	if err != nil {
 		return err
 	}
@@ -1922,7 +1940,7 @@ func forEachTableDescWithTableLookupInternal(
 	}
 
 	// Generate all schema names, and keep a mapping.
-	schemaNames, err := getSchemaNames(ctx, p, dbContext)
+	schemaNames, err := getSchemaNames(ctx, p, dbContext, !validate)
 	if err != nil {
 		return err
 	}
@@ -1930,13 +1948,17 @@ func forEachTableDescWithTableLookupInternal(
 	// Physical descriptors next.
 	for _, tbID := range lCtx.tbIDs {
 		table := lCtx.tbDescs[tbID]
-		dbDesc, parentExists := lCtx.dbDescs[table.GetParentID()]
-		if table.Dropped() || !userCanSeeDescriptor(ctx, p, table, allowAdding) || !parentExists {
+		if table.Dropped() || !userCanSeeDescriptor(ctx, p, table, allowAdding) {
 			continue
 		}
-		scName, ok := schemaNames[table.GetParentSchemaID()]
-		if !ok {
-			return errors.AssertionFailedf("schema id %d not found", table.GetParentSchemaID())
+		var scName string
+		dbDesc, parentExists := lCtx.dbDescs[table.GetParentID()]
+		if parentExists {
+			var ok bool
+			scName, ok = schemaNames[table.GetParentSchemaID()]
+			if !ok && validate {
+				return errors.AssertionFailedf("schema id %d not found", table.GetParentSchemaID())
+			}
 		}
 		if err := fn(dbDesc, scName, table, lCtx); err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1401,4 +1401,3 @@ ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT v_unique TO 
 
 statement error relation idx_v already exists
 ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO idx_v;
-

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -27,6 +27,7 @@ crdb_internal  gossip_liveness              table  NULL  NULL
 crdb_internal  gossip_network               table  NULL  NULL
 crdb_internal  gossip_nodes                 table  NULL  NULL
 crdb_internal  index_columns                table  NULL  NULL
+crdb_internal  invalid_objects              table  NULL  NULL
 crdb_internal  jobs                         table  NULL  NULL
 crdb_internal  kv_node_status               table  NULL  NULL
 crdb_internal  kv_store_status              table  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -52,6 +52,7 @@ test           crdb_internal       gossip_liveness                    public   S
 test           crdb_internal       gossip_network                     public   SELECT
 test           crdb_internal       gossip_nodes                       public   SELECT
 test           crdb_internal       index_columns                      public   SELECT
+test           crdb_internal       invalid_objects                    public   SELECT
 test           crdb_internal       jobs                               public   SELECT
 test           crdb_internal       kv_node_status                     public   SELECT
 test           crdb_internal       kv_store_status                    public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -238,6 +238,7 @@ crdb_internal       gossip_liveness
 crdb_internal       gossip_network
 crdb_internal       gossip_nodes
 crdb_internal       index_columns
+crdb_internal       invalid_objects
 crdb_internal       jobs
 crdb_internal       kv_node_status
 crdb_internal       kv_store_status
@@ -391,6 +392,7 @@ gossip_liveness
 gossip_network
 gossip_nodes
 index_columns
+invalid_objects
 jobs
 kv_node_status
 kv_store_status
@@ -553,6 +555,7 @@ system         crdb_internal       gossip_liveness                    SYSTEM VIE
 system         crdb_internal       gossip_network                     SYSTEM VIEW  NO                  1
 system         crdb_internal       gossip_nodes                       SYSTEM VIEW  NO                  1
 system         crdb_internal       index_columns                      SYSTEM VIEW  NO                  1
+system         crdb_internal       invalid_objects                    SYSTEM VIEW  NO                  1
 system         crdb_internal       jobs                               SYSTEM VIEW  NO                  1
 system         crdb_internal       kv_node_status                     SYSTEM VIEW  NO                  1
 system         crdb_internal       kv_store_status                    SYSTEM VIEW  NO                  1
@@ -1661,6 +1664,7 @@ NULL     public   system         crdb_internal       gossip_liveness            
 NULL     public   system         crdb_internal       gossip_network                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       gossip_nodes                       SELECT          NULL          YES
 NULL     public   system         crdb_internal       index_columns                      SELECT          NULL          YES
+NULL     public   system         crdb_internal       invalid_objects                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       jobs                               SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_node_status                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_store_status                    SELECT          NULL          YES
@@ -2039,6 +2043,7 @@ NULL     public   system         crdb_internal       gossip_liveness            
 NULL     public   system         crdb_internal       gossip_network                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       gossip_nodes                       SELECT          NULL          YES
 NULL     public   system         crdb_internal       index_columns                      SELECT          NULL          YES
+NULL     public   system         crdb_internal       invalid_objects                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       jobs                               SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_node_status                     SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_store_status                    SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -945,8 +945,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967218  2143281868  0         4294967220  450499961  0            n
-4294967218  4089604113  0         4294967220  450499960  0            n
+4294967217  2143281868  0         4294967219  450499961  0            n
+4294967217  4089604113  0         4294967219  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -958,7 +958,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967218  4294967220  pg_constraint  pg_class
+4294967217  4294967219  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1628,123 +1628,124 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967220  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967220  0         built-in functions (RAM/static)
-4294967291  4294967220  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967220  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967220  0         cluster settings (RAM)
-4294967290  4294967220  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967220  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967220  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967220  0         databases accessible by the current user (KV scan)
-4294967284  4294967220  0         telemetry counters (RAM; local node only)
-4294967283  4294967220  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967220  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967220  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967220  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967220  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967220  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967277  4294967220  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967220  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967220  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967220  0         acquired table leases (RAM; local node only)
-4294967293  4294967220  0         detailed identification strings (RAM, local node only)
-4294967270  4294967220  0         current values for metrics (RAM; local node only)
-4294967273  4294967220  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967220  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967220  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967220  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967256  4294967220  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967220  0         running user transactions visible by the current user (RAM; local node only)
-4294967255  4294967220  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967220  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967220  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967220  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967220  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967220  0         session trace accumulated so far (RAM)
-4294967262  4294967220  0         session variables (RAM)
-4294967260  4294967220  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967220  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967220  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967220  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967254  4294967220  0         decoded zone configurations from system.zones (KV scan)
-4294967252  4294967220  0         roles for which the current user has admin option
-4294967251  4294967220  0         roles available to the current user
-4294967250  4294967220  0         check constraints
-4294967249  4294967220  0         column privilege grants (incomplete)
-4294967247  4294967220  0         columns with user defined types
-4294967248  4294967220  0         table and view columns (incomplete)
-4294967246  4294967220  0         columns usage by constraints
-4294967245  4294967220  0         roles for the current user
-4294967244  4294967220  0         column usage by indexes and key constraints
-4294967243  4294967220  0         built-in function parameters (empty - introspection not yet supported)
-4294967242  4294967220  0         foreign key constraints
-4294967241  4294967220  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967240  4294967220  0         built-in functions (empty - introspection not yet supported)
-4294967238  4294967220  0         schema privileges (incomplete; may contain excess users or roles)
-4294967239  4294967220  0         database schemas (may contain schemata without permission)
-4294967237  4294967220  0         sequences
-4294967236  4294967220  0         index metadata and statistics (incomplete)
-4294967235  4294967220  0         table constraints
-4294967234  4294967220  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967233  4294967220  0         tables and views
-4294967232  4294967220  0         type privileges (incomplete; may contain excess users or roles)
-4294967230  4294967220  0         grantable privileges (incomplete)
-4294967231  4294967220  0         views (incomplete)
-4294967228  4294967220  0         aggregated built-in functions (incomplete)
-4294967227  4294967220  0         index access methods (incomplete)
-4294967226  4294967220  0         column default values
-4294967225  4294967220  0         table columns (incomplete - see also information_schema.columns)
-4294967223  4294967220  0         role membership
-4294967224  4294967220  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967222  4294967220  0         available extensions
-4294967221  4294967220  0         casts (empty - needs filling out)
-4294967220  4294967220  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967219  4294967220  0         available collations (incomplete)
-4294967218  4294967220  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967217  4294967220  0         encoding conversions (empty - unimplemented)
-4294967216  4294967220  0         available databases (incomplete)
-4294967215  4294967220  0         default ACLs (empty - unimplemented)
-4294967214  4294967220  0         dependency relationships (incomplete)
-4294967213  4294967220  0         object comments
-4294967211  4294967220  0         enum types and labels (empty - feature does not exist)
-4294967210  4294967220  0         event triggers (empty - feature does not exist)
-4294967209  4294967220  0         installed extensions (empty - feature does not exist)
-4294967208  4294967220  0         foreign data wrappers (empty - feature does not exist)
-4294967207  4294967220  0         foreign servers (empty - feature does not exist)
-4294967206  4294967220  0         foreign tables (empty  - feature does not exist)
-4294967205  4294967220  0         indexes (incomplete)
-4294967204  4294967220  0         index creation statements
-4294967203  4294967220  0         table inheritance hierarchy (empty - feature does not exist)
-4294967202  4294967220  0         available languages (empty - feature does not exist)
-4294967201  4294967220  0         locks held by active processes (empty - feature does not exist)
-4294967200  4294967220  0         available materialized views (empty - feature does not exist)
-4294967199  4294967220  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967198  4294967220  0         operators (incomplete)
-4294967197  4294967220  0         prepared statements
-4294967196  4294967220  0         prepared transactions (empty - feature does not exist)
-4294967195  4294967220  0         built-in functions (incomplete)
-4294967194  4294967220  0         range types (empty - feature does not exist)
-4294967193  4294967220  0         rewrite rules (empty - feature does not exist)
-4294967192  4294967220  0         database roles
-4294967179  4294967220  0         security labels (empty - feature does not exist)
-4294967191  4294967220  0         security labels (empty)
-4294967190  4294967220  0         sequences (see also information_schema.sequences)
-4294967189  4294967220  0         session variables (incomplete)
-4294967188  4294967220  0         shared dependencies (empty - not implemented)
-4294967212  4294967220  0         shared object comments
-4294967178  4294967220  0         shared security labels (empty - feature not supported)
-4294967180  4294967220  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967185  4294967220  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967184  4294967220  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967183  4294967220  0         triggers (empty - feature does not exist)
-4294967182  4294967220  0         scalar types (incomplete)
-4294967187  4294967220  0         database users
-4294967186  4294967220  0         local to remote user mapping (empty - feature does not exist)
-4294967181  4294967220  0         view definitions (incomplete - see also information_schema.views)
-4294967176  4294967220  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967175  4294967220  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967174  4294967220  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967219  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967219  0         built-in functions (RAM/static)
+4294967291  4294967219  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967219  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967219  0         cluster settings (RAM)
+4294967290  4294967219  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967219  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967219  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967219  0         databases accessible by the current user (KV scan)
+4294967284  4294967219  0         telemetry counters (RAM; local node only)
+4294967283  4294967219  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967219  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967219  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967219  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967219  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967219  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967253  4294967219  0         virtual table to validate descriptors
+4294967277  4294967219  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967219  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967219  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967219  0         acquired table leases (RAM; local node only)
+4294967293  4294967219  0         detailed identification strings (RAM, local node only)
+4294967270  4294967219  0         current values for metrics (RAM; local node only)
+4294967273  4294967219  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967219  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967219  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967219  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967256  4294967219  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967219  0         running user transactions visible by the current user (RAM; local node only)
+4294967255  4294967219  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967219  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967219  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967219  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967219  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967219  0         session trace accumulated so far (RAM)
+4294967262  4294967219  0         session variables (RAM)
+4294967260  4294967219  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967219  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967219  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967219  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967254  4294967219  0         decoded zone configurations from system.zones (KV scan)
+4294967251  4294967219  0         roles for which the current user has admin option
+4294967250  4294967219  0         roles available to the current user
+4294967249  4294967219  0         check constraints
+4294967248  4294967219  0         column privilege grants (incomplete)
+4294967246  4294967219  0         columns with user defined types
+4294967247  4294967219  0         table and view columns (incomplete)
+4294967245  4294967219  0         columns usage by constraints
+4294967244  4294967219  0         roles for the current user
+4294967243  4294967219  0         column usage by indexes and key constraints
+4294967242  4294967219  0         built-in function parameters (empty - introspection not yet supported)
+4294967241  4294967219  0         foreign key constraints
+4294967240  4294967219  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967239  4294967219  0         built-in functions (empty - introspection not yet supported)
+4294967237  4294967219  0         schema privileges (incomplete; may contain excess users or roles)
+4294967238  4294967219  0         database schemas (may contain schemata without permission)
+4294967236  4294967219  0         sequences
+4294967235  4294967219  0         index metadata and statistics (incomplete)
+4294967234  4294967219  0         table constraints
+4294967233  4294967219  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967232  4294967219  0         tables and views
+4294967231  4294967219  0         type privileges (incomplete; may contain excess users or roles)
+4294967229  4294967219  0         grantable privileges (incomplete)
+4294967230  4294967219  0         views (incomplete)
+4294967227  4294967219  0         aggregated built-in functions (incomplete)
+4294967226  4294967219  0         index access methods (incomplete)
+4294967225  4294967219  0         column default values
+4294967224  4294967219  0         table columns (incomplete - see also information_schema.columns)
+4294967222  4294967219  0         role membership
+4294967223  4294967219  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967221  4294967219  0         available extensions
+4294967220  4294967219  0         casts (empty - needs filling out)
+4294967219  4294967219  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967218  4294967219  0         available collations (incomplete)
+4294967217  4294967219  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967216  4294967219  0         encoding conversions (empty - unimplemented)
+4294967215  4294967219  0         available databases (incomplete)
+4294967214  4294967219  0         default ACLs (empty - unimplemented)
+4294967213  4294967219  0         dependency relationships (incomplete)
+4294967212  4294967219  0         object comments
+4294967210  4294967219  0         enum types and labels (empty - feature does not exist)
+4294967209  4294967219  0         event triggers (empty - feature does not exist)
+4294967208  4294967219  0         installed extensions (empty - feature does not exist)
+4294967207  4294967219  0         foreign data wrappers (empty - feature does not exist)
+4294967206  4294967219  0         foreign servers (empty - feature does not exist)
+4294967205  4294967219  0         foreign tables (empty  - feature does not exist)
+4294967204  4294967219  0         indexes (incomplete)
+4294967203  4294967219  0         index creation statements
+4294967202  4294967219  0         table inheritance hierarchy (empty - feature does not exist)
+4294967201  4294967219  0         available languages (empty - feature does not exist)
+4294967200  4294967219  0         locks held by active processes (empty - feature does not exist)
+4294967199  4294967219  0         available materialized views (empty - feature does not exist)
+4294967198  4294967219  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967197  4294967219  0         operators (incomplete)
+4294967196  4294967219  0         prepared statements
+4294967195  4294967219  0         prepared transactions (empty - feature does not exist)
+4294967194  4294967219  0         built-in functions (incomplete)
+4294967193  4294967219  0         range types (empty - feature does not exist)
+4294967192  4294967219  0         rewrite rules (empty - feature does not exist)
+4294967191  4294967219  0         database roles
+4294967178  4294967219  0         security labels (empty - feature does not exist)
+4294967190  4294967219  0         security labels (empty)
+4294967189  4294967219  0         sequences (see also information_schema.sequences)
+4294967188  4294967219  0         session variables (incomplete)
+4294967187  4294967219  0         shared dependencies (empty - not implemented)
+4294967211  4294967219  0         shared object comments
+4294967177  4294967219  0         shared security labels (empty - feature not supported)
+4294967179  4294967219  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967184  4294967219  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967183  4294967219  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967182  4294967219  0         triggers (empty - feature does not exist)
+4294967181  4294967219  0         scalar types (incomplete)
+4294967186  4294967219  0         database users
+4294967185  4294967219  0         local to remote user mapping (empty - feature does not exist)
+4294967180  4294967219  0         view definitions (incomplete - see also information_schema.views)
+4294967175  4294967219  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967174  4294967219  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967173  4294967219  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -548,6 +548,7 @@ gossip_liveness                    NULL
 gossip_network                     NULL
 gossip_nodes                       NULL
 index_columns                      NULL
+invalid_objects                    NULL
 jobs                               NULL
 kv_node_status                     NULL
 kv_store_status                    NULL


### PR DESCRIPTION
This commit adds a new crdb_internal table that pulls all of the
descriptors for a given db context and validates them all (including
their cross-database references). To use it one can do the following to
validate all of the tables in the current database:

```
SELECT * FROM crdb_internal.invalid_descriptors
```

To validate all descriptors in all databases, one uses the special ""
database context like in all other crdb_internal tables. That looks
like:

```
SELECT * FROM "".crdb_internal.invalid_descriptors
```

Touches #53571.
Touches #53754.

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): Added a new virtual table
`crdb_internal.invalid_descriptors` which runs validations on
descriptors in the database context and reports any errors.