### PR TITLE
opt: fix issue with FastIntSet copy in statisticsBuilder

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -640,7 +640,7 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 	// unconstrained scan over a partial index. The selectivity of the partial
 	// index predicate expression must be applied to the underlying table stats.
 	if scan.Constraint == nil && scan.InvertedConstraint == nil {
-		notNullCols := relProps.NotNullCols
+		notNullCols := relProps.NotNullCols.Copy()
 		// Add any not-null columns from the predicate constraints.
 		for i := range pred {
 			if c := pred[i].ScalarProps().Constraints; c != nil {
@@ -761,7 +761,7 @@ func (sb *statisticsBuilder) constrainScan(
 
 	// Set null counts to 0 for non-nullable columns
 	// ---------------------------------------------
-	notNullCols := relProps.NotNullCols
+	notNullCols := relProps.NotNullCols.Copy()
 	if constraint != nil {
 		// Add any not-null columns from this constraint.
 		notNullCols.UnionWith(constraint.ExtractNotNullCols(sb.evalCtx))


### PR DESCRIPTION
Release justification: low risk, high benefit changes to existing
functionality

This commit fixes a bug that could happen in rare cases when there were
many columns in a query (due to a single table with many columns or many
tables), causing any `ColSets` maintained by the optimizer to use the `Sparse`
format. When the `Sparse` format is used, it is not safe to perform a shallow
copy of the `ColSet`, because modifying the copy can corrupt the original
version. This  commit fixes two instances in the `statisticsBuilder` where we
were performing a shallow copy of the relational property `NotNullCols` and
modifying it, causing the relational property to be corrupted.

Fixes #54011

Release note (bug fix): Fixed a rare bug where the optimizer incorrectly
classified some columns as not-null, possibly leading to invalid query plans
and incorrect results.