### PR TITLE
doctor: report more on stuck GC jobs

### DIFF
--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -336,6 +336,8 @@ func runZipDirDoctor(cmd *cobra.Command, args []string) (retErr error) {
 func tableMap(in io.Reader, fn func(string) error) error {
 	firstLine := true
 	sc := bufio.NewScanner(in)
+	// Read lines up to 50 MB in size.
+	sc.Buffer(make([]byte, 64*1024), 50*1024*1024)
 	for sc.Scan() {
 		if firstLine {
 			firstLine = false

--- a/pkg/cli/testdata/doctor/testzipdir
+++ b/pkg/cli/testdata/doctor/testzipdir
@@ -11,4 +11,6 @@ Examining 38 descriptors and 43 namespace entries...
 Descriptor 52: has namespace row(s) [{ParentID:0 ParentSchemaID:0 Name:movr}] but no descriptor
 Examining 1 running jobs...
 job 587337426984566785: schema change GC refers to missing table descriptor(s) [59]
+	existing descriptors that still need to be dropped []
+	job 587337426984566785 can be safely deleted
 ERROR: validation failed

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -331,9 +331,40 @@ func TestExamineJobs(t *testing.T) {
 							},
 						})},
 				},
+				{
+					ID:      200,
+					Payload: &jobspb.Payload{Details: jobspb.WrapPayloadDetails(jobspb.SchemaChangeGCDetails{})},
+					Progress: &jobspb.Progress{Details: jobspb.WrapProgressDetails(
+						jobspb.SchemaChangeGCProgress{
+							Tables: []jobspb.SchemaChangeGCProgress_TableProgress{
+								{ID: 1, Status: jobspb.SchemaChangeGCProgress_DELETED},
+								{ID: 3, Status: jobspb.SchemaChangeGCProgress_WAITING_FOR_GC},
+							},
+						})},
+				},
+				{
+					ID:      300,
+					Payload: &jobspb.Payload{Details: jobspb.WrapPayloadDetails(jobspb.SchemaChangeGCDetails{})},
+					Progress: &jobspb.Progress{Details: jobspb.WrapProgressDetails(
+						jobspb.SchemaChangeGCProgress{
+							Tables: []jobspb.SchemaChangeGCProgress_TableProgress{
+								{ID: 1, Status: jobspb.SchemaChangeGCProgress_DELETED},
+								{ID: 3, Status: jobspb.SchemaChangeGCProgress_WAITING_FOR_GC},
+							},
+							Indexes: []jobspb.SchemaChangeGCProgress_IndexProgress{
+								{IndexID: 10, Status: jobspb.SchemaChangeGCProgress_WAITING_FOR_GC},
+							},
+						})},
+				},
 			},
-			expected: `Examining 1 running jobs...
+			expected: `Examining 3 running jobs...
 job 100: schema change GC refers to missing table descriptor(s) [3]
+	existing descriptors that still need to be dropped [2]
+job 200: schema change GC refers to missing table descriptor(s) [3]
+	existing descriptors that still need to be dropped []
+	job 200 can be safely deleted
+job 300: schema change GC refers to missing table descriptor(s) [3]
+	existing descriptors that still need to be dropped []
 `,
 		},
 	}


### PR DESCRIPTION
It is useful to understand if stuck jobs can be deleted. We improve the
tool to report these jobs. And also increase the buffer size for the
scanner reading system tables which can occasionally be as large as a
few 100 MBs.

Release note: none.