### PR TITLE
roachtest: disable load-based splitting in copy/bank/rows=10000000,nodes=9,txn=false

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -45,6 +45,13 @@ func registerCopy(r *testRegistry) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 
+			// Disable load-based splitting so that we can more accurately
+			// predict an upper-bound on the number of ranges that the cluster
+			// will end up with.
+			if err := disableLoadBasedSplitting(ctx, db); err != nil {
+				return errors.Wrap(err, "disabling load-based splitting")
+			}
+
 			t.Status("importing Bank fixture")
 			c.Run(ctx, c.Node(1), fmt.Sprintf(
 				"./workload fixtures load bank --rows=%d --payload-bytes=%d {pgurl:1}",


### PR DESCRIPTION
Fixes #54301.

Speculative fix for that roachtest.