### PR TITLE
release-20.2: cli: add deprecation notice to dump CLI command

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1423,7 +1423,6 @@ Available Commands:
   statement-diag    commands for managing statement diagnostics bundles
   auth-session      log in and out of HTTP sessions
   node              list, inspect, drain or remove nodes
-  dump              dump sql tables
 
   nodelocal         upload and delete nodelocal files
   userfile          upload, list and delete user scoped files

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -49,6 +49,8 @@ Dump SQL tables of a cockroach database. If the table name
 is omitted, dump all tables in the database.
 `,
 	RunE: MaybeDecorateGRPCError(runDump),
+	Deprecated: "cockroach dump will be removed in a subsequent release.\n" +
+		"For details, see: https://github.com/cockroachdb/cockroach/issues/54040",
 }
 
 // We accept versions that are strictly newer than v2.1.0-alpha.20180416

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -625,7 +625,7 @@ var nodeCmds = []*cobra.Command{
 
 var nodeCmd = &cobra.Command{
 	Use:   "node [command]",
-	Short: "list, inspect, drain or remove nodes",
+	Short: "list, inspect, drain or remove nodes\n",
 	Long:  "List, inspect, drain or remove nodes.",
 	RunE:  usageAndErr,
 }


### PR DESCRIPTION
Backport 1/1 commits from #54044.

/cc @cockroachdb/release

---

Fixes: #54040

Release justification: low risk, high benefit changes to existing functionality
