### PR TITLE
release-20.2: Revert "sql: fix inflated "overhead" in statement timings"

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -67,14 +67,7 @@ type phaseTimes [sessionNumPhases]time.Time
 // getServiceLatency returns the time between a query being received and the end
 // of run.
 func (p *phaseTimes) getServiceLatency() time.Duration {
-	// To have an accurate representation of how long it took to service this
-	// single query, we ignore the time between when parsing ends and planning
-	// begins. This avoids the latency being inflated in a few different cases:
-	// when there are internal transaction retries, and when multiple statements
-	// are submitted together, e.g. "SELECT 1; SELECT 2".
-	parseLatency := p[sessionEndParse].Sub(p[sessionQueryReceived])
-	planAndExecuteLatency := p[plannerEndExecStmt].Sub(p[plannerStartLogicalPlan])
-	return parseLatency + planAndExecuteLatency
+	return p[plannerEndExecStmt].Sub(p[sessionQueryReceived])
 }
 
 // getRunLatency returns the time between a query execution starting and ending.


### PR DESCRIPTION
Backport 1/1 commits from #54124.

/cc @cockroachdb/release

---

This reverts commit 6371d37b6c0f7031c3da596a5149227c36a2d753.

This commit introduced a bug where service latencies could be negative.
I believe this happens when the sessionEndParse phase time is not set.
Reverting this commit until we have a proper fix.

Fixes #45011
Fixes #54087

Release justification: release blocker fix

Release note: None
