### PR TITLE
sql: fix adding constraints in same transaction as table

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -606,7 +606,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateCheckInTxn(
-					params.ctx, params.p.LeaseMgr(), &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+					params.ctx, params.p.LeaseMgr(), &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -587,7 +587,7 @@ func (sc *SchemaChanger) validateConstraints(
 				defer func() { collection.ReleaseAll(ctx) }()
 				switch c.ConstraintType {
 				case descpb.ConstraintToUpdate_CHECK:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Expr); err != nil {
 						return err
 					}
 				case descpb.ConstraintToUpdate_FOREIGN_KEY:
@@ -595,7 +595,7 @@ func (sc *SchemaChanger) validateConstraints(
 						return err
 					}
 				case descpb.ConstraintToUpdate_NOT_NULL:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Expr); err != nil {
 						// TODO (lucy): This should distinguish between constraint
 						// validation errors and other types of unexpected errors, and
 						// return a different error code in the former case
@@ -1483,8 +1483,24 @@ func runSchemaChangesInTxn(
 	// Only needed because columnBackfillInTxn() backfills
 	// all column mutations.
 	doneColumnBackfill := false
-	// Checks are validated after all other mutations have been applied.
-	var constraintsToValidate []descpb.ConstraintToUpdate
+
+	// Mutations are processed in multiple steps: First we process all mutations
+	// for schema changes other than adding check or FK constraints, then we
+	// validate those constraints, and only after that do we process the
+	// constraint mutations. We need an in-memory copy of the table descriptor
+	// that contains newly added columns (since constraints being added can
+	// reference them), but that doesn't contain constraints (since otherwise we'd
+	// plan the query assuming the constraint holds). This is a different
+	// procedure than in the schema changer for existing tables, since all the
+	// "steps" in the schema change occur within the same transaction here.
+	//
+	// In the future it would be good to either unify the two implementations more
+	// or make this in-transaction implementation more principled. We expect
+	// constraint validation to be refactored and treated as a first-class concept
+	// in the world of transactional schema changes.
+
+	// Collect constraint mutations to process later.
+	var constraintAdditionMutations []descpb.DescriptorMutation
 
 	// We use a range loop here as the processing of some mutations
 	// such as the primary key swap mutations result in queueing more
@@ -1494,7 +1510,7 @@ func runSchemaChangesInTxn(
 		immutDesc := tabledesc.NewImmutable(*tableDesc.TableDesc())
 		switch m.Direction {
 		case descpb.DescriptorMutation_ADD:
-			switch t := m.Descriptor_.(type) {
+			switch m.Descriptor_.(type) {
 			case *descpb.DescriptorMutation_PrimaryKeySwap:
 				// Don't need to do anything here, as the call to MakeMutationComplete
 				// will perform the steps for this operation.
@@ -1515,42 +1531,9 @@ func runSchemaChangesInTxn(
 				}
 
 			case *descpb.DescriptorMutation_Constraint:
-				switch t.Constraint.ConstraintType {
-				case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-					tableDesc.Checks = append(tableDesc.Checks, &t.Constraint.Check)
-				case descpb.ConstraintToUpdate_FOREIGN_KEY:
-					fk := t.Constraint.ForeignKey
-					var referencedTableDesc *tabledesc.Mutable
-					// We don't want to lookup/edit a second copy of the same table.
-					selfReference := tableDesc.ID == fk.ReferencedTableID
-					if selfReference {
-						referencedTableDesc = tableDesc
-					} else {
-						lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
-						if err != nil {
-							return errors.Errorf("error resolving referenced table ID %d: %v", fk.ReferencedTableID, err)
-						}
-						referencedTableDesc = lookup
-					}
-					referencedTableDesc.InboundFKs = append(referencedTableDesc.InboundFKs, fk)
-					tableDesc.OutboundFKs = append(tableDesc.OutboundFKs, fk)
-
-					// Write the other table descriptor here if it's not the current table
-					// we're already modifying.
-					if !selfReference {
-						if err := planner.writeSchemaChange(
-							ctx, referencedTableDesc, descpb.InvalidMutationID,
-							fmt.Sprintf("updating referenced FK table %s(%d) table %s(%d)",
-								referencedTableDesc.Name, referencedTableDesc.ID, tableDesc.Name, tableDesc.ID),
-						); err != nil {
-							return err
-						}
-					}
-				default:
-					return errors.AssertionFailedf(
-						"unsupported constraint type: %d", errors.Safe(t.Constraint.ConstraintType))
-				}
-				constraintsToValidate = append(constraintsToValidate, *t.Constraint)
+				// This is processed later. Do not proceed to MakeMutationComplete.
+				constraintAdditionMutations = append(constraintAdditionMutations, m)
+				continue
 
 			default:
 				return errors.AssertionFailedf(
@@ -1608,9 +1591,6 @@ func runSchemaChangesInTxn(
 			}
 
 		}
-		// TODO (lucy): This seems suspicious, since MakeMutationsComplete should
-		// add unvalidated foreign keys, but we unconditionally add them above. Do
-		// unvalidated FKs get added twice?
 		if err := tableDesc.MakeMutationComplete(m); err != nil {
 			return err
 		}
@@ -1666,17 +1646,22 @@ func runSchemaChangesInTxn(
 			}
 		}
 	}
-	tableDesc.Mutations = nil
+	// Clear all the mutations except for adding constraints.
+	tableDesc.Mutations = constraintAdditionMutations
 
 	// Now that the table descriptor is in a valid state with all column and index
-	// mutations applied, it can be used for validating check constraints
-	for _, c := range constraintsToValidate {
-		switch c.ConstraintType {
+	// mutations applied, it can be used for validating check/FK constraints.
+	for _, m := range constraintAdditionMutations {
+		constraint := m.GetConstraint()
+		switch constraint.ConstraintType {
 		case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-			if err := validateCheckInTxn(
-				ctx, planner.Descriptors().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, c.Check.Name,
-			); err != nil {
-				return err
+			if constraint.Check.Validity == descpb.ConstraintValidity_Validating {
+				if err := validateCheckInTxn(
+					ctx, planner.Descriptors().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, constraint.Check.Expr,
+				); err != nil {
+					return err
+				}
+				constraint.Check.Validity = descpb.ConstraintValidity_Validated
 			}
 		case descpb.ConstraintToUpdate_FOREIGN_KEY:
 			// We can't support adding a validated foreign key constraint in the same
@@ -1685,24 +1670,61 @@ func runSchemaChangesInTxn(
 			// for whatever rows were inserted into the referencing table in this
 			// transaction, which requires multiple schema changer states across
 			// multiple transactions.
-			// TODO (lucy): Add a validation job that runs after the user transaction.
-			// This won't roll back the original transaction if validation fails, but
-			// it will at least leave the constraint in the Validated state if
-			// validation succeeds.
+			//
+			// We could partially fix this by queuing a validation job to run post-
+			// transaction. Better yet would be to absorb this into the transactional
+			// schema change framework eventually.
+			//
+			// For now, just always add the FK as unvalidated.
+			constraint.ForeignKey.Validity = descpb.ConstraintValidity_Unvalidated
+		default:
+			return errors.AssertionFailedf(
+				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
+		}
+	}
 
-			// For now, revert the constraint to an unvalidated state.
-			for i := range tableDesc.OutboundFKs {
-				desc := &tableDesc.OutboundFKs[i]
-				if desc.Name == c.ForeignKey.Name {
-					desc.Validity = descpb.ConstraintValidity_Unvalidated
-					break
+	// Finally, add the constraints. We bypass MakeMutationsComplete (which makes
+	// certain assumptions about the state in the usual schema changer) and just
+	// update the table descriptor directly.
+	for _, m := range constraintAdditionMutations {
+		constraint := m.GetConstraint()
+		switch constraint.ConstraintType {
+		case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
+			tableDesc.Checks = append(tableDesc.Checks, &constraint.Check)
+		case descpb.ConstraintToUpdate_FOREIGN_KEY:
+			fk := constraint.ForeignKey
+			var referencedTableDesc *tabledesc.Mutable
+			// We don't want to lookup/edit a second copy of the same table.
+			selfReference := tableDesc.ID == fk.ReferencedTableID
+			if selfReference {
+				referencedTableDesc = tableDesc
+			} else {
+				lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
+				if err != nil {
+					return errors.Errorf("error resolving referenced table ID %d: %v", fk.ReferencedTableID, err)
+				}
+				referencedTableDesc = lookup
+			}
+			referencedTableDesc.InboundFKs = append(referencedTableDesc.InboundFKs, fk)
+			tableDesc.OutboundFKs = append(tableDesc.OutboundFKs, fk)
+
+			// Write the other table descriptor here if it's not the current table
+			// we're already modifying.
+			if !selfReference {
+				if err := planner.writeSchemaChange(
+					ctx, referencedTableDesc, descpb.InvalidMutationID,
+					fmt.Sprintf("updating referenced FK table %s(%d) table %s(%d)",
+						referencedTableDesc.Name, referencedTableDesc.ID, tableDesc.Name, tableDesc.ID),
+				); err != nil {
+					return err
 				}
 			}
 		default:
 			return errors.AssertionFailedf(
-				"unsupported constraint type: %d", errors.Safe(c.ConstraintType))
+				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
 		}
 	}
+	tableDesc.Mutations = nil
 	return nil
 }
 
@@ -1725,7 +1747,7 @@ func validateCheckInTxn(
 	evalCtx *tree.EvalContext,
 	tableDesc *tabledesc.Mutable,
 	txn *kv.Txn,
-	checkName string,
+	checkExpr string,
 ) error {
 	ie := evalCtx.InternalExecutor.(*InternalExecutor)
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
@@ -1740,12 +1762,7 @@ func validateCheckInTxn(
 			ie.tcModifier = nil
 		}()
 	}
-
-	check, err := tableDesc.FindCheckByName(checkName)
-	if err != nil {
-		return err
-	}
-	return validateCheckExpr(ctx, semaCtx, check.Expr, tableDesc, ie, txn)
+	return validateCheckExpr(ctx, semaCtx, checkExpr, tableDesc, ie, txn)
 }
 
 // validateFkInTxn validates foreign key constraints within the provided

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2616,18 +2616,6 @@ func (desc *Immutable) FindIndexByName(
 	return nil, false, fmt.Errorf("index %q does not exist", name)
 }
 
-// FindCheckByName finds the check constraint with the specified name.
-func (desc *Immutable) FindCheckByName(
-	name string,
-) (*descpb.TableDescriptor_CheckConstraint, error) {
-	for _, c := range desc.Checks {
-		if c.Name == name {
-			return c, nil
-		}
-	}
-	return nil, fmt.Errorf("check %q does not exist", name)
-}
-
 // NamesForColumnIDs returns the names for the given column ids, or an error
 // if one or more column ids was missing. Note - this allocates! It's not for
 // hot path code.

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1831,3 +1831,69 @@ SELECT * FROM self_ref_fk;
 
 statement ok
 DROP TABLE self_ref_fk;
+
+# Test that NOT NULL constraints can be created and validated on a newly created
+# table.
+subtest 52501
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t_52501_valid(a INT)
+
+statement ok
+INSERT INTO t_52501_valid VALUES (1)
+
+statement ok
+ALTER TABLE t_52501_valid ALTER COLUMN a SET NOT NULL
+
+statement ok
+COMMIT
+
+query TTTTB
+SHOW CONSTRAINTS FROM t_52501_valid
+----
+t_52501_valid  a_auto_not_null  CHECK  CHECK ((a IS NOT NULL))  true
+
+statement ok
+DROP TABLE t_52501_valid
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t_52501_invalid(a INT)
+
+statement ok
+INSERT INTO t_52501_invalid VALUES (NULL)
+
+statement error pgcode 23514 validation of CHECK "a IS NOT NULL" failed
+ALTER TABLE t_52501_invalid ALTER COLUMN a SET NOT NULL
+
+statement ok
+ROLLBACK
+
+# Test that NOT VALID foreign keys can be added in the same transaction as the
+# table.
+subtest 54265
+
+statement ok
+CREATE TABLE parent_54265 (a INT PRIMARY KEY)
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE child_54265 (a INT)
+
+statement ok
+ALTER TABLE child_54265 ADD FOREIGN KEY (a) REFERENCES parent_54265 NOT VALID
+
+statement ok
+COMMIT
+
+query TTTTB
+SHOW CONSTRAINTS FROM child_54265
+----
+child_54265  fk_a_ref_parent_54265  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a)  false


### PR DESCRIPTION
Previously in `runSchemaChangesInTxn()`, which is called when schema
changes are run on a table created earlier in the same transaction, we
would validate the constraints after they'd already been made "public"
on the in-memory table descriptor. The problem was that for NOT NULL
constraints, which use a temporary check constraint, the check
constraint no longer exists at that point, so we'd return an error about
the check not being found.

This commit rearranges the steps so that we don't process constraint
addition mutations until the end. It also opportunistically fixes
another bug related to calling `MakeMutationComplete`, which would cause
NOT VALID foreign keys to be erroneously added twice.

Fixes #54265.
Fixes #52501.

Release note (bug fix): Fixed two bugs when attempting to add
constraints in the same transaction in which the table was created:
Adding a NOT NULL constraint no longer fails with the error `check ...
does not exist`, and adding a NOT VALID foreign key constraint no longer
fails with the internal error `table descriptor is not valid: duplicate
constraint name`.