### PR TITLE
geo/geomfn: Implement ST_SwapOrdinates

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2055,6 +2055,9 @@ The paths themselves are given in the direction of the first geometry.</p>
 <li>S: has spatial reference system</li>
 </ul>
 </span></td></tr>
+<tr><td><a name="st_swapordinates"></a><code>st_swapordinates(geometry: geometry, cstring: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a version of the given geometry with given ordinates swapped.
+The ords parameter is a 2-characters string naming the ordinates to swap. Valid names are: x,y,z and m.</p>
+</span></td></tr>
 <tr><td><a name="st_symdifference"></a><code>st_symdifference(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the symmetric difference of both geometries.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/swap_ordinates.go
+++ b/pkg/geo/geomfn/swap_ordinates.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// SwapOrdinates returns a version of the given geometry with given ordinates swapped.
+// The ords parameter is a 2-characters string naming the ordinates to swap. Valid names are: x,y,z and m.
+func SwapOrdinates(geometry geo.Geometry, ords string) (geo.Geometry, error) {
+	if geometry.Empty() {
+		return geometry, nil
+	}
+
+	t, err := geometry.AsGeomT()
+	if err != nil {
+		return geometry, err
+	}
+
+	newT, err := applyOnCoordsForGeomT(t, func(l geom.Layout, dst, src []float64) error {
+		if len(ords) != 2 {
+			return errInvalidOrdinate
+		}
+		ordIndex, err := getOrdsIndex(l, src, ords)
+		if err != nil {
+			return err
+		}
+
+		dst[ordIndex[0]], dst[ordIndex[1]] = src[ordIndex[1]], src[ordIndex[0]]
+		return nil
+	})
+	if err != nil {
+		return geometry, err
+	}
+
+	return geo.MakeGeometryFromGeomT(newT)
+}
+
+var ordsMap = map[uint8]int{
+	'x': 0,
+	'y': 1,
+	'z': 2,
+	'm': 3,
+}
+
+var errInvalidOrdinate = errors.New("invalid ordinate specification. need two letters from the set (x,y,z and m)")
+
+func getOrdsIndex(l geom.Layout, src []float64, ords string) ([2]int, error) {
+	ords = strings.ToLower(ords)
+	var ordsIndex [2]int
+	for i := 0; i < len(ords); i++ {
+		o, ok := ordsMap[ords[i]]
+		if !ok {
+			return ordsIndex, errInvalidOrdinate
+		}
+		if o > len(src)/l.Stride() {
+			return ordsIndex, fmt.Errorf("geometry does not have an %s ordinate", string(ords[i]))
+		}
+		ordsIndex[i] = o
+	}
+
+	return ordsIndex, nil
+}

--- a/pkg/geo/geomfn/swap_ordinates_test.go
+++ b/pkg/geo/geomfn/swap_ordinates_test.go
@@ -1,0 +1,182 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestSwapOrdinates(t *testing.T) {
+	tests := []struct {
+		name      string
+		input1    geom.T
+		input2    string
+		want      geom.T
+		errString string
+	}{
+		{
+			name:      "swap ordinates with invalid ords spec",
+			input1:    geom.NewPointFlat(geom.XY, []float64{10.2, 20.2}),
+			input2:    "ax",
+			want:      geom.NewPointFlat(geom.XY, []float64{10.2, 20.2}),
+			errString: "invalid ordinate specification. need two letters from the set (x,y,z and m)",
+		},
+
+		{
+			name:      "swap ordinates with the geometry doesn't have m ordinate",
+			input1:    geom.NewPointFlat(geom.XY, []float64{10.2, 20.2}),
+			input2:    "mx",
+			want:      geom.NewPointFlat(geom.XY, []float64{10.2, 20.2}),
+			errString: "geometry does not have an m ordinate",
+		},
+		{
+			name:   "swap ordinate 2D point XY with the same X and Y value",
+			input1: geom.NewPointFlat(geom.XY, []float64{20.2, 20.2}),
+			input2: "yx",
+			want:   geom.NewPointFlat(geom.XY, []float64{20.2, 20.2}),
+		},
+		{
+			name:   "swap ordinate 2D point XY(capitalize)  with the same X and Y value",
+			input1: geom.NewPointFlat(geom.XY, []float64{20.2, 20.2}),
+			input2: "Yx",
+			want:   geom.NewPointFlat(geom.XY, []float64{20.2, 20.2}),
+		},
+		{
+			name:   "swap x to y from ordinate 2D POINT",
+			input1: geom.NewPointFlat(geom.XY, []float64{10.2, 20.2}),
+			input2: "xy",
+			want:   geom.NewPointFlat(geom.XY, []float64{20.2, 10.2}),
+		},
+		{
+			name:   "swap y to x from ordinate 2D Line String",
+			input1: geom.NewLineStringFlat(geom.XY, []float64{1, 2, 3, 4}),
+			input2: "yx",
+			want:   geom.NewLineStringFlat(geom.XY, []float64{2, 1, 4, 3}),
+		},
+		{
+			name:   "swap y to x from ordinate 2D Line String with same coordinates",
+			input1: geom.NewLineStringFlat(geom.XY, []float64{2, 2, 3, 3}),
+			input2: "yx",
+			want:   geom.NewLineStringFlat(geom.XY, []float64{2, 2, 3, 3}),
+		},
+		{
+			name:   "swap y to x from ordinate 2D Polygon",
+			input1: geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 0, 10, 0, 0}, []int{8}),
+			input2: "yx",
+			want:   geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 10, 0, 0, 0}, []int{8}),
+		},
+		{
+			name:   "swap y to x from coordinates of a multi polygon",
+			input1: geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 4, 0, 4, 4, 0, 4, 0, 0, 1, 1, 2, 1, 2, 2, 1, 2, 1, 1, -1, -1, -1, -2, -2, -2, -2, -1, -1, -1}, [][]int{{10, 20}, {30}}),
+			input2: "yx",
+			want:   geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 0, 4, 4, 4, 4, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, -1, -1, -2, -1, -2, -2, -1, -2, -1, -1}, [][]int{{10, 20}, {30}}),
+		},
+		{
+			name:   "swap y to x from coordinates of a multi line string",
+			input1: geom.NewMultiLineStringFlat(geom.XY, []float64{0, 0, 1, 1, 1, 2, 2, 3, 3, 2, 5, 4}, []int{6, 12}),
+			input2: "yx",
+			want:   geom.NewMultiLineStringFlat(geom.XY, []float64{0, 0, 1, 1, 2, 1, 3, 2, 2, 3, 4, 5}, []int{6, 12}),
+		},
+		{
+			name:   "swap y to x from coordinates of an empty line string",
+			input1: geom.NewLineString(geom.XY),
+			input2: "yx",
+			want:   geom.NewLineString(geom.XY),
+		},
+		{
+			name:   "swap y to x from coordinates of an empty polygon",
+			input1: geom.NewPolygon(geom.XY),
+			input2: "yx",
+			want:   geom.NewPolygon(geom.XY),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geometry, err := geo.MakeGeometryFromGeomT(tt.input1)
+			require.NoError(t, err)
+
+			got, err := SwapOrdinates(geometry, tt.input2)
+			if (err != nil) && (tt.errString != err.Error()) {
+				t.Errorf("SwapOrdinates() error = %v, wantErr %v", err, tt.errString)
+				return
+			}
+
+			geometryWant, err := geo.MakeGeometryFromGeomT(tt.want)
+			require.NoError(t, err)
+			require.Equal(t, geometryWant, got)
+		})
+	}
+}
+
+func TestSwapOrdinates_Collection(t *testing.T) {
+	tests := []struct {
+		name      string
+		input1    *geom.GeometryCollection
+		input2    string
+		want      *geom.GeometryCollection
+		errString string
+	}{
+		{
+			name: "swap xy from coordinates of non-empty collection with no error",
+			input1: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+				geom.NewPolygonFlat(geom.XY, []float64{150, 85, -30, 85, -20, 85, 160, 85, 150, 85}, []int{10}),
+			),
+			input2: "xy",
+			want: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{3, 1.1}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+				geom.NewPolygonFlat(geom.XY, []float64{85, 150, 85, -30, 85, -20, 85, 160, 85, 150}, []int{10}),
+			),
+			errString: "",
+		},
+		{
+			name: "swap xy from coordinates of non-empty collection with error",
+			input1: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+			),
+			input2: "xz",
+			want: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+			),
+			errString: "geometry does not have an z ordinate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geometry, err := geo.MakeGeometryFromGeomT(tt.input1)
+			require.NoError(t, err)
+
+			got, err := SwapOrdinates(geometry, tt.input2)
+			if (err != nil) && (tt.errString != err.Error()) {
+				t.Errorf("SwapOrdinates() error = %v, wantErr %v", err, tt.errString)
+				return
+			}
+
+			g, err := got.AsGeomT()
+			require.NoError(t, err)
+
+			gotCollection, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+
+			require.Equal(t, tt.want, gotCollection)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4735,3 +4735,24 @@ POINT EMPTY                                            POINT EMPTY              
 POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0.1 -0, -1 0, -1 -1, 0.1 -1, 0.1 -0))        POLYGON ((-0.070710678118655 -0.070710678118655, 0.707106781186548 0.707106781186547, 0 1.414213562373095, -0.777817459305202 0.636396103067893, -0.070710678118655 -0.070710678118655))
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((1 -0, 0 0, -0 -1, 1 -1, 1 -0))               POLYGON ((-0.707106781186548 -0.707106781186547, 0 0, -0.707106781186547 0.707106781186548, -1.414213562373095 0, -0.707106781186548 -0.707106781186547))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, -1 0, -1 -1, -0 -1, 0 0))               POLYGON ((0 0, 0.707106781186548 0.707106781186547, 0 1.414213562373095, -0.707106781186547 0.707106781186548, 0 0))
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_SwapOrdinates(a.geom,'Xy'))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION EMPTY	                             GEOMETRYCOLLECTION EMPTY
+GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0)))	   GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0)))
+LINESTRING(-0.5 0.5,0.5 0.5)	                         LINESTRING(0.5 -0.5,0.5 0.5)
+LINESTRING EMPTY	                                     LINESTRING EMPTY
+POINT(-0.5 0.5)	                                       POINT(0.5 -0.5)
+POINT(0.5 0.5)	                                       POINT(0.5 0.5)
+POINT(5 5)	                                           POINT(5 5)
+POINT EMPTY	                                           POINT EMPTY
+POLYGON((0 0,1 0,1 1,0 1,0 0))	                       POLYGON((0 0,0 1,1 1,1 0,0 0))
+POLYGON((-0.1 0,1 0,1 1,-0.1 1,-0.1 0))	               POLYGON((0 -0.1,0 1,1 1,1 -0.1,0 -0.1))
+POLYGON((-1 0,0 0,0 1,-1 1,-1 0))	                     POLYGON((0 -1,0 0,1 0,1 -1,0 -1))
+

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4181,6 +4181,38 @@ Bottom Left.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_swapordinates": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{
+					Name: "geometry",
+					Typ:  types.Geometry,
+				},
+				{
+					Name: "cstring",
+					Typ:  types.String,
+				},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				cString := tree.MustBeDString(args[1])
+
+				ret, err := geomfn.SwapOrdinates(g.Geometry, string(cString))
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a version of the given geometry with given ordinates swapped.
+The ords parameter is a 2-characters string naming the ordinates to swap. Valid names are: x,y,z and m.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
 	//
 	// BoundingBox
@@ -4691,7 +4723,6 @@ Bottom Left.`,
 	"st_snaptogrid":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49042}),
 	"st_split":                   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49045}),
 	"st_subdivide":               makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49048}),
-	"st_swapordinates":           makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49050}),
 	"st_tileenvelope":            makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49053}),
 	"st_transscale":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49061}),
 	"st_unaryunion":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49062}),


### PR DESCRIPTION
Currently PostGIS has the ST_SwapOrdinates, but CRDB hasn't.

Fixes #49050.

Release note (sql change): Implemented the geometry based builtins
`ST_SwapOrdinates`.