### PR TITLE
release-20.1: kvserver: remove bad wto assertion

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -13,7 +13,6 @@ package kvserver
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -218,14 +217,6 @@ func evaluateBatch(
 		// cantDeferWTOE is set when a WriteTooOldError cannot be deferred past the
 		// end of the current batch.
 		cantDeferWTOE bool
-
-		// The following fields help with debugging #50317.
-		msg              string
-		initialTxnStatus roachpb.TransactionStatus
-	}
-
-	if baHeader.Txn != nil {
-		writeTooOldState.initialTxnStatus = baHeader.Txn.Status
 	}
 
 	for index, union := range baReqs {
@@ -284,7 +275,6 @@ func evaluateBatch(
 				// other concurrent overlapping transactions are forced
 				// through intent resolution and the chances of this batch
 				// succeeding when it will be retried are increased.
-				writeTooOldState.msg += fmt.Sprintf("request %d (%s) got WriteTooOldErr; ", index, args.Method())
 				if writeTooOldState.err != nil {
 					writeTooOldState.err.ActualTimestamp.Forward(
 						tErr.ActualTimestamp)
@@ -391,20 +381,6 @@ func evaluateBatch(
 				header.Txn = nil
 				reply.SetHeader(header)
 			}
-		}
-	}
-
-	if writeTooOldState.err != nil {
-		if baHeader.Txn != nil && baHeader.Txn.Status.IsCommittedOrStaging() {
-			err := errorutil.UnexpectedWithIssueErrorf(
-				50317,
-				"committed txn with writeTooOld; "+
-					"requests: %s, msg: %s, txn: %s, initial txn status: %s, cantDeferErr: %t, err: %s",
-				ba.RequestsSafe(), log.Safe(writeTooOldState.msg), baHeader.Txn,
-				log.Safe(writeTooOldState.initialTxnStatus.String()),
-				writeTooOldState.cantDeferWTOE, writeTooOldState.err)
-			log.Errorf(ctx, "%v", err)
-			errorutil.SendReport(ctx, &rec.ClusterSettings().SV, err)
 		}
 	}
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -550,16 +549,6 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 		ba.Requests = ba.Requests[len(part):]
 	}
 	return parts
-}
-
-// RequestsSafe lists all the request types in the batch. Also see Summary().
-func (ba BatchRequest) RequestsSafe() log.SafeType {
-	var sb strings.Builder
-	for _, arg := range ba.Requests {
-		req := arg.GetInner()
-		sb.WriteString(req.Method().String() + " ")
-	}
-	return log.Safe(sb.String())
 }
 
 // String gives a brief summary of the contained requests and keys in the batch.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -766,12 +766,6 @@ func (ts TransactionStatus) IsFinalized() bool {
 	return ts == COMMITTED || ts == ABORTED
 }
 
-// IsCommittedOrStaging determines if the transaction is morally committed (i.e.
-// in the COMMITTED or STAGING state).
-func (ts TransactionStatus) IsCommittedOrStaging() bool {
-	return ts == COMMITTED || ts == STAGING
-}
-
 var _ log.SafeMessager = Transaction{}
 
 // MakeTransaction creates a new transaction. The transaction key is


### PR DESCRIPTION
Backport 1/1 commits from #53851.

/cc @cockroachdb/release

---

Release justification: bug fix

This patch removes a faulty assertion: when evaluating a batch we were
checking that the txn doesn't progress to the STAGING or COMMITTED
states with the WriteTooOld flag set. The idea was that evaluating an
EndTxn when that flag is supposed to result in an error, not in a
transition to STAGING. Unfortunately the assertion was failing to
consider requests that came in with the txn already in the STAGING
state. Such a request is unusual because the TxnCoordSender terminates
the wto flag on responses, and also because the txnCommitter reverts
back from STAGING to PENDING when errors happen after the txn has
transitioned to STAGING, but it can still happen due to the DistSender
splitting batches into sub-batches and executing those sub-batches
(sometimes) serially. For example, the following scenario is possible:
1. client sends Put(a)+Put(b)+EndTxn
2. DistSender splits into [Put(a)+EndTxn, Put(b)]
3. The first sub-batch succeeds; the status is now STAGING
4. The 2nd batch is sent with the STAGING status. If this 2nd
batch now encounters a wto condition, the assertion is triggered.

Release note: A bug causing servers to crash with the message "committed
txn with writeTooOld" has been fixed. Versions below 20.1.4 were
susceptible to this bug; versions 20.1.4+ were no longer crashing, just
printing scary messages in the log files.
