### PR TITLE
ccl/backupccl: skip TestBackupRestoreAppend

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -444,6 +444,7 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 54039, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 1000


### PR DESCRIPTION
Refs: #54039

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None