### PR TITLE
server: introduce Test{ClusterConnectivity,JoinVersionGate}

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -43,6 +44,13 @@ type TestServerArgs struct {
 	// tests don't get log spam about ranges not being replicated enough. This
 	// is always set to true when the server is started via a TestCluster.
 	PartOfCluster bool
+
+	// Listener (if nonempty) is the listener to use for all incoming RPCs.
+	// If a listener is installed, it informs the RPC `Addr` used below. The
+	// Server itself knows to close it out. This is useful for when a test wants
+	// manual control over how the join flags (`JoinAddr`) are populated, and
+	// installs listeners manually to know which addresses to point to.
+	Listener net.Listener
 
 	// Addr (if nonempty) is the RPC address to use for the test server.
 	Addr string

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -1,0 +1,334 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+)
+
+// TestClusterConnectivity sets up an uninitialized cluster with custom join
+// flags (individual nodes point to specific others, instead of all pointing to
+// n1), and tests that the cluster/node IDs are distributed correctly
+// throughout.
+func TestClusterConnectivity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// TODO(irfansharif): Teach TestServer to accept a list of join addresses
+	// instead of just one.
+
+	var testConfigurations = []struct {
+		// bootstrapNode controls which node is `cockroach init`-ialized.
+		// Everything is 0-indexed.
+		bootstrapNode int
+
+		// joinConfig[i] returns the node the i-th node is pointing to through
+		// its join flags. Everything is 0-indexed.
+		joinConfig []int
+	}{
+		// 0. Every node points to the first, including the first.
+		{0, []int{0, 0, 0, 0, 0}},
+
+		// 1. Every node points to the previous, except the first, which points to
+		// itself.
+		//
+		// 0 <-- 1 <-- 2 <-- 3 <-- 4
+		{0, []int{0, 0, 1, 2, 3}},
+
+		// 2. Same as previous, but a few links switched around.
+		//
+		// 0 <-- 2 <-- 1 <-- 3 <-- 4
+		{0, []int{0, 2, 0, 1, 3}},
+
+		// 3. Introduce a bidirectional link.
+		//
+		// 1 <-> 2 <-- 0 <-- 3
+		// 1 <-- 4
+		{1, []int{2, 2, 1, 0, 1}},
+
+		// 4. Same as above, but bootstrap the other node in the bidirectional
+		// link.
+		//
+		// 1 <-> 2 <-- 0 <-- 3
+		// 1 <-- 4
+		{2, []int{2, 2, 1, 0, 1}},
+
+		// 5. Another topology centered around node 1, which itself is pointed
+		// to node 0.
+		//
+		// 0 <-> 1 <-- 2
+		//       1 <-- 3
+		{0, []int{1, 0, 1, 1}},
+
+		// 6. Same as above, but bootstrapping the centered node directly.
+		//
+		// 0 <-> 1 <-- 2
+		//       1 <-- 3
+		{1, []int{1, 0, 1, 1}},
+
+		// TODO(irfansharif): We would really like to be able to set up test
+		// clusters that are only partially connected, and assert that only
+		// nodes that are supposed to find out about bootstrap, actually do.
+		// Something like:
+		//
+		// 		0 <-> 1 <-- 2
+		// 		5 <-- 4 <-- 3 <-- 5
+		//
+		// A version of this was originally prototyped in #52526 but the changes
+		// required in Test{Cluster,Server} were too invasive to justify at the
+		// time.
+	}
+
+	// getListener is a short hand to allocate a listener to an unbounded port.
+	getListener := func() net.Listener {
+		t.Helper()
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return listener
+	}
+	baseServerArgs := base.TestServerArgs{
+		// We're going to manually control initialization in this test.
+		NoAutoInitializeCluster: true,
+		StoreSpecs:              []base.StoreSpec{{InMemory: true}},
+	}
+
+	for i, test := range testConfigurations {
+		t.Run(fmt.Sprintf("topology=%d", i), func(t *testing.T) {
+			numNodes := len(test.joinConfig)
+			var serverArgsPerNode = make(map[int]base.TestServerArgs)
+
+			// We start off with installing a listener for each server. We
+			// pre-bind a listener so the kernel can go ahead and assign an
+			// address for us. We'll later use this address to populate join
+			// flags for neighboring nodes.
+			var listeners = make([]net.Listener, numNodes)
+			for i := 0; i < numNodes; i++ {
+				listener := getListener()
+
+				serverArg := baseServerArgs
+				serverArg.Listener = listener
+				serverArg.Addr = listener.Addr().String()
+				serverArgsPerNode[i] = serverArg
+				listeners[i] = listener
+			}
+
+			// We'll annotate the server args with the right join flags.
+			for i := 0; i < numNodes; i++ {
+				joinNode := test.joinConfig[i]
+				joinAddr := listeners[joinNode].Addr().String()
+
+				serverArg := serverArgsPerNode[i]
+				serverArg.JoinAddr = joinAddr
+				serverArgsPerNode[i] = serverArg
+			}
+
+			tcArgs := base.TestClusterArgs{
+				// Saves time in this test.
+				ReplicationMode:   base.ReplicationManual,
+				ServerArgsPerNode: serverArgsPerNode,
+
+				// We have to start servers in parallel because we're looking to
+				// bootstrap the cluster manually in a separate thread. Each
+				// individual Server.Start is a blocking call (it waits for
+				// init). We want to start all of them in parallel to simulate a
+				// bunch of servers each waiting for init.
+				ParallelStart: true,
+			}
+
+			// The test structure here is a bit convoluted, but necessary given
+			// the current implementation of TestCluster. TestCluster.Start
+			// wants to wait for all the nodes in the test cluster to be fully
+			// initialized before returning. Given we're testing initialization
+			// behavior, we do all the real work in a separate thread and keep
+			// the main thread limited to simply starting and stopping the test
+			// cluster.
+			//
+			// NB: That aside, TestCluster very much wants to live on the main
+			// goroutine running the test. That's mostly to do with its internal
+			// error handling and the limitations imposed by
+			// https://golang.org/pkg/testing/#T.FailNow (which sits underneath
+			// t.Fatal).
+
+			tc := testcluster.NewTestCluster(t, numNodes, tcArgs)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Attempt to bootstrap the cluster through the configured node.
+				bootstrapNode := test.bootstrapNode
+				testutils.SucceedsSoon(t, func() (e error) {
+					ctx := context.Background()
+					serv := tc.Server(bootstrapNode)
+
+					dialOpts, err := tc.Server(bootstrapNode).RPCContext().GRPCDialOptions()
+					if err != nil {
+						return err
+					}
+
+					conn, err := grpc.DialContext(ctx, serv.ServingRPCAddr(), dialOpts...)
+					if err != nil {
+						return err
+					}
+					defer func() {
+						_ = conn.Close()
+					}()
+
+					client := serverpb.NewInitClient(conn)
+					_, err = client.Bootstrap(context.Background(), &serverpb.BootstrapRequest{})
+					return err
+				})
+
+				// Wait to get a real cluster ID (doesn't always get populated
+				// right after bootstrap).
+				testutils.SucceedsSoon(t, func() error {
+					clusterID := tc.Server(bootstrapNode).ClusterID()
+					if clusterID.Equal(uuid.UUID{}) {
+						return errors.New("cluster ID still not recorded")
+					}
+					return nil
+				})
+
+				clusterID := tc.Server(bootstrapNode).ClusterID()
+				testutils.SucceedsSoon(t, func() error {
+					var nodeIDs []roachpb.NodeID
+					var storeIDs []roachpb.StoreID
+
+					// Sanity check that all the nodes we expect to join this
+					// network actually do (by checking they discover the right
+					// cluster ID). Also collect node/store IDs for below.
+					for i := 0; i < numNodes; i++ {
+						if got := tc.Server(i).ClusterID(); got != clusterID {
+							return errors.Newf("mismatched cluster IDs; %s (for node %d) != %s (for node %d)",
+								clusterID.String(), bootstrapNode, got.String(), i)
+						}
+
+						nodeIDs = append(nodeIDs, tc.Server(i).NodeID())
+						storeIDs = append(storeIDs, tc.Server(i).GetFirstStoreID())
+					}
+
+					sort.Slice(nodeIDs, func(i, j int) bool {
+						return nodeIDs[i] < nodeIDs[j]
+					})
+					sort.Slice(storeIDs, func(i, j int) bool {
+						return storeIDs[i] < storeIDs[j]
+					})
+
+					// Double check that we have the full set of node/store IDs
+					// we expect.
+					for i := 1; i <= len(nodeIDs); i++ {
+						expNodeID := roachpb.NodeID(i)
+						if got := nodeIDs[i-1]; got != expNodeID {
+							return errors.Newf("unexpected node ID; expected %s, got %s", expNodeID.String(), got.String())
+						}
+
+						expStoreID := roachpb.StoreID(i)
+						if got := storeIDs[i-1]; got != expStoreID {
+							return errors.Newf("unexpected store ID; expected %s, got %s", expStoreID.String(), got.String())
+						}
+					}
+
+					return nil
+				})
+			}()
+
+			// Start the test cluster. This is a blocking call, and expects the
+			// configured number of servers in the cluster to be fully
+			// initialized before it returns. Given that the initialization
+			// happens in the other thread, we'll only get past it after having
+			// bootstrapped the test cluster in the thread above.
+			tc.Start(t)
+			defer tc.Stopper().Stop(context.Background())
+
+			wg.Wait()
+		})
+	}
+}
+
+// TestJoinVersionGate checks to see that improperly versioned cockroach nodes
+// are not able to join a cluster.
+func TestJoinVersionGate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	commonArg := base.TestServerArgs{
+		StoreSpecs: []base.StoreSpec{
+			{InMemory: true},
+		},
+	}
+
+	numNodes := 3
+	tcArgs := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual, // Saves time in this test.
+		ServerArgs:      commonArg,
+		ParallelStart:   true,
+	}
+
+	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
+	defer tc.Stopper().Stop(context.Background())
+
+	testutils.SucceedsSoon(t, func() error {
+		for i := 0; i < numNodes; i++ {
+			clusterID := tc.Server(0).ClusterID()
+			got := tc.Server(i).ClusterID()
+
+			if got != clusterID {
+				return errors.Newf("mismatched cluster IDs; %s (for node %d) != %s (for node %d)", clusterID.String(), 0, got.String(), i)
+			}
+		}
+		return nil
+	})
+
+	var newVersion = clusterversion.TestingBinaryVersion
+	var oldVersion = prev(newVersion)
+
+	knobs := base.TestingKnobs{
+		Server: &server.TestingKnobs{
+			BinaryVersionOverride: oldVersion,
+		},
+	}
+
+	oldVersionServerArgs := commonArg
+	oldVersionServerArgs.Knobs = knobs
+	oldVersionServerArgs.JoinAddr = tc.Servers[0].ServingRPCAddr()
+
+	serv, err := tc.AddServer(oldVersionServerArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serv.Stop()
+
+	if err := serv.Start(); !errors.Is(errors.Cause(err), server.ErrIncompatibleBinaryVersion) {
+		t.Fatalf("expected error %s, got %v", server.ErrIncompatibleBinaryVersion.Error(), err.Error())
+	}
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -292,6 +292,11 @@ func (ts *TestServer) Node() interface{} {
 	return ts.node
 }
 
+// NodeID returns the ID of this node within its cluster.
+func (ts *TestServer) NodeID() roachpb.NodeID {
+	return ts.rpcContext.NodeID.Get()
+}
+
 // Stopper returns the embedded server's Stopper.
 func (ts *TestServer) Stopper() *stop.Stopper {
 	return ts.stopper

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -30,7 +30,7 @@ import (
 type TestClusterInterface interface {
 	// Start is used to start up the servers that were instantiated when
 	// creating this cluster.
-	Start(t testing.TB, args base.TestClusterArgs)
+	Start(t testing.TB)
 
 	// NumServers returns the number of servers this test cluster is configured
 	// with.
@@ -144,7 +144,7 @@ func StartNewTestCluster(
 	t testing.TB, numNodes int, args base.TestClusterArgs,
 ) TestClusterInterface {
 	cluster := NewTestCluster(t, numNodes, args)
-	cluster.Start(t, args)
+	cluster.Start(t)
 	return cluster
 }
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // TestServerInterface defines test server functionality that tests need; it is
@@ -49,6 +50,10 @@ type TestServerInterface interface {
 
 	// NodeID returns the ID of this node within its cluster.
 	NodeID() roachpb.NodeID
+
+	// ClusterID returns the cluster ID as understood by this node in the
+	// cluster.
+	ClusterID() uuid.UUID
 
 	// ServingRPCAddr returns the server's advertised address.
 	ServingRPCAddr() string

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -44,7 +44,8 @@ import (
 )
 
 // TestCluster represents a set of TestServers. The hope is that it can be used
-// analogous to TestServer, but with control over range replication.
+// analogous to TestServer, but with control over range replication and join
+// flags.
 type TestCluster struct {
 	Servers         []*server.TestServer
 	Conns           []*gosql.DB
@@ -167,14 +168,7 @@ func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *
 		noLocalities = false
 	}
 
-	// Pre-bind a listener for node zero so the kernel can go ahead and
-	// assign its address for use in the other nodes' join flags.
-	// The Server becomes responsible for closing this.
-	firstListener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {
 		var serverArgs base.TestServerArgs
 		if perNodeServerArgs, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok {
@@ -194,18 +188,25 @@ func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *
 		}
 
 		if i == 0 {
-			if serverArgs.Knobs.Server == nil {
-				serverArgs.Knobs.Server = &server.TestingKnobs{}
+			if serverArgs.Listener != nil {
+				// If the test installed a listener for us, use that.
+				firstListener = serverArgs.Listener
 			} else {
-				// Copy the knobs so the struct with the listener is not
-				// reused for other nodes.
-				knobs := *serverArgs.Knobs.Server.(*server.TestingKnobs)
-				serverArgs.Knobs.Server = &knobs
+				// Pre-bind a listener for node zero so the kernel can go ahead and
+				// assign its address for use in the other nodes' join flags.
+				// The Server becomes responsible for closing this.
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatal(err)
+				}
+				firstListener = listener
+				serverArgs.Listener = listener
 			}
-			serverArgs.Knobs.Server.(*server.TestingKnobs).RPCListener = firstListener
-			serverArgs.Addr = firstListener.Addr().String()
 		} else {
-			serverArgs.JoinAddr = firstListener.Addr().String()
+			if serverArgs.JoinAddr == "" {
+				// Point to the first listener unless told explicitly otherwise.
+				serverArgs.JoinAddr = firstListener.Addr().String()
+			}
 			serverArgs.NoAutoInitializeCluster = true
 		}
 
@@ -376,6 +377,23 @@ func (tc *TestCluster) AddServer(serverArgs base.TestServerArgs) (*server.TestSe
 		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
 		serverArgs.Knobs.Store = &stkCopy
+	}
+
+	// Install listener, if non-empty.
+	if serverArgs.Listener != nil {
+		// Instantiate the server testing knobs if non-empty.
+		if serverArgs.Knobs.Server == nil {
+			serverArgs.Knobs.Server = &server.TestingKnobs{}
+		} else {
+			// Copy the knobs so the struct with the listener is not
+			// reused for other nodes.
+			knobs := *serverArgs.Knobs.Server.(*server.TestingKnobs)
+			serverArgs.Knobs.Server = &knobs
+		}
+
+		// Install the provided listener.
+		serverArgs.Knobs.Server.(*server.TestingKnobs).RPCListener = serverArgs.Listener
+		serverArgs.Addr = serverArgs.Listener.Addr().String()
 	}
 
 	s := serverutils.NewServer(serverArgs).(*server.TestServer)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -44,18 +44,18 @@ import (
 )
 
 // TestCluster represents a set of TestServers. The hope is that it can be used
-// analoguous to TestServer, but with control over range replication.
+// analogous to TestServer, but with control over range replication.
 type TestCluster struct {
 	Servers         []*server.TestServer
 	Conns           []*gosql.DB
 	stopper         *stop.Stopper
-	replicationMode base.TestClusterReplicationMode
 	scratchRangeKey roachpb.Key
 	mu              struct {
 		syncutil.Mutex
 		serverStoppers []*stop.Stopper
 	}
-	serverArgs []base.TestServerArgs
+	serverArgs  []base.TestServerArgs
+	clusterArgs base.TestClusterArgs
 }
 
 var _ serverutils.TestClusterInterface = &TestCluster{}
@@ -126,44 +126,44 @@ func (tc *TestCluster) StopServer(idx int) {
 // The cluster should be stopped using TestCluster.Stopper().Stop().
 func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestCluster {
 	cluster := NewTestCluster(t, nodes, args)
-	cluster.Start(t, args)
+	cluster.Start(t)
 	return cluster
 }
 
 // NewTestCluster initializes a TestCluster made up of `nodes` in-memory testing
 // servers. It needs to be started separately using the return type.
-func NewTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestCluster {
+func NewTestCluster(t testing.TB, nodes int, clusterArgs base.TestClusterArgs) *TestCluster {
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
 
 	if err := checkServerArgsForCluster(
-		args.ServerArgs, args.ReplicationMode, disallowJoinAddr,
+		clusterArgs.ServerArgs, clusterArgs.ReplicationMode, disallowJoinAddr,
 	); err != nil {
 		t.Fatal(err)
 	}
-	for _, sargs := range args.ServerArgsPerNode {
+	for _, sargs := range clusterArgs.ServerArgsPerNode {
 		if err := checkServerArgsForCluster(
-			sargs, args.ReplicationMode, disallowJoinAddr,
+			sargs, clusterArgs.ReplicationMode, allowJoinAddr,
 		); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	tc := &TestCluster{
-		stopper:         stop.NewStopper(),
-		replicationMode: args.ReplicationMode,
+		stopper:     stop.NewStopper(),
+		clusterArgs: clusterArgs,
 	}
 
 	// Check if any of the args have a locality set.
 	noLocalities := true
-	for _, arg := range args.ServerArgsPerNode {
+	for _, arg := range tc.clusterArgs.ServerArgsPerNode {
 		if len(arg.Locality.Tiers) > 0 {
 			noLocalities = false
 			break
 		}
 	}
-	if len(args.ServerArgs.Locality.Tiers) > 0 {
+	if len(tc.clusterArgs.ServerArgs.Locality.Tiers) > 0 {
 		noLocalities = false
 	}
 
@@ -177,10 +177,10 @@ func NewTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestClu
 
 	for i := 0; i < nodes; i++ {
 		var serverArgs base.TestServerArgs
-		if perNodeServerArgs, ok := args.ServerArgsPerNode[i]; ok {
+		if perNodeServerArgs, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok {
 			serverArgs = perNodeServerArgs
 		} else {
-			serverArgs = args.ServerArgs
+			serverArgs = tc.clusterArgs.ServerArgs
 		}
 
 		// If no localities are specified in the args, we'll generate some
@@ -224,10 +224,10 @@ func NewTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestClu
 // If looking to test initialization/bootstrap behavior, Start should be invoked
 // in a separate thread and with ParallelStart enabled (otherwise it'll block
 // on waiting for init for the first server).
-func (tc *TestCluster) Start(t testing.TB, args base.TestClusterArgs) {
+func (tc *TestCluster) Start(t testing.TB) {
 	nodes := len(tc.Servers)
 	var errCh chan error
-	if args.ParallelStart {
+	if tc.clusterArgs.ParallelStart {
 		errCh = make(chan error, nodes)
 	}
 
@@ -238,7 +238,7 @@ func (tc *TestCluster) Start(t testing.TB, args base.TestClusterArgs) {
 			disableLBS = true
 		}
 
-		if args.ParallelStart {
+		if tc.clusterArgs.ParallelStart {
 			go func(i int) {
 				errCh <- tc.StartServer(t, tc.Server(i), tc.serverArgs[i])
 			}(i)
@@ -253,7 +253,7 @@ func (tc *TestCluster) Start(t testing.TB, args base.TestClusterArgs) {
 		}
 	}
 
-	if args.ParallelStart {
+	if tc.clusterArgs.ParallelStart {
 		for i := 0; i < nodes; i++ {
 			if err := <-errCh; err != nil {
 				t.Fatal(err)
@@ -263,7 +263,7 @@ func (tc *TestCluster) Start(t testing.TB, args base.TestClusterArgs) {
 		tc.WaitForNStores(t, tc.NumServers(), tc.Servers[0].Gossip())
 	}
 
-	if tc.replicationMode == base.ReplicationManual {
+	if tc.clusterArgs.ReplicationMode == base.ReplicationManual {
 		// We've already disabled the merge queue via testing knobs above, but ALTER
 		// TABLE ... SPLIT AT will throw an error unless we also disable merges via
 		// the cluster setting.
@@ -285,7 +285,7 @@ func (tc *TestCluster) Start(t testing.TB, args base.TestClusterArgs) {
 	// cluster stopper is stopped.
 	tc.stopper.AddCloser(stop.CloserFn(tc.stopServers))
 
-	if tc.replicationMode == base.ReplicationAuto {
+	if tc.clusterArgs.ReplicationMode == base.ReplicationAuto {
 		if err := tc.WaitForFullReplication(); err != nil {
 			t.Fatal(err)
 		}
@@ -359,7 +359,7 @@ func (tc *TestCluster) AddServer(serverArgs base.TestServerArgs) (*server.TestSe
 	// started, in which case the check has not been performed.
 	if err := checkServerArgsForCluster(
 		serverArgs,
-		tc.replicationMode,
+		tc.clusterArgs.ReplicationMode,
 		// Allow JoinAddr here; servers being added after the TestCluster has been
 		// started should have a JoinAddr filled in at this point.
 		allowJoinAddr,
@@ -367,7 +367,7 @@ func (tc *TestCluster) AddServer(serverArgs base.TestServerArgs) (*server.TestSe
 		return nil, err
 	}
 	serverArgs.Stopper = stop.NewStopper()
-	if tc.replicationMode == base.ReplicationManual {
+	if tc.clusterArgs.ReplicationMode == base.ReplicationManual {
 		var stkCopy kvserver.StoreTestingKnobs
 		if stk := serverArgs.Knobs.Store; stk != nil {
 			stkCopy = *stk.(*kvserver.StoreTestingKnobs)
@@ -917,7 +917,7 @@ func (tc *TestCluster) WaitForNodeLiveness(t testing.TB) {
 
 // ReplicationMode implements TestClusterInterface.
 func (tc *TestCluster) ReplicationMode() base.TestClusterReplicationMode {
-	return tc.replicationMode
+	return tc.clusterArgs.ReplicationMode
 }
 
 // ToggleReplicateQueues activates or deactivates the replication queues on all


### PR DESCRIPTION
Re-adding a few tests that I didn't check in while working on #52526.

---

TestClusterConnectivity sets up an uninitialized cluster with custom join
flags (individual nodes point to specific others, constructed using
connectivity matrices). Included in the test configurations are the more
"standard" ones where every node points to n1, or where there are
bidirectional links set up between nodes. It tests various topologies
and ensures that cluster IDs are distributed throughout connected
components, and store/node IDs are allocated in the way we'd expect them
to be.

TestJoinVersionGate checks to see that improperly versioned cockroach
nodes are not able to join a cluster.

Release note: None
