### PR TITLE
debug: remove logspy max line count limit

### DIFF
--- a/pkg/server/debug/logspy.go
+++ b/pkg/server/debug/logspy.go
@@ -88,7 +88,6 @@ func (d durationAsString) String() string {
 
 const (
 	logSpyDefaultDuration = durationAsString(5 * time.Second)
-	logSpyMaxCount        = 10000
 	logSpyDefaultCount    = 1000
 	logSpyChanCap         = 4096
 )
@@ -120,11 +119,6 @@ func logSpyOptionsFromValues(values url.Values) (logSpyOptions, error) {
 
 	if opts.Count == 0 {
 		opts.Count = logSpyDefaultCount
-	} else if opts.Count > logSpyMaxCount {
-		return logSpyOptions{}, errors.Errorf(
-			"count %d is too large (limit is %d); consider restricting your filter",
-			opts.Count, logSpyMaxCount,
-		)
 	}
 	return opts, nil
 }

--- a/pkg/server/debug/logspy_test.go
+++ b/pkg/server/debug/logspy_test.go
@@ -73,13 +73,6 @@ func TestDebugLogSpyOptions(t *testing.T) {
 				Duration: logSpyDefaultDuration,
 			},
 		},
-		{
-			// Can't stream out too much at once.
-			vals: map[string][]string{
-				"Count": {strconv.Itoa(2 * logSpyMaxCount)},
-			},
-			expErr: (`count .* is too large .limit is .*.`),
-		},
 		// Various parse errors.
 		{
 			vals: map[string][]string{


### PR DESCRIPTION
It wasn't useful and is getting in the way of effective debugging.

Closes #54119

Release justification: zero-risk change to debugging tools
Release note: None
