### PR TITLE
release-20.2: build: disable release justifications after release branch cut

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -2,7 +2,7 @@
 
 # Set this to 1 to require a "release justification" note in the commit message
 # or the PR description.
-require_justification=1
+require_justification=0
 
 set -euo pipefail
 

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -52,7 +52,7 @@ IFS='
 notes=($($grep -iE '^release note' "$1"))
 
 # Set this to 1 to require a release justification note.
-require_justification=1
+require_justification=0
 justification=($($grep -iE '^release justification: \S+' "$1"))
 
 IFS=$saveIFS

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,7 +2,7 @@
 #
 # Prepare the commit message by adding a release note.
 
-require_justification=1
+require_justification=0
 set -euo pipefail
 
 if [[ "${2-}" = "message" ]]; then


### PR DESCRIPTION
Backport 1/1 commits from #54053.

/cc @cockroachdb/release

---

Release note: None
