### PR TITLE
release-20.1: kv: don't leak raft application tracing spans on or after ErrRemoved

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -599,7 +599,7 @@ func registerKVRangeLookups(r *testRegistry) {
 			duration := " --duration=" + ifLocal("10s", "10m")
 			readPercent := " --read-percent=50"
 			// We run kv with --tolerate-errors, since the relocate workload is
-			// expected to create `result is ambiguous (removing replica)` errors.
+			// expected to create `result is ambiguous (replica removed)` errors.
 			cmd = fmt.Sprintf("./workload run kv --tolerate-errors"+
 				concurrency+duration+readPercent+
 				" {pgurl:1-%d}", nodes)

--- a/pkg/kv/kvserver/apply/cmd.go
+++ b/pkg/kv/kvserver/apply/cmd.go
@@ -24,6 +24,15 @@ type Command interface {
 	// that were locally proposed typically have a client waiting on a
 	// response, so there is additional urgency to apply them quickly.
 	IsLocal() bool
+	// AckErrAndFinish signals that the application of the command has been
+	// rejected due to the provided error. It also relays this rejection of
+	// the command to its client if it was proposed locally. An error will
+	// immediately stall entry application, so one must only be returned if
+	// the state machine is no longer able to make progress.
+	//
+	// Either AckOutcomeAndFinish or AckErrAndFinish will be called exactly
+	// once per Command.
+	AckErrAndFinish(context.Context, error) error
 }
 
 // CheckedCommand is a command that has been checked to see whether it can
@@ -41,7 +50,7 @@ type CheckedCommand interface {
 	CanAckBeforeApplication() bool
 	// AckSuccess acknowledges the success of the command to its client.
 	// Must only be called if !Rejected.
-	AckSuccess() error
+	AckSuccess(context.Context) error
 }
 
 // AppliedCommand is a command that has been applied to the replicated state
@@ -52,13 +61,15 @@ type CheckedCommand interface {
 // the state machine.
 type AppliedCommand interface {
 	CheckedCommand
-	// FinishAndAckOutcome signals that the application of the command has
+	// AckOutcomeAndFinish signals that the application of the command has
 	// completed. It also acknowledges the outcome of the command to its
 	// client if it was proposed locally. An error will immediately stall
 	// entry application, so one must only be returned if the state machine
-	// is no longer able to make progress. The method will be called exactly
+	// is no longer able to make progress.
+	//
+	// Either AckOutcomeAndFinish or AckErrAndFinish will be called exactly
 	// once per Command.
-	FinishAndAckOutcome(context.Context) error
+	AckOutcomeAndFinish(context.Context) error
 }
 
 // CommandIteratorBase is a common interface extended by all iterator and
@@ -193,12 +204,35 @@ func mapCheckedCmdIter(
 	return ret, nil
 }
 
-// forEachCheckedCmdIter calls a closure on each command in the provided
-// iterator. The function closes the provided iterator.
-func forEachCheckedCmdIter(iter CheckedCommandIterator, fn func(CheckedCommand) error) error {
+// In the following three functions, fn is written with ctx as a 2nd param
+// because callers want to bind it to methods that have Commands (or variants)
+// as the receiver, which mandates that to be the first param. The caller didn't
+// want to introduce a callback instead to make it clear that nothing escapes to
+// the heap.
+
+// forEachCmdIter calls a closure on each command in the provided iterator. The
+// function closes the provided iterator.
+func forEachCmdIter(
+	ctx context.Context, iter CommandIterator, fn func(Command, context.Context) error,
+) error {
 	defer iter.Close()
 	for iter.Valid() {
-		if err := fn(iter.CurChecked()); err != nil {
+		if err := fn(iter.Cur(), ctx); err != nil {
+			return err
+		}
+		iter.Next()
+	}
+	return nil
+}
+
+// forEachCheckedCmdIter calls a closure on each command in the provided
+// iterator. The function closes the provided iterator.
+func forEachCheckedCmdIter(
+	ctx context.Context, iter CheckedCommandIterator, fn func(CheckedCommand, context.Context) error,
+) error {
+	defer iter.Close()
+	for iter.Valid() {
+		if err := fn(iter.CurChecked(), ctx); err != nil {
 			return err
 		}
 		iter.Next()
@@ -209,13 +243,7 @@ func forEachCheckedCmdIter(iter CheckedCommandIterator, fn func(CheckedCommand) 
 // forEachAppliedCmdIter calls a closure on each command in the provided
 // iterator. The function closes the provided iterator.
 func forEachAppliedCmdIter(
-	ctx context.Context,
-	iter AppliedCommandIterator,
-	// fn is weirdly written with ctx as a 2nd param because the caller wants to
-	// bind it to a method that has the AppliedCommand on the receiver, thus
-	// forcing that to be the first param. The caller didn't want to introduce a
-	// callback instead to make it clear that nothing escapes to the heap.
-	fn func(AppliedCommand, context.Context) error,
+	ctx context.Context, iter AppliedCommandIterator, fn func(AppliedCommand, context.Context) error,
 ) error {
 	defer iter.Close()
 	for iter.Valid() {

--- a/pkg/kv/kvserver/apply/cmd.go
+++ b/pkg/kv/kvserver/apply/cmd.go
@@ -163,6 +163,7 @@ func mapCmdIter(
 	for iter.Valid() {
 		checked, err := fn(iter.Cur())
 		if err != nil {
+			ret.Close()
 			return nil, err
 		}
 		iter.Next()
@@ -183,6 +184,7 @@ func mapCheckedCmdIter(
 	for iter.Valid() {
 		applied, err := fn(iter.CurChecked())
 		if err != nil {
+			ret.Close()
 			return nil, err
 		}
 		iter.Next()

--- a/pkg/kv/kvserver/apply/doc_test.go
+++ b/pkg/kv/kvserver/apply/doc_test.go
@@ -95,15 +95,15 @@ it likes.
 	//  applying side-effects of command 3
 	//  applying side-effects of command 4
 	//  finishing command 1; rejected=false
-	//  finishing and acknowledging command 2; rejected=false
-	//  finishing and acknowledging command 3; rejected=true
+	//  acknowledging and finishing command 2; rejected=false
+	//  acknowledging and finishing command 3; rejected=true
 	//  finishing command 4; rejected=false
 	//  applying batch with commands=[5]
 	//  applying side-effects of command 5
-	//  finishing and acknowledging command 5; rejected=false
+	//  acknowledging and finishing command 5; rejected=false
 	//  applying batch with commands=[6 7]
 	//  applying side-effects of command 6
 	//  applying side-effects of command 7
-	//  finishing and acknowledging command 6; rejected=true
-	//  finishing and acknowledging command 7; rejected=false
+	//  acknowledging and finishing command 6; rejected=true
+	//  acknowledging and finishing command 7; rejected=false
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5209,7 +5209,7 @@ func TestReplicaRemovalClosesProposalQuota(t *testing.T) {
 				RangeID: desc.RangeID,
 			}, putArgs(k, bytes.Repeat([]byte{'a'}, 1000)))
 			require.Regexp(t,
-				`result is ambiguous \(removing replica\)|`+
+				`result is ambiguous \(replica removed\)|`+
 					`r`+strconv.Itoa(int(desc.RangeID))+" was not found on s1", pErr.GoError())
 		}(i)
 	}

--- a/pkg/kv/kvserver/replica_application_cmd.go
+++ b/pkg/kv/kvserver/replica_application_cmd.go
@@ -57,7 +57,7 @@ type replicatedCmd struct {
 	// ApplyCommittedEntries.
 	ctx context.Context
 	// sp is the tracing span corresponding to ctx. It is closed in
-	// FinishAndAckOutcome. This span "follows from" the proposer's span (even
+	// finishTracingSpan. This span "follows from" the proposer's span (even
 	// when the proposer is remote; we marshall tracing info through the
 	// proposal).
 	sp opentracing.Span
@@ -115,6 +115,16 @@ func (c *replicatedCmd) IsLocal() bool {
 	return c.proposal != nil
 }
 
+// AckErrAndFinish implements the apply.Command interface.
+func (c *replicatedCmd) AckErrAndFinish(ctx context.Context, err error) error {
+	if c.IsLocal() {
+		c.response.Err = roachpb.NewError(
+			roachpb.NewAmbiguousResultError(
+				err.Error()))
+	}
+	return c.AckOutcomeAndFinish(ctx)
+}
+
 // Rejected implements the apply.CheckedCommand interface.
 func (c *replicatedCmd) Rejected() bool {
 	return c.forcedErr != nil
@@ -134,7 +144,7 @@ func (c *replicatedCmd) CanAckBeforeApplication() bool {
 }
 
 // AckSuccess implements the apply.CheckedCommand interface.
-func (c *replicatedCmd) AckSuccess() error {
+func (c *replicatedCmd) AckSuccess(_ context.Context) error {
 	if !c.IsLocal() {
 		return nil
 	}
@@ -153,8 +163,8 @@ func (c *replicatedCmd) AckSuccess() error {
 	return nil
 }
 
-// FinishAndAckOutcome implements the apply.AppliedCommand interface.
-func (c *replicatedCmd) FinishAndAckOutcome(ctx context.Context) error {
+// AckOutcomeAndFinish implements the apply.AppliedCommand interface.
+func (c *replicatedCmd) AckOutcomeAndFinish(ctx context.Context) error {
 	if c.IsLocal() {
 		c.proposal.finishApplication(ctx, c.response)
 	}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -999,8 +999,10 @@ func (sm *replicaStateMachine) ApplySideEffects(
 	clearTrivialReplicatedEvalResultFields(cmd.replicatedResult())
 	if !cmd.IsTrivial() {
 		shouldAssert, isRemoved := sm.handleNonTrivialReplicatedEvalResult(ctx, *cmd.replicatedResult())
-
 		if isRemoved {
+			// The proposal must not have been local, because we don't allow a
+			// proposing replica to remove itself from the Range.
+			cmd.FinishNonLocal(ctx)
 			return nil, apply.ErrRemoved
 		}
 		// NB: Perform state assertion before acknowledging the client.

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -16,6 +16,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -250,7 +251,9 @@ func (r *Replica) disconnectReplicationRaftMuLocked(ctx context.Context) {
 		// NB: each proposal needs its own version of the error (i.e. don't try to
 		// share the error across proposals).
 		p.finishApplication(ctx, proposalResult{
-			Err: roachpb.NewError(roachpb.NewAmbiguousResultError("removing replica")),
+			Err: roachpb.NewError(
+				roachpb.NewAmbiguousResultError(
+					apply.ErrRemoved.Error())),
 		})
 	}
 	r.mu.internalRaftGroup = nil


### PR DESCRIPTION
Backport 3/3 commits from #54140.

The cherry-picks were all clean except for a few import paths that needed updating.

/cc @cockroachdb/release

---

Fixes #53677.

This change ensures that we properly finish tracing spans of Raft commands that throw ErrRemoved errors in ApplySideEffects. It then ensures that we properly finish tracing spans of Raft commands that follow a command that throws an `ErrRemoved`. Before this, these commands would be abandoned and would never be finished. The effects of this are theoretically even worse than those fixed in the previous commit because these leaked commands could be locally proposed, so we may be abandoning a local proposer indefinitely.

It's not clear that we ever saw an instance of this. It seems rare for a local proposal to end up in the same CommittedEntries batch as a command that removes a replica because of the lease requirements, but it doesn't seem impossible, especially of the local proposal was a RequestLease request.

I was originally intending to do something more dramatic and make `replicaStateMachine.ApplySideEffects` responsible for acknowledging proposers in all cases, but doing so turned out to be pretty invasive so I was concerned that it would be harder to backport to v20.2 and to v20.1. I may revisit that in the future.

Release justification: low risk, high benefit changes to existing functionality.
