### PR TITLE
ui: add transactions page to Admin UI

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -13,7 +13,7 @@
     "cypress:update-snapshots": "yarn cypress run --env updateSnapshots=true --spec 'cypress/integration/**/*.visual.spec.ts'"
   },
   "dependencies": {
-    "@cockroachlabs/admin-ui-components": "^0.1.10",
+    "@cockroachlabs/admin-ui-components": "^0.1.16",
     "analytics-node": "^3.4.0-beta.1",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/src/app.tsx
+++ b/pkg/ui/src/app.tsx
@@ -61,6 +61,7 @@ import StatementDetails from "src/views/statements/statementDetails";
 import StatementsPage from "src/views/statements/statementsPage";
 import SessionsPage from "src/views/sessions/sessionsPage";
 import SessionDetails from "src/views/sessions/sessionDetails";
+import TransactionsPage from "src/views/transactions/transactionsPage";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import "styl/app.styl";
 
@@ -144,6 +145,8 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   { /* sessions */ }
                   <Route exact path="/sessions" component={ SessionsPage }/>
                   <Route exact path={ `/session/:${sessionAttr}`} component={ SessionDetails } />
+                  { /* transactions */ }
+                  <Route exact path="/transactions" component={ TransactionsPage }/>
 
                   { /* debug pages */ }
                   <Route exact path="/debug" component={Debug}/>

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -41,6 +41,7 @@ export class Sidebar extends React.Component<SidebarProps> {
     { path: "/databases", text: "Databases", activeFor: ["/database"] },
     { path: "/sessions", text: "Active Sessions", activeFor: ["/session"] },
     { path: "/statements", text: "Statements", activeFor: ["/statement"] },
+    { path: "/transactions", text: "Transactions", activeFor: ["/transactions"] },
     {
       path: "/reports/network",
       text: "Network Latency",

--- a/pkg/ui/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/src/views/transactions/transactionsPage.tsx
@@ -1,0 +1,60 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+import { withRouter } from "react-router-dom";
+import {
+  refreshStatements,
+} from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { AdminUIState } from "src/redux/state";
+import { StatementsResponseMessage } from "src/util/api";
+
+import { TimestampToMoment } from "src/util/convert";
+import { PrintTime } from "src/views/reports/containers/range/print";
+
+import { TransactionsPage } from "@cockroachlabs/admin-ui-components";
+
+// selectStatements returns the array of AggregateStatistics to show on the
+// TransactionsPage, based on if the appAttr route parameter is set.
+export const selectData = createSelector(
+  (state: AdminUIState) => state.cachedData.statements,
+  (state: CachedDataReducerState<StatementsResponseMessage>) => {
+    return state.data || null;
+  },
+);
+
+// selectLastReset returns a string displaying the last time the statement
+// statistics were reset.
+export const selectLastReset = createSelector(
+  (state: AdminUIState) => state.cachedData.statements,
+  (state: CachedDataReducerState<StatementsResponseMessage>) => {
+    if (!state.data) {
+      return "unknown";
+    }
+
+    return PrintTime(TimestampToMoment(state.data.last_reset));
+  },
+);
+
+// tslint:disable-next-line:variable-name
+const TransactionsPageConnected = withRouter(connect(
+  (state: AdminUIState) => ({
+    data: selectData(state),
+    statementsError: state.cachedData.statements.lastError,
+    lastReset: selectLastReset(state),
+  }),
+  {
+    refreshData: refreshStatements,
+  },
+)(TransactionsPage));
+
+export default TransactionsPageConnected;

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1806,23 +1806,46 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cockroachlabs/admin-ui-components@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/admin-ui-components/-/admin-ui-components-0.1.10.tgz#e71e7f00ba4a51e868b01bae3479e3b28cff5014"
-  integrity sha512-t0fza4KPVEdsgmcfY8WW3QUC5r2+PvzZgWCiHShzTKyElZTqyXYbqpzTDsrJoD+wNXqy5L5Y/7yBvrINWEpCYw==
+"@cockroachlabs/admin-ui-components@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/admin-ui-components/-/admin-ui-components-0.1.16.tgz#01060843a1f66a545d5dc7f9b2c3e5ef228ed930"
+  integrity sha512-RM3D90NoubKm+fUjnUnFnTz3w17Neyk25mpJORiUh9t8feBWiv0Q6ORQe3qQvyyO48dEahOmMdQz5dHXX1mgPQ==
   dependencies:
+    "@cockroachlabs/crdb-protobuf-client" "^0.0.2"
     "@cockroachlabs/icons" "^0.2.2"
+    "@cockroachlabs/ui-components" "^0.2.8"
     "@popperjs/core" "^2.4.0"
+    babel-polyfill "^6.26.0"
+    highlight.js "^10.2.0"
     long "^4.0.0"
     react-helmet "^5.2.0"
     react-popper "^2.2.3"
     react-select "^1.2.1"
     reselect "^4.0.0"
 
+"@cockroachlabs/crdb-protobuf-client@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.2.tgz#0dff7158b75971adfa18e7f32e90b9d88d6215a7"
+  integrity sha512-p/FyoVLeXTluRwPPwkRE6dU/cfTq01ej4vBNC64nxM4PDEcKOdlAt3xT+j9GD1m/f8VYdk7kksdFUOty+Ilklw==
+
 "@cockroachlabs/icons@^0.2.2":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.2.9.tgz#b626fe409ea49be66b19a9a0358a082d50ade2d0"
   integrity sha512-s1kH8sU/DeIGrGUwUMVMAjxGTOn6SHAK8q0tmJY6zcIUaoYb/5UfnQjzdG+ybflgBdyMTB41/bWTXnpsYxxSpw==
+
+"@cockroachlabs/icons@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.3.0.tgz#160573074396f266e92fcbe5e520c5ba1d8750f9"
+  integrity sha512-GJxhlXy8Z3/PYFb9C3iM1dvU9wajGoaA/+VCj0an2ipfbkI2fhToq+h0b33vu7JuZ3dS4QMRjfVE4uhlyIUH2Q==
+
+"@cockroachlabs/ui-components@^0.2.8":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.10.tgz#3c1492ae4397204fba8dcafc6fe09e2a0e1aaa57"
+  integrity sha512-m3csfYolWh6Rn0xuDRf0wqr1vErLgK1RVYywzM6k7Tld5O2XI993NyhCi5GNCBjOfbov7Ikq+UE6uc3S3Di9dQ==
+  dependencies:
+    "@cockroachlabs/icons" "^0.3.0"
+    "@popperjs/core" "^2.4.3"
+    react-popper "^2.2.3"
 
 "@emotion/cache@^10.0.27":
   version "10.0.27"
@@ -1943,6 +1966,11 @@
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
+
+"@popperjs/core@^2.4.3":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.2.tgz#d3217d5f630766c0c92fbd55cf285ba64de0578b"
+  integrity sha512-tVkIU9JQw5fYPxLQgok/a7I6J1eEZ79svwQGpe2mb3jlVsPADOleefOnQBiS/takK7jQuNeswCUicMH1VWVziA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -6858,6 +6886,11 @@ he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.2.0.tgz#367151bcf813adebc54822f1cb51d2e1e599619f"
+  integrity sha512-OryzPiqqNCfO/wtFo619W+nPYALM6u7iCQkum4bqRmmlcTikOkmlL06i009QelynBPAlNByTQU6cBB2cOBQtCw==
 
 highlight.js@^9.10.0:
   version "9.10.0"


### PR DESCRIPTION
This commit adds the new Transactions Page to the Admin UI.

This page is much like the Statements Page but differs in that
it shows Transaction-level statistics in tabular and detail form.

Every Transaction is able to display its contained Statements
for more detailed analysis.

The page and its components are imported from the
`admin-ui-components` library.

Depends on: https://github.com/cockroachdb/yarn-vendored/pull/38

Release justification: low-risk high impact addition to Admin UI

Release note (admin ui change): add Transactions and Transactions
details pages. These pages allow for viewing stats at the
transaction level.