### PR TITLE
release-20.1: opt: fix CopyAndReplace for RecursiveCTE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -587,3 +587,20 @@ aabb
 babb
 abbb
 bbbb
+
+# Regression test for #53951: placeholder inside a recursive CTE.
+statement ok
+PREPARE
+  ctestmt
+AS
+  (WITH RECURSIVE cte (x) AS (VALUES (1) UNION ALL SELECT x + $1 FROM cte WHERE x < 50) SELECT * FROM cte)
+
+query I rowsort
+EXECUTE ctestmt (10)
+----
+1
+11
+21
+31
+41
+51

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -552,6 +552,11 @@ func (w *WithExpr) WithBindingID() opt.WithID {
 	return w.ID
 }
 
+// WithBindingID is used by factory.Replace as a uniform way to get the with ID.
+func (r *RecursiveCTEExpr) WithBindingID() opt.WithID {
+	return r.WithID
+}
+
 // initUnexportedFields is called when a project expression is created.
 func (prj *ProjectExpr) initUnexportedFields(mem *Memo) {
 	inputProps := prj.Input.Relational()

--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -176,6 +176,10 @@ project
  │    ├── initial columns: test.id:1(string)
  │    ├── recursive columns: c.id:4(string)
  │    ├── stats: [rows=10]
+ │    ├── fake-rel
+ │    │    ├── columns: test.id:1(string)
+ │    │    ├── cardinality: [1 - ]
+ │    │    └── stats: [rows=1]
  │    ├── values
  │    │    ├── columns: test.id:1(string!null)
  │    │    ├── cardinality: [0 - 0]

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -137,6 +137,7 @@ func TestCopyAndReplaceWithScan(t *testing.T) {
 		"UPDATE child SET p=p+1 WHERE c > 1",
 		"UPDATE parent SET p=p+1 WHERE p > 1",
 		"DELETE FROM parent WHERE p < 10",
+		"WITH RECURSIVE cte(x) AS (VALUES (1) UNION ALL SELECT x+1 FROM cte WHERE x < 10) SELECT * FROM cte",
 	} {
 		t.Run(query, func(t *testing.T) {
 			var o xform.Optimizer

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -911,9 +911,20 @@ define WithScanPrivate {
 #    - the Recursive query (which refers to the working table using a specific
 #      WithID) is evaluated; the results are emitted and also saved into a new
 #      "working table" for the next iteration.
-[Relational]
+[Relational, WithBinding]
 define RecursiveCTE {
+    # Binding is a dummy relational expression that is associated with the
+    # WithID; its logical properties are used by WithScan.
+    # TODO(radu): this is a little hacky; investigate other ways to fill out the
+    # WithScan properties in this case.
+    Binding RelExpr
+
+    # Initial is the expression that is executed once and returns the initial
+    # set of rows for the "working table".
     Initial RelExpr
+
+    # Recursive is the expression that is executed repeatedly; it reads the
+    # "working table" using WithScan.
     Recursive RelExpr
     _ RecursiveCTEPrivate
 }

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -849,6 +849,8 @@ with &2 (t)
  │    ├── working table binding: &1
  │    ├── initial columns: column1:1
  │    ├── recursive columns: "?column?":4
+ │    ├── fake-rel
+ │    │    └── columns: column1:1
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    └── (1,)
@@ -897,6 +899,8 @@ with &2 (included_parts)
  │    ├── working table binding: &1
  │    ├── initial columns: parts.sub_part:2 parts.part:1 parts.quantity:3
  │    ├── recursive columns: p.sub_part:12 p.part:11 p.quantity:13
+ │    ├── fake-rel
+ │    │    └── columns: parts.part:1 parts.sub_part:2 parts.quantity:3
  │    ├── project
  │    │    ├── columns: parts.part:1!null parts.sub_part:2 parts.quantity:3
  │    │    └── select
@@ -964,6 +968,8 @@ with &2 (search_graph)
  │    ├── working table binding: &1
  │    ├── initial columns: g.id:1 g.link:2 g.data:3 "?column?":4 array:5 bool:6
  │    ├── recursive columns: g.id:13 g.link:14 g.data:15 "?column?":22 "?column?":23 "?column?":24
+ │    ├── fake-rel
+ │    │    └── columns: g.id:1 g.link:2 g.data:3 "?column?":4 array:5 bool:6
  │    ├── project
  │    │    ├── columns: "?column?":4!null array:5!null bool:6!null g.id:1!null g.link:2 g.data:3
  │    │    ├── scan g
@@ -1021,6 +1027,8 @@ with &2 (cte)
  │    ├── working table binding: &1
  │    ├── initial columns: "?column?":1 "?column?":1
  │    ├── recursive columns: "?column?":6 "?column?":7
+ │    ├── fake-rel
+ │    │    └── columns: "?column?":1
  │    ├── project
  │    │    ├── columns: "?column?":1!null
  │    │    ├── values
@@ -1062,6 +1070,8 @@ with &2 (cte)
  │    ├── working table binding: &1
  │    ├── initial columns: "?column?":1 "?column?":2
  │    ├── recursive columns: "?column?":7 "?column?":7
+ │    ├── fake-rel
+ │    │    └── columns: "?column?":1 "?column?":2
  │    ├── project
  │    │    ├── columns: "?column?":1!null "?column?":2!null
  │    │    ├── values
@@ -1228,6 +1238,8 @@ with &3 (cte)
  │    ├── working table binding: &1
  │    ├── initial columns: "?column?":1 "?column?":2
  │    ├── recursive columns: "?column?":11 "?column?":12
+ │    ├── fake-rel
+ │    │    └── columns: "?column?":1 "?column?":2
  │    ├── project
  │    │    ├── columns: "?column?":1!null "?column?":2!null
  │    │    ├── values
@@ -1281,6 +1293,8 @@ with &3 (cte)
  │    ├── working table binding: &1
  │    ├── initial columns: "?column?":4
  │    ├── recursive columns: "?column?":7
+ │    ├── fake-rel
+ │    │    └── columns: "?column?":4
  │    ├── with &2 (v)
  │    │    ├── columns: "?column?":4!null
  │    │    ├── values

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -203,7 +203,7 @@ func (b *Builder) buildCTE(
 		OutCols:       colsToColList(outScope.cols),
 	}
 
-	expr := b.factory.ConstructRecursiveCTE(initialScope.expr, recursiveScope.expr, &private)
+	expr := b.factory.ConstructRecursiveCTE(cteSrc.expr, initialScope.expr, recursiveScope.expr, &private)
 	return expr, cteSrc.cols
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #53982.

/cc @cockroachdb/release

---

PR #51788 introduced a new way to build properties for WithScan. This
requires special code for CopyAndReplace. Unfortunately, RecursiveCTE
was omitted from that change and it also uses a WithScan.

The difficulty is that we don't have a real expression that the
WithScan can refer to (it refers to the working table which goes
through multiple iterations). We internally use a FakeRelExpression
set up with some conservative properties. In order to make
CopyAndReplace work, we have to expose this expression as a child of
the `RecursiveCTE` operator. Then we can rely on the `WithBinding` tag
to do the right thing (the tag assumes that the first child is the
bound expression).

Fixes #53951.

Release justification: fix for important regression

Release note (bug fix): fixed "no binding for WithID" internal error
when using WITH RECURSIVE in queries with placeholders.
