### PR TITLE
sql: add framework for testing only descriptor validation

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -117,6 +117,9 @@ type TestServerArgs struct {
 	// If set, web session authentication will be disabled, even if the server
 	// is running in secure mode.
 	DisableWebSessionAuthentication bool
+
+	// If set, testing specific descriptor validation will be disabled. even if the server
+	DisableTestingDescriptorValidation bool
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -59,7 +59,7 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mutDesc, mutDesc.ValidateTable()
+	return mutDesc, mutDesc.ValidateTable(ctx)
 }
 
 func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.EncDatumRow, error) {

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -155,7 +155,7 @@ var defaultGens = []avroGen{
 	&nilOrStrGen{namedField{name: "notes"}},
 }
 
-func newTestHelper(t *testing.T, gens ...avroGen) *testHelper {
+func newTestHelper(ctx context.Context, t *testing.T, gens ...avroGen) *testHelper {
 	if len(gens) == 0 {
 		gens = defaultGens
 	}
@@ -199,7 +199,7 @@ func newTestHelper(t *testing.T, gens ...avroGen) *testHelper {
 
 	return &testHelper{
 		schemaJSON: string(schemaJSON),
-		schemaTable: descForTable(t, createStmt, 10, 20, NoFKs).
+		schemaTable: descForTable(ctx, t, createStmt, 10, 20, NoFKs).
 			ImmutableCopy().(*tabledesc.Immutable),
 		codec:    codec,
 		gens:     gens,
@@ -320,7 +320,8 @@ func (th *testHelper) genRecordsData(
 func TestReadsAvroRecords(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	th := newTestHelper(t)
+	ctx := context.Background()
+	th := newTestHelper(ctx, t)
 
 	formats := []roachpb.AvroOptions_Format{
 		roachpb.AvroOptions_BIN_RECORDS,
@@ -357,7 +358,8 @@ func TestReadsAvroRecords(t *testing.T) {
 func TestReadsAvroOcf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	th := newTestHelper(t)
+	ctx := context.Background()
+	th := newTestHelper(ctx, t)
 
 	for _, skip := range []bool{false, true} {
 		t.Run(fmt.Sprintf("skip=%v", skip), func(t *testing.T) {
@@ -383,6 +385,7 @@ func TestReadsAvroOcf(t *testing.T) {
 func TestRelaxedAndStrictImport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 
 	tests := []struct {
 		name         string
@@ -407,7 +410,7 @@ func TestRelaxedAndStrictImport(t *testing.T) {
 				f1.excludeSQL = test.excludeTable
 				f2.excludeAvro = test.excludeAvro
 
-				th := newTestHelper(t, f1, f2)
+				th := newTestHelper(ctx, t, f1, f2)
 				stream := th.newRecordStream(t, format, test.strict, 1)
 
 				if !stream.producer.Scan() {
@@ -428,7 +431,8 @@ func TestRelaxedAndStrictImport(t *testing.T) {
 func TestHandlesArrayData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	th := newTestHelper(t, &intArrGen{namedField{
+	ctx := context.Background()
+	th := newTestHelper(ctx, t, &intArrGen{namedField{
 		name: "arr_of_ints",
 	}})
 

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -415,6 +415,7 @@ func mysqlTableToCockroach(
 			}
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
 			seqDesc, err = sql.NewSequenceTableDesc(
+				ctx,
 				seqName,
 				opts,
 				parentID,
@@ -428,6 +429,7 @@ func mysqlTableToCockroach(
 		} else {
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
 			seqDesc, err = sql.NewSequenceTableDesc(
+				ctx,
 				seqName,
 				opts,
 				parentID,
@@ -491,7 +493,7 @@ func mysqlTableToCockroach(
 	if p != nil {
 		semaCtxPtr = p.SemaCtx()
 	}
-	desc, err := MakeSimpleTableDescriptor(evalCtx.Ctx(), semaCtxPtr, evalCtx.Settings, stmt, parentID, keys.PublicSchemaID, id, fks, time.WallTime)
+	desc, err := MakeSimpleTableDescriptor(ctx, semaCtxPtr, evalCtx.Settings, stmt, parentID, keys.PublicSchemaID, id, fks, time.WallTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -567,7 +569,7 @@ func addDelayedFKs(
 		if err := fixDescriptorFKState(def.tbl); err != nil {
 			return err
 		}
-		if err := def.tbl.AllocateIDs(); err != nil {
+		if err := def.tbl.AllocateIDs(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -42,7 +42,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	files := getMysqldumpTestdata(t)
 
 	ctx := context.Background()
-	table := descForTable(t, `CREATE TABLE simple (i INT PRIMARY KEY, s text, b bytea)`, 10, 20, NoFKs)
+	table := descForTable(ctx, t, `CREATE TABLE simple (i INT PRIMARY KEY, s text, b bytea)`, 10, 20, NoFKs)
 	tables := map[string]*execinfrapb.ReadImportDataSpec_ImportTable{"simple": {Desc: table.TableDesc()}}
 
 	kvCh := make(chan row.KVBatch, 10)
@@ -127,11 +127,12 @@ func readMysqlCreateFrom(
 func TestMysqldumpSchemaReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 
 	files := getMysqldumpTestdata(t)
 
-	simpleTable := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
-	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
+	simpleTable := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
+	referencedSimple := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed: true,
 		resolver: fkResolver(map[string]*tabledesc.Mutable{
@@ -146,14 +147,14 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	})
 
 	t.Run("second", func(t *testing.T) {
-		secondTable := descForTable(t, readFile(t, `second.cockroach-schema.sql`), expectedParent, 53, fks)
+		secondTable := descForTable(ctx, t, readFile(t, `second.cockroach-schema.sql`), expectedParent, 53, fks)
 		expected := secondTable
 		got := readMysqlCreateFrom(t, files.second, "", 53, fks)
 		compareTables(t, expected.TableDesc(), got)
 	})
 
 	t.Run("everything", func(t *testing.T) {
-		expected := descForTable(t, readFile(t, `everything.cockroach-schema.sql`), expectedParent, 53, NoFKs)
+		expected := descForTable(ctx, t, readFile(t, `everything.cockroach-schema.sql`), expectedParent, 53, NoFKs)
 		got := readMysqlCreateFrom(t, files.everything, "", 53, NoFKs)
 		compareTables(t, expected.TableDesc(), got)
 	})
@@ -166,7 +167,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 
 	t.Run("third-in-multi", func(t *testing.T) {
 		skip := fkHandler{allowed: true, skip: true, resolver: make(fkResolver)}
-		expected := descForTable(t, readFile(t, `third.cockroach-schema.sql`), expectedParent, 52, skip)
+		expected := descForTable(ctx, t, readFile(t, `third.cockroach-schema.sql`), expectedParent, 52, skip)
 		got := readMysqlCreateFrom(t, files.wholeDB, "third", 51, skip)
 		compareTables(t, expected.TableDesc(), got)
 	})

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -248,6 +248,7 @@ func readPostgresCreateTable(
 			for name, seq := range createSeq {
 				id := descpb.ID(int(defaultCSVTableID) + len(ret))
 				desc, err := sql.NewSequenceTableDesc(
+					ctx,
 					name,
 					seq.Options,
 					parentID,

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func descForTable(
-	t *testing.T, create string, parent, id descpb.ID, fks fkHandler,
+	ctx context.Context, t *testing.T, create string, parent, id descpb.ID, fks fkHandler,
 ) *tabledesc.Mutable {
 	t.Helper()
 	parsed, err := parser.Parse(create)
@@ -55,6 +55,7 @@ func descForTable(
 		ts := hlc.Timestamp{WallTime: nanos}
 		priv := descpb.NewDefaultPrivilegeDescriptor(security.AdminRole)
 		desc, err := sql.NewSequenceTableDesc(
+			ctx,
 			name,
 			tree.SequenceOptions{},
 			parent,

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -139,7 +139,7 @@ func (pt *partitioningTest) parse() error {
 			return err
 		}
 		pt.parsed.tableDesc = mutDesc
-		if err := pt.parsed.tableDesc.ValidateTable(); err != nil {
+		if err := pt.parsed.tableDesc.ValidateTable(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -256,6 +256,14 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TestingKnobs.Store = &kvserver.StoreTestingKnobs{}
 	}
 	cfg.TestingKnobs.Store.(*kvserver.StoreTestingKnobs).SkipMinSizeCheck = true
+
+	if params.Knobs.SQLExecutor == nil {
+		cfg.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{}
+	}
+	if !params.DisableTestingDescriptorValidation {
+		cfg.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs).TestingDescriptorValidation = true
+	}
+
 	return cfg
 }
 

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -352,7 +352,7 @@ func alterColumnTypeGeneral(
 
 	tableDesc.AddColumnMutation(&newCol, descpb.DescriptorMutation_ADD)
 
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -90,7 +90,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		}
 	}
 
-	if err := n.tableDesc.AllocateIDs(); err != nil {
+	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -174,7 +174,7 @@ func (p *planner) AlterPrimaryKey(
 	if err := tableDesc.AddIndexMutation(newPrimaryIndexDesc, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 
@@ -223,7 +223,7 @@ func (p *planner) AlterPrimaryKey(
 		// Make the copy of the old primary index not-interleaved. This decision
 		// can be revisited based on user experience.
 		oldPrimaryIndexCopy.Interleave = descpb.InterleaveDescriptor{}
-		if err := addIndexMutationWithSpecificPrimaryKey(tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
 			return err
 		}
 	}
@@ -281,7 +281,7 @@ func (p *planner) AlterPrimaryKey(
 		newIndex := protoutil.Clone(idx).(*descpb.IndexDescriptor)
 		basename := newIndex.Name + "_rewrite_for_primary_key_change"
 		newIndex.Name = tabledesc.GenerateUniqueConstraintName(basename, nameExists)
-		if err := addIndexMutationWithSpecificPrimaryKey(tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
 			return err
 		}
 		// If the index that we are rewriting is interleaved, we need to setup the rewritten

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -755,7 +755,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 		}
 
 		// Allocate IDs now, so new IDs are available to subsequent commands
-		if err := n.tableDesc.AllocateIDs(); err != nil {
+		if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 			return err
 		}
 	}
@@ -832,14 +832,17 @@ func (n *alterTableNode) Close(context.Context)        {}
 // addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given table descriptor, but sets up
 // the index with ExtraColumnIDs from the given index, rather than the table's primary key.
 func addIndexMutationWithSpecificPrimaryKey(
-	table *tabledesc.Mutable, toAdd *descpb.IndexDescriptor, primary *descpb.IndexDescriptor,
+	ctx context.Context,
+	table *tabledesc.Mutable,
+	toAdd *descpb.IndexDescriptor,
+	primary *descpb.IndexDescriptor,
 ) error {
 	// Reset the ID so that a call to AllocateIDs will set up the index.
 	toAdd.ID = 0
 	if err := table.AddIndexMutation(toAdd, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := table.AllocateIDs(); err != nil {
+	if err := table.AllocateIDs(ctx); err != nil {
 		return err
 	}
 	// Use the columns in the given primary index to construct this indexes ExtraColumnIDs list.

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -331,7 +331,7 @@ func unwrapDescriptorMutable(
 		if err != nil {
 			return nil, err
 		}
-		if err := mutTable.ValidateTable(); err != nil {
+		if err := mutTable.ValidateTable(ctx); err != nil {
 			return nil, err
 		}
 		return mutTable, nil

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -52,6 +52,7 @@ func makeIndexDescriptor(name string, columnNames []string) descpb.IndexDescript
 
 func TestAllocateIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	desc := NewCreatedMutable(descpb.TableDescriptor{
 		ParentID: keys.MinUserDescID,
@@ -75,7 +76,7 @@ func TestAllocateIDs(t *testing.T) {
 		Privileges:    descpb.NewDefaultPrivilegeDescriptor(security.AdminRole),
 		FormatVersion: descpb.FamilyFormatVersion,
 	})
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -126,7 +127,7 @@ func TestAllocateIDs(t *testing.T) {
 		t.Fatalf("expected %s, but found %s", a, b)
 	}
 
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(expected, desc) {
@@ -138,6 +139,8 @@ func TestAllocateIDs(t *testing.T) {
 
 func TestValidateTableDesc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
 
 	testData := []struct {
 		err  string
@@ -646,7 +649,7 @@ func TestValidateTableDesc(t *testing.T) {
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {
 			desc := NewImmutable(d.desc)
-			if err := desc.ValidateTable(); err == nil {
+			if err := desc.ValidateTable(ctx); err == nil {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
 			} else if d.err != err.Error() && "internal error: "+d.err != err.Error() {
 				t.Errorf("%d: expected \"%s\", but found \"%+v\"", i, d.err, err)
@@ -1359,6 +1362,8 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 }
 
 func TestUnvalidateConstraints(t *testing.T) {
+	ctx := context.Background()
+
 	desc := NewCreatedMutable(descpb.TableDescriptor{
 		Name:     "test",
 		ParentID: descpb.ID(1),
@@ -1377,7 +1382,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 			},
 		},
 	})
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		t.Fatal(err)
 	}
 	lookup := func(_ descpb.ID) (catalog.TableDescriptor, error) {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -219,7 +219,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 	}
 	// Assign an ID to the newly-added shard column, which is needed for the creation
 	// of a valid check constraint.
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 
@@ -550,7 +550,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	if err := n.tableDesc.AddIndexMutation(indexDesc, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := n.tableDesc.AllocateIDs(); err != nil {
+	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
 	// The index name may have changed as a result of

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -103,6 +103,7 @@ func doCreateSequence(
 	// currently relied on in import and restore code and tests.
 	var creationTime hlc.Timestamp
 	desc, err := NewSequenceTableDesc(
+		params.ctx,
 		name.Object(),
 		opts,
 		dbDesc.GetID(),
@@ -168,6 +169,7 @@ func (*createSequenceNode) Close(context.Context)        {}
 
 // NewSequenceTableDesc creates a sequence descriptor.
 func NewSequenceTableDesc(
+	ctx context.Context,
 	sequenceName string,
 	sequenceOptions tree.SequenceOptions,
 	parentID descpb.ID,
@@ -227,7 +229,7 @@ func NewSequenceTableDesc(
 	// immediately.
 	desc.State = descpb.DescriptorState_PUBLIC
 
-	if err := desc.ValidateTable(); err != nil {
+	if err := desc.ValidateTable(ctx); err != nil {
 		return nil, err
 	}
 	return &desc, nil

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -176,7 +176,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			desc.IsMaterializedView = true
 			desc.State = descpb.DescriptorState_ADD
 			desc.CreateAsOfTime = params.p.Txn().ReadTimestamp()
-			if err := desc.AllocateIDs(); err != nil {
+			if err := desc.AllocateIDs(params.ctx); err != nil {
 				return err
 			}
 		}
@@ -394,7 +394,7 @@ func addResultColumns(
 		}
 		desc.AddColumn(col)
 	}
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -163,7 +163,7 @@ func (p *planner) createDescriptorWithID(
 		}
 	case *tabledesc.Mutable:
 		isTable = true
-		if err := desc.ValidateTable(); err != nil {
+		if err := desc.ValidateTable(ctx); err != nil {
 			return err
 		}
 		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -170,7 +170,7 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 		}
 	}
 
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
 	mutationID := tableDesc.ClusterVersion.NextMutationID

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -818,6 +818,11 @@ type ExecutorTestingKnobs struct {
 	// RunAfterSCJobsCacheLookup is called after the SchemaChangeJobCache is checked for
 	// a given table id.
 	RunAfterSCJobsCacheLookup func(*jobs.Job)
+
+	// TestingDescriptorValidation dictates if stronger descriptor validation
+	// should be performed (typically turned on during tests only to guard against
+	// wild descriptors which are corrupted due to bugs).
+	TestingDescriptorValidation bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -143,7 +143,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 		&descpb.PrivilegeDescriptor{},
 		tree.PersistencePermanent,
 	)
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if err := kvDB.Put(ctx, mKey, desc.DescriptorProto()); err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -289,7 +289,7 @@ func (p *planner) writeTableDescToBatch(
 		tableDesc.MaybeIncrementVersion()
 	}
 
-	if err := tableDesc.ValidateTable(); err != nil {
+	if err := tableDesc.ValidateTable(ctx); err != nil {
 		return errors.AssertionFailedf("table descriptor is not valid: %s\n%v", err, tableDesc)
 	}
 

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -316,14 +316,15 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s := "CREATE TABLE foo.test (a INT, b INT, CONSTRAINT c UNIQUE (b))"
-	desc, err := CreateTestTableDescriptor(context.Background(), 1, 100, s,
+	ctx := context.Background()
+	desc, err := CreateTestTableDescriptor(ctx, 1, 100, s,
 		descpb.NewDefaultPrivilegeDescriptor(security.AdminRole))
 	if err != nil {
 		t.Fatal(err)
 	}
 	desc.PrimaryIndex = descpb.IndexDescriptor{}
 
-	err = desc.ValidateTable()
+	err = desc.ValidateTable(ctx)
 	if !testutils.IsError(err, tabledesc.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -159,6 +159,7 @@ func TestInitialKeysAndSplits(t *testing.T) {
 func TestSystemTableLiterals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	type testcase struct {
 		id     descpb.ID
 		schema string
@@ -203,7 +204,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test: %+v, err: %v", test, err)
 		}
-		require.NoError(t, gen.ValidateTable())
+		require.NoError(t, gen.ValidateTable(ctx))
 
 		if !proto.Equal(test.pkg.TableDesc(), gen.TableDesc()) {
 			diff := strings.Join(pretty.Diff(test.pkg.TableDesc(), gen.TableDesc()), "\n")

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -60,6 +60,7 @@ func CreateTestTableDescriptor(
 		return desc, err
 	case *tree.CreateSequence:
 		desc, err := NewSequenceTableDesc(
+			ctx,
 			n.Name.Table(),
 			n.Options,
 			parentID, keys.PublicSchemaID, id,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -212,7 +212,7 @@ func (p *planner) truncateTable(
 		tableDesc.Indexes[i].ID = descpb.IndexID(0)
 	}
 	// Create new ID's for all of the indexes in the table.
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This patch adds a new field on the `ExecutorTestingKnobs` called
`TestingDescriptorValidation`. This creates the structure to perform
certain table descriptor validation only during testing scenarios, i.e,
when this knob is turned on. This is achieved by intercepting the
context at the `conn_executor` level to include a value that indicates
to the validation functions if extra validation should be performed.
By intercepting the context at this level, instead of somewhere closer
to the Validate calls, we avoid having to find and intercept the context
in all possible codepaths -- which was getting quite messy.

On the validation side, this patch adds two to be filled functions --
validateCrossReferencesIfTesting and validateTableIfTesting. We don't
validate cross references for mutable descriptors, so providing these
two functions allows us to preserve this pattern and cover both
mutable/immutable descriptors in testing only validation. The functions
are currently no-ops and will be filled in in upcoming patches.

Currently, the testing knob is turned on by default for all test
servers. If you're writing a test and don't want to opt into this
validation for some reason, there's a
`DisableTestingDescriptorValidation` on server args that can be set.

Release note: None