### PR TITLE
release-20.1: sql: emit more tracing events from the stats cache

### DIFF
--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -331,6 +331,7 @@ func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo,
 		// If the memo doesn't have placeholders, then fully optimize it, since
 		// it can be reused without further changes to build the execution tree.
 		if !f.Memo().HasPlaceholders() {
+			opc.log(ctx, "optimizing (no placeholders)")
 			if _, err := opc.optimizer.Optimize(); err != nil {
 				return nil, err
 			}
@@ -424,6 +425,8 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		}
 		opc.flags.Set(planFlagOptCacheMiss)
 		opc.log(ctx, "query cache miss")
+	} else {
+		opc.log(ctx, "not using query cache")
 	}
 
 	// We are executing a statement for which there is no reusable memo


### PR DESCRIPTION
Backport 2/2 commits from #54035.

/cc @cockroachdb/release

---

The stats cache has various "slow" paths (where we need to query the
system table). These are currently only logged if verbosity is high.

This change switches to `VEvent` in most cases, so that these are
visible during tracing (including in statement diagnostics bundles).
This will allow us to diagnose slow planning times, e.g. due to the
stats cache getting full.

Release justification: low-risk change to existing functionality, high
potential benefit for debugging issues.

Release note: None
