### PR TITLE
sql/pgwire: min/max report correct return type for prepared statements

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -111,11 +111,11 @@
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
-<tr><td><a name="max"></a><code>max(arg1: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+<tr><td><a name="max"></a><code>max(arg1: anyenum) &rarr; anyenum</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: box2d) &rarr; box2d</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
-<tr><td><a name="max"></a><code>max(arg1: collatedstring{*}) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+<tr><td><a name="max"></a><code>max(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: geography) &rarr; geography</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
@@ -155,11 +155,11 @@
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
-<tr><td><a name="min"></a><code>min(arg1: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+<tr><td><a name="min"></a><code>min(arg1: anyenum) &rarr; anyenum</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: box2d) &rarr; box2d</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
-<tr><td><a name="min"></a><code>min(arg1: collatedstring{*}) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+<tr><td><a name="min"></a><code>min(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: geography) &rarr; geography</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -533,13 +533,13 @@ has no relationship with the commit order of concurrent transactions.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><a name="enum_first"></a><code>enum_first(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the first value of the input enum type.</p>
+<tr><td><a name="enum_first"></a><code>enum_first(val: anyenum) &rarr; anyenum</code></td><td><span class="funcdesc"><p>Returns the first value of the input enum type.</p>
 </span></td></tr>
-<tr><td><a name="enum_last"></a><code>enum_last(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the last value of the input enum type.</p>
+<tr><td><a name="enum_last"></a><code>enum_last(val: anyenum) &rarr; anyenum</code></td><td><span class="funcdesc"><p>Returns the last value of the input enum type.</p>
 </span></td></tr>
-<tr><td><a name="enum_range"></a><code>enum_range(lower: anyenum, upper: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array between the two arguments (inclusive).</p>
+<tr><td><a name="enum_range"></a><code>enum_range(lower: anyenum, upper: anyenum) &rarr; anyenum[]</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array between the two arguments (inclusive).</p>
 </span></td></tr>
-<tr><td><a name="enum_range"></a><code>enum_range(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array.</p>
+<tr><td><a name="enum_range"></a><code>enum_range(val: anyenum) &rarr; anyenum[]</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array.</p>
 </span></td></tr></tbody>
 </table>
 
@@ -984,7 +984,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="generate_subscripts"></a><code>generate_subscripts(array: anyelement[], dim: <a href="int.html">int</a>, reverse: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a series comprising the given array’s subscripts.</p>
 <p>When reverse is true, the series is returned in reverse order.</p>
 </span></td></tr>
-<tr><td><a name="information_schema._pg_expandarray"></a><code>information_schema._pg_expandarray(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows with an index</p>
+<tr><td><a name="information_schema._pg_expandarray"></a><code>information_schema._pg_expandarray(input: anyelement[]) &rarr; tuple{anyelement AS x, int AS n}</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows with an index</p>
 </span></td></tr>
 <tr><td><a name="json_array_elements"></a><code>json_array_elements(input: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
@@ -1082,7 +1082,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 </tbody>
 </table>
 </span></td></tr>
-<tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
+<tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple{anyelement AS unnest, anyelement AS unnest, anyelement AS unnest}</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
 </span></td></tr>
 <tr><td><a name="unnest"></a><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
 </span></td></tr></tbody>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -196,7 +196,7 @@ func generateFunctions(from []string, categorize bool) []byte {
 			}
 			args := fn.Types.String()
 
-			retType := fn.FixedReturnType()
+			retType := fn.InferReturnTypeFromInputArgTypes(fn.Types.Types())
 			ret := retType.String()
 
 			cat := props.Category

--- a/pkg/sql/colexec/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/hash_min_max_agg.eg.go
@@ -509,9 +509,9 @@ type minInt16HashAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int16
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int16s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -524,7 +524,7 @@ var _ aggregateFunc = &minInt16HashAgg{}
 func (a *minInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int16()
 	a.Reset()
 }
 
@@ -551,7 +551,7 @@ func (a *minInt16HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -575,7 +575,7 @@ func (a *minInt16HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -588,7 +588,7 @@ func (a *minInt16HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -612,7 +612,7 @@ func (a *minInt16HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -661,9 +661,9 @@ type minInt32HashAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int32
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int32s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -676,7 +676,7 @@ var _ aggregateFunc = &minInt32HashAgg{}
 func (a *minInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int32()
 	a.Reset()
 }
 
@@ -703,7 +703,7 @@ func (a *minInt32HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -727,7 +727,7 @@ func (a *minInt32HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -740,7 +740,7 @@ func (a *minInt32HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -764,7 +764,7 @@ func (a *minInt32HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -855,7 +855,7 @@ func (a *minInt64HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -879,7 +879,7 @@ func (a *minInt64HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -892,7 +892,7 @@ func (a *minInt64HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -916,7 +916,7 @@ func (a *minInt64HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1967,9 +1967,9 @@ type maxInt16HashAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int16
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int16s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -1982,7 +1982,7 @@ var _ aggregateFunc = &maxInt16HashAgg{}
 func (a *maxInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int16()
 	a.Reset()
 }
 
@@ -2009,7 +2009,7 @@ func (a *maxInt16HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2033,7 +2033,7 @@ func (a *maxInt16HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -2046,7 +2046,7 @@ func (a *maxInt16HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2070,7 +2070,7 @@ func (a *maxInt16HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -2119,9 +2119,9 @@ type maxInt32HashAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int32
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int32s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -2134,7 +2134,7 @@ var _ aggregateFunc = &maxInt32HashAgg{}
 func (a *maxInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int32()
 	a.Reset()
 }
 
@@ -2161,7 +2161,7 @@ func (a *maxInt32HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2185,7 +2185,7 @@ func (a *maxInt32HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -2198,7 +2198,7 @@ func (a *maxInt32HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2222,7 +2222,7 @@ func (a *maxInt32HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -2313,7 +2313,7 @@ func (a *maxInt64HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2337,7 +2337,7 @@ func (a *maxInt64HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -2350,7 +2350,7 @@ func (a *maxInt64HashAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -2374,7 +2374,7 @@ func (a *maxInt64HashAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -45,12 +45,6 @@ func _ASSIGN_CMP(_, _, _, _, _, _ string) bool {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
-// _COPYVAL_MAYBE_CAST is the template function for copying the second argument
-// into the first one, possibly performing a cast in the process.
-func _COPYVAL_MAYBE_CAST(_, _ string) bool {
-	colexecerror.InternalError(errors.AssertionFailedf(""))
-}
-
 // */}}
 
 func newMin_AGGKINDAggAlloc(
@@ -310,14 +304,14 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _H
 	if !isNull {
 		if !a.foundNonNullForCurrentGroup {
 			val := col.Get(i)
-			_COPYVAL_MAYBE_CAST(a.curAgg, val)
+			execgen.COPYVAL(a.curAgg, val)
 			a.foundNonNullForCurrentGroup = true
 		} else {
 			var cmp bool
 			candidate := col.Get(i)
 			_ASSIGN_CMP(cmp, candidate, a.curAgg, _, col, _)
 			if cmp {
-				_COPYVAL_MAYBE_CAST(a.curAgg, candidate)
+				execgen.COPYVAL(a.curAgg, candidate)
 			}
 		}
 	}

--- a/pkg/sql/colexec/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/ordered_min_max_agg.eg.go
@@ -854,9 +854,9 @@ type minInt16OrderedAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int16
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int16s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -869,7 +869,7 @@ var _ aggregateFunc = &minInt16OrderedAgg{}
 func (a *minInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int16()
 	a.Reset()
 }
 
@@ -910,7 +910,7 @@ func (a *minInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -934,7 +934,7 @@ func (a *minInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -959,7 +959,7 @@ func (a *minInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -983,7 +983,7 @@ func (a *minInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1011,7 +1011,7 @@ func (a *minInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1035,7 +1035,7 @@ func (a *minInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1060,7 +1060,7 @@ func (a *minInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1084,7 +1084,7 @@ func (a *minInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1137,9 +1137,9 @@ type minInt32OrderedAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int32
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int32s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -1152,7 +1152,7 @@ var _ aggregateFunc = &minInt32OrderedAgg{}
 func (a *minInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int32()
 	a.Reset()
 }
 
@@ -1193,7 +1193,7 @@ func (a *minInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1217,7 +1217,7 @@ func (a *minInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1242,7 +1242,7 @@ func (a *minInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1266,7 +1266,7 @@ func (a *minInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1294,7 +1294,7 @@ func (a *minInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1318,7 +1318,7 @@ func (a *minInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1343,7 +1343,7 @@ func (a *minInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1367,7 +1367,7 @@ func (a *minInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1476,7 +1476,7 @@ func (a *minInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1500,7 +1500,7 @@ func (a *minInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1525,7 +1525,7 @@ func (a *minInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1549,7 +1549,7 @@ func (a *minInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1577,7 +1577,7 @@ func (a *minInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1601,7 +1601,7 @@ func (a *minInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -1626,7 +1626,7 @@ func (a *minInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -1650,7 +1650,7 @@ func (a *minInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3542,9 +3542,9 @@ type maxInt16OrderedAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int16
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int16s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -3557,7 +3557,7 @@ var _ aggregateFunc = &maxInt16OrderedAgg{}
 func (a *maxInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int16()
 	a.Reset()
 }
 
@@ -3598,7 +3598,7 @@ func (a *maxInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3622,7 +3622,7 @@ func (a *maxInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3647,7 +3647,7 @@ func (a *maxInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3671,7 +3671,7 @@ func (a *maxInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3699,7 +3699,7 @@ func (a *maxInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3723,7 +3723,7 @@ func (a *maxInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3748,7 +3748,7 @@ func (a *maxInt16OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3772,7 +3772,7 @@ func (a *maxInt16OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3825,9 +3825,9 @@ type maxInt32OrderedAgg struct {
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
-	curAgg int64
+	curAgg int32
 	// col points to the output vector we are updating.
-	col coldata.Int64s
+	col coldata.Int32s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
@@ -3840,7 +3840,7 @@ var _ aggregateFunc = &maxInt32OrderedAgg{}
 func (a *maxInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.col = vec.Int64()
+	a.col = vec.Int32()
 	a.Reset()
 }
 
@@ -3881,7 +3881,7 @@ func (a *maxInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3905,7 +3905,7 @@ func (a *maxInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3930,7 +3930,7 @@ func (a *maxInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -3954,7 +3954,7 @@ func (a *maxInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -3982,7 +3982,7 @@ func (a *maxInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4006,7 +4006,7 @@ func (a *maxInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -4031,7 +4031,7 @@ func (a *maxInt32OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4055,7 +4055,7 @@ func (a *maxInt32OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -4164,7 +4164,7 @@ func (a *maxInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4188,7 +4188,7 @@ func (a *maxInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -4213,7 +4213,7 @@ func (a *maxInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4237,7 +4237,7 @@ func (a *maxInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -4265,7 +4265,7 @@ func (a *maxInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4289,7 +4289,7 @@ func (a *maxInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}
@@ -4314,7 +4314,7 @@ func (a *maxInt64OrderedAgg) Compute(
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
 								val := col.Get(i)
-								a.curAgg = int64(val)
+								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
@@ -4338,7 +4338,7 @@ func (a *maxInt64OrderedAgg) Compute(
 								}
 
 								if cmp {
-									a.curAgg = int64(candidate)
+									a.curAgg = candidate
 								}
 							}
 						}

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -211,12 +211,8 @@ func TestTypingAggregateAssumptions(t *testing.T) {
 			if name == "min" || name == "max" {
 				// Evaluate the return typer.
 				types := overload.Types.Types()
-				args := make([]tree.TypedExpr, len(types))
-				for i, t := range types {
-					args[i] = &tree.TypedDummy{Typ: t}
-				}
-				retType = overload.ReturnType(args)
-				if retType != overload.Types.Types()[0] {
+				retType = overload.InferReturnTypeFromInputArgTypes(types)
+				if retType != types[0] {
 					t.Errorf("return type differs from arg type for %s: %+v", name, overload.Types.Types())
 				}
 				continue

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -1,4 +1,14 @@
 send
+Query {"String": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
 Query {"String": "CREATE TABLE t (i INT8, t TEXT)"}
 ----
 

--- a/pkg/sql/pgwire/testdata/pgtest/copy_file_upload
+++ b/pkg/sql/pgwire/testdata/pgtest/copy_file_upload
@@ -12,10 +12,17 @@ CopyDone
 
 # We expect an error here because file uploads aren't enabled in the
 # test server. This test is here to verify that there wasn't a panic.
-until
+until crdb_only
 ErrorResponse
 ReadyForQuery
 ----
 {"Type":"CopyInResponse","ColumnFormatCodes":[0]}
 {"Type":"ErrorResponse","Code":"XXUUU"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42601"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/data_type_size
+++ b/pkg/sql/pgwire/testdata/pgtest/data_type_size
@@ -1,0 +1,85 @@
+# This test verifies that the DataTypeSize field in the RowDescription and
+# DataRow messages both agree when using the MAX aggregate on an INT4 column.
+
+# Prepare the environment.
+send
+Query {"String": "DROP TABLE IF EXISTS minmax_test"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE minmax_test (id INT8 PRIMARY KEY, b INT4, c FLOAT4)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send
+Query {"String": "INSERT INTO minmax_test (id, b, c) VALUES (1, 1000, 11.1), (2, 250, 55.5)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT max(b), min(c) FROM minmax_test"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1000"},{"text":"11.1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+send
+Parse {"Name": "s1", "Query": "SELECT max(b), min(c) FROM minmax_test"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1"}
+Describe {"ObjectType": 80, "Name": "p1"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1000"},{"text":"11.1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+# ResultFormatCodes [1] = FormatBinary
+send
+Parse {"Name": "s2", "Query": "SELECT max(b), min(c) FROM minmax_test"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2", "ResultFormatCodes": [1,1]}
+Describe {"ObjectType": 80, "Name": "p2"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":1},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":1}]}
+{"Type":"DataRow","Values":[{"binary":"000003e8"},{"text":"A1\ufffd\ufffd"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -2,7 +2,7 @@
 
 # Prepare the environment.
 send noncrdb_only
-Query {"String": "DROP TYPE IF EXISTS te"}
+Query {"String": "DROP TYPE IF EXISTS te CASCADE"}
 ----
 
 until noncrdb_only ignore=NoticeResponse
@@ -73,14 +73,14 @@ ReadyForQuery
 
 # Prepare a query and type hint a user defined type. Then bind this prepared
 # statement with a user defined type argument ([104, 105] = 'hi').
-send
+send crdb_only
 Parse {"Name": "s1", "Query": "INSERT INTO tb VALUES ($1)", "ParameterOIDs": [100052]}
 Bind {"DestinationPortal": "p", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [[104, 105]]}
 Execute {"Portal": "p"}
 Sync
 ----
 
-until
+until crdb_only
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
@@ -89,21 +89,12 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Ensure that our value was successfully inserted.
-send
+send crdb_only
 Query {"String": "SELECT * FROM tb"}
 ----
 
-until ignore_table_oids ignore_type_oids noncrdb_only
-RowDescription
-----
-{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":0,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-
 until crdb_only
-RowDescription
-----
-{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-
-until
 DataRow
 ----
+{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hi"}]}

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -42,12 +42,16 @@ send
 Query {"String": "DISCARD ALL"}
 ----
 
-until
+until crdb_only ignore=ParameterStatus
 ReadyForQuery
 ----
-{"Type":"ParameterStatus","Name":"application_name","Value":""}
-{"Type":"ParameterStatus","Name":"TimeZone","Value":"UTC"}
 {"Type":"CommandComplete","CommandTag":"DISCARD"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only ignore=ParameterStatus
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DISCARD ALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Send a simple query in the middle of extended protocol, which is apparently

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -300,18 +300,22 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send
+send crdb_only
 Query {"String": "SET enable_experimental_alter_column_type_general = true"}
 ----
 
-until
+until crdb_only
 ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"SET"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send
+send crdb_only
 Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE STRING"}
+----
+
+send noncrdb_only
+Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE TEXT"}
 ----
 
 until
@@ -341,7 +345,7 @@ BindComplete
 until noncrdb_only ignore_table_oids
 RowDescription
 ----
-{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":1015,"DataTypeSize":-1,"TypeModifier":260,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 
 until crdb_only
 RowDescription

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -209,28 +209,18 @@ var aggregates = map[string]builtinDefinition{
 		func(t *types.T) tree.Overload {
 			info := "Identifies the maximum selected value."
 			vol := tree.VolatilityImmutable
-			// If t is an ambiguous type (like AnyCollatedString), then our aggregate
-			// does not have a fixed return type.
-			if t.IsAmbiguous() {
-				return makeAggOverloadWithReturnType(
-					[]*types.T{t}, tree.FirstNonNullReturnType(), newMaxAggregate, info, vol,
-				)
-			}
-			return makeAggOverload([]*types.T{t}, t, newMaxAggregate, info, vol)
+			return makeAggOverloadWithReturnType(
+				[]*types.T{t}, tree.IdentityReturnType(0), newMaxAggregate, info, vol,
+			)
 		}),
 
 	"min": collectOverloads(aggProps(), allMaxMinAggregateTypes,
 		func(t *types.T) tree.Overload {
 			info := "Identifies the minimum selected value."
 			vol := tree.VolatilityImmutable
-			// If t is an ambiguous type (like AnyCollatedString), then our aggregate
-			// does not have a fixed return type.
-			if t.IsAmbiguous() {
-				return makeAggOverloadWithReturnType(
-					[]*types.T{t}, tree.FirstNonNullReturnType(), newMinAggregate, info, vol,
-				)
-			}
-			return makeAggOverload([]*types.T{t}, t, newMinAggregate, info, vol)
+			return makeAggOverloadWithReturnType(
+				[]*types.T{t}, tree.IdentityReturnType(0), newMinAggregate, info, vol,
+			)
 		}),
 
 	"string_agg": makeBuiltin(aggPropsNullableArgs(),

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -201,6 +201,8 @@ var generators = map[string]builtinDefinition{
 				FixedTypes: []*types.T{types.AnyArray, types.AnyArray},
 				VarType:    types.AnyArray,
 			},
+			// TODO(rafiss): update this or docgen so that functions.md shows the
+			// return type as variadic.
 			func(args []tree.TypedExpr) *types.T {
 				returnTypes := make([]*types.T, len(args))
 				labels := make([]string, len(args))

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1243,7 +1243,7 @@ func newBinExprIfValidOverload(op BinaryOperator, left TypedExpr, right TypedExp
 			Right:    right,
 			Fn:       fn,
 		}
-		expr.typ = returnTypeToFixedType(fn.returnType())
+		expr.typ = returnTypeToFixedType(fn.returnType(), []TypedExpr{left, right})
 		return expr
 	}
 	return nil

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -102,7 +102,32 @@ func (b Overload) FixedReturnType() *types.T {
 	if b.ReturnType == nil {
 		return nil
 	}
-	return returnTypeToFixedType(b.ReturnType)
+	return returnTypeToFixedType(b.ReturnType, nil)
+}
+
+// InferReturnTypeFromInputArgTypes returns the type that the function returns,
+// inferring the type based on the function's inputTypes if necessary.
+func (b Overload) InferReturnTypeFromInputArgTypes(inputTypes []*types.T) *types.T {
+	retTyp := b.FixedReturnType()
+	// If the output type of the function depends on its inputs, then
+	// the output of FixedReturnType will be ambiguous. In the ambiguous
+	// cases, use the information about the input types to construct the
+	// appropriate output type. The tree.ReturnTyper interface is
+	// []tree.TypedExpr -> *types.T, so construct the []tree.TypedExpr
+	// from the types that we know are the inputs. Note that we don't
+	// try to create datums of each input type, and instead use this
+	// "TypedDummy" construct. This is because some types don't have resident
+	// members (like an ENUM with no values), and we shouldn't error out
+	// trying to infer the return type in those cases.
+	if retTyp.IsAmbiguous() {
+		args := make([]TypedExpr, len(inputTypes))
+		for i, t := range inputTypes {
+			args[i] = &TypedDummy{Typ: t}
+		}
+		// Evaluate ReturnType with the fake input set of arguments.
+		retTyp = returnTypeToFixedType(b.ReturnType, args)
+	}
+	return retTyp
 }
 
 // Signature returns a human-readable signature.
@@ -409,8 +434,8 @@ func FirstNonNullReturnType() ReturnTyper {
 	}
 }
 
-func returnTypeToFixedType(s ReturnTyper) *types.T {
-	if t := s(nil); t != UnknownReturnType {
+func returnTypeToFixedType(s ReturnTyper, inputTyps []TypedExpr) *types.T {
+	if t := s(inputTyps); t != UnknownReturnType {
 		return t
 	}
 	return types.Any
@@ -936,15 +961,17 @@ func formatCandidates(prefix string, candidates []overloadImpl) string {
 		buf.WriteByte('(')
 		params := candidate.params()
 		tLen := params.Length()
+		inputTyps := make([]TypedExpr, tLen)
 		for i := 0; i < tLen; i++ {
 			t := params.GetAt(i)
+			inputTyps[i] = &TypedDummy{Typ: t}
 			if i > 0 {
 				buf.WriteString(", ")
 			}
 			buf.WriteString(t.String())
 		}
 		buf.WriteString(") -> ")
-		buf.WriteString(returnTypeToFixedType(candidate.returnType()).String())
+		buf.WriteString(returnTypeToFixedType(candidate.returnType(), inputTyps).String())
 		if candidate.preferred() {
 			buf.WriteString(" [preferred]")
 		}


### PR DESCRIPTION
fixes #54016
fixes #55313 

When using a prepared statement, the optimizer is used in order to
determine the type OIDs of the resulting row. Since the min/max
aggregates had an overload that used a fix return type, min/max over
INT4 columns were reported as INT8. However, when it came to execution
time, they would in fact be INT4. This confuses drivers, and in the case
of pgx and pgjdbc, causes a runtime exception because the wrong number
of bytes was returned (it had to read 4 bytes for something we reported
was an 8 byte column).

Now, the min/max overloads return the same type as the argument type.
This allows us to remove special-case logic in the vectorized engine for
int64s. It also requires an update to how the engine calculates the
return type of window functions.

Also, there is a pgwire test for checking the data type size in the
RowDescription now.

The first commit in this PR cleans up existing pgwire tests so they pass against Postgres.

Release note (bug fix): Using the min/max aggregates in a prepared
statement will now report the correct data type size.