### PR TITLE
kv: increment bytesSent, not batchSize in kvBatchSnapshotStrategy.sendBatch

### DIFF
--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -476,7 +476,7 @@ func (kvSS *kvBatchSnapshotStrategy) sendBatch(
 		return err
 	}
 	repr := batch.Repr()
-	kvSS.batchSize += int64(len(repr))
+	kvSS.bytesSent += int64(len(repr))
 	batch.Close()
 	return stream.Send(&SnapshotRequest{KVBatch: repr})
 }


### PR DESCRIPTION
Partly responsible for https://github.com/cockroachdb/cockroach/issues/54311.

This commit fixes a bug introduced in #48579 where the snapshot
batch size was increased when each batch was sent instead of the
bytesSent metric. This had two effects:
1. it undermined the memory footprint limit (256 KB) placed on
   snapshot senders by doubling the batch size on each subsequent
   batch.
2. it failed to track the snapshot data rate properly, so the log
   message introduced in #48579 always contained "0 B/s".

This needs to be backported to release-20.1 and release-20.2.