### PR TITLE
release-20.1: gcjob: handle missing tables when refreshing status

### DIFF
--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -140,6 +140,11 @@ func (r schemaChangeGCResumer) Resume(
 				return nil
 			}
 			expired, earliestDeadline = refreshTables(ctx, execCfg, remainingTables, tableDropTimes, indexDropTimes, r.jobID, progress)
+
+			if isDoneGC(progress) {
+				return nil
+			}
+
 			timerDuration := time.Until(earliestDeadline)
 			if expired {
 				timerDuration = 0

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -28,7 +28,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
+
+var maxDeadline = timeutil.Unix(0, math.MaxInt64)
 
 // refreshTables updates the status of tables/indexes that are waiting to be
 // GC'd.
@@ -43,25 +46,24 @@ func refreshTables(
 	jobID int64,
 	progress *jobspb.SchemaChangeGCProgress,
 ) (expired bool, earliestDeadline time.Time) {
-	earliestDeadline = timeutil.Unix(0, math.MaxInt64)
-
+	earliestDeadline = maxDeadline
+	var haveAnyMissing bool
 	for _, tableID := range tableIDs {
-		tableHasExpiredElem, deadline := updateStatusForGCElements(
+		tableHasExpiredElem, tableIsMissing, deadline := updateStatusForGCElements(
 			ctx,
 			execCfg,
 			tableID,
 			tableDropTimes, indexDropTimes,
 			progress,
 		)
-		if tableHasExpiredElem {
-			expired = true
-		}
+		expired = expired || tableHasExpiredElem
+		haveAnyMissing = haveAnyMissing || tableIsMissing
 		if deadline.Before(earliestDeadline) {
 			earliestDeadline = deadline
 		}
 	}
 
-	if expired {
+	if expired || haveAnyMissing {
 		persistProgress(ctx, execCfg, jobID, progress)
 	}
 
@@ -72,7 +74,9 @@ func refreshTables(
 // are waiting for GC. If the table is waiting for GC then the status of the table
 // will be updated.
 // It returns whether any indexes or the table have expired as well as the time
-// until the next index expires if there are any more to drop.
+// until the next index expires if there are any more to drop. It also returns
+// whether the table descriptor is missing indicating that it was gc'd by
+// another job, in which case the progress will have been updated.
 func updateStatusForGCElements(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
@@ -80,7 +84,7 @@ func updateStatusForGCElements(
 	tableDropTimes map[sqlbase.ID]int64,
 	indexDropTimes map[sqlbase.IndexID]int64,
 	progress *jobspb.SchemaChangeGCProgress,
-) (expired bool, timeToNextTrigger time.Time) {
+) (expired, missing bool, timeToNextTrigger time.Time) {
 	defTTL := execCfg.DefaultZoneConfig.GC.TTLSeconds
 	cfg := execCfg.Gossip.GetSystemConfig()
 	protectedtsCache := execCfg.ProtectedTimestampProvider
@@ -124,11 +128,16 @@ func updateStatusForGCElements(
 
 		return nil
 	}); err != nil {
+		if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+			log.Warningf(ctx, "table %d not found, marking as GC'd", tableID)
+			markTableGCed(ctx, tableID, progress)
+			return false, true, maxDeadline
+		}
 		log.Warningf(ctx, "error while calculating GC time for table %d, err: %+v", tableID, err)
-		return false, earliestDeadline
+		return false, false, maxDeadline
 	}
 
-	return expired, earliestDeadline
+	return expired, false, earliestDeadline
 }
 
 // updateTableStatus sets the status the table to DELETING if the GC TTL has


### PR DESCRIPTION
Backport 1/1 commits from #52818.

/cc @cockroachdb/release

---

Fixes #50344.

Release note (bug fix): Fixed a bug whereby gc jobs for tables dropped as
part of a DROP DATABASE CASCADE might never complete.
