### PR TITLE
release-20.2: gcjobnotifier: unify gcjobs around a single copy of the system config

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/gcjob/gcjobnotifier"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -701,6 +702,8 @@ type ExecutorConfig struct {
 	// HydratedTables is a node-level cache of table descriptors which utilize
 	// user-defined types.
 	HydratedTables *hydratedtables.Cache
+
+	GCJobNotifier *gcjobnotifier.Notifier
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/gcjob/gcjobnotifier/notifier.go
+++ b/pkg/sql/gcjob/gcjobnotifier/notifier.go
@@ -1,0 +1,171 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package gcjobnotifier provides a mechanism to share a SystemConfigDeltaFilter
+// among all gc jobs.
+//
+// It exists in a separate package to avoid import cycles between sql and gcjob.
+package gcjobnotifier
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// Notifier is used to maybeNotify GC jobs of their need to potentially
+// update gc ttls. It exists to be a single copy of the system config rather
+// than one per GC job.
+type Notifier struct {
+	provider config.SystemConfigProvider
+	prefix   roachpb.Key
+	stopper  *stop.Stopper
+	settings *cluster.Settings
+	mu       struct {
+		syncutil.Mutex
+		started, stopped bool
+		deltaFilter      *gossip.SystemConfigDeltaFilter
+		notifyees        map[chan struct{}]struct{}
+	}
+}
+
+// New constructs a new Notifier.
+func New(
+	settings *cluster.Settings,
+	provider config.SystemConfigProvider,
+	codec keys.SQLCodec,
+	stopper *stop.Stopper,
+) *Notifier {
+	n := &Notifier{
+		provider: provider,
+		prefix:   codec.IndexPrefix(keys.ZonesTableID, keys.ZonesTablePrimaryIndexID),
+		stopper:  stopper,
+		settings: settings,
+	}
+	n.mu.notifyees = make(map[chan struct{}]struct{})
+	return n
+}
+
+func noopFunc() {}
+
+// AddNotifyee should be called prior to the first reading of the system config.
+//
+// TODO(lucy,ajwerner): Currently we're calling refreshTables on every zone
+// config update to any table. We should really be only updating a cached
+// TTL whenever we get an update on one of the tables/indexes (or the db)
+// that this job is responsible for, and computing the earliest deadline
+// from our set of cached TTL values. To do this we'd need to know the full
+// set of zone object IDs which may be relevant for a given table. In general
+// that should be fine as a the relevant IDs should be stable for the life of
+// anything being deleted. If we did this, we'd associate a set of keys with
+// each notifyee.
+func (n *Notifier) AddNotifyee(ctx context.Context) (onChange <-chan struct{}, cleanup func()) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if !n.mu.started {
+		log.ReportOrPanic(ctx, &n.settings.SV,
+			"adding a notifyee to a Notifier before starting")
+	}
+	if n.mu.stopped {
+		return nil, noopFunc
+	}
+	if n.mu.deltaFilter == nil {
+		zoneCfgFilter := gossip.MakeSystemConfigDeltaFilter(n.prefix)
+		n.mu.deltaFilter = &zoneCfgFilter
+		// Initialize the filter with the current values.
+		n.mu.deltaFilter.ForModified(n.provider.GetSystemConfig(), func(kv roachpb.KeyValue) {})
+	}
+	c := make(chan struct{}, 1)
+	n.mu.notifyees[c] = struct{}{}
+	return c, func() { n.cleanup(c) }
+}
+
+func (n *Notifier) cleanup(c chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.mu.notifyees, c)
+	if len(n.mu.notifyees) == 0 {
+		n.mu.deltaFilter = nil
+	}
+}
+
+func (n *Notifier) markStopped() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.mu.stopped = true
+}
+
+func (n *Notifier) markStarted() (alreadyStarted bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	alreadyStarted = n.mu.started
+	n.mu.started = true
+	return alreadyStarted
+}
+
+// Start starts the notifier. It must be started before calling AddNotifyee.
+// Start must not be called more than once.
+func (n *Notifier) Start(ctx context.Context) {
+	if alreadyStarted := n.markStarted(); alreadyStarted {
+		log.ReportOrPanic(ctx, &n.settings.SV, "started Notifier more than once")
+		return
+	}
+	if err := n.stopper.RunAsyncTask(ctx, "gcjob.Notifier", n.run); err != nil {
+		n.markStopped()
+	}
+}
+
+func (n *Notifier) run(_ context.Context) {
+	defer n.markStopped()
+	gossipUpdateCh := n.provider.RegisterSystemConfigChannel()
+	for {
+		select {
+		case <-n.stopper.ShouldQuiesce():
+			return
+		case <-gossipUpdateCh:
+			n.maybeNotify()
+		}
+	}
+}
+
+func (n *Notifier) maybeNotify() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Nobody is listening.
+	if len(n.mu.notifyees) == 0 {
+		return
+	}
+
+	cfg := n.provider.GetSystemConfig()
+	zoneConfigUpdated := false
+	n.mu.deltaFilter.ForModified(cfg, func(kv roachpb.KeyValue) {
+		zoneConfigUpdated = true
+	})
+
+	// Nothing we care about was updated.
+	if !zoneConfigUpdated {
+		return
+	}
+
+	for c := range n.mu.notifyees {
+		select {
+		case c <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/pkg/sql/gcjob/gcjobnotifier/notifier_test.go
+++ b/pkg/sql/gcjob/gcjobnotifier/notifier_test.go
@@ -1,0 +1,160 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gcjobnotifier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
+)
+
+type testingProvider struct {
+	syncutil.Mutex
+	cfg *config.SystemConfig
+	ch  chan struct{}
+}
+
+func (t *testingProvider) GetSystemConfig() *config.SystemConfig {
+	t.Lock()
+	defer t.Unlock()
+	return t.cfg
+}
+
+func (t *testingProvider) setSystemConfig(cfg *config.SystemConfig) {
+	t.Lock()
+	defer t.Unlock()
+	t.cfg = cfg
+}
+
+func (t *testingProvider) RegisterSystemConfigChannel() <-chan struct{} {
+	return t.ch
+}
+
+var _ config.SystemConfigProvider = (*testingProvider)(nil)
+
+func TestNotifier(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	settings := cluster.MakeTestingClusterSettings()
+	t.Run("start with stopped stopper leads to nil being returned", func(t *testing.T) {
+		stopper := stop.NewStopper()
+		stopper.Stop(ctx)
+		n := New(settings, &testingProvider{}, keys.SystemSQLCodec, stopper)
+		n.Start(ctx)
+		ch, _ := n.AddNotifyee(ctx)
+		require.Nil(t, ch)
+	})
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	t.Run("panic on double start", func(t *testing.T) {
+		n := New(settings, &testingProvider{ch: make(chan struct{})}, keys.SystemSQLCodec, stopper)
+		n.Start(ctx)
+		require.Panics(t, func() {
+			n.Start(ctx)
+		})
+	})
+	t.Run("panic on AddNotifyee before start", func(t *testing.T) {
+		n := New(settings, &testingProvider{ch: make(chan struct{})}, keys.SystemSQLCodec, stopper)
+		require.Panics(t, func() {
+			n.AddNotifyee(ctx)
+		})
+	})
+	t.Run("notifies on changed delta and cleanup", func(t *testing.T) {
+		cfg := config.NewSystemConfig(zonepb.DefaultSystemZoneConfigRef())
+		cfg.Values = []roachpb.KeyValue{
+			mkZoneConfigKV(1, 1, "1"),
+		}
+		ch := make(chan struct{}, 1)
+		p := &testingProvider{
+			cfg: mkSystemConfig(mkZoneConfigKV(1, 1, "1")),
+			ch:  ch,
+		}
+		n := New(settings, p, keys.SystemSQLCodec, stopper)
+		n.Start(ctx)
+		n1Ch, cleanup1 := n.AddNotifyee(ctx)
+
+		t.Run("don't receive on new notifyee", func(t *testing.T) {
+			expectNoSend(t, n1Ch)
+		})
+		t.Run("don't receive with no change", func(t *testing.T) {
+			ch <- struct{}{}
+			expectNoSend(t, n1Ch)
+		})
+		n2Ch, _ := n.AddNotifyee(ctx)
+		t.Run("receive from all notifyees when data does change", func(t *testing.T) {
+			p.setSystemConfig(mkSystemConfig(mkZoneConfigKV(1, 2, "2")))
+			ch <- struct{}{}
+			expectSend(t, n1Ch)
+			expectSend(t, n2Ch)
+		})
+		t.Run("don't receive after cleanup", func(t *testing.T) {
+			cleanup1()
+			p.setSystemConfig(mkSystemConfig(mkZoneConfigKV(1, 3, "3")))
+			ch <- struct{}{}
+			expectSend(t, n2Ch)
+			expectNoSend(t, n1Ch)
+		})
+	})
+}
+
+const (
+	// used for timeouts of things which should be fast
+	longTime = time.Second
+	// used for sanity check of channel sends which shouldn't happen
+	shortTime = 10 * time.Millisecond
+)
+
+func expectNoSend(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("did not expect to receive")
+	case <-time.After(shortTime):
+	}
+}
+
+func expectSend(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(longTime):
+		t.Fatal("expected to receive")
+	}
+}
+
+func mkZoneConfigKV(id config.SystemTenantObjectID, ts int64, value string) roachpb.KeyValue {
+	kv := roachpb.KeyValue{
+		Key: config.MakeZoneKey(id),
+		Value: roachpb.Value{
+			Timestamp: hlc.Timestamp{WallTime: ts},
+		},
+	}
+	kv.Value.SetString(value)
+	return kv
+}
+
+func mkSystemConfig(kvs ...roachpb.KeyValue) *config.SystemConfig {
+	cfg := config.NewSystemConfig(zonepb.DefaultSystemZoneConfigRef())
+	cfg.Values = kvs
+	return cfg
+}

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -16,9 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -275,15 +273,4 @@ func isProtected(
 			return true
 		})
 	return protected
-}
-
-// setupConfigWatcher returns a filter to watch zone config changes and a
-// channel that is notified when there are changes.
-func setupConfigWatcher(
-	execCfg *sql.ExecutorConfig,
-) (gossip.SystemConfigDeltaFilter, <-chan struct{}) {
-	k := execCfg.Codec.IndexPrefix(keys.ZonesTableID, keys.ZonesTablePrimaryIndexID)
-	zoneCfgFilter := gossip.MakeSystemConfigDeltaFilter(k)
-	gossipUpdateC := execCfg.SystemConfig.RegisterSystemConfigChannel()
-	return zoneCfgFilter, gossipUpdateC
 }


### PR DESCRIPTION
Backport 1/1 commits from #54266.

/cc @cockroachdb/release

---

Prior to this change, each GC job would hold on to a complete copy of the
system config. This was problematic in cases where there were a large number
of GC jobs. This PR introduces a new object in a new package to coordinate
the relevant notifications.

Release note (bug fix): Fixed a bug which could lead to out of memory errors
when dropping large numbers of tables at high frequency.
