### PR TITLE
release-20.1: backupccl: clear table stats from manifest on canceled backup

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -544,8 +544,7 @@ func (b *backupResumer) Resume(
 		}
 	}
 
-	err = b.clearStats(ctx, p.ExecCfg().DB)
-	if err != nil {
+	if err := b.clearStats(ctx, p.ExecCfg().DB); err != nil {
 		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
 	}
 	b.deleteCheckpoint(ctx, p.ExecCfg())
@@ -610,6 +609,9 @@ func (b *backupResumer) OnFailOrCancel(ctx context.Context, phs interface{}) err
 		int64(timeutil.Since(timeutil.FromUnixMicros(b.job.Payload().StartedMicros)).Seconds()))
 
 	cfg := phs.(sql.PlanHookState).ExecCfg()
+	if err := b.clearStats(ctx, cfg.DB); err != nil {
+		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
+	}
 	b.deleteCheckpoint(ctx, cfg)
 	return cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return b.releaseProtectedTimestamp(ctx, txn, cfg.ProtectedTimestampProvider)


### PR DESCRIPTION
The table statistics that are being backed up are stored in the backup
manifest, and thus the job description in v19.2 and v20.1. They are
cleared when the job completes successfully. This commit changes backup
to also clear the statistics when the job either fails or is canceled.
Failing to do this may leave behind unnecessarily large job rows.

Release note (bug fix): Clear table statistics from job description in
failed and canceled backup jobs.