### PR TITLE
parser: fix drop schedule help message

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6997,7 +6997,7 @@ resume_schedules_stmt:
 // DROP SCHEDULES <selectclause>
 //  selectclause: select statement returning schedule IDs to resume.
 //
-// DROP SCHEDULES <jobid>
+// DROP SCHEDULE <jobid>
 //
 // %SeeAlso: PAUSE SCHEDULES, SHOW JOBS, CANCEL JOBS
 drop_schedule_stmt:


### PR DESCRIPTION
Updates the help message for `DROP SCHEDULE JOBID`.

Fixes:  #54209

Release note: None