### PR TITLE
jobs: don't redact status strings

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -105,6 +106,13 @@ func init() {
 
 // Status represents the status of a job in the system.jobs table.
 type Status string
+
+// SafeFormat implements redact.SafeFormatter.
+func (s Status) SafeFormat(sp redact.SafePrinter, verb rune) {
+	sp.SafeString(redact.SafeString(s))
+}
+
+var _ redact.SafeFormatter = Status("")
 
 // RunningStatus represents the more detailed status of a running job in
 // the system.jobs table.

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
@@ -2378,4 +2379,12 @@ func TestRegistryTestingNudgeAdoptionQueue(t *testing.T) {
 	case <-time.After(aLongTime):
 		t.Fatal("job was not adopted")
 	}
+}
+
+func TestStatusSafeFormatter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	redacted := string(redact.Sprint(jobs.StatusCanceled).Redact())
+	expected := string(jobs.StatusCanceled)
+	require.Equal(t, expected, redacted)
 }


### PR DESCRIPTION
They are handy to know and are not PII.

Release justification: low risk, high benefit changes to existing functionality

Release note: None