### PR TITLE
sql: stats cache refreshes don't count as accesses

### DIFF
--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -240,7 +240,16 @@ func (bc *baseCache) Get(key interface{}) (value interface{}, ok bool) {
 		bc.access(e)
 		return e.Value, true
 	}
-	return
+	return nil, false
+}
+
+// StealthyGet looks up a key's value from the cache but does not consider it an
+// "access" (with respect to the policy).
+func (bc *baseCache) StealthyGet(key interface{}) (value interface{}, ok bool) {
+	if e := bc.store.get(key); e != nil {
+		return e.Value, true
+	}
+	return nil, false
 }
 
 // Del removes the provided key from the cache.

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -139,7 +139,11 @@ func TestCacheLRU(t *testing.T) {
 	if _, ok := mc.Get(testKey("a")); !ok {
 		t.Fatal("failed to get key a")
 	}
-	// Add another entry to evict; should evict key "b".
+	// Verify that a StealthyGet won't make b the most recently used.
+	if _, ok := mc.StealthyGet(testKey("b")); !ok {
+		t.Fatal("failed to get key b")
+	}
+	// Add another entry to cause an eviction; should evict key "b".
 	mc.Add(testKey("c"), 3)
 	// Verify eviction of least recently used key "b".
 	if _, ok := mc.Get(testKey("b")); ok {


### PR DESCRIPTION
The stats cache entries are now being refreshed asynchronously. The
refresh itself needs to get the entry for the cache, so it ends up
counting as an "access" (with respect to the LRU eviction policy).
This is not ideal - a table that hasn't been used in a while but which
is being updated frequently will "stay alive" in the cache and
possibly cause eviction of other tables.

This commit modifies the cache to use a "stealthy get" which does not
count as an access.

Release justification: fix to existing infrastructure

Release note: None