### PR TITLE
sql: disallow role/user drops if they own a schema or a type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant(49854)
+
 statement ok
 GRANT CREATE ON DATABASE test TO testuser
 
@@ -188,7 +190,7 @@ user root
 statement ok
 REVOKE ALL ON DATABASE test FROM testuser
 
-statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table t
+statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table test.public.t.*\n.*owner of table d.public.t
 DROP ROLE testuser
 
 # Cannot drop object due to owned objects message should only show the owned
@@ -200,5 +202,28 @@ user testuser2
 statement ok
 CREATE TABLE t2()
 
-statement error pq: role testuser2 cannot be dropped because some objects depend on it.*\n.*owner of table t
+statement error pq: role testuser2 cannot be dropped because some objects depend on it.*\n.*owner of table test.public.t2
 DROP ROLE testuser2, testuser
+
+# Ensure role cannot be dropped if it is an owner of a schema.
+
+user testuser
+
+statement ok
+USE d
+
+statement ok
+CREATE SCHEMA s
+
+statement ok
+CREATE TYPE typ AS ENUM ()
+
+user root
+
+statement ok
+REVOKE ALL ON DATABASE test FROM testuser
+
+user testuser
+
+statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table test.public.t.*\n.*owner of table d.public.t.*\n.*owner of schema s.*\n.*owner of type d.public._?typ.*\n.*owner of type d.public._?typ
+DROP ROLE testuser

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -810,6 +810,31 @@ func getTableNameFromTableDescriptor(
 	return tableName, nil
 }
 
+// getTypeNameFromTypeDescriptor returns a TypeName object for a given
+// TableDescriptor.
+func getTypeNameFromTypeDescriptor(
+	l simpleSchemaResolver, typ catalog.TypeDescriptor,
+) (tree.TypeName, error) {
+	var typeName tree.TypeName
+	tableDbDesc, err := l.getDatabaseByID(typ.GetParentID())
+	if err != nil {
+		return typeName, err
+	}
+	var parentSchemaName string
+	if typ.GetParentSchemaID() == keys.PublicSchemaID {
+		parentSchemaName = tree.PublicSchema
+	} else {
+		parentSchema, err := l.getSchemaByID(typ.GetParentSchemaID())
+		if err != nil {
+			return typeName, err
+		}
+		parentSchemaName = parentSchema.Name
+	}
+	typeName = tree.MakeNewQualifiedTypeName(tableDbDesc.GetName(),
+		parentSchemaName, typ.GetName())
+	return typeName, nil
+}
+
 // ResolveMutableTypeDescriptor resolves a type descriptor for mutable access.
 func (p *planner) ResolveMutableTypeDescriptor(
 	ctx context.Context, name *tree.UnresolvedObjectName, required bool,


### PR DESCRIPTION
Now that we have user defined schemas and types, they need to play well
with the concept of ownership as well. If a user/role owns a schema or a
type, the `DROP ROLE` command will fail with the appropriate message.

fixes #54015

Release justification: bug fix for new functionality.
Release note (sql change): If a user/role has ownership over a type or
a schema, it is no longer possible to drop them.