### PR TITLE
schemafeed: fix race when peeking events from schema feed

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -340,7 +340,8 @@ func (tf *SchemaFeed) peekOrPop(
 	if i == -1 {
 		i = 0
 	}
-	events = tf.mu.events[:i]
+	events = make([]TableEvent, i)
+	copy(events, tf.mu.events[:i])
 	if pop {
 		tf.mu.events = tf.mu.events[i:]
 	}


### PR DESCRIPTION
When peeking a schema-feed, Peek would return a reference to events that
are otherwise guarded under a mutex. Instead, it should return a copy of
the events to avoid a race between Peeking events and writing them
during descriptor validation.

Fixes #48459.

Release note: None