### PR TITLE
release-20.1: backupccl: add logging when descriptor fails validation

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1094,7 +1094,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 			newSchemaChangeJobs = append(newSchemaChangeJobs, newJobs...)
 			existingDescVal, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, tbl)
 			if err != nil {
-				return errors.Wrap(err, "validating table descriptor has not changed")
+				return errors.Wrapf(err, "validating table descriptor has not changed, expected: %v", tbl)
 			}
 			b.CPut(
 				sqlbase.MakeDescMetadataKey(tableDesc.ID),


### PR DESCRIPTION
When a table descriptor has changed unexpectedly during a restore, we
log the unexpected value, but not the expected value. Logging the
expected value will make it easier to determine what change was applied
to the table descriptor.

Release note: None