### PR TITLE
builtins: implement ST_MinimumClearance and ST_MinimumClearanceLine

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1838,6 +1838,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_maxdistance"></a><code>st_maxdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the maximum distance across every pair of points comprising the given geometries. Note if the geometries are the same, it will return the maximum distance between the geometry’s vertexes.</p>
 </span></td></tr>
+<tr><td><a name="st_minimumclearance"></a><code>st_minimumclearance(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the minimum distance a vertex can move before producing an invalid geometry. Returns Infinity if no minimum clearance can be found (e.g. for a single point).</p>
+</span></td></tr>
+<tr><td><a name="st_minimumclearanceline"></a><code>st_minimumclearanceline(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a LINESTRING spanning the minimum distance a vertex can move before producing an invalid geometry. If no minimum clearance can be found (e.g. for a single point), an empty LINESTRING is returned.</p>
+</span></td></tr>
 <tr><td><a name="st_mlinefromtext"></a><code>st_mlinefromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not MultiLineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_mlinefromtext"></a><code>st_mlinefromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not MultiLineString, NULL is returned.</p>

--- a/pkg/geo/geomfn/unary_operators.go
+++ b/pkg/geo/geomfn/unary_operators.go
@@ -215,3 +215,20 @@ func Normalize(g geo.Geometry) (geo.Geometry, error) {
 	}
 	return geo.ParseGeometryFromEWKB(retEWKB)
 }
+
+// MinimumClearance returns the minimum distance a vertex can move to produce
+// an invalid geometry, or infinity if no clearance was found.
+func MinimumClearance(g geo.Geometry) (float64, error) {
+	return geos.MinimumClearance(g.EWKB())
+}
+
+// MinimumClearanceLine returns the line spanning the minimum distance a vertex
+// can move to produce an invalid geometry, or an empty line if no clearance was
+// found.
+func MinimumClearanceLine(g geo.Geometry) (geo.Geometry, error) {
+	retEWKB, err := geos.MinimumClearanceLine(g.EWKB())
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	return geo.ParseGeometryFromEWKB(retEWKB)
+}

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -519,6 +519,34 @@ func MinDistance(a geopb.EWKB, b geopb.EWKB) (float64, error) {
 	return float64(distance), nil
 }
 
+// MinimumClearance returns the minimum distance a vertex can move to result in an
+// invalid geometry.
+func MinimumClearance(ewkb geopb.EWKB) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(C.CR_GEOS_MinimumClearance(g, goToCSlice(ewkb), &distance)); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
+// MinimumClearanceLine returns the line spanning the minimum clearance a vertex can
+// move before producing an invalid geometry.
+func MinimumClearanceLine(ewkb geopb.EWKB) (geopb.EWKB, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, err
+	}
+	var clearanceEWKB C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_MinimumClearanceLine(g, goToCSlice(ewkb), &clearanceEWKB)); err != nil {
+		return nil, err
+	}
+	return cStringToSafeGoBytes(clearanceEWKB), nil
+}
+
 // ClipByRect clips a EWKB to the specified rectangle.
 func ClipByRect(
 	ewkb geopb.EWKB, xMin float64, yMin float64, xMax float64, yMax float64,

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -86,6 +86,9 @@ CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Normalize(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* normalizedEWKB);
 CR_GEOS_Status CR_GEOS_LineMerge(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* ewkb);
+CR_GEOS_Status CR_GEOS_MinimumClearance(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
+CR_GEOS_Status CR_GEOS_MinimumClearanceLine(CR_GEOS* lib, CR_GEOS_Slice a,
+                                            CR_GEOS_String* clearanceEWKB);
 
 //
 // Unary predicates.

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -942,7 +942,7 @@ invalid polygon            false  false  false  Self-intersection[1.5 1.5]     S
 self-intersecting polygon  false  false  true   Ring Self-intersection[14 20]  Ring Self-intersection  Valid Geometry     POLYGON ((14 20, 8 45, 20 35, 14 20), (14 20, 16 30, 12 30, 14 20))
 
 # Unary operators
-query TRRRRRR
+query TRRRRRRRT
 SELECT
   a.dsc,
   ST_Area(a.geom),
@@ -950,22 +950,24 @@ SELECT
   ST_Length(a.geom),
   ST_Length2D(a.geom),
   ST_Perimeter(a.geom),
-  ST_Perimeter2D(a.geom)
+  ST_Perimeter2D(a.geom),
+  ST_MinimumClearance(a.geom),
+  ST_AsText(ST_MinimumClearanceLine(a.geom))
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  0     0     0     0     0     0
-Empty LineString                          0     0     0     0     0     0
-Empty Point                               0     0     0     0     0     0
-Faraway point                             0     0     0     0     0     0
-Line going through left and right square  0     0     1     1     0     0
-NULL                                      NULL  NULL  NULL  NULL  NULL  NULL
-Nested Geometry Collection                0     0     0     0     0     0
-Point middle of Left Square               0     0     0     0     0     0
-Point middle of Right Square              0     0     0     0     0     0
-Square (left)                             1     1     0     0     4     4
-Square (right)                            1     1     0     0     4     4
-Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2
+Empty GeometryCollection                  0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Empty LineString                          0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Empty Point                               0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Faraway point                             0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Line going through left and right square  0     0     1     1     0     0     1     LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                      NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+Nested Geometry Collection                0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Point middle of Left Square               0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Point middle of Right Square              0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Square (left)                             1     1     0     0     4     4     1     LINESTRING (-1 0, 0 0)
+Square (right)                            1     1     0     0     4     4     1     LINESTRING (0 0, 1 0)
+Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2   1     LINESTRING (-0.1 0, -0.1 1)
 
 # Unary predicates
 query TBBBB

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1962,6 +1962,43 @@ Flags shown square brackets after the geometry type have the following meaning:
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_minimumclearance": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MinimumClearance(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: `Returns the minimum distance a vertex can move before producing an invalid geometry. ` +
+					`Returns Infinity if no minimum clearance can be found (e.g. for a single point).`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_minimumclearanceline": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MinimumClearanceLine(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Returns a LINESTRING spanning the minimum distance a vertex can move before producing ` +
+					`an invalid geometry. If no minimum clearance can be found (e.g. for a single point), an ` +
+					`empty LINESTRING is returned.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_numinteriorrings": makeBuiltin(
 		defProps(),
 		geometryOverload1(
@@ -4856,8 +4893,6 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 	"st_memsize":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48985}),
 	"st_minimumboundingcircle":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48987}),
 	"st_minimumboundingradius":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48988}),
-	"st_minimumclearance":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48989}),
-	"st_minimumclearanceline":    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48990}),
 	"st_node":                    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48993}),
 	"st_orderingequals":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49002}),
 	"st_orientedenvelope":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49003}),


### PR DESCRIPTION
Release note (sql change): Implement the geometry builtins
`ST_MinimumClearance` and `ST_MinimumClearanceLine`.

Closes #48989.
Closes #48990.