### PR TITLE
storage,server: Add Disk{Slow,Stalled} metrics, connect them to Pebble

### DIFF
--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -15,20 +15,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
-
-// maxSyncDuration is the threshold above which an observed engine sync duration
-// triggers either a warning or a fatal error.
-var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_SYNC_DURATION", 10*time.Second)
-
-// maxSyncDurationFatalOnExceeded defaults to false due to issues such as
-// https://github.com/cockroachdb/cockroach/issues/34860#issuecomment-469262019.
-// Similar problems have been known to occur during index backfill and, possibly,
-// IMPORT/RESTORE.
-var maxSyncDurationFatalOnExceeded = envutil.EnvOrDefaultBool("COCKROACH_ENGINE_MAX_SYNC_DURATION_FATAL", false)
 
 // startAssertEngineHealth starts a goroutine that periodically verifies that
 // syncing the engines is possible within maxSyncDuration. If not,
@@ -43,7 +32,7 @@ func (n *Node) startAssertEngineHealth(ctx context.Context, engines []storage.En
 			case <-t.C:
 				t.Read = true
 				t.Reset(10 * time.Second)
-				n.assertEngineHealth(ctx, engines, maxSyncDuration)
+				n.assertEngineHealth(ctx, engines, storage.MaxSyncDuration)
 			case <-n.stopper.ShouldQuiesce():
 				return
 			}
@@ -65,12 +54,12 @@ func (n *Node) assertEngineHealth(
 				n.metrics.DiskStalls.Inc(1)
 				stats := "\n" + eng.GetCompactionStats()
 				logger := log.Warningf
-				if maxSyncDurationFatalOnExceeded {
+				if storage.MaxSyncDurationFatalOnExceeded {
 					logger = guaranteedExitFatal
 				}
 				// NB: the disk-stall-detected roachtest matches on this message.
 				logger(ctx, "disk stall detected: unable to write to %s within %s %s",
-					eng, maxSyncDuration, stats,
+					eng, storage.MaxSyncDuration, stats,
 				)
 			})
 			defer t.Stop()

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -496,6 +496,8 @@ type Stats struct {
 	BlockCachePinnedUsage          int64
 	BloomFilterPrefixChecked       int64
 	BloomFilterPrefixUseful        int64
+	DiskSlowCount                  int64
+	DiskStallCount                 int64
 	MemtableTotalSize              int64
 	Flushes                        int64
 	FlushedBytes                   int64

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2154,6 +2154,13 @@ var charts = []sectionDescription{
 					"capacity.used",
 				},
 			},
+			{
+				Title: "Disk Health",
+				Metrics: []string{
+					"storage.disk-slow",
+					"storage.disk-stalled",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This change adds two metric counters, one for slow disk events (>10s)
and one for stalled disk events (>30s). The latter is to match
COCKROACH_LOG_MAX_SYNC_DURATION which is currently at 30s, though
if that triggers too often, we can consider bumping it up to 60s.

These metrics are connected right to the Pebble EventListener
using a new EventMetrics struct passed into the Engine instance.

Release note (general change): Adds increased logging and metrics
around slow disk operations.