### PR TITLE
opt: unwrap explain.Node in ConstructScanBuffer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -604,3 +604,34 @@ EXECUTE ctestmt (10)
 31
 41
 51
+
+# Verify that the query inside the CTE can refer to an outer CTE.
+statement ok
+DROP TABLE IF EXISTS ab
+
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO ab VALUES (1,1)
+
+query I rowsort
+WITH
+  cte1 AS MATERIALIZED (SELECT a FROM ab WHERE a = b)
+SELECT * FROM
+  (
+    WITH RECURSIVE
+      cte2 (x) AS (SELECT 1 UNION ALL SELECT x + a FROM cte2, cte1 WHERE x < 10)
+    SELECT * FROM cte2
+  )
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -873,6 +873,11 @@ func (ef *execFactory) ConstructBuffer(input exec.Node, label string) (exec.Node
 
 // ConstructScanBuffer is part of the exec.Factory interface.
 func (ef *execFactory) ConstructScanBuffer(ref exec.Node, label string) (exec.Node, error) {
+	if n, ok := ref.(*explain.Node); ok {
+		// This can happen if we used explain on the main query but we construct the
+		// scan buffer inside a separate plan (e.g. recursive CTEs).
+		ref = n.WrappedNode()
+	}
 	return &scanBufferNode{
 		buffer: ref.(*bufferNode),
 		label:  label,


### PR DESCRIPTION
When the new explain infrastructure is in use, the plan is built
against an explain.Factory but the "inner" recursive CTE plan is built
against a normal factory. This leads to an internal error. To avoid
this, we unwrap the node in `ConstructScanBuffer`.

Note that the new explain infrastructure is used automatically for the
first instance of a query fingerprint, in order to populate the plan
in the UI.

Fixes #54324.

Release note (bug fix): fixed an internal error in some cases when
recursive CTEs are used.
