### PR TITLE
storage: fix encryption-at-rest on RocksDB

### DIFF
--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -1,0 +1,28 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package engineccl
+
+import "github.com/cockroachdb/cockroach/pkg/storage"
+
+// #cgo CPPFLAGS: -I../../../../c-deps/libroach/include -I../../../../c-deps/libroach/ccl/include
+// #cgo LDFLAGS: -lroachccl
+// #cgo LDFLAGS: -lroach
+// #cgo LDFLAGS: -lprotobuf
+// #cgo LDFLAGS: -lrocksdb
+// #cgo LDFLAGS: -lsnappy
+// #cgo LDFLAGS: -lcryptopp
+// #cgo linux LDFLAGS: -lrt -lpthread
+// #cgo windows LDFLAGS: -lshlwapi -lrpcrt4
+//
+// #include <libroachccl.h>
+import "C"
+
+func init() {
+	storage.SetRocksDBOpenHook(C.DBOpenHookCCL)
+}

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -152,6 +152,12 @@ type RocksDBCache struct {
 	cache *C.DBCache
 }
 
+// SetRocksDBOpenHook sets the DBOpenHook function that will be called during
+// RocksDB initialization. It is intended to be called by CCL code.
+func SetRocksDBOpenHook(fn unsafe.Pointer) {
+	C.DBSetOpenHook(fn)
+}
+
 // NewRocksDBCache creates a new cache of the specified size. Note that the
 // cache is refcounted internally and starts out with a refcount of one (i.e.
 // Release() should be called after having used the cache).


### PR DESCRIPTION
29cb28d4f6468d33f23818b57a42823045e21a97 accidentally broke
encryption-at-rest on RocksDB by removing the call to
`SetRocksDBOpenHook(C.DBOpenHookCCL)`.

Fixes #54300

Release note: none