### PR TITLE
opt: remove unnecessary columns in lookup semi/anti-join special case

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -446,12 +446,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if !t.Flags.Empty() {
 			tp.Childf("flags: %s", t.Flags.String())
 		}
-		idxCols := make(opt.ColList, len(t.KeyCols))
-		idx := md.Table(t.Table).Index(t.Index)
-		for i := range idxCols {
-			idxCols[i] = t.Table.ColumnID(idx.Column(i).Ordinal())
-		}
 		if !f.HasFlags(ExprFmtHideColumns) {
+			idxCols := make(opt.ColList, len(t.KeyCols))
+			idx := md.Table(t.Table).Index(t.Index)
+			for i := range idxCols {
+				idxCols[i] = t.Table.ColumnID(idx.Column(i).Ordinal())
+			}
 			tp.Childf("key columns: %v = %v", t.KeyCols, idxCols)
 		}
 		if t.LookupColsAreTableKey {

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1368,7 +1368,7 @@ inner-join (lookup def)
 expr format=show-all colstat=6 colstat=7 colstat=(6, 7) colstat=1 colstat=2 colstat=3 colstat=(1, 2, 3)
 (MakeLookupJoin
   (Scan [ (Table "abc") (Cols "a,b,c") ])
-  [ (JoinType "semi-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e,f") ]
+  [ (JoinType "semi-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e") ]
   [ ]
 )
 ----
@@ -1376,7 +1376,7 @@ semi-join (lookup def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [5 6]
  ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=1, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(6,7)=1, null(6,7)=0, distinct(1-3)=100, null(1-3)=0]
- ├── cost: 2110.0507
+ ├── cost: 2110.0506
  ├── key: (1,2)
  ├── fd: (1,2)-->(3)
  ├── interesting orderings: (+1,+2)
@@ -1393,7 +1393,7 @@ semi-join (lookup def)
 expr format=show-all colstat=6 colstat=7 colstat=(6, 7) colstat=1 colstat=2 colstat=3 colstat=(1, 2, 3)
 (MakeLookupJoin
   (Scan [ (Table "abc") (Cols "a,b,c") ])
-  [ (JoinType "anti-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e,f") ]
+  [ (JoinType "anti-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e") ]
   [ ]
 )
 ----
@@ -1401,7 +1401,7 @@ anti-join (lookup def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [5 6]
  ├── stats: [rows=1e-10, distinct(1)=1e-10, null(1)=0, distinct(2)=1e-10, null(2)=0, distinct(3)=1e-10, null(3)=1e-10, distinct(6)=1e-10, null(6)=0, distinct(7)=1e-10, null(7)=0, distinct(6,7)=1e-10, null(6,7)=0, distinct(1-3)=1e-10, null(1-3)=0]
- ├── cost: 2110.0507
+ ├── cost: 2110.0506
  ├── key: (1,2)
  ├── fd: (1,2)-->(3)
  ├── interesting orderings: (+1,+2)
@@ -1418,7 +1418,7 @@ anti-join (lookup def)
 expr format=show-all colstat=6 colstat=7 colstat=(6, 7) colstat=1 colstat=2 colstat=3 colstat=(1, 2, 3)
 (MakeLookupJoin
   (Scan [ (Table "abc") (Cols "a,b,c") ])
-  [ (JoinType "semi-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e,f") ]
+  [ (JoinType "semi-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e") ]
   [ (False) ]
 )
 ----
@@ -1426,7 +1426,7 @@ semi-join (lookup def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [5 6]
  ├── stats: [rows=0, distinct(1)=0, null(1)=0, distinct(2)=0, null(2)=0, distinct(3)=0, null(3)=0, distinct(6)=0, null(6)=0, distinct(7)=0, null(7)=0, distinct(6,7)=0, null(6,7)=0, distinct(1-3)=0, null(1-3)=0]
- ├── cost: 2110.0607
+ ├── cost: 2110.0606
  ├── key: (1,2)
  ├── fd: (1,2)-->(3)
  ├── interesting orderings: (+1,+2)
@@ -1444,7 +1444,7 @@ semi-join (lookup def)
 expr format=show-all colstat=6 colstat=7 colstat=(6, 7) colstat=1 colstat=2 colstat=3 colstat=(1, 2, 3)
 (MakeLookupJoin
   (Scan [ (Table "abc") (Cols "a,b,c") ])
-  [ (JoinType "anti-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e,f") ]
+  [ (JoinType "anti-join") (Table "def") (Index "def@primary") (KeyCols "a,b") (Cols "a,b,c,d,e") ]
   [ (False) ]
 )
 ----
@@ -1452,7 +1452,7 @@ anti-join (lookup def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [5 6]
  ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=1, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(6,7)=1, null(6,7)=0, distinct(1-3)=100, null(1-3)=0]
- ├── cost: 2110.0607
+ ├── cost: 2110.0606
  ├── key: (1,2)
  ├── fd: (1,2)-->(3)
  ├── interesting orderings: (+1,+2)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3276,6 +3276,42 @@ project
       └── filters
            └── n:2 = i:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
+# A lookup semi-join on a partial index should have the same cost as a lookup
+# semi-join on a non-partial index.
+exec-ddl
+CREATE INDEX full_idx ON partial_tab (i)
+----
+
+opt format=show-cost
+SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE n = i)
+----
+project
+ ├── columns: m:1
+ ├── cost: 234.836
+ └── semi-join (lookup partial_tab@full_idx)
+      ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
+      ├── cost: 234.726
+      ├── scan small
+      │    ├── columns: m:1 n:2
+      │    └── cost: 14.52
+      └── filters (true)
+
+opt format=show-cost
+SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s IN ('foo', 'bar', 'baz') AND n = i)
+----
+project
+ ├── columns: m:1
+ ├── cost: 234.836
+ └── semi-join (lookup partial_tab@partial_idx,partial)
+      ├── columns: m:1 n:2
+      ├── key columns: [2] = [6]
+      ├── cost: 234.726
+      ├── scan small
+      │    ├── columns: m:1 n:2
+      │    └── cost: 14.52
+      └── filters (true)
+
 # -------------------------------------------------------
 # GenerateInvertedJoins + GenerateInvertedJoinsFromSelect
 # -------------------------------------------------------
@@ -5131,7 +5167,7 @@ ALTER TABLE abc INJECT STATISTICS '[
     "distinct_count": 100
   },
   {
-    "columns": ["a"],
+    "columns": ["b"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
     "row_count": 100,
     "distinct_count": 100


### PR DESCRIPTION
Previously, when generating a special case of lookup semi/anti-joins on
partial indexes, all columns from the right side of the input join would
be included in the lookup join's columns. These columns were included
even though they were no longer needed (in this special case, the ON
filters have been reduced during filter/predicate implication).

Fetching unnecessary columns was was causing a slight difference between
the estimated cost of a lookup semi/anti-join on a non-partial index
versus a partial index. This is because the coster adds a slight
overhead for each column looked-up by the lookup join.

This commit correctly assigns the lookup join columns in this special
case so that unnecessary columns are not included.

In addition, an assertion has been added to `check_expr.go` (run during
`make testrace`) to catch future mistakes like this. Some tests that
manually build expressions had to be edited to avoid violating this
assertion.

Release note: None