### PR TITLE
roachtest: unskip cdc/crdb-chaos

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -543,7 +543,6 @@ func registerCDC(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("cdc/crdb-chaos"),
 		Owner:   `cdc`,
-		Skip:    "#37716",
 		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -552,11 +551,9 @@ func registerCDC(r *testRegistry) {
 				workloadDuration:         "30m",
 				crdbChaos:                true,
 				targetInitialScanLatency: 3 * time.Minute,
-				// TODO(dan): It should be okay to drop this as low as 2 to 3 minutes,
-				// but we're occasionally seeing it take between 11 and 12 minutes to
-				// get everything running again after a chaos event. There's definitely
-				// a thread worth pulling on here. See #36879.
-				targetSteadyLatency: 15 * time.Minute,
+				// TODO(aayush): It should be okay to drop this as low as 2 to 3 minutes. See
+				// #36879 for some discussion.
+				targetSteadyLatency: 5 * time.Minute,
 			})
 		},
 	})


### PR DESCRIPTION
I ran this test a total of 15 times in parallel and wasn't able to
reproduce. Since its been skipped for 2+ releases, it's hard to know
what fixed it, but a good guess is #48561.

Release note: None

Fixes #37716 

Informs #36879

Release justification: testing only