### PR TITLE
release-20.2: kvserver: remove bad wto assertion

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2319,4 +2321,74 @@ func TestUpdateRoootWithLeafFinalStateInAbortedTxn(t *testing.T) {
 	if leafInputState2.Txn.Status != roachpb.PENDING {
 		t.Fatalf("expected PENDING txn, got: %s", leafInputState2.Txn.Status)
 	}
+}
+
+// Test that evaluating a request within a txn with the STAGING status works
+// fine. It's unusual for the server to receive a request in the STAGING status
+// (other than a single EndTxn which transitions from STAGING->COMMITTED),
+// because the committer interceptor reverts the status from STAGING->PENDING if
+// the batch moving to STAGING has been split and some part of it failed.
+// However, it can still happen that the server receives a request with the
+// STAGING record when the DistSender splits a batch and doesn't send all the
+// sub-batches in parallel; in that case it's possible that a sub-batch with the
+// EndTxn succeeds, and then the DistSender will send the remaining sub-batches
+// with a STAGING status.
+func TestPutsInStagingTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+
+	var putInStagingSeen bool
+	var storeKnobs kvserver.StoreTestingKnobs
+	storeKnobs.TestingRequestFilter = func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		put, ok := ba.GetArg(roachpb.Put)
+		if !ok || !put.(*roachpb.PutRequest).Key.Equal(keyB) {
+			return nil
+		}
+		txn := ba.Txn
+		if txn == nil {
+			return nil
+		}
+		if txn.Status == roachpb.STAGING {
+			putInStagingSeen = true
+		}
+		return nil
+	}
+
+	// Disable the DistSender concurrency so that sub-batches split by the
+	// DistSender are send serially and the transaction is updated from one to
+	// another. See below.
+	settings := cluster.MakeTestingClusterSettings()
+	senderConcurrencyLimit.Override(&settings.SV, 0)
+
+	s, _, db := serverutils.StartServer(t,
+		base.TestServerArgs{
+			Settings: settings,
+			Knobs:    base.TestingKnobs{Store: &storeKnobs},
+		})
+	defer s.Stopper().Stop(ctx)
+
+	require.NoError(t, db.AdminSplit(ctx, keyB /* splitKey */, hlc.MaxTimestamp /* expirationTimestamp */))
+
+	txn := db.NewTxn(ctx, "test")
+
+	// Cause a write too old condition for the upcoming txn writes, to spicy up
+	// the test.
+	require.NoError(t, db.Put(ctx, keyB, "b"))
+
+	// Send a batch that will be split into two sub-batches: [Put(a)+EndTxn,
+	// Put(b)] (the EndTxn is grouped with the first write). These sub-batches are
+	// sent serially since we've inhibited the DistSender's concurrency. The first
+	// one will transition the txn to STAGING, and the DistSender will use that
+	// updated txn when sending the 2nd sub-batch.
+	b := txn.NewBatch()
+	b.Put(keyA, "a")
+	b.Put(keyB, "b")
+	require.NoError(t, txn.CommitInBatch(ctx, b))
+	// Verify that the test isn't fooling itself by checking that we've indeed
+	// seen a batch with the STAGING status.
+	require.True(t, putInStagingSeen)
 }

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 //go:generate go run -tags gen-batch gen_batch.go
@@ -570,16 +569,6 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 		ba.Requests = ba.Requests[len(part):]
 	}
 	return parts
-}
-
-// RequestsSafe lists all the request types in the batch. Also see Summary().
-func (ba BatchRequest) RequestsSafe() redact.SafeString {
-	var sb strings.Builder
-	for _, arg := range ba.Requests {
-		req := arg.GetInner()
-		sb.WriteString(req.Method().String() + " ")
-	}
-	return redact.SafeString(sb.String())
 }
 
 // String gives a brief summary of the contained requests and keys in the batch.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -868,12 +868,6 @@ func (ts TransactionStatus) IsFinalized() bool {
 	return ts == COMMITTED || ts == ABORTED
 }
 
-// IsCommittedOrStaging determines if the transaction is morally committed (i.e.
-// in the COMMITTED or STAGING state).
-func (ts TransactionStatus) IsCommittedOrStaging() bool {
-	return ts == COMMITTED || ts == STAGING
-}
-
 var _ errors.SafeMessager = Transaction{}
 
 // MakeTransaction creates a new transaction. The transaction key is


### PR DESCRIPTION
Backport 1/1 commits from #53851.

/cc @cockroachdb/release

---

Release justification: bug fix

This patch removes a faulty assertion: when evaluating a batch we were
checking that the txn doesn't progress to the STAGING or COMMITTED
states with the WriteTooOld flag set. The idea was that evaluating an
EndTxn when that flag is supposed to result in an error, not in a
transition to STAGING. Unfortunately the assertion was failing to
consider requests that came in with the txn already in the STAGING
state. Such a request is unusual because the TxnCoordSender terminates
the wto flag on responses, and also because the txnCommitter reverts
back from STAGING to PENDING when errors happen after the txn has
transitioned to STAGING, but it can still happen due to the DistSender
splitting batches into sub-batches and executing those sub-batches
(sometimes) serially. For example, the following scenario is possible:
1. client sends Put(a)+Put(b)+EndTxn
2. DistSender splits into [Put(a)+EndTxn, Put(b)]
3. The first sub-batch succeeds; the status is now STAGING
4. The 2nd batch is sent with the STAGING status. If this 2nd
batch now encounters a wto condition, the assertion is triggered.

Release note: A bug causing servers to crash with the message "committed
txn with writeTooOld" has been fixed. Versions below 20.1.4 were
susceptible to this bug; versions 20.1.4+ were no longer crashing, just
printing scary messages in the log files.
