### PR TITLE
sql: clone parent permissions when creating schema

### DIFF
--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 type createSchemaNode struct {
@@ -95,7 +96,7 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	}
 
 	// Inherit the parent privileges.
-	privs := db.GetPrivileges()
+	privs := protoutil.Clone(db.GetPrivileges()).(*descpb.PrivilegeDescriptor)
 
 	if n.AuthRole != "" {
 		exists, err := p.RoleExists(params.ctx, n.AuthRole)

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -412,3 +412,35 @@ user root
 
 statement ok
 USE defaultdb
+
+# Ensure that when we create a schema, we do not modify the database privileges.
+subtest create_schema_does_not_modify_db_privileges
+
+user root
+
+statement ok
+CREATE DATABASE new_db
+
+statement ok
+USE new_db
+
+user testuser
+
+statement ok
+USE new_db
+
+statement error user testuser does not have CREATE privilege on database new_db
+CREATE TABLE new_db.public.bar()
+
+user root
+
+statement ok
+CREATE SCHEMA AUTHORIZATION testuser
+
+user testuser
+
+statement error user testuser does not have CREATE privilege on database new_db
+CREATE TABLE new_db.public.bar()
+
+statement ok
+CREATE TABLE new_db.testuser.bar()


### PR DESCRIPTION
Prior to this patch, we'd modify the parent databases permissions which was
totally unintended.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None