### PR TITLE
vendor: Bump pebble to a9c6d3b6685c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200904203921-b66f9d0155ab
+	github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c
 	github.com/cockroachdb/redact v1.0.5
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200904203921-b66f9d0155ab h1:NBGEsgZzdE1OuFzndcoSsX36law5tjEqfsn4U8EnZYs=
-github.com/cockroachdb/pebble v0.0.0-20200904203921-b66f9d0155ab/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c h1:BNozL+EzkybaDuPWgnnwGxfSe+jbokBvRvF+TX0RDCo=
+github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.5 h1:yxqIMS6G2Bvi6GiSHFmsrFGO3aP1rwt8cOm4pixw9eY=


### PR DESCRIPTION
Pulls in these changes:

```
a9c6d3b6685c4735626436bde19c8f0d1ac46572 Revert "db: optimize levelIter for repeated seeks with narrow and monotonic bounds"
d3f98730b077cb4c0f1c659002baaa24c53d89e3 Revert "sstable: optimize seeks to use next"
ddf147d590db73a9a960b56236d47685e9f48ed0 tool: fix removing same file twice
15d7907d1ca511fdae8a6eecc55e9e97d529aab3 sstable: support >1GB sstable blocks
33001e5ac80f2ce37d37b3aacbf8b84bf3a9f8a2 bloom: minor test ergonomic adjustments
9f65089e108ad1ed40d84d115a6468066200b46b bloom: adjust tableFilter.String format
91c911a77ad895a7754c206a84f81416ac274113 bloom: verify small bloom filter test
```

Release justification: Pebble revert to fix tpcc roachtest failures
Release note: None.