### PR TITLE
opt: alias partial index put and del columns

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1948,18 +1948,18 @@ update partial_indexes
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
  │    └── b_new:10 => b:2
- ├── partial index put columns: column11:11
- ├── partial index del columns: column9:9
+ ├── partial index put columns: partial_index_put1:11
+ ├── partial index del columns: partial_index_del1:9
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column11:11 a:5!null b:6 c:7 column9:9 b_new:10
+      ├── columns: partial_index_put1:11 a:5!null b:6 c:7 partial_index_del1:9 b_new:10
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(5-7,9-11)
       ├── project
-      │    ├── columns: b_new:10 column9:9 a:5!null b:6 c:7
+      │    ├── columns: b_new:10 partial_index_del1:9 a:5!null b:6 c:7
       │    ├── cardinality: [0 - 1]
       │    ├── immutable
       │    ├── key: ()
@@ -1980,9 +1980,9 @@ update partial_indexes
       │    │         └── a:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
       │    └── projections
       │         ├── b:6 + 1 [as=b_new:10, outer=(6), immutable]
-      │         └── b:6 > 1 [as=column9:9, outer=(6)]
+      │         └── b:6 > 1 [as=partial_index_del1:9, outer=(6)]
       └── projections
-           └── b_new:10 > 1 [as=column11:11, outer=(10)]
+           └── b_new:10 > 1 [as=partial_index_put1:11, outer=(10)]
 
 # Prune secondary family column not needed for the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -461,9 +461,9 @@ DELETE FROM partial_indexes
 delete partial_indexes
  ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7
- ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
+ ├── partial index del columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
  └── project
-      ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      ├── columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       ├── scan partial_indexes
       │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    └── partial index predicates
@@ -473,7 +473,37 @@ delete partial_indexes
       │              ├── a:5 > b:6
       │              └── c:7 = 'bar'
       └── projections
-           ├── c:7 = 'foo' [as=column9:9]
-           ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
-           ├── c:7 = 'delete-only' [as=column11:11]
-           └── c:7 = 'write-only' [as=column12:12]
+           ├── c:7 = 'foo' [as=partial_index_del1:9]
+           ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]
+           ├── c:7 = 'delete-only' [as=partial_index_del3:11]
+           └── c:7 = 'write-only' [as=partial_index_del4:12]
+
+# Do not error with "column reference is ambiguous" when table column names
+# match synthesized column names.
+exec-ddl
+CREATE TABLE t (
+    partial_index_del1 INT,
+    UNIQUE INDEX (partial_index_del1) WHERE partial_index_del1 > 0
+)
+----
+
+build
+DELETE FROM t WHERE partial_index_del1 = 5
+----
+delete t
+ ├── columns: <none>
+ ├── fetch columns: t.partial_index_del1:4 rowid:5
+ ├── partial index del columns: partial_index_del1:7
+ └── project
+      ├── columns: partial_index_del1:7!null t.partial_index_del1:4!null rowid:5!null crdb_internal_mvcc_timestamp:6
+      ├── select
+      │    ├── columns: t.partial_index_del1:4!null rowid:5!null crdb_internal_mvcc_timestamp:6
+      │    ├── scan t
+      │    │    ├── columns: t.partial_index_del1:4 rowid:5!null crdb_internal_mvcc_timestamp:6
+      │    │    └── partial index predicates
+      │    │         └── secondary: filters
+      │    │              └── t.partial_index_del1:4 > 0
+      │    └── filters
+      │         └── t.partial_index_del1:4 = 5
+      └── projections
+           └── t.partial_index_del1:4 > 0 [as=partial_index_del1:7]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1260,17 +1260,47 @@ insert partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column8:8 column9:9 column10:10 column11:11
+ ├── partial index put columns: partial_index_put1:8 partial_index_put2:9 partial_index_put3:10 partial_index_put4:11
  └── project
-      ├── columns: column8:8!null column9:9!null column10:10!null column11:11!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:8!null partial_index_put2:9!null partial_index_put3:10!null partial_index_put4:11!null column1:5!null column2:6!null column3:7!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── (2, 1, 'bar')
       └── projections
-           ├── column3:7 = 'foo' [as=column8:8]
-           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=column9:9]
-           ├── column3:7 = 'delete-only' [as=column10:10]
-           └── column3:7 = 'write-only' [as=column11:11]
+           ├── column3:7 = 'foo' [as=partial_index_put1:8]
+           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=partial_index_put2:9]
+           ├── column3:7 = 'delete-only' [as=partial_index_put3:10]
+           └── column3:7 = 'write-only' [as=partial_index_put4:11]
+
+# Do not error with "column reference is ambiguous" when table column names
+# match synthesized column names.
+exec-ddl
+CREATE TABLE t (
+    partial_index_put1 INT,
+    UNIQUE INDEX (partial_index_put1) WHERE partial_index_put1 > 0
+)
+----
+
+build
+INSERT INTO t (partial_index_put1) VALUES (1)
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => t.partial_index_put1:1
+ │    └── column5:5 => rowid:2
+ ├── partial index put columns: partial_index_put1:6
+ └── project
+      ├── columns: partial_index_put1:6!null column1:4!null column5:5
+      ├── project
+      │    ├── columns: column5:5 column1:4!null
+      │    ├── values
+      │    │    ├── columns: column1:4!null
+      │    │    └── (1,)
+      │    └── projections
+      │         └── unique_rowid() [as=column5:5]
+      └── projections
+           └── column1:4 > 0 [as=partial_index_put1:6]
 
 # Regression test for issue #52546. Building partial index predicate expressions
 # that are only a single column reference should not panic.

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1686,14 +1686,14 @@ update partial_indexes
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
  │    └── a_new:13 => a:1
- ├── partial index put columns: column9:9 column14:14 column11:11 column12:12
- ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
+ ├── partial index put columns: partial_index_del1:9 partial_index_put2:14 partial_index_del3:11 partial_index_del4:12
+ ├── partial index del columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
  └── project
-      ├── columns: column14:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12 a_new:13!null
+      ├── columns: partial_index_put2:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a_new:13!null
       ├── project
-      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12
+      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
       │    ├── project
-      │    │    ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    ├── columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    ├── scan partial_indexes
       │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    │    └── partial index predicates
@@ -1703,14 +1703,14 @@ update partial_indexes
       │    │    │              ├── a:5 > b:6
       │    │    │              └── c:7 = 'bar'
       │    │    └── projections
-      │    │         ├── c:7 = 'foo' [as=column9:9]
-      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
-      │    │         ├── c:7 = 'delete-only' [as=column11:11]
-      │    │         └── c:7 = 'write-only' [as=column12:12]
+      │    │         ├── c:7 = 'foo' [as=partial_index_del1:9]
+      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]
+      │    │         ├── c:7 = 'delete-only' [as=partial_index_del3:11]
+      │    │         └── c:7 = 'write-only' [as=partial_index_del4:12]
       │    └── projections
       │         └── 1 [as=a_new:13]
       └── projections
-           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=column14:14]
+           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=partial_index_put2:14]
 
 build
 UPDATE partial_indexes SET a = a + 5 RETURNING *
@@ -1720,14 +1720,14 @@ update partial_indexes
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
  │    └── a_new:13 => a:1
- ├── partial index put columns: column9:9 column14:14 column11:11 column12:12
- ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
+ ├── partial index put columns: partial_index_del1:9 partial_index_put2:14 partial_index_del3:11 partial_index_del4:12
+ ├── partial index del columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
  └── project
-      ├── columns: column14:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12 a_new:13!null
+      ├── columns: partial_index_put2:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a_new:13!null
       ├── project
-      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12
+      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
       │    ├── project
-      │    │    ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    ├── columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    ├── scan partial_indexes
       │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    │    └── partial index predicates
@@ -1737,11 +1737,56 @@ update partial_indexes
       │    │    │              ├── a:5 > b:6
       │    │    │              └── c:7 = 'bar'
       │    │    └── projections
-      │    │         ├── c:7 = 'foo' [as=column9:9]
-      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
-      │    │         ├── c:7 = 'delete-only' [as=column11:11]
-      │    │         └── c:7 = 'write-only' [as=column12:12]
+      │    │         ├── c:7 = 'foo' [as=partial_index_del1:9]
+      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]
+      │    │         ├── c:7 = 'delete-only' [as=partial_index_del3:11]
+      │    │         └── c:7 = 'write-only' [as=partial_index_del4:12]
       │    └── projections
       │         └── a:5 + 5 [as=a_new:13]
       └── projections
-           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=column14:14]
+           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=partial_index_put2:14]
+
+# Do not error with "column reference is ambiguous" when table column names
+# match synthesized column names.
+exec-ddl
+CREATE TABLE t (
+    partial_index_put1 INT,
+    partial_index_del1 INT,
+    UNIQUE INDEX (partial_index_put1) WHERE partial_index_put1 > 0 AND partial_index_del1 > 0
+)
+----
+
+build
+UPDATE t SET partial_index_put1 = 1, partial_index_del1 = 2 WHERE partial_index_put1 = 10 and partial_index_del1 = 20
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: t.partial_index_put1:5 t.partial_index_del1:6 rowid:7
+ ├── update-mapping:
+ │    ├── partial_index_put1_new:10 => t.partial_index_put1:1
+ │    └── partial_index_del1_new:11 => t.partial_index_del1:2
+ ├── partial index put columns: partial_index_put1:12
+ ├── partial index del columns: partial_index_del1:9
+ └── project
+      ├── columns: partial_index_put1:12!null t.partial_index_put1:5!null t.partial_index_del1:6!null rowid:7!null crdb_internal_mvcc_timestamp:8 partial_index_del1:9!null partial_index_put1_new:10!null partial_index_del1_new:11!null
+      ├── project
+      │    ├── columns: partial_index_put1_new:10!null partial_index_del1_new:11!null t.partial_index_put1:5!null t.partial_index_del1:6!null rowid:7!null crdb_internal_mvcc_timestamp:8 partial_index_del1:9!null
+      │    ├── project
+      │    │    ├── columns: partial_index_del1:9!null t.partial_index_put1:5!null t.partial_index_del1:6!null rowid:7!null crdb_internal_mvcc_timestamp:8
+      │    │    ├── select
+      │    │    │    ├── columns: t.partial_index_put1:5!null t.partial_index_del1:6!null rowid:7!null crdb_internal_mvcc_timestamp:8
+      │    │    │    ├── scan t
+      │    │    │    │    ├── columns: t.partial_index_put1:5 t.partial_index_del1:6 rowid:7!null crdb_internal_mvcc_timestamp:8
+      │    │    │    │    └── partial index predicates
+      │    │    │    │         └── secondary: filters
+      │    │    │    │              ├── t.partial_index_put1:5 > 0
+      │    │    │    │              └── t.partial_index_del1:6 > 0
+      │    │    │    └── filters
+      │    │    │         └── (t.partial_index_put1:5 = 10) AND (t.partial_index_del1:6 = 20)
+      │    │    └── projections
+      │    │         └── (t.partial_index_put1:5 > 0) AND (t.partial_index_del1:6 > 0) [as=partial_index_del1:9]
+      │    └── projections
+      │         ├── 1 [as=partial_index_put1_new:10]
+      │         └── 2 [as=partial_index_del1_new:11]
+      └── projections
+           └── (partial_index_put1_new:10 > 0) AND (partial_index_del1_new:11 > 0) [as=partial_index_put1:12]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1924,9 +1924,9 @@ insert partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column16:16 column17:17 column18:18 column19:19
+ ├── partial index put columns: partial_index_put1:16 partial_index_put2:17 partial_index_put3:18 partial_index_put4:19
  └── project
-      ├── columns: column16:16!null column17:17!null column18:18!null column19:19!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:16!null partial_index_put2:17!null partial_index_put3:18!null partial_index_put4:19!null column1:5!null column2:6!null column3:7!null
       ├── upsert-distinct-on
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    ├── grouping columns: column2:6!null column3:7!null
@@ -1982,10 +1982,10 @@ insert partial_indexes
       │         └── first-agg [as=column1:5]
       │              └── column1:5
       └── projections
-           ├── column3:7 = 'foo' [as=column16:16]
-           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=column17:17]
-           ├── column3:7 = 'delete-only' [as=column18:18]
-           └── column3:7 = 'write-only' [as=column19:19]
+           ├── column3:7 = 'foo' [as=partial_index_put1:16]
+           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=partial_index_put2:17]
+           ├── column3:7 = 'delete-only' [as=partial_index_put3:18]
+           └── column3:7 = 'write-only' [as=partial_index_put4:19]
 
 build
 INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SET b = partial_indexes.b + 1, c = 'baz'
@@ -2002,16 +2002,16 @@ upsert partial_indexes
  ├── update-mapping:
  │    ├── upsert_b:19 => b:2
  │    └── upsert_c:20 => c:3
- ├── partial index put columns: column21:21 column22:22 column23:23 column24:24
- ├── partial index del columns: column12:12 column13:13 column14:14 column15:15
+ ├── partial index put columns: partial_index_put1:21 partial_index_put2:22 partial_index_put3:23 partial_index_put4:24
+ ├── partial index del columns: partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15
  └── project
-      ├── columns: column21:21!null column22:22 column23:23!null column24:24!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 b_new:16 c_new:17!null upsert_a:18 upsert_b:19 upsert_c:20!null
+      ├── columns: partial_index_put1:21!null partial_index_put2:22 partial_index_put3:23!null partial_index_put4:24!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15 b_new:16 c_new:17!null upsert_a:18 upsert_b:19 upsert_c:20!null
       ├── project
-      │    ├── columns: upsert_a:18 upsert_b:19 upsert_c:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 b_new:16 c_new:17!null
+      │    ├── columns: upsert_a:18 upsert_b:19 upsert_c:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15 b_new:16 c_new:17!null
       │    ├── project
-      │    │    ├── columns: b_new:16 c_new:17!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15
+      │    │    ├── columns: b_new:16 c_new:17!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15
       │    │    ├── project
-      │    │    │    ├── columns: column12:12 column13:13 column14:14 column15:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    ├── columns: partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
       │    │    │    │    ├── ensure-upsert-distinct-on
@@ -2035,10 +2035,10 @@ upsert partial_indexes
       │    │    │    │         ├── column2:6 = b:9
       │    │    │    │         └── column3:7 = c:10
       │    │    │    └── projections
-      │    │    │         ├── c:10 = 'foo' [as=column12:12]
-      │    │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=column13:13]
-      │    │    │         ├── c:10 = 'delete-only' [as=column14:14]
-      │    │    │         └── c:10 = 'write-only' [as=column15:15]
+      │    │    │         ├── c:10 = 'foo' [as=partial_index_del1:12]
+      │    │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=partial_index_del2:13]
+      │    │    │         ├── c:10 = 'delete-only' [as=partial_index_del3:14]
+      │    │    │         └── c:10 = 'write-only' [as=partial_index_del4:15]
       │    │    └── projections
       │    │         ├── b:9 + 1 [as=b_new:16]
       │    │         └── 'baz' [as=c_new:17]
@@ -2047,10 +2047,10 @@ upsert partial_indexes
       │         ├── CASE WHEN a:8 IS NULL THEN column2:6 ELSE b_new:16 END [as=upsert_b:19]
       │         └── CASE WHEN a:8 IS NULL THEN column3:7 ELSE c_new:17 END [as=upsert_c:20]
       └── projections
-           ├── upsert_c:20 = 'foo' [as=column21:21]
-           ├── (upsert_a:18 > upsert_b:19) AND (upsert_c:20 = 'bar') [as=column22:22]
-           ├── upsert_c:20 = 'delete-only' [as=column23:23]
-           └── upsert_c:20 = 'write-only' [as=column24:24]
+           ├── upsert_c:20 = 'foo' [as=partial_index_put1:21]
+           ├── (upsert_a:18 > upsert_b:19) AND (upsert_c:20 = 'bar') [as=partial_index_put2:22]
+           ├── upsert_c:20 = 'delete-only' [as=partial_index_put3:23]
+           └── upsert_c:20 = 'write-only' [as=partial_index_put4:24]
 
 build
 UPSERT INTO partial_indexes VALUES (2, 1, 'bar')
@@ -2067,14 +2067,14 @@ upsert partial_indexes
  ├── update-mapping:
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column17:17 column18:18 column19:19 column20:20
- ├── partial index del columns: column12:12 column13:13 column14:14 column15:15
+ ├── partial index put columns: partial_index_put1:17 partial_index_put2:18 partial_index_put3:19 partial_index_put4:20
+ ├── partial index del columns: partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15
  └── project
-      ├── columns: column17:17!null column18:18 column19:19!null column20:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 upsert_a:16
+      ├── columns: partial_index_put1:17!null partial_index_put2:18 partial_index_put3:19!null partial_index_put4:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15 upsert_a:16
       ├── project
-      │    ├── columns: upsert_a:16 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15
+      │    ├── columns: upsert_a:16 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15
       │    ├── project
-      │    │    ├── columns: column12:12 column13:13 column14:14 column15:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    ├── columns: partial_index_del1:12 partial_index_del2:13 partial_index_del3:14 partial_index_del4:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
       │    │    │    ├── ensure-upsert-distinct-on
@@ -2099,17 +2099,17 @@ upsert partial_indexes
       │    │    │    └── filters
       │    │    │         └── column1:5 = a:8
       │    │    └── projections
-      │    │         ├── c:10 = 'foo' [as=column12:12]
-      │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=column13:13]
-      │    │         ├── c:10 = 'delete-only' [as=column14:14]
-      │    │         └── c:10 = 'write-only' [as=column15:15]
+      │    │         ├── c:10 = 'foo' [as=partial_index_del1:12]
+      │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=partial_index_del2:13]
+      │    │         ├── c:10 = 'delete-only' [as=partial_index_del3:14]
+      │    │         └── c:10 = 'write-only' [as=partial_index_del4:15]
       │    └── projections
       │         └── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a:8 END [as=upsert_a:16]
       └── projections
-           ├── column3:7 = 'foo' [as=column17:17]
-           ├── (upsert_a:16 > column2:6) AND (column3:7 = 'bar') [as=column18:18]
-           ├── column3:7 = 'delete-only' [as=column19:19]
-           └── column3:7 = 'write-only' [as=column20:20]
+           ├── column3:7 = 'foo' [as=partial_index_put1:17]
+           ├── (upsert_a:16 > column2:6) AND (column3:7 = 'bar') [as=partial_index_put2:18]
+           ├── column3:7 = 'delete-only' [as=partial_index_put3:19]
+           └── column3:7 = 'write-only' [as=partial_index_put4:20]
 
 # Columns referenced in the SET expression are ambiguous without a table name.
 # Is it the value of the column being inserted or the value of the column
@@ -2142,9 +2142,9 @@ insert unique_partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column17:17
+ ├── partial index put columns: partial_index_put1:17
  └── project
-      ├── columns: column17:17!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:17!null column1:5!null column2:6!null column3:7!null
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── upsert-distinct-on
@@ -2206,7 +2206,7 @@ insert unique_partial_indexes
       │              └── first-agg [as=column3:7]
       │                   └── column3:7
       └── projections
-           └── column3:7 = 'foo' [as=column17:17]
+           └── column3:7 = 'foo' [as=partial_index_put1:17]
 
 exec-ddl
 CREATE UNIQUE INDEX u2 ON unique_partial_indexes (b) WHERE c = 'bar'
@@ -2223,9 +2223,9 @@ insert unique_partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column18:18 column19:19
+ ├── partial index put columns: partial_index_put1:18 partial_index_put2:19
  └── project
-      ├── columns: column18:18!null column19:19!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:18!null partial_index_put2:19!null column1:5!null column2:6!null column3:7!null
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── upsert-distinct-on
@@ -2302,8 +2302,8 @@ insert unique_partial_indexes
       │              └── first-agg [as=column3:7]
       │                   └── column3:7
       └── projections
-           ├── column3:7 = 'foo' [as=column18:18]
-           └── column3:7 = 'bar' [as=column19:19]
+           ├── column3:7 = 'foo' [as=partial_index_put1:18]
+           └── column3:7 = 'bar' [as=partial_index_put2:19]
 
 exec-ddl
 CREATE UNIQUE INDEX u3 ON unique_partial_indexes (b)
@@ -2320,9 +2320,9 @@ insert unique_partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column12:12 column13:13
+ ├── partial index put columns: partial_index_put1:12 partial_index_put2:13
  └── project
-      ├── columns: column12:12!null column13:13!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:12!null partial_index_put2:13!null column1:5!null column2:6!null column3:7!null
       ├── upsert-distinct-on
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    ├── grouping columns: column2:6!null
@@ -2352,8 +2352,8 @@ insert unique_partial_indexes
       │         └── first-agg [as=column3:7]
       │              └── column3:7
       └── projections
-           ├── column3:7 = 'foo' [as=column12:12]
-           └── column3:7 = 'bar' [as=column13:13]
+           ├── column3:7 = 'foo' [as=partial_index_put1:12]
+           └── column3:7 = 'bar' [as=partial_index_put2:13]
 
 exec-ddl
 DROP INDEX u3
@@ -2382,9 +2382,9 @@ insert unique_partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: column13:13 column14:14 column15:15
+ ├── partial index put columns: partial_index_put1:13 partial_index_put2:14 partial_index_put3:15
  └── project
-      ├── columns: column13:13!null column14:14!null column15:15!null column1:5!null column2:6!null column3:7!null
+      ├── columns: partial_index_put1:13!null partial_index_put2:14!null partial_index_put3:15!null column1:5!null column2:6!null column3:7!null
       ├── select
       │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9
       │    ├── right-join (cross)
@@ -2402,9 +2402,9 @@ insert unique_partial_indexes
       │    └── filters
       │         └── a:8 IS NULL
       └── projections
-           ├── column3:7 = 'foo' [as=column13:13]
-           ├── column3:7 = 'bar' [as=column14:14]
-           └── true [as=column15:15]
+           ├── column3:7 = 'foo' [as=partial_index_put1:13]
+           ├── column3:7 = 'bar' [as=partial_index_put2:14]
+           └── true [as=partial_index_put3:15]
 
 exec-ddl
 DROP INDEX u4
@@ -2430,16 +2430,16 @@ upsert unique_partial_indexes
  │    └── column3:7 => c:3
  ├── update-mapping:
  │    └── upsert_b:17 => b:2
- ├── partial index put columns: column19:19 column20:20
- ├── partial index del columns: column13:13 column14:14
+ ├── partial index put columns: partial_index_put1:19 partial_index_put2:20
+ ├── partial index del columns: partial_index_del1:13 partial_index_del2:14
  └── project
-      ├── columns: column19:19 column20:20 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14 b_new:15!null upsert_a:16 upsert_b:17!null upsert_c:18
+      ├── columns: partial_index_put1:19 partial_index_put2:20 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13 partial_index_del2:14 b_new:15!null upsert_a:16 upsert_b:17!null upsert_c:18
       ├── project
-      │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14 b_new:15!null
+      │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13 partial_index_del2:14 b_new:15!null
       │    ├── project
-      │    │    ├── columns: b_new:15!null column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 column13:13 column14:14
+      │    │    ├── columns: b_new:15!null column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13 partial_index_del2:14
       │    │    ├── project
-      │    │    │    ├── columns: column13:13 column14:14 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    ├── columns: partial_index_del1:13 partial_index_del2:14 column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:12
       │    │    │    │    ├── project
@@ -2474,8 +2474,8 @@ upsert unique_partial_indexes
       │    │    │    │         ├── column2:6 = b:10
       │    │    │    │         └── column3:7 = 'foo'
       │    │    │    └── projections
-      │    │    │         ├── c:11 = 'foo' [as=column13:13]
-      │    │    │         └── c:11 = 'bar' [as=column14:14]
+      │    │    │         ├── c:11 = 'foo' [as=partial_index_del1:13]
+      │    │    │         └── c:11 = 'bar' [as=partial_index_del2:14]
       │    │    └── projections
       │    │         └── 10 [as=b_new:15]
       │    └── projections
@@ -2483,5 +2483,91 @@ upsert unique_partial_indexes
       │         ├── CASE WHEN a:9 IS NULL THEN column2:6 ELSE b_new:15 END [as=upsert_b:17]
       │         └── CASE WHEN a:9 IS NULL THEN column3:7 ELSE c:11 END [as=upsert_c:18]
       └── projections
-           ├── upsert_c:18 = 'foo' [as=column19:19]
-           └── upsert_c:18 = 'bar' [as=column20:20]
+           ├── upsert_c:18 = 'foo' [as=partial_index_put1:19]
+           └── upsert_c:18 = 'bar' [as=partial_index_put2:20]
+
+
+# Do not error with "column reference is ambiguous" when table column names
+# match synthesized column names.
+exec-ddl
+CREATE TABLE t (
+    partial_index_put1 INT,
+    partial_index_del1 INT,
+    UNIQUE INDEX (partial_index_put1) WHERE partial_index_put1 > 0 AND partial_index_del1 > 0
+)
+----
+
+build
+INSERT INTO t VALUES (1, 2)
+ON CONFLICT (partial_index_put1) WHERE partial_index_put1 > 0 AND partial_index_del1 > 0
+DO UPDATE SET partial_index_put1 = 10, partial_index_del1 = 20
+----
+upsert t
+ ├── columns: <none>
+ ├── arbiter indexes: secondary
+ ├── canary column: rowid:11
+ ├── fetch columns: t.partial_index_put1:9 t.partial_index_del1:10 rowid:11
+ ├── insert-mapping:
+ │    ├── column1:5 => t.partial_index_put1:1
+ │    ├── column2:6 => t.partial_index_del1:2
+ │    └── column7:7 => rowid:3
+ ├── update-mapping:
+ │    ├── upsert_partial_index_put1:16 => t.partial_index_put1:1
+ │    └── upsert_partial_index_del1:17 => t.partial_index_del1:2
+ ├── partial index put columns: partial_index_put1:19
+ ├── partial index del columns: partial_index_del1:13
+ └── project
+      ├── columns: partial_index_put1:19!null column1:5!null column2:6!null column7:7 t.partial_index_put1:9 t.partial_index_del1:10 rowid:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13 partial_index_put1_new:14!null partial_index_del1_new:15!null upsert_partial_index_put1:16!null upsert_partial_index_del1:17!null upsert_rowid:18
+      ├── project
+      │    ├── columns: upsert_partial_index_put1:16!null upsert_partial_index_del1:17!null upsert_rowid:18 column1:5!null column2:6!null column7:7 t.partial_index_put1:9 t.partial_index_del1:10 rowid:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13 partial_index_put1_new:14!null partial_index_del1_new:15!null
+      │    ├── project
+      │    │    ├── columns: partial_index_put1_new:14!null partial_index_del1_new:15!null column1:5!null column2:6!null column7:7 t.partial_index_put1:9 t.partial_index_del1:10 rowid:11 crdb_internal_mvcc_timestamp:12 partial_index_del1:13
+      │    │    ├── project
+      │    │    │    ├── columns: partial_index_del1:13 column1:5!null column2:6!null column7:7 t.partial_index_put1:9 t.partial_index_del1:10 rowid:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 t.partial_index_put1:9 t.partial_index_del1:10 rowid:11 crdb_internal_mvcc_timestamp:12
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7
+      │    │    │    │    │    └── ensure-upsert-distinct-on
+      │    │    │    │    │         ├── columns: column1:5!null column2:6!null column7:7 upsert_partial_index_distinct1:8
+      │    │    │    │    │         ├── grouping columns: column1:5!null upsert_partial_index_distinct1:8
+      │    │    │    │    │         ├── project
+      │    │    │    │    │         │    ├── columns: upsert_partial_index_distinct1:8 column1:5!null column2:6!null column7:7
+      │    │    │    │    │         │    ├── project
+      │    │    │    │    │         │    │    ├── columns: column7:7 column1:5!null column2:6!null
+      │    │    │    │    │         │    │    ├── values
+      │    │    │    │    │         │    │    │    ├── columns: column1:5!null column2:6!null
+      │    │    │    │    │         │    │    │    └── (1, 2)
+      │    │    │    │    │         │    │    └── projections
+      │    │    │    │    │         │    │         └── unique_rowid() [as=column7:7]
+      │    │    │    │    │         │    └── projections
+      │    │    │    │    │         │         └── ((column1:5 > 0) AND (column2:6 > 0)) OR NULL::BOOL [as=upsert_partial_index_distinct1:8]
+      │    │    │    │    │         └── aggregations
+      │    │    │    │    │              ├── first-agg [as=column2:6]
+      │    │    │    │    │              │    └── column2:6
+      │    │    │    │    │              └── first-agg [as=column7:7]
+      │    │    │    │    │                   └── column7:7
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: t.partial_index_put1:9!null t.partial_index_del1:10!null rowid:11!null crdb_internal_mvcc_timestamp:12
+      │    │    │    │    │    ├── scan t
+      │    │    │    │    │    │    ├── columns: t.partial_index_put1:9 t.partial_index_del1:10 rowid:11!null crdb_internal_mvcc_timestamp:12
+      │    │    │    │    │    │    └── partial index predicates
+      │    │    │    │    │    │         └── secondary: filters
+      │    │    │    │    │    │              ├── t.partial_index_put1:9 > 0
+      │    │    │    │    │    │              └── t.partial_index_del1:10 > 0
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── (t.partial_index_put1:9 > 0) AND (t.partial_index_del1:10 > 0)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column1:5 = t.partial_index_put1:9
+      │    │    │    │         └── (column1:5 > 0) AND (column2:6 > 0)
+      │    │    │    └── projections
+      │    │    │         └── (t.partial_index_put1:9 > 0) AND (t.partial_index_del1:10 > 0) [as=partial_index_del1:13]
+      │    │    └── projections
+      │    │         ├── 10 [as=partial_index_put1_new:14]
+      │    │         └── 20 [as=partial_index_del1_new:15]
+      │    └── projections
+      │         ├── CASE WHEN rowid:11 IS NULL THEN column1:5 ELSE partial_index_put1_new:14 END [as=upsert_partial_index_put1:16]
+      │         ├── CASE WHEN rowid:11 IS NULL THEN column2:6 ELSE partial_index_del1_new:15 END [as=upsert_partial_index_del1:17]
+      │         └── CASE WHEN rowid:11 IS NULL THEN column7:7 ELSE rowid:11 END [as=upsert_rowid:18]
+      └── projections
+           └── (upsert_partial_index_put1:16 > 0) AND (upsert_partial_index_del1:17 > 0) [as=partial_index_put1:19]


### PR DESCRIPTION
This commit aliases synthesized partial index PUT and DEL columns with
names like `partial_index_put1` and `partial_index_del1`. This makes opt
trees more human-readable, and should aid in debugging.

Fixes #51859

Release note: None