### PR TITLE
release-20.2: vendor: bump Pebble to e9a2c44e0bf1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c
+	github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1
 	github.com/cockroachdb/redact v1.0.5
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c h1:BNozL+EzkybaDuPWgnnwGxfSe+jbokBvRvF+TX0RDCo=
-github.com/cockroachdb/pebble v0.0.0-20200908153531-a9c6d3b6685c/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1 h1:F2ixCinj/ffpGnxHTg3uLWrDiAfInAB0+Fi1cuxLPY8=
+github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.5 h1:yxqIMS6G2Bvi6GiSHFmsrFGO3aP1rwt8cOm4pixw9eY=


### PR DESCRIPTION
```
e9a2c44e db: close previous WAL before linking next WAL
```

Fixes #54142.

Release note (bug fix): Fixes a bug whereby a crash during WAL rotation
could cause Cockroach to error on restart reporting corruption.