### PR TITLE
ui: Show error info for failed job

### DIFF
--- a/pkg/ui/assets/info-filled-circle.svg
+++ b/pkg/ui/assets/info-filled-circle.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 10C0 4.47726 4.47726 0 10 0C15.5227 0 20 4.47726 20 10C20 15.5227 15.5227 20 10 20C4.47726 20 0 15.5227 0 10Z" fill="#0788FF"/>
+<rect x="10.833" y="15" width="1.66667" height="6.66667" rx="0.833334" transform="rotate(180 10.833 15)" fill="white"/>
+<ellipse cx="9.99967" cy="5.83329" rx="0.833334" ry="0.833333" transform="rotate(180 9.99967 5.83329)" fill="white"/>
+</svg>

--- a/pkg/ui/src/components/index.ts
+++ b/pkg/ui/src/components/index.ts
@@ -11,6 +11,7 @@
 export * from "./badge";
 export * from "./button";
 export * from "./icon";
+export * from "./inlineAlert/inlineAlert";
 export * from "./globalNavigation";
 export * from "./anchor";
 export * from "./sideNavigation";

--- a/pkg/ui/src/components/inlineAlert/inlineAlert.module.styl
+++ b/pkg/ui/src/components/inlineAlert/inlineAlert.module.styl
@@ -1,0 +1,38 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~src/components/core/index"
+
+.root
+  display flex
+  flex-direction row
+  width 75%
+  border-left solid 4px
+  border-radius 5px
+  padding $spacing-smaller $spacing-medium $spacing-smaller 0
+
+.main-container
+  display flex
+  flex-direction column
+  flex-grow 1
+
+.title
+  @extends $text--body-strong
+
+.icon-container
+  padding 0 $spacing-small
+
+.intent-info
+  border-left-color $colors--primary-blue-3
+  background-color $colors--primary-blue-1
+
+.intent-error
+  border-left-color $colors--functional-red-3
+  background-color $colors--functional-red-1

--- a/pkg/ui/src/components/inlineAlert/inlineAlert.stories.tsx
+++ b/pkg/ui/src/components/inlineAlert/inlineAlert.stories.tsx
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { InlineAlert } from "./inlineAlert";
+import { styledWrapper } from "src/util/decorators";
+import { Anchor } from "src/components";
+
+storiesOf("InlineAlert", module)
+  .addDecorator(styledWrapper({padding: "24px"}))
+  .add("with text title", () => (
+    <InlineAlert title="Hello world!" message="blah-blah-blah" />
+  ))
+  .add("with Error intent", () => (
+    <InlineAlert title="Hello world!" message="blah-blah-blah" intent="error" />
+  ))
+  .add("with link in title", () => (
+    <InlineAlert
+      title={<span>You do not have permission to view this information. <Anchor href="#">Learn more.</Anchor></span>}
+    />
+  ))
+  .add("with multiline message", () => (
+    <InlineAlert
+      title="Hello world!"
+      message={<div>
+        <div>Message 1</div>
+        <div>Message 2</div>
+        <div>Message 3</div>
+      </div>}
+    />
+  ));

--- a/pkg/ui/src/components/inlineAlert/inlineAlert.tsx
+++ b/pkg/ui/src/components/inlineAlert/inlineAlert.tsx
@@ -1,0 +1,59 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useMemo } from "react";
+import classNames from "classnames/bind";
+
+import styles from "./inlineAlert.module.styl";
+import ErrorIcon from "assets/error-circle.svg";
+import InfoIcon from "assets/info-filled-circle.svg";
+
+export type InlineAlertIntent = "info" | "error";
+
+const cn = classNames.bind(styles);
+
+export interface InlineAlertProps {
+  title: React.ReactNode;
+  message?: React.ReactNode;
+  intent?: InlineAlertIntent;
+  className?: string;
+}
+
+export const InlineAlert: React.FC<InlineAlertProps> = ({
+  title,
+  message,
+  intent = "info",
+  className,
+}) => {
+  const Icon = useMemo(
+    () => {
+      switch (intent) {
+        case "error":
+          return ErrorIcon;
+        case "info":
+        default:
+          return InfoIcon;
+      }
+  },
+    [intent],
+  );
+
+  return (
+    <div className={cn("root", `intent-${intent}`, className)}>
+      <div className={cn("icon-container")}>
+        <img src={Icon} className={cn("icon")} />
+      </div>
+      <div className={cn("main-container")}>
+        <div className={cn("title")}>{title}</div>
+        <div className={cn("message")}>{message}</div>
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/src/views/jobs/jobStatus.module.styl
+++ b/pkg/ui/src/views/jobs/jobStatus.module.styl
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~src/components/core/index"
+
+.inline-message
+  margin-top $spacing-smaller
+  width 100%

--- a/pkg/ui/src/views/jobs/jobStatus.tsx
+++ b/pkg/ui/src/views/jobs/jobStatus.tsx
@@ -9,48 +9,68 @@
 // licenses/APL.txt.
 
 import React from "react";
+import classNames from "classnames/bind";
 import {JobStatusBadge, ProgressBar} from "src/views/jobs/progressBar";
 import {Duration} from "src/views/jobs/duration";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import {cockroach} from "src/js/protos";
 import {JobStatusVisual, jobToVisual} from "src/views/jobs/jobStatusOptions";
+import { InlineAlert } from "src/components";
+import styles from "./jobStatus.module.styl";
 
-export class JobStatus extends React.PureComponent<{ job: Job, lineWidth?: number }> {
-  render() {
-    const visualType = jobToVisual(this.props.job);
-
-    switch (visualType) {
-      case JobStatusVisual.BadgeOnly:
-        return <JobStatusBadge jobStatus={this.props.job.status} />;
-      case JobStatusVisual.BadgeWithDuration:
-        return (
-          <div>
-            <JobStatusBadge jobStatus={this.props.job.status} />
-            <span className="jobs-table__duration">
-              <Duration job={this.props.job}/>
-            </span>
-          </div>
-        );
-      case JobStatusVisual.ProgressBarWithDuration:
-        return (
-          <div>
-            <ProgressBar job={this.props.job} lineWidth={this.props.lineWidth || 11} showPercentage={true}/>
-            <span className="jobs-table__duration">
-              <Duration job={this.props.job}/>
-            </span>
-          </div>
-        );
-      case JobStatusVisual.BadgeWithMessage:
-        return (
-          <div>
-            <JobStatusBadge jobStatus={this.props.job.status} />
-            <span className="jobs-table__duration">
-              {this.props.job.running_status}
-            </span>
-          </div>
-        );
-      default:
-        return <JobStatusBadge jobStatus={this.props.job.status} />;
-    }
-  }
+export interface JobStatusProps {
+  job: Job;
+  lineWidth?: number;
+  compact?: boolean;
 }
+
+const cn = classNames.bind(styles);
+
+export const JobStatus: React.FC<JobStatusProps> = ({ job, compact, lineWidth }) => {
+  const visualType = jobToVisual(job);
+
+  switch (visualType) {
+    case JobStatusVisual.BadgeOnly:
+      return <JobStatusBadge jobStatus={job.status} />;
+    case JobStatusVisual.BadgeWithDuration:
+      return (
+        <div>
+          <JobStatusBadge jobStatus={job.status} />
+          <span className="jobs-table__duration">
+            <Duration job={job}/>
+          </span>
+        </div>
+      );
+    case JobStatusVisual.ProgressBarWithDuration:
+      return (
+        <div>
+          <ProgressBar job={job} lineWidth={lineWidth || 11} showPercentage={true}/>
+          <span className="jobs-table__duration">
+            <Duration job={job}/>
+          </span>
+        </div>
+      );
+    case JobStatusVisual.BadgeWithMessage:
+      return (
+        <div>
+          <JobStatusBadge jobStatus={job.status} />
+          <span className="jobs-table__duration">
+            {job.running_status}
+          </span>
+        </div>
+      );
+    case JobStatusVisual.BadgeWithErrorMessage:
+      return (
+        <div>
+          <JobStatusBadge jobStatus={job.status} />
+          {
+            !compact && (
+              <InlineAlert title={job.error} intent="error" className={cn("inline-message")} />
+            )
+          }
+        </div>
+      );
+    default:
+      return <JobStatusBadge jobStatus={job.status} />;
+  }
+};

--- a/pkg/ui/src/views/jobs/jobStatusCell.tsx
+++ b/pkg/ui/src/views/jobs/jobStatusCell.tsx
@@ -14,11 +14,19 @@ import {HighwaterTimestamp} from "src/views/jobs/highwaterTimestamp";
 import {JobStatus} from "./jobStatus";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 
-export class JobStatusCell extends React.Component<{ job: Job, lineWidth?: number }, {}> {
-  render() {
-    if (this.props.job.highwater_timestamp) {
-      return <HighwaterTimestamp highwater={this.props.job.highwater_timestamp} tooltip={this.props.job.highwater_decimal}/>;
-    }
-    return <JobStatus job={this.props.job} lineWidth={this.props.lineWidth} />;
-  }
+export interface JobStatusCellProps {
+  job: Job;
+  lineWidth?: number;
+  compact?: boolean;
 }
+
+export const JobStatusCell: React.FC<JobStatusCellProps> = ({
+  job,
+  lineWidth,
+  compact = false,
+}) => {
+  if (job.highwater_timestamp) {
+    return <HighwaterTimestamp highwater={job.highwater_timestamp} tooltip={job.highwater_decimal}/>;
+  }
+  return <JobStatus job={job} lineWidth={lineWidth} compact={compact} />;
+};

--- a/pkg/ui/src/views/jobs/jobStatusOptions.ts
+++ b/pkg/ui/src/views/jobs/jobStatusOptions.ts
@@ -17,6 +17,7 @@ export enum JobStatusVisual {
   BadgeWithDuration,
   ProgressBarWithDuration,
   BadgeWithMessage,
+  BadgeWithErrorMessage,
 }
 
 export function jobToVisual(job: Job): JobStatusVisual {
@@ -27,7 +28,7 @@ export function jobToVisual(job: Job): JobStatusVisual {
     case JOB_STATUS_SUCCEEDED:
       return JobStatusVisual.BadgeWithDuration;
     case JOB_STATUS_FAILED:
-      return JobStatusVisual.BadgeOnly;
+      return JobStatusVisual.BadgeWithErrorMessage;
     case JOB_STATUS_CANCELED:
       return JobStatusVisual.BadgeOnly;
     case JOB_STATUS_PAUSED:

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -52,7 +52,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
   },
   {
     title: "Status",
-    cell: job => <JobStatusCell job={job} />,
+    cell: job => <JobStatusCell job={job} compact />,
     sort: job => job.fraction_completed,
   },
 ];


### PR DESCRIPTION
Resolves #52695

Before, Job details page didn't show any information which described
the reason for failure.
    
Now, the error description is shown on Job details page for failed jobs.
    
This required to add the following changes:
 - `compact` prop is added to `JobStatus` and `JobStatusCell` components
to show status with or without extra information for status. In our case,
we don't need to show an error message in Jobs table (in the status column) and
error message has to be shown on Job details page.
- `JobStatus` and `JobStatusCell` components are refactored to functional
components instead of class components.
- `InlineMessage` component is added to show error description (from design system)

<img width="1372" alt="Screenshot 2020-09-11 at 5 17 11 PM" src="https://user-images.githubusercontent.com/3106437/92950443-513c4500-f465-11ea-9e52-886b0fbb0e90.png">

TODO: clarify the design of message.

Release note (admin ui change): Show description for failed job on Job details page.
