### PR TITLE
opt: generate lookup semi- and anti-joins in more partial index cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1039,6 +1039,21 @@ SELECT m FROM join_small JOIN join_large ON n = i AND s = 'foo'
 ----
 1
 
+# A lookup semi-join is used when an expression in the semi-join filter exactly
+# matches the partial index predicate.
+query I rowsort
+SELECT m FROM join_small WHERE EXISTS (SELECT 1 FROM join_large WHERE n = i AND s IN ('foo', 'bar', 'baz'))
+----
+1
+3
+
+# A lookup anti-join is used when an expression in the anti-join filter exactly
+# matches the partial index predicate.
+query I rowsort
+SELECT m FROM join_small WHERE NOT EXISTS (SELECT 1 FROM join_large WHERE n = i AND s IN ('foo', 'bar', 'baz'))
+----
+2
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3198,25 +3198,19 @@ project
       └── filters
            └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
 
-# TODO: We can generate a lookup semi-join when the index does not cover "s" but
-# the reference to "s" no longer exists in the filters.
+# Generate a lookup semi-join when the index does not cover "s", but the
+# reference to "s" no longer exists in the filters.
 opt expect=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
 ----
 project
  ├── columns: m:1
- └── semi-join (hash)
+ └── semi-join (lookup partial_tab@partial_idx,partial)
       ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
       ├── scan small
       │    └── columns: m:1 n:2
-      ├── index-join partial_tab
-      │    ├── columns: i:6 s:7!null
-      │    └── scan partial_tab@partial_idx,partial
-      │         ├── columns: k:5!null i:6
-      │         ├── key: (5)
-      │         └── fd: (5)-->(6)
-      └── filters
-           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── filters (true)
 
 # We should not generate a lookup semi-join when the index does not cover "s"
 # which is referenced in the remaining filter.
@@ -3243,25 +3237,19 @@ project
       └── filters
            └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
-# TODO: We can generate a lookup anti-join when the index does not cover "s" but
-# the reference to "s" no longer exists in the filters.
+# Generate a lookup anti-join when the index does not cover "s", but the
+# reference to "s" no longer exists in the filters.
 opt expect=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
 ----
 project
  ├── columns: m:1
- └── anti-join (hash)
+ └── anti-join (lookup partial_tab@partial_idx,partial)
       ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
       ├── scan small
       │    └── columns: m:1 n:2
-      ├── index-join partial_tab
-      │    ├── columns: i:6 s:7!null
-      │    └── scan partial_tab@partial_idx,partial
-      │         ├── columns: k:5!null i:6
-      │         ├── key: (5)
-      │         └── fd: (5)-->(6)
-      └── filters
-           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── filters (true)
 
 # We should not generate a lookup anti-join when the index does not cover "s"
 # which is referenced in the remaining filter.


### PR DESCRIPTION
This commit updates `GenerateLookupJoins` to generate lookup semi- and
anti-joins in cases where the columns in the original ON filters are not
covered by the index, but the columns in the filters remaining after
proving filter-predicate implication are covered by the index. This is a
special case only possible for semi- and anti-joins because they never
include columns from the right side of the join in their output columns.
See the comment added in `GenerateLookupJoins` for more details.

Release note (performance improvement): Lookup semi- and anti-joins are
now explored by the optimizer in more cases when the ON filter implies
a partial index predicate. This may lead to more efficient query plans
in some cases.