### PR TITLE
roachtest: de-flake 'inconsistent'

### DIFF
--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -39,10 +39,6 @@ func runInconsistency(ctx context.Context, t *test, c *cluster) {
 
 	{
 		db := c.Conn(ctx, 1)
-		_, err := db.ExecContext(ctx, `SET CLUSTER SETTING server.consistency_check.interval = '10ms'`)
-		if err != nil {
-			t.Fatal(err)
-		}
 		waitForFullReplication(t, db)
 		_, db = db.Close(), nil
 	}
@@ -85,6 +81,20 @@ func runInconsistency(ctx context.Context, t *test, c *cluster) {
 		}
 		return nil
 	})
+
+	// set an aggressive consistency check interval, but only now (that we're
+	// reasonably sure all nodes are live, etc). This makes sure that the consistency
+	// check runs against all three nodes. If it targeted only two nodes, a random
+	// one would fatal - not what we want.
+	{
+		db := c.Conn(ctx, 2)
+		_, err := db.ExecContext(ctx, `SET CLUSTER SETTING server.consistency_check.interval = '10ms'`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = db.Close()
+	}
+
 	if err := m.WaitE(); err == nil {
 		t.Fatal("expected a node to crash")
 	}


### PR DESCRIPTION
This test sets up an intentionally corrupted replica and wants its node
to shut down as a result of its detection. When only two of the three
nodes were included in the consistency check, either one of them could
end up terminating (as no obvious majority of healthy replicas can be
determined). Change the test so that we wait for the cluster to come
fully together before setting a low consistency check interval.

Closes #54005.

Release justification: testing
Release note: None
