### PR TITLE
sql: add placeholder values to the statement diagnostics bundle

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -345,9 +345,10 @@ func (ex *connExecutor) execStmtInOpenState(
 			sp.Finish()
 			trace := tracing.GetRecording(sp)
 			ie := p.extendedEvalCtx.InternalExecutor.(*InternalExecutor)
+			placeholders := p.extendedEvalCtx.Placeholders
 			if finishCollectionDiagnostics != nil {
 				bundle, collectionErr := buildStatementBundle(
-					origCtx, ex.server.cfg.DB, ie, &p.curPlan, trace,
+					origCtx, ex.server.cfg.DB, ie, &p.curPlan, trace, placeholders,
 				)
 				finishCollectionDiagnostics(origCtx, bundle.trace, bundle.zip, collectionErr)
 			} else {
@@ -355,7 +356,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				// If there was a communication error, no point in setting any results.
 				if retErr == nil {
 					retErr = setExplainBundleResult(
-						origCtx, res, stmt.AST, trace, &p.curPlan, ie, ex.server.cfg,
+						origCtx, res, stmt.AST, trace, &p.curPlan, placeholders, ie, ex.server.cfg,
 					)
 				}
 			}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -41,6 +41,7 @@ func setExplainBundleResult(
 	ast tree.Statement,
 	trace tracing.Recording,
 	plan *planTop,
+	placeholders *tree.PlaceholderInfo,
 	ie *InternalExecutor,
 	execCfg *ExecutorConfig,
 ) error {
@@ -49,7 +50,7 @@ func setExplainBundleResult(
 
 	var text []string
 	func() {
-		bundle, err := buildStatementBundle(ctx, execCfg.DB, ie, plan, trace)
+		bundle, err := buildStatementBundle(ctx, execCfg.DB, ie, plan, trace, placeholders)
 		if err != nil {
 			// TODO(radu): we cannot simply set an error on the result here without
 			// changing the executor logic (e.g. an implicit transaction could have
@@ -152,12 +153,17 @@ type diagnosticsBundle struct {
 // the statement. It generates a bundle for storage in
 // system.statement_diagnostics.
 func buildStatementBundle(
-	ctx context.Context, db *kv.DB, ie *InternalExecutor, plan *planTop, trace tracing.Recording,
+	ctx context.Context,
+	db *kv.DB,
+	ie *InternalExecutor,
+	plan *planTop,
+	trace tracing.Recording,
+	placeholders *tree.PlaceholderInfo,
 ) (diagnosticsBundle, error) {
 	if plan == nil {
 		return diagnosticsBundle{}, errors.AssertionFailedf("execution terminated early")
 	}
-	b := makeStmtBundleBuilder(db, ie, plan, trace)
+	b := makeStmtBundleBuilder(db, ie, plan, trace, placeholders)
 
 	b.addStatement()
 	b.addOptPlans()
@@ -180,16 +186,21 @@ type stmtBundleBuilder struct {
 	db *kv.DB
 	ie *InternalExecutor
 
-	plan  *planTop
-	trace tracing.Recording
+	plan         *planTop
+	trace        tracing.Recording
+	placeholders *tree.PlaceholderInfo
 
 	z memZipper
 }
 
 func makeStmtBundleBuilder(
-	db *kv.DB, ie *InternalExecutor, plan *planTop, trace tracing.Recording,
+	db *kv.DB,
+	ie *InternalExecutor,
+	plan *planTop,
+	trace tracing.Recording,
+	placeholders *tree.PlaceholderInfo,
 ) stmtBundleBuilder {
-	b := stmtBundleBuilder{db: db, ie: ie, plan: plan, trace: trace}
+	b := stmtBundleBuilder{db: db, ie: ie, plan: plan, trace: trace, placeholders: placeholders}
 	b.z.Init()
 	return b
 }
@@ -203,8 +214,19 @@ func (b *stmtBundleBuilder) addStatement() {
 	cfg.Simplify = true
 	cfg.Align = tree.PrettyNoAlign
 	cfg.JSONFmt = true
+	output := cfg.Pretty(b.plan.stmt.AST)
 
-	b.z.AddFile("statement.txt", cfg.Pretty(b.plan.stmt.AST))
+	if b.placeholders != nil && len(b.placeholders.Values) != 0 {
+		var buf bytes.Buffer
+		buf.WriteString(output)
+		buf.WriteString("\n\nArguments:\n")
+		for i, v := range b.placeholders.Values {
+			fmt.Fprintf(&buf, "  %s: %v\n", tree.PlaceholderIdx(i), v)
+		}
+		output = buf.String()
+	}
+
+	b.z.AddFile("statement.txt", output)
 }
 
 // addOptPlans adds the EXPLAIN (OPT) variants as files opt.txt, opt-v.txt,


### PR DESCRIPTION
This change adds the placeholder values when we are using statement
diagnostics on a prepared statement.

This is pretty hard to test - `EXPLAIN ANALYZE (DEBUG)` itself does
not support placeholders; I tested it manually using the UI and a test
program.

Fixes #54025.

Release note: None