### PR TITLE
release-20.2: opt: generate lookup joins on partial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1024,6 +1024,21 @@ SELECT m FROM join_small JOIN join_large ON n = i AND s = 'foo'
 ----
 1
 
+# A lookup semi-join is used when an expression in the semi-join filter exactly
+# matches the partial index predicate.
+query I rowsort
+SELECT m FROM join_small WHERE EXISTS (SELECT 1 FROM join_large WHERE n = i AND s IN ('foo', 'bar', 'baz'))
+----
+1
+3
+
+# A lookup anti-join is used when an expression in the anti-join filter exactly
+# matches the partial index predicate.
+query I rowsort
+SELECT m FROM join_small WHERE NOT EXISTS (SELECT 1 FROM join_large WHERE n = i AND s IN ('foo', 'bar', 'baz'))
+----
+2
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -981,6 +981,49 @@ DROP INDEX i2
 statement ok
 DELETE from u
 
+# Test partial indexes with lookup joins.
+subtest join
+
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+CREATE TABLE join_small (m INT, n INT);
+CREATE TABLE join_large (i INT, s STRING, INDEX (i) WHERE s IN ('foo', 'bar', 'baz'));
+ALTER TABLE join_small INJECT STATISTICS '[
+  {
+    "columns": ["m"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 20,
+    "distinct_count": 20
+  }
+]';
+ALTER TABLE join_large INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 50
+  }
+]';
+INSERT INTO join_small VALUES (1, 1), (2, 2), (3, 3);
+INSERT INTO join_large VALUES (1, 'foo'), (2, 'not'), (3, 'bar'), (4, 'not');
+
+query I rowsort
+SELECT m FROM join_small JOIN join_large ON n = i AND s IN ('foo', 'bar', 'baz')
+----
+1
+3
+
+query I rowsort
+SELECT m FROM join_small JOIN join_large ON n = i AND s = 'foo'
+----
+1
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1286,7 +1286,11 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if t.Index == cat.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, " %s", tab.Name())
 		} else {
-			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name(), tab.Index(t.Index).Name())
+			partialStr := ""
+			if _, isPartial := tab.Index(t.Index).Predicate(); isPartial {
+				partialStr = ",partial"
+			}
+			fmt.Fprintf(f.Buffer, " %s@%s%s", tab.Name(), tab.Index(t.Index).Name(), partialStr)
 		}
 
 	case *InvertedJoinPrivate:

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3198,25 +3198,19 @@ project
       └── filters
            └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
 
-# TODO: We can generate a lookup semi-join when the index does not cover "s" but
-# the reference to "s" no longer exists in the filters.
+# Generate a lookup semi-join when the index does not cover "s", but the
+# reference to "s" no longer exists in the filters.
 opt expect=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
 ----
 project
  ├── columns: m:1
- └── semi-join (hash)
+ └── semi-join (lookup partial_tab@partial_idx,partial)
       ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
       ├── scan small
       │    └── columns: m:1 n:2
-      ├── index-join partial_tab
-      │    ├── columns: i:6 s:7!null
-      │    └── scan partial_tab@partial_idx,partial
-      │         ├── columns: k:5!null i:6
-      │         ├── key: (5)
-      │         └── fd: (5)-->(6)
-      └── filters
-           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── filters (true)
 
 # We should not generate a lookup semi-join when the index does not cover "s"
 # which is referenced in the remaining filter.
@@ -3243,25 +3237,19 @@ project
       └── filters
            └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
-# TODO: We can generate a lookup anti-join when the index does not cover "s" but
-# the reference to "s" no longer exists in the filters.
+# Generate a lookup anti-join when the index does not cover "s", but the
+# reference to "s" no longer exists in the filters.
 opt expect=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
 ----
 project
  ├── columns: m:1
- └── anti-join (hash)
+ └── anti-join (lookup partial_tab@partial_idx,partial)
       ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
       ├── scan small
       │    └── columns: m:1 n:2
-      ├── index-join partial_tab
-      │    ├── columns: i:6 s:7!null
-      │    └── scan partial_tab@partial_idx,partial
-      │         ├── columns: k:5!null i:6
-      │         ├── key: (5)
-      │         └── fd: (5)-->(6)
-      └── filters
-           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── filters (true)
 
 # We should not generate a lookup anti-join when the index does not cover "s"
 # which is referenced in the remaining filter.

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2151,6 +2151,18 @@ left-join (lookup abcd@secondary)
  │    └── columns: m:1 n:2
  └── filters (true)
 
+# Covering case, left-join, extra filter bound by index.
+opt
+SELECT a,b,n,m FROM small LEFT JOIN abcd ON a=m AND b>n
+----
+left-join (lookup abcd@secondary)
+ ├── columns: a:5 b:6 n:2 m:1
+ ├── key columns: [1] = [5]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      └── b:6 > n:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
+
 # Non-covering case.
 opt
 SELECT * FROM small JOIN abcd ON a=m
@@ -3013,6 +3025,268 @@ anti-join (hash)
  └── filters
       ├── m:1 = a:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── n:2 = c:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
+# --------------------------------------------------
+# GenerateLookupJoinsWithFilter + Partial Indexes
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE partial_tab (
+    k INT PRIMARY KEY,
+    i INT,
+    s STRING
+)
+----
+
+exec-ddl
+ALTER TABLE partial_tab INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 50
+  }
+]'
+----
+
+# Storing the index predicate column.
+
+exec-ddl
+CREATE INDEX partial_idx ON partial_tab (i) STORING (s) WHERE s IN ('foo', 'bar', 'baz')
+----
+
+# Lookup inner-join with no remaining filters.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small JOIN partial_tab ON n = i WHERE s IN ('foo', 'bar', 'baz')
+----
+project
+ ├── columns: m:1
+ └── inner-join (lookup partial_tab@partial_idx,partial)
+      ├── columns: m:1 n:2!null i:6!null s:7!null
+      ├── key columns: [2] = [6]
+      ├── fd: (2)==(6), (6)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters (true)
+
+# Lookup inner-join with remaining filters.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small JOIN partial_tab ON n = i WHERE s = 'foo'
+----
+project
+ ├── columns: m:1
+ └── inner-join (lookup partial_tab@partial_idx,partial)
+      ├── columns: m:1 n:2!null i:6!null s:7!null
+      ├── key columns: [2] = [6]
+      ├── fd: ()-->(7), (2)==(6), (6)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters
+           └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+
+# Lookup semi-join.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
+----
+project
+ ├── columns: m:1
+ └── semi-join (lookup partial_tab@partial_idx,partial)
+      ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters
+           └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+
+# Lookup anti-join.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
+----
+project
+ ├── columns: m:1
+ └── anti-join (lookup partial_tab@partial_idx,partial)
+      ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters
+           └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+
+# Do not generate a lookup join when the predicate is not implied by the filter.
+opt
+SELECT m FROM small JOIN partial_tab ON n = i WHERE s = 'not_implied'
+----
+project
+ ├── columns: m:1
+ └── inner-join (hash)
+      ├── columns: m:1 n:2!null i:6!null s:7!null
+      ├── fd: ()-->(7), (2)==(6), (6)==(2)
+      ├── select
+      │    ├── columns: i:6 s:7!null
+      │    ├── fd: ()-->(7)
+      │    ├── scan partial_tab
+      │    │    ├── columns: i:6 s:7
+      │    │    └── partial index predicates
+      │    │         └── partial_idx: filters
+      │    │              └── s:7 IN ('bar', 'baz', 'foo') [outer=(7), constraints=(/7: [/'bar' - /'bar'] [/'baz' - /'baz'] [/'foo' - /'foo']; tight)]
+      │    └── filters
+      │         └── s:7 = 'not_implied' [outer=(7), constraints=(/7: [/'not_implied' - /'not_implied']; tight), fd=()-->(7)]
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters
+           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+exec-ddl
+DROP INDEX partial_idx
+----
+
+# Not storing the index predicate column.
+
+exec-ddl
+CREATE INDEX partial_idx ON partial_tab (i) WHERE s IN ('foo', 'bar', 'baz')
+----
+
+# The remaining filters are empty when the query filters exactly match the
+# partial index predicate.
+#
+# TODO(mgartner): The outer inner-join is not necessary here and should be
+# eliminated, like in EliminateIndexJoinInsideProject.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small JOIN partial_tab ON n = i WHERE s IN ('foo', 'bar', 'baz')
+----
+project
+ ├── columns: m:1
+ └── inner-join (lookup partial_tab)
+      ├── columns: m:1 n:2!null i:6!null s:7!null
+      ├── key columns: [5] = [5]
+      ├── lookup columns are key
+      ├── fd: (2)==(6), (6)==(2)
+      ├── inner-join (lookup partial_tab@partial_idx,partial)
+      │    ├── columns: m:1 n:2!null k:5!null i:6!null
+      │    ├── key columns: [2] = [6]
+      │    ├── fd: (5)-->(6), (2)==(6), (6)==(2)
+      │    ├── scan small
+      │    │    └── columns: m:1 n:2
+      │    └── filters (true)
+      └── filters (true)
+
+# The remaining filters are not empty when the query filters imply but do not
+# exactly match the partial index predicate.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small JOIN partial_tab ON n = i WHERE s = 'foo'
+----
+project
+ ├── columns: m:1
+ └── inner-join (lookup partial_tab)
+      ├── columns: m:1 n:2!null i:6!null s:7!null
+      ├── key columns: [5] = [5]
+      ├── lookup columns are key
+      ├── fd: ()-->(7), (2)==(6), (6)==(2)
+      ├── inner-join (lookup partial_tab@partial_idx,partial)
+      │    ├── columns: m:1 n:2!null k:5!null i:6!null
+      │    ├── key columns: [2] = [6]
+      │    ├── fd: (5)-->(6), (2)==(6), (6)==(2)
+      │    ├── scan small
+      │    │    └── columns: m:1 n:2
+      │    └── filters (true)
+      └── filters
+           └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+
+# TODO: We can generate a lookup semi-join when the index does not cover "s" but
+# the reference to "s" no longer exists in the filters.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
+----
+project
+ ├── columns: m:1
+ └── semi-join (hash)
+      ├── columns: m:1 n:2
+      ├── scan small
+      │    └── columns: m:1 n:2
+      ├── index-join partial_tab
+      │    ├── columns: i:6 s:7!null
+      │    └── scan partial_tab@partial_idx,partial
+      │         ├── columns: k:5!null i:6
+      │         ├── key: (5)
+      │         └── fd: (5)-->(6)
+      └── filters
+           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+# We should not generate a lookup semi-join when the index does not cover "s"
+# which is referenced in the remaining filter.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
+----
+project
+ ├── columns: m:1
+ └── semi-join (hash)
+      ├── columns: m:1 n:2
+      ├── scan small
+      │    └── columns: m:1 n:2
+      ├── select
+      │    ├── columns: i:6 s:7!null
+      │    ├── fd: ()-->(7)
+      │    ├── index-join partial_tab
+      │    │    ├── columns: i:6 s:7
+      │    │    └── scan partial_tab@partial_idx,partial
+      │    │         ├── columns: k:5!null i:6
+      │    │         ├── key: (5)
+      │    │         └── fd: (5)-->(6)
+      │    └── filters
+      │         └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+      └── filters
+           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+# TODO: We can generate a lookup anti-join when the index does not cover "s" but
+# the reference to "s" no longer exists in the filters.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
+----
+project
+ ├── columns: m:1
+ └── anti-join (hash)
+      ├── columns: m:1 n:2
+      ├── scan small
+      │    └── columns: m:1 n:2
+      ├── index-join partial_tab
+      │    ├── columns: i:6 s:7!null
+      │    └── scan partial_tab@partial_idx,partial
+      │         ├── columns: k:5!null i:6
+      │         ├── key: (5)
+      │         └── fd: (5)-->(6)
+      └── filters
+           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+# We should not generate a lookup anti-join when the index does not cover "s"
+# which is referenced in the remaining filter.
+opt expect=GenerateLookupJoinsWithFilter
+SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
+----
+project
+ ├── columns: m:1
+ └── anti-join (hash)
+      ├── columns: m:1 n:2
+      ├── scan small
+      │    └── columns: m:1 n:2
+      ├── select
+      │    ├── columns: i:6 s:7!null
+      │    ├── fd: ()-->(7)
+      │    ├── index-join partial_tab
+      │    │    ├── columns: i:6 s:7
+      │    │    └── scan partial_tab@partial_idx,partial
+      │    │         ├── columns: k:5!null i:6
+      │    │         ├── key: (5)
+      │    │         └── fd: (5)-->(6)
+      │    └── filters
+      │         └── s:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+      └── filters
+           └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 # -------------------------------------------------------
 # GenerateInvertedJoins + GenerateInvertedJoinsFromSelect


### PR DESCRIPTION
Backport:
  * 1/1 commits from "opt: use partial indexes for lookup joins" (#54157)
  * 1/1 commits from "opt: generate lookup semi- and anti-joins in more partial index cases" (#54217)

Please see individual PRs for details.

/cc @cockroachdb/release
