### PR TITLE
sql: improve error message when an un-qualified object can't be resolved

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -952,7 +952,7 @@ SET DATABASE = ""
 statement error at or near "@": syntax error
 GRANT ALL ON a.t@xyz TO readwrite
 
-statement error no database specified
+statement error no database or schema specified
 GRANT ALL ON * TO readwrite
 
 statement error pgcode 42P01 relation "a.tt" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -40,7 +40,7 @@ SHOW database
 database
 ·
 
-statement error no database specified
+statement error no database or schema specified
 SHOW TABLES
 
 # Verify SHOW TABLES FROM works when there is no current database.

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,7 +1,7 @@
 statement ok
 SET DATABASE = ""
 
-statement error no database specified
+statement error no database or schema specified
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error invalid table name: test.""

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -174,7 +174,7 @@ func (oc *optCatalog) ResolveSchema(
 	if !found {
 		if !name.ExplicitSchema && !name.ExplicitCatalog {
 			return nil, cat.SchemaName{}, pgerror.New(
-				pgcode.InvalidName, "no database specified",
+				pgcode.InvalidName, "no database or schema specified",
 			)
 		}
 		return nil, cat.SchemaName{}, pgerror.Newf(


### PR DESCRIPTION
Previously, when an un-qualified object name couldn't be resolved the
error message would say that the database wasn't specified. Now that we
support user defined schemas, the error message should be updated to
reflect that no database or schema was specified.

Closes #53845

Release note: None