### PR TITLE
workload: adjust TPCH query 15

### DIFF
--- a/pkg/workload/tpch/queries.go
+++ b/pkg/workload/tpch/queries.go
@@ -455,6 +455,9 @@ WHERE
 	AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
 `
 
+	// Note that the main query has been adjusted to go around issues with
+	// floating point computations when the order of summation is different
+	// (see #53946 for more details).
 	query15 = `
 CREATE VIEW revenue0 (supplier_no, total_revenue) AS
 	SELECT
@@ -479,12 +482,12 @@ FROM
 	revenue0
 WHERE
 	s_suppkey = supplier_no
-	AND total_revenue = (
+	AND abs(total_revenue - (
 		SELECT
 			max(total_revenue)
 		FROM
 			revenue0
-	)
+	)) < 0.001
 ORDER BY
 	s_suppkey;
 


### PR DESCRIPTION
TPCH query 15 finds the supplier that has the largest total revenue
during a certain period of time. To do that in the subquery it
calculates the maximum total revenue and then filters based on that
`max` value. Currently, the total revenue is of FLOAT type. As it turns
out, it is possible that the subquery and the main query have "different
physical plans" when calculating the total revenue which could result in
summation of float numbers in a different order which, in turn, would
result in no supplier having the largest total revenue, so we would
return an incorrect result (empty set whereas we expect exactly one
row). This is a limitation of floating point arithmetic, and the
behavior is expected.

One way to fix this issue would be to use DECIMAl type, however, that
would make the benchmark less useful for us (we would be benchmarking
the performance of the DECIMAL type because that would be the
bottleneck). So we chose an alternative fix - introducing an allowed
delta when filtering.

Fixes: #53946.

Release justification: non-production code change.

Release note: None