### PR TITLE
kv/kvserver: don't use indexed batches when sending snapshots

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1932,7 +1932,7 @@ func (r *Replica) sendSnapshot(
 		r.store.allocator.storePool,
 		req,
 		snap,
-		r.store.Engine().NewBatch,
+		r.store.Engine().NewWriteOnlyBatch,
 		sent,
 	); err != nil {
 		if errors.Is(err, errMalformedSnapshot) {


### PR DESCRIPTION
This commit updates the Range snapshot logic to use a "write-only"
(non-indexed) batch when sending snapshots. This avoids unnecessary
work to maintain the index and limits the memory footprint of a
snapshot sender because it no longer needs to create an arena Skiplist
to store the key-values being inserted.

@petermattis how do you feel about putting this into release-20.2?