### PR TITLE
release-20.2: pkg/util/log: use unix.FcntlInt instead of unix.Syscall

### DIFF
--- a/pkg/util/log/stderr_redirect_unix.go
+++ b/pkg/util/log/stderr_redirect_unix.go
@@ -32,11 +32,11 @@ func dupFD(fd uintptr) (uintptr, error) {
 	// subprocesses that hold references to the stdin or stderr pipes, go test
 	// will hang until the subprocesses exit, rather defeating the purpose of
 	// a timeout.
-	nfd, _, errno := unix.Syscall(unix.SYS_FCNTL, fd, unix.F_DUPFD_CLOEXEC, 0)
-	if errno != 0 {
-		return 0, errno
+	nfd, err := unix.FcntlInt(fd, unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return 0, err
 	}
-	return nfd, nil
+	return uintptr(nfd), nil
 }
 
 // redirectStderr is used to redirect internal writes to fd 2 to the


### PR DESCRIPTION
Backport 1/1 commits from #54203.

/cc @cockroachdb/release

---

Direct syscalls haven't been supported since Go 1.13 and recently the
unix.SYS_FCNTL constant was removed from golang.org/x/sys.

See #54193.

Release note: none
