### PR TITLE
backfill: add memory accounting to the column/index backfiller

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -295,6 +295,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	bulkMemoryMonitor.SetMetrics(bulkMetrics.CurBytesCount, bulkMetrics.MaxBytesHist)
 	bulkMemoryMonitor.Start(context.Background(), rootSQLMemoryMonitor, mon.BoundAccount{})
 
+	backfillMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backfill-mon")
+
 	// Set up the DistSQL temp engine.
 
 	useStoreSpec := cfg.TempStorageConfig.Spec
@@ -352,8 +354,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		// descriptors that the vectorized execution engine may have open at any
 		// one time. This limit is implemented as a weighted semaphore acquired
 		// before opening files.
-		VecFDSemaphore: semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", colexec.VecMaxOpenFDsLimit)),
-		DiskMonitor:    cfg.TempStorageConfig.Mon,
+		VecFDSemaphore:    semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", colexec.VecMaxOpenFDsLimit)),
+		DiskMonitor:       cfg.TempStorageConfig.Mon,
+		BackfillerMonitor: backfillMemoryMonitor,
 
 		ParentMemoryMonitor: rootSQLMemoryMonitor,
 		BulkAdder: func(

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -43,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -1814,10 +1816,17 @@ func columnBackfillInTxn(
 	if tableDesc.Adding() {
 		return nil
 	}
+	var columnBackfillerMon *mon.BytesMonitor
+	// This is the planner's memory monitor.
+	if evalCtx.Mon != nil {
+		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-column-backfill-mon")
+	}
+
 	var backfiller backfill.ColumnBackfiller
-	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc); err != nil {
+	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc, columnBackfillerMon); err != nil {
 		return err
 	}
+	defer backfiller.Close(ctx)
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
@@ -1828,6 +1837,7 @@ func columnBackfillInTxn(
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -1844,10 +1854,17 @@ func indexBackfillInTxn(
 	tableDesc *tabledesc.Immutable,
 	traceKV bool,
 ) error {
+	var indexBackfillerMon *mon.BytesMonitor
+	// This is the planner's memory monitor.
+	if evalCtx.Mon != nil {
+		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-index-backfill-mon")
+	}
+
 	var backfiller backfill.IndexBackfiller
-	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc); err != nil {
+	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc, indexBackfillerMon); err != nil {
 		return err
 	}
+	defer backfiller.Close(ctx)
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
@@ -1857,6 +1874,7 @@ func indexBackfillInTxn(
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -14,6 +14,7 @@ package backfill
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -30,6 +31,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
 )
 
 // MutationFilter is the type of a simple predicate on a mutation.
@@ -65,6 +68,12 @@ type ColumnBackfiller struct {
 	updateCols  []descpb.ColumnDescriptor
 	updateExprs []tree.TypedExpr
 	evalCtx     *tree.EvalContext
+
+	// mon is a memory monitor linked with the ColumnBackfiller on creation.
+	mon *mon.BytesMonitor
+	// boundAccount is associated with mon and is used to track allocations during
+	// a column backfill.
+	boundAccount mon.BoundAccount
 }
 
 // initCols is a helper to populate some column metadata on a ColumnBackfiller.
@@ -91,6 +100,7 @@ func (cb *ColumnBackfiller) init(
 	defaultExprs []tree.TypedExpr,
 	computedExprs []tree.TypedExpr,
 	desc *tabledesc.Immutable,
+	mon *mon.BytesMonitor,
 ) error {
 	cb.evalCtx = evalCtx
 	cb.updateCols = append(cb.added, cb.dropped...)
@@ -121,6 +131,14 @@ func (cb *ColumnBackfiller) init(
 		Cols:            desc.Columns,
 		ValNeededForCol: valNeededForCol,
 	}
+
+	// Create a bound account associated with the column backfiller.
+	if mon == nil {
+		return errors.AssertionFailedf("no memory monitor linked to ColumnBackfiller during init")
+	}
+	cb.mon = mon
+	cb.boundAccount = mon.MakeBoundAccount()
+
 	return cb.fetcher.Init(
 		evalCtx.Context,
 		evalCtx.Codec,
@@ -129,8 +147,7 @@ func (cb *ColumnBackfiller) init(
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&cb.alloc,
-		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
-		nil, /* memMonitor */
+		mon,
 		tableArgs,
 	)
 }
@@ -143,6 +160,7 @@ func (cb *ColumnBackfiller) InitForLocalUse(
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
 	desc *tabledesc.Immutable,
+	mon *mon.BytesMonitor,
 ) error {
 	cb.initCols(desc)
 	defaultExprs, err := schemaexpr.MakeDefaultExprs(
@@ -162,7 +180,7 @@ func (cb *ColumnBackfiller) InitForLocalUse(
 	if err != nil {
 		return err
 	}
-	return cb.init(evalCtx, defaultExprs, computedExprs, desc)
+	return cb.init(evalCtx, defaultExprs, computedExprs, desc, mon)
 }
 
 // InitForDistributedUse initializes a ColumnBackfiller for use as part of a
@@ -171,7 +189,7 @@ func (cb *ColumnBackfiller) InitForLocalUse(
 // necessary due to the different procedure for accessing user defined type
 // metadata as part of a distributed flow.
 func (cb *ColumnBackfiller) InitForDistributedUse(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, desc *tabledesc.Immutable,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, desc *tabledesc.Immutable, mon *mon.BytesMonitor,
 ) error {
 	cb.initCols(desc)
 	evalCtx := flowCtx.NewEvalCtx()
@@ -214,7 +232,16 @@ func (cb *ColumnBackfiller) InitForDistributedUse(
 	// entire backfill process.
 	flowCtx.TypeResolverFactory.Descriptors.ReleaseAll(ctx)
 
-	return cb.init(evalCtx, defaultExprs, computedExprs, desc)
+	return cb.init(evalCtx, defaultExprs, computedExprs, desc, mon)
+}
+
+// Close frees the resources used by the ColumnBackfiller.
+func (cb *ColumnBackfiller) Close(ctx context.Context) {
+	cb.fetcher.Close(ctx)
+	if cb.mon != nil {
+		cb.boundAccount.Close(ctx)
+		cb.mon.Stop(ctx)
+	}
 }
 
 // RunColumnBackfillChunk runs column backfill over a chunk of the table using
@@ -370,6 +397,12 @@ type IndexBackfiller struct {
 	// It is a field of IndexBackfiller to avoid allocating a slice for each row
 	// backfilled.
 	indexesToEncode []*descpb.IndexDescriptor
+
+	// mon is a memory monitor linked with the IndexBackfiller on creation.
+	mon *mon.BytesMonitor
+	// boundAccount is associated with mon and is used to track allocations during
+	// an	index backfill.
+	boundAccount mon.BoundAccount
 }
 
 // ContainsInvertedIndex returns true if backfilling an inverted index.
@@ -390,6 +423,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
 	desc *tabledesc.Immutable,
+	mon *mon.BytesMonitor,
 ) error {
 	// Initialize ib.cols and ib.colIdxMap.
 	ib.initCols(desc)
@@ -416,7 +450,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 		valNeededForCol.Add(ib.colIdxMap[col])
 	})
 
-	return ib.init(evalCtx, predicates, valNeededForCol, desc)
+	return ib.init(evalCtx, predicates, valNeededForCol, desc, mon)
 }
 
 // InitForDistributedUse initializes an IndexBackfiller for use as part of a
@@ -425,7 +459,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 // due to the different procedure for accessing user defined type metadata as
 // part of a distributed flow.
 func (ib *IndexBackfiller) InitForDistributedUse(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, desc *tabledesc.Immutable,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, desc *tabledesc.Immutable, mon *mon.BytesMonitor,
 ) error {
 	// Initialize ib.cols and ib.colIdxMap.
 	ib.initCols(desc)
@@ -451,7 +485,8 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 
 		// Convert any partial index predicate strings into expressions.
 		var err error
-		predicates, predicateRefColIDs, err = schemaexpr.MakePartialIndexExprs(ctx, ib.added, ib.cols, desc, evalCtx, &semaCtx)
+		predicates, predicateRefColIDs, err =
+			schemaexpr.MakePartialIndexExprs(ctx, ib.added, ib.cols, desc, evalCtx, &semaCtx)
 		if err != nil {
 			return err
 		}
@@ -471,7 +506,16 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 		valNeededForCol.Add(ib.colIdxMap[col])
 	})
 
-	return ib.init(evalCtx, predicates, valNeededForCol, desc)
+	return ib.init(evalCtx, predicates, valNeededForCol, desc, mon)
+}
+
+// Close releases the resources used by the IndexBackfiller.
+func (ib *IndexBackfiller) Close(ctx context.Context) {
+	ib.fetcher.Close(ctx)
+	if ib.mon != nil {
+		ib.boundAccount.Close(ctx)
+		ib.mon.Stop(ctx)
+	}
 }
 
 // initCols is a helper to populate column metadata of an IndexBackfiller. It
@@ -535,6 +579,7 @@ func (ib *IndexBackfiller) init(
 	predicateExprs map[descpb.IndexID]tree.TypedExpr,
 	valNeededForCol util.FastIntSet,
 	desc *tabledesc.Immutable,
+	mon *mon.BytesMonitor,
 ) error {
 	ib.evalCtx = evalCtx
 	ib.predicates = predicateExprs
@@ -560,6 +605,14 @@ func (ib *IndexBackfiller) init(
 		Cols:            ib.cols,
 		ValNeededForCol: valNeededForCol,
 	}
+
+	// Create a bound account associated with the index backfiller monitor.
+	if mon == nil {
+		return errors.AssertionFailedf("no memory monitor linked to IndexBacfiller during init")
+	}
+	ib.mon = mon
+	ib.boundAccount = mon.MakeBoundAccount()
+
 	return ib.fetcher.Init(
 		evalCtx.Context,
 		evalCtx.Codec,
@@ -568,8 +621,7 @@ func (ib *IndexBackfiller) init(
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&ib.alloc,
-		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
-		nil, /* memMonitor */
+		mon,
 		tableArgs,
 	)
 }
@@ -587,6 +639,14 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	// This ought to be chunkSize but in most tests we are actually building smaller
 	// indexes so use a smaller value.
 	const initBufferSize = 1000
+
+	indexEntriesInChunkInitialBufferSize :=
+		int64(unsafe.Sizeof(rowenc.IndexEntry{})) * initBufferSize * int64(len(ib.added))
+	if err := ib.boundAccount.Grow(ctx,
+		indexEntriesInChunkInitialBufferSize); err != nil {
+		return nil, nil, errors.Wrap(err,
+			"failed to initialize empty buffer to store the index entries of all rows in the chunk")
+	}
 	entries := make([]rowenc.IndexEntry, 0, initBufferSize*int64(len(ib.added)))
 
 	// Get the next set of rows.
@@ -610,6 +670,12 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	}
 	ib.evalCtx.IVarContainer = iv
 
+	indexEntriesPerRowInitialBufferSize := int64(len(ib.added)) *
+		int64(unsafe.Sizeof(rowenc.IndexEntry{}))
+	if err := ib.boundAccount.Grow(ctx, indexEntriesPerRowInitialBufferSize); err != nil {
+		return nil, nil, errors.Wrap(err,
+			"failed to initialize empty buffer to store the index entries of a single row")
+	}
 	buffer := make([]rowenc.IndexEntry, len(ib.added))
 	for i := int64(0); i < chunkSize; i++ {
 		encRow, _, _, err := ib.fetcher.NextRow(ctx)
@@ -662,6 +728,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 		// not want to include empty k/v pairs while backfilling.
 		buffer = buffer[:0]
 		if buffer, err = rowenc.EncodeSecondaryIndexes(
+			ctx,
 			ib.evalCtx.Codec,
 			tableDesc,
 			ib.indexesToEncode,
@@ -669,16 +736,26 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 			ib.rowVals,
 			buffer,
 			false, /* includeEmpty */
+			ib.boundAccount,
 		); err != nil {
 			return nil, nil, err
 		}
+
+		// If the number of index entries are going to cause the entries buffer to
+		// re-slice, we must account for this in the index memory account.
+		if cap(entries)-len(entries) < len(buffer) {
+			if err := ib.boundAccount.Grow(ctx, int64(cap(entries))); err != nil {
+				return nil, nil, err
+			}
+		}
+
 		entries = append(entries, buffer...)
 	}
 	return entries, ib.fetcher.Key(), nil
 }
 
 // RunIndexBackfillChunk runs an index backfill over a chunk of the table
-// by tracversing the span sp provided. The backfill is run for the added
+// by traversing the span sp provided. The backfill is run for the added
 // indexes.
 func (ib *IndexBackfiller) RunIndexBackfillChunk(
 	ctx context.Context,
@@ -689,7 +766,8 @@ func (ib *IndexBackfiller) RunIndexBackfillChunk(
 	alsoCommit bool,
 	traceKV bool,
 ) (roachpb.Key, error) {
-	entries, key, err := ib.BuildIndexEntriesChunk(ctx, txn, tableDesc, sp, chunkSize, traceKV)
+	entries, key, err := ib.BuildIndexEntriesChunk(ctx, txn, tableDesc, sp,
+		chunkSize, traceKV)
 	if err != nil {
 		return nil, err
 	}
@@ -708,5 +786,6 @@ func (ib *IndexBackfiller) RunIndexBackfillChunk(
 	if err := writeBatch(ctx, batch); err != nil {
 		return nil, ConvertBackfillError(ctx, tableDesc, batch)
 	}
+
 	return key, nil
 }

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -97,6 +97,10 @@ type ServerConfig struct {
 	// BulkAdder is used by some processors to bulk-ingest data as SSTs.
 	BulkAdder kvserverbase.BulkAdderFactory
 
+	// Child monitor of the bulk monitor which will be used to monitor the memory
+	// used by the column and index backfillers.
+	BackfillerMonitor *mon.BytesMonitor
+
 	// DiskMonitor is used to monitor temporary storage disk usage. Actual disk
 	// space used will be a small multiple (~1.1) of this because of RocksDB
 	// space amplification.


### PR DESCRIPTION
This change introduces a new child "backfiller" monitor of the parent
bulk monitor.  This is used by both the index and column backfiller to
account for the memory usage of the row fetchers used in both.

Additionally, in the index backfiller, we account for the size of the
index keys, as well as the number of KVs, generated when building the
index entry for a chunk.

Closes: #46346

Release note: None