### PR TITLE
release-19.2: sql: fix adding constraints in same transaction as table

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -539,7 +539,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateCheckInTxn(
-					params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+					params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1771,3 +1771,69 @@ ALTER TABLE t42508 ADD COLUMN y INT DEFAULT nextval('s42508')
 
 statement error pgcode XXA00 unimplemented: cannot backfill such sequence operation.*\nHINT.*\n.*42508
 COMMIT
+
+# Test that NOT NULL constraints can be created and validated on a newly created
+# table.
+subtest 52501
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t_52501_valid(a INT)
+
+statement ok
+INSERT INTO t_52501_valid VALUES (1)
+
+statement ok
+ALTER TABLE t_52501_valid ALTER COLUMN a SET NOT NULL
+
+statement ok
+COMMIT
+
+query TTTTB
+SHOW CONSTRAINTS FROM t_52501_valid
+----
+t_52501_valid  a_auto_not_null  CHECK  CHECK ((a IS NOT NULL))  true
+
+statement ok
+DROP TABLE t_52501_valid
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t_52501_invalid(a INT)
+
+statement ok
+INSERT INTO t_52501_invalid VALUES (NULL)
+
+statement error pgcode 23514 validation of CHECK "a IS NOT NULL" failed
+ALTER TABLE t_52501_invalid ALTER COLUMN a SET NOT NULL
+
+statement ok
+ROLLBACK
+
+# Test that NOT VALID foreign keys can be added in the same transaction as the
+# table.
+subtest 54265
+
+statement ok
+CREATE TABLE parent_54265 (a INT PRIMARY KEY)
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE child_54265 (a INT)
+
+statement ok
+ALTER TABLE child_54265 ADD FOREIGN KEY (a) REFERENCES parent_54265 NOT VALID
+
+statement ok
+COMMIT
+
+query TTTTB
+SHOW CONSTRAINTS FROM child_54265
+----
+child_54265  fk_a_ref_parent_54265  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a)  false

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2547,18 +2547,6 @@ func (desc *TableDescriptor) FindIndexByName(name string) (*IndexDescriptor, boo
 	return nil, false, fmt.Errorf("index %q does not exist", name)
 }
 
-// FindCheckByName finds the check constraint with the specified name.
-func (desc *TableDescriptor) FindCheckByName(
-	name string,
-) (*TableDescriptor_CheckConstraint, error) {
-	for _, c := range desc.Checks {
-		if c.Name == name {
-			return c, nil
-		}
-	}
-	return nil, fmt.Errorf("check %q does not exist", name)
-}
-
 // NamesForColumnIDs returns the names for the given column ids, or an error
 // if one or more column ids was missing. Note - this allocates! It's not for
 // hot path code.


### PR DESCRIPTION
Backport 1/1 commits from #54276.

/cc @cockroachdb/release

---

Previously in `runSchemaChangesInTxn()`, which is called when schema
changes are run on a table created earlier in the same transaction, we
would validate the constraints after they'd already been made "public"
on the in-memory table descriptor. The problem was that for NOT NULL
constraints, which use a temporary check constraint, the check
constraint no longer exists at that point, so we'd return an error about
the check not being found.

This commit rearranges the steps so that we don't process constraint
addition mutations until the end. It also opportunistically fixes
another bug related to calling `MakeMutationComplete`, which would cause
NOT VALID foreign keys to be erroneously added twice.

Release note (bug fix): Fixed two bugs when attempting to add
constraints in the same transaction in which the table was created:
Adding a NOT NULL constraint no longer fails with the error `check ...
does not exist`, and adding a NOT VALID foreign key constraint no longer
fails with the internal error `table descriptor is not valid: duplicate
constraint name`.