### PR TITLE
backupccl: disallow incrementals with new complete databases

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -14,6 +14,7 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -750,6 +751,11 @@ func backupPlanHook(
 				if err := checkForNewTables(ctx, p.ExecCfg().DB, targetDescs, tablesInPrev, dbsInPrev, priorIDs, startTime, endTime); err != nil {
 					return err
 				}
+				// Let's check that we're not widening the scope of this backup to an
+				// entire database, even if no tables were created in the meantime.
+				if err := checkForNewCompleteDatabases(targetDescs, completeDBs, dbsInPrev); err != nil {
+					return err
+				}
 			}
 
 			var err error
@@ -1117,6 +1123,28 @@ func getEncryptedDataKeyByKMSMasterKeyID(
 	}
 
 	return encryptedDataKeyByKMSMasterKeyID, kmsInfo, nil
+}
+
+// checkForNewDatabases returns an error if any new complete databases were
+// introduced.
+func checkForNewCompleteDatabases(
+	targetDescs []catalog.Descriptor, curDBs []descpb.ID, prevDBs map[descpb.ID]struct{},
+) error {
+	for _, dbID := range curDBs {
+		if _, inPrevious := prevDBs[dbID]; !inPrevious {
+			// Search for the name for a nicer error message.
+			violatingDatabase := strconv.Itoa(int(dbID))
+			for _, desc := range targetDescs {
+				if desc.GetID() == dbID {
+					violatingDatabase = desc.GetName()
+					break
+				}
+			}
+			return errors.Errorf("previous backup does not contain the complete database %q",
+				violatingDatabase)
+		}
+	}
+	return nil
 }
 
 // checkForNewTables returns an error if any new tables were introduced with the

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2411,11 +2411,11 @@ INSERT INTO d.t3 VALUES ('hi');
 		// Create a backup of all the tables in d.
 		{
 			// Backup all of the tables.
-			sqlDB.Exec(t, `BACKUP d.* TO 'nodelocal://0/test3/'`)
+			sqlDB.Exec(t, `BACKUP d.* TO 'nodelocal://0/test_all_tables/'`)
 			// Create a new database to restore all of the tables into.
 			sqlDB.Exec(t, `CREATE DATABASE d4`)
 			// Restore all of the tables.
-			sqlDB.Exec(t, `RESTORE TABLE d.* FROM 'nodelocal://0/test3/' WITH into_db = 'd4'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.* FROM 'nodelocal://0/test_all_tables/' WITH into_db = 'd4'`)
 			// Check that all of the tables have expected data.
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d4.t ORDER BY x`, [][]string{{"hello"}, {"howdy"}})
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d4.t2 ORDER BY x`, [][]string{{"{hello}"}})
@@ -2509,14 +2509,14 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			// Create a table using these ___typ1.
 			sqlDB.Exec(t, `CREATE TABLE d5.tb1 (x d5.typ1[])`)
 			// Backup tb1.
-			sqlDB.Exec(t, `BACKUP TABLE d5.tb1 TO 'nodelocal://0/test3/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d5.tb1 TO 'nodelocal://0/testd5/'`)
 
 			// Create another database with a compatible type.
 			sqlDB.Exec(t, `CREATE DATABASE d6`)
 			sqlDB.Exec(t, `CREATE TYPE d6.typ1 AS ENUM ('v1', 'v2')`)
 			// Restoring tb1 into d6 will remap d5.typ1 to d6.typ1 and d5.___typ1
 			// to d6._typ1.
-			sqlDB.Exec(t, `RESTORE TABLE d5.tb1 FROM 'nodelocal://0/test3/' WITH into_db = 'd6'`)
+			sqlDB.Exec(t, `RESTORE TABLE d5.tb1 FROM 'nodelocal://0/testd5/' WITH into_db = 'd6'`)
 			sqlDB.Exec(t, `INSERT INTO d6.tb1 VALUES (ARRAY['v1']::d6._typ1)`)
 		}
 
@@ -2564,13 +2564,13 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 		{
 			// Create a database with a type, and take a backup.
 			sqlDB.Exec(t, `CREATE DATABASE d3`)
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3/'`)
 
 			// Now create a new type in that database.
 			sqlDB.Exec(t, `CREATE TYPE d3.farewell AS ENUM ('bye', 'cya')`)
 
 			// Perform an incremental backup, which should pick up the new type.
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3/'`)
 
 			// Until #51362 lands we have to manually clean up this type before the
 			// DROP DATABASE statement otherwise we'll leave behind an orphaned desc.
@@ -2578,7 +2578,8 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 
 			// Now restore it.
 			sqlDB.Exec(t, `DROP DATABASE d3`)
-			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/testd3/'`)
+
 			// Check that we are able to use the type.
 			sqlDB.Exec(t, `CREATE TABLE d3.t (x d3.farewell)`)
 			sqlDB.Exec(t, `DROP TABLE d3.t`)
@@ -2586,9 +2587,9 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 			// If we drop the type and back up again, it should be gone.
 			sqlDB.Exec(t, `DROP TYPE d3.farewell`)
 
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3_2/'`)
 			sqlDB.Exec(t, `DROP DATABASE d3`)
-			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/testd3_2/'`)
 			sqlDB.ExpectErr(t, `pq: type "d3.farewell" does not exist`, `CREATE TABLE d3.t (x d3.farewell)`)
 		}
 	})

--- a/pkg/ccl/backupccl/testdata/backup-restore/descriptor-broadening
+++ b/pkg/ccl/backupccl/testdata/backup-restore/descriptor-broadening
@@ -1,0 +1,18 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE TABLE db1.t (a INT);
+BACKUP DATABASE db1 TO 'nodelocal://1/backup';
+BACKUP DATABASE db1,db2 TO 'nodelocal://1/backup';
+----
+pq: previous backup does not contain the complete database "db2"
+
+exec-sql
+BACKUP db1.t TO 'nodelocal://1/backup_2';
+BACKUP DATABASE db1 TO 'nodelocal://1/backup_2';
+----
+pq: previous backup does not contain the complete database "db1"
+


### PR DESCRIPTION
BACKUP usually disallows the expansion of targets included in a backup
chain. That is to say, given a base backup or a chain of backups, an
incremental backup should not be more general then the previous backups.

However, we would previously allow the inclusion of a new empty database
in backup chains that previously backed up other databases. E.g.:
```
BACKUP DATABASE db1 TO ...
CREATE DATABASE db2;
BACKUP DATABASE db1,db2 TO...
```
or
```
CREATE DATABASE db1;
CREATE TABLE db1.t (a INT);
BACKUP db1.t TO ...
BACKUP DATABASE db1 TO ...
```

These scenarios were okay since the incremental backup was not including
any more tables whose history extended beyond the previous
incremental backup. However, this provided a confusing user experience.
In order to remain consistent, we should disallow such target
"widening".

Fixes #48502.

Release note (enterprise change): Disallow widening an
incremental-backup chain with the inclusion of new complete empty DBs.