### PR TITLE
changefeedccl/schemafeed: only sort the unsorted tail of descriptors

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -26,7 +26,7 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 
 	ctx := context.Background()
 	ts := func(wt int64) hlc.Timestamp { return hlc.Timestamp{WallTime: wt} }
-	validateFn := func(_ context.Context, desc catalog.Descriptor) error {
+	validateFn := func(_ context.Context, _ hlc.Timestamp, desc catalog.Descriptor) error {
 		if desc.GetName() != `` {
 			return errors.Newf("descriptor: %s", desc.GetName())
 		}


### PR DESCRIPTION
This lead to a race detector warning firing (theorized).

I'd love to validate that this is the bug but I feel pretty good about it.

Fixes #48459.

Release note: None