### PR TITLE
release-20.2: sql: disable interleaved joins by default

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -240,7 +240,7 @@ var insertFastPathClusterMode = settings.RegisterBoolSetting(
 var planInterleavedJoins = settings.RegisterBoolSetting(
 	"sql.distsql.interleaved_joins.enabled",
 	"if set we plan interleaved table joins instead of merge joins when possible",
-	true,
+	false,
 )
 var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_alter_column_type.enabled",

--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -30,6 +30,9 @@
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
+statement ok
+SET enable_interleaved_joins = true
+
 #################
 # Create tables #
 #################

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -25,6 +25,9 @@
 #   - no interleaved relationship (parent1 - parent2, parent2 - child1)
 #   - TODO(richardwu): sibling-sibling (child1 - child2)
 
+statement ok
+SET enable_interleaved_joins = true
+
 #################
 # Create tables #
 #################

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1830,7 +1830,7 @@ distsql                                        off                 NULL      NUL
 enable_experimental_alter_column_type_general  off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update              on                  NULL      NULL        NULL        string
 enable_insert_fast_path                        on                  NULL      NULL        NULL        string
-enable_interleaved_joins                       on                  NULL      NULL        NULL        string
+enable_interleaved_joins                       off                 NULL      NULL        NULL        string
 enable_seqscan                                 on                  NULL      NULL        NULL        string
 enable_zigzag_join                             on                  NULL      NULL        NULL        string
 experimental_distsql_planning                  off                 NULL      NULL        NULL        string
@@ -1901,7 +1901,7 @@ distsql                                        off                 NULL  user   
 enable_experimental_alter_column_type_general  off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update              on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                        on                  NULL  user     NULL      on                  on
-enable_interleaved_joins                       on                  NULL  user     NULL      on                  on
+enable_interleaved_joins                       off                 NULL  user     NULL      off                 off
 enable_seqscan                                 on                  NULL  user     NULL      on                  on
 enable_zigzag_join                             on                  NULL  user     NULL      on                  on
 experimental_distsql_planning                  off                 NULL  user     NULL      off                 off

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
@@ -7,6 +7,12 @@
 # when possible. This is true even with interleaved scans, which complicate the
 # logic of mapping a WriteIntentError back to the corresponding table.
 
+# Note that we're changing the cluster setting instead of a session variable
+# to enable the interleaved joins because we're switching the users below with
+# each switch starting a new session.
+statement ok
+SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true
+
 statement ok
 CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -43,7 +43,7 @@ distsql                                        off
 enable_experimental_alter_column_type_general  off
 enable_implicit_select_for_update              on
 enable_insert_fast_path                        on
-enable_interleaved_joins                       on
+enable_interleaved_joins                       off
 enable_seqscan                                 on
 enable_zigzag_join                             on
 experimental_distsql_planning                  off

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -27,6 +27,9 @@
 #   - no interleaved relationship (parent1 - parent2, parent2 - child1)
 #   - TODO(richardwu): sibling-sibling (child1 - child2)
 
+statement ok
+SET enable_interleaved_joins = true
+
 #################
 # Create tables #
 #################

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -1,5 +1,8 @@
 # LogicTest: local
 
+statement ok
+SET enable_interleaved_joins = true
+
 # ------------------------------------------------------------------------------
 # Test index selection for deeply interleaved tables.
 # These tests are in their own file because table IDs appear in EXPLAIN output.


### PR DESCRIPTION
This commit switches the default value of a cluster setting to disable
planning the interleaved joins because they are under-tested and often
are actually slower than the merge joins. In 21.1 release we will be
removing the corresponding code entirely.

Release note (sql change): Interleaved joins are now disabled by default
and will be entirely removed in 21.1 release because they are often
slower than the merge join.