### PR TITLE
release-20.2: sql: fix DROP COLUMN bug which ignores containing indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1364,3 +1364,23 @@ statement ok
 CREATE TABLE t52816 (x INT, y INT);
 ALTER TABLE t52816 RENAME COLUMN x TO x2, RENAME COLUMN y TO y;
 SELECT x2, y FROM t52816
+
+# Regression test for #54196.
+statement ok
+CREATE TABLE IF NOT EXISTS regression_54196 (
+	col1 int,
+	col2 int,
+	col3 int,
+	INDEX (col1, col2),
+	INDEX (col1, col3),
+	INDEX (col2, col3)
+); ALTER TABLE regression_54196 DROP COLUMN col1
+
+query TT
+SELECT index_name, column_name FROM [SHOW INDEXES FROM regression_54196]
+ORDER BY index_name, column_name ASC
+----
+primary                         rowid
+regression_54196_col2_col3_idx  col2
+regression_54196_col2_col3_idx  col3
+regression_54196_col2_col3_idx  rowid


### PR DESCRIPTION
Backport 1/1 commits from #54228.

/cc @cockroachdb/release

---

AllNonDropIndexes returns an array of pointers to index descriptors.
After deleting one of the indexes, the array of pointers point
to a different element. This ends up accidentally missing some
indexes that require deletion.

Resolves #54196 (introduced in #51661).

Release note (bug fix): Fixed a bug introduced in earlier v20.2 versions
where when attempting to drop a column which is referenced by multiple
indexes fails to drop all relevant indexes.


