### PR TITLE
geo/geomfn: Implement ST_SwapOrdinates

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2070,6 +2070,9 @@ The paths themselves are given in the direction of the first geometry.</p>
 <li>S: has spatial reference system</li>
 </ul>
 </span></td></tr>
+<tr><td><a name="st_swapordinates"></a><code>st_swapordinates(geometry: geometry, swap_ordinate_string: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a version of the given geometry with given ordinates swapped.
+The swap_ordinate_string parameter is a 2-character string naming the ordinates to swap. Valid names are: x, y, z and m.</p>
+</span></td></tr>
 <tr><td><a name="st_symdifference"></a><code>st_symdifference(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the symmetric difference of both geometries.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/swap_ordinates.go
+++ b/pkg/geo/geomfn/swap_ordinates.go
@@ -1,0 +1,84 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// SwapOrdinates returns a version of the given geometry with given ordinates swapped.
+// The ords parameter is a 2-characters string naming the ordinates to swap. Valid names are: x,y,z and m.
+func SwapOrdinates(geometry geo.Geometry, ords string) (geo.Geometry, error) {
+	if geometry.Empty() {
+		return geometry, nil
+	}
+
+	t, err := geometry.AsGeomT()
+	if err != nil {
+		return geometry, err
+	}
+
+	newT, err := applyOnCoordsForGeomT(t, func(l geom.Layout, dst, src []float64) error {
+		if len(ords) != 2 {
+			return errors.New("invalid ordinate specification. need two letters from the set (x, y, z and m)")
+		}
+		ordsIndices, err := getOrdsIndices(l, ords)
+		if err != nil {
+			return err
+		}
+
+		dst[ordsIndices[0]], dst[ordsIndices[1]] = src[ordsIndices[1]], src[ordsIndices[0]]
+		return nil
+	})
+	if err != nil {
+		return geometry, err
+	}
+
+	return geo.MakeGeometryFromGeomT(newT)
+}
+
+// getOrdsIndices get the indices position of ordinates string
+func getOrdsIndices(l geom.Layout, ords string) ([2]int, error) {
+	ords = strings.ToUpper(ords)
+	var ordIndices [2]int
+	for i := 0; i < len(ords); i++ {
+		oi := findOrdIndex(ords[i], l)
+		if oi == -2 {
+			return ordIndices, errors.New("invalid ordinate specification. need two letters from the set (x, y, z and m)")
+		}
+		if oi == -1 {
+			return ordIndices, fmt.Errorf("geometry does not have a %s ordinate", string(ords[i]))
+		}
+		ordIndices[i] = oi
+	}
+
+	return ordIndices, nil
+}
+
+func findOrdIndex(ordString uint8, l geom.Layout) int {
+	switch ordString {
+	case 'X':
+		return 0
+	case 'Y':
+		return 1
+	case 'Z':
+		return l.ZIndex()
+	case 'M':
+		return l.MIndex()
+	default:
+		return -2
+	}
+}

--- a/pkg/geo/geomfn/swap_ordinates_test.go
+++ b/pkg/geo/geomfn/swap_ordinates_test.go
@@ -1,0 +1,187 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestSwapOrdinates(t *testing.T) {
+	tests := []struct {
+		name                  string
+		inGeomCollection      *geom.GeometryCollection
+		inSwapOrdinatesString string
+		wantGeomCollection    *geom.GeometryCollection
+		errString             string
+	}{
+		{
+			name:                  "swap ordinates with invalid ords spec",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{10.2, 20.2})),
+			inSwapOrdinatesString: "ax",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{10.2, 20.2})),
+			errString:             "invalid ordinate specification. need two letters from the set (x, y, z and m)",
+		},
+		{
+			name:                  "swap ordinates with the geometry doesn't have m ordinate",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{10.2, 20.2})),
+			inSwapOrdinatesString: "mx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{10.2, 20.2})),
+			errString:             "geometry does not have a M ordinate",
+		},
+		{
+			name:                  "swap ordinate 2D point XY with the same X and Y value",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{20.2, 20.2})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{20.2, 20.2})),
+		},
+		{
+			name:                  "swap ordinate 2D point XY(capitalize)  with the same X and Y value",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{20.2, 20.2})),
+			inSwapOrdinatesString: "Yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{20.2, 20.2})),
+		},
+		{
+			name:                  "swap x to y from ordinate 2D POINT",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{10.2, 20.2})),
+			inSwapOrdinatesString: "xy",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPointFlat(geom.XY, []float64{20.2, 10.2})),
+		},
+		{
+			name:                  "swap y to x from ordinate 2D Line String",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewLineStringFlat(geom.XY, []float64{1, 2, 3, 4})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewLineStringFlat(geom.XY, []float64{2, 1, 4, 3})),
+		},
+		{
+			name:                  "swap y to x from ordinate 2D Line String with same coordinates",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewLineStringFlat(geom.XY, []float64{2, 2, 3, 3})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewLineStringFlat(geom.XY, []float64{2, 2, 3, 3})),
+		},
+		{
+			name:                  "swap y to x from ordinate 2D Polygon",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 0, 10, 0, 0}, []int{8})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5.55, 5.55, 10, 0, 0, 0}, []int{8})),
+		},
+		{
+			name:                  "swap y to x from coordinates of a multi polygon",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 4, 0, 4, 4, 0, 4, 0, 0, 1, 1, 2, 1, 2, 2, 1, 2, 1, 1, -1, -1, -1, -2, -2, -2, -2, -1, -1, -1}, [][]int{{10, 20}, {30}})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 0, 4, 4, 4, 4, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, -1, -1, -2, -1, -2, -2, -1, -2, -1, -1}, [][]int{{10, 20}, {30}})),
+		},
+		{
+			name:                  "swap y to x from coordinates of a multi line string",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewMultiLineStringFlat(geom.XY, []float64{0, 0, 1, 1, 1, 2, 2, 3, 3, 2, 5, 4}, []int{6, 12})),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewMultiLineStringFlat(geom.XY, []float64{0, 0, 1, 1, 2, 1, 3, 2, 2, 3, 4, 5}, []int{6, 12})),
+		},
+		{
+			name:                  "swap y to x from coordinates of an empty line string",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewLineString(geom.XY)),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewLineString(geom.XY)),
+		},
+		{
+			name:                  "swap y to x from coordinates of an empty polygon",
+			inGeomCollection:      geom.NewGeometryCollection().MustPush(geom.NewPolygon(geom.XY)),
+			inSwapOrdinatesString: "yx",
+			wantGeomCollection:    geom.NewGeometryCollection().MustPush(geom.NewPolygon(geom.XY)),
+		},
+		{
+			name: "swap xy from coordinates of non-empty collection with no error",
+			inGeomCollection: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+				geom.NewPolygonFlat(geom.XY, []float64{150, 85, -30, 85, -20, 85, 160, 85, 150, 85}, []int{10}),
+			),
+			inSwapOrdinatesString: "xy",
+			wantGeomCollection: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{3, 1.1}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+				geom.NewPolygonFlat(geom.XY, []float64{85, 150, 85, -30, 85, -20, 85, 160, 85, 150}, []int{10}),
+			),
+			errString: "",
+		},
+		{
+			name: "swap xy from coordinates of non-empty collection with error",
+			inGeomCollection: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+			),
+			inSwapOrdinatesString: "xz",
+			wantGeomCollection: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1.1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{3, 3}),
+			),
+			errString: "geometry does not have a Z ordinate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geometry, err := geo.MakeGeometryFromGeomT(tt.inGeomCollection)
+			require.NoError(t, err)
+
+			got, err := SwapOrdinates(geometry, tt.inSwapOrdinatesString)
+			if (err != nil) && (tt.errString != err.Error()) {
+				t.Errorf("SwapOrdinates() error = %v, wantErr %v", err, tt.errString)
+				return
+			}
+
+			geometryWant, err := geo.MakeGeometryFromGeomT(tt.wantGeomCollection)
+			require.NoError(t, err)
+			require.Equal(t, geometryWant, got)
+		})
+	}
+}
+
+// TestGetOrdsIndices tests the index position of Z and M
+// since currently the geo.Geometry doesn't support ordinates Z and M
+func TestGetOrdsIndices(t *testing.T) {
+	tests := []struct {
+		name               string
+		inputGeom          geom.T
+		inputSwapOrdinates string
+		wantIndices        [2]int
+	}{
+		{
+			name:               "the index position of m is on index 2",
+			inputGeom:          geom.NewPointFlat(geom.XYM, []float64{12, 2, 6}),
+			inputSwapOrdinates: "xm",
+			wantIndices:        [2]int{0, 2},
+		},
+		{
+			name:               "the index position of m is on index 3",
+			inputGeom:          geom.NewPointFlat(geom.XYZM, []float64{12, 2, 6, 7}),
+			inputSwapOrdinates: "xm",
+			wantIndices:        [2]int{0, 3},
+		},
+		{
+			name:               "the index position of z is on index 2",
+			inputGeom:          geom.NewPointFlat(geom.XYZM, []float64{12, 2, 6, 7}),
+			inputSwapOrdinates: "zy",
+			wantIndices:        [2]int{2, 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getOrdsIndices(tt.inputGeom.Layout(), tt.inputSwapOrdinates)
+			assert.NoError(t, err)
+			assert.Equal(t, got, tt.wantIndices)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4804,3 +4804,23 @@ POINT EMPTY                                            POINT EMPTY              
 POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.15 0, 0.95 0, 0.95 1, -0.15 1, -0.15 0))
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-0.95 0, 0.05 0, 0.05 1, -0.95 1, -0.95 0))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0.05 0, 0.95 0, 0.95 1, 0.05 1, 0.05 0))
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_SwapOrdinates(a.geom,'Xy'))
+FROM geom_operators_test a
+ORDER BY d
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (0.5 -0.5, 0.5 0.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (0.5 -0.5)
+POINT (0.5 0.5)                                        POINT (0.5 0.5)
+POINT (5 5)                                            POINT (5 5)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0 -0.1, 0 1, 1 1, 1 -0.1, 0 -0.1))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((0 -1, 0 0, 1 0, 1 -1, 0 -1))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4333,6 +4333,38 @@ Bottom Left.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_swapordinates": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{
+					Name: "geometry",
+					Typ:  types.Geometry,
+				},
+				{
+					Name: "swap_ordinate_string",
+					Typ:  types.String,
+				},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				cString := tree.MustBeDString(args[1])
+
+				ret, err := geomfn.SwapOrdinates(g.Geometry, string(cString))
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a version of the given geometry with given ordinates swapped.
+The swap_ordinate_string parameter is a 2-character string naming the ordinates to swap. Valid names are: x, y, z and m.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
 	//
 	// BoundingBox
@@ -4839,7 +4871,6 @@ Bottom Left.`,
 	"st_snap":                    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49040}),
 	"st_split":                   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49045}),
 	"st_subdivide":               makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49048}),
-	"st_swapordinates":           makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49050}),
 	"st_tileenvelope":            makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49053}),
 	"st_transscale":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49061}),
 	"st_unaryunion":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49062}),


### PR DESCRIPTION
Currently PostGIS has the ST_SwapOrdinates, but CRDB hasn't.

Fixes #49050.

Release note (sql change): Implemented the geometry based builtins
`ST_SwapOrdinates`.