### PR TITLE
backupccl,importccl: only reset ModificationTime on tables after upgrade

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -685,6 +685,16 @@ type restoreResumer struct {
 	settings *cluster.Settings
 	execCfg  *sql.ExecutorConfig
 
+	// versionAtLeast20_2 is true if the cluster version is new enough.
+	// In release-20.1, any decoded table descriptor needed a populated
+	// modification time regardless of its version number. In 20.2 and later we've
+	// relaxed this requirement to allow version 1 descriptors to be serialized
+	// with a zero modification time. Furthermore, in 20.1, database descriptors
+	// could not be safely put into the offiline state.
+	//
+	// TODO(ajwerner): Remove in 21.1.
+	versionAtLeast20_2 bool
+
 	testingKnobs struct {
 		// beforePublishingDescriptors is called right before publishing
 		// descriptors, after any data has been restored.
@@ -850,7 +860,10 @@ func createImportingDescriptors(
 
 	// Assign new IDs and privileges to the tables, and update all references to
 	// use the new IDs.
-	if err := RewriteTableDescs(mutableTables, details.DescriptorRewrites, details.OverrideDB); err != nil {
+	if err := RewriteTableDescs(
+		mutableTables, details.DescriptorRewrites, details.OverrideDB,
+		r.versionAtLeast20_2,
+	); err != nil {
 		return nil, nil, nil, err
 	}
 	tableDescs := make([]*descpb.TableDescriptor, len(mutableTables))
@@ -907,7 +920,7 @@ func createImportingDescriptors(
 	}
 	// 20.1 nodes won't make OFFLINE database descriptors public, so write them
 	// in the PUBLIC state.
-	if r.settings.Version.IsActive(ctx, clusterversion.VersionLeasedDatabaseDescriptors) {
+	if r.versionAtLeast20_2 {
 		for _, desc := range mutableDatabases {
 			desc.SetOffline("restoring")
 		}
@@ -1052,6 +1065,8 @@ func (r *restoreResumer) Resume(
 ) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 	p := phs.(sql.PlanHookState)
+	r.versionAtLeast20_2 = p.ExecCfg().Settings.Version.IsActive(
+		ctx, clusterversion.VersionLeasedDatabaseDescriptors)
 
 	backupManifests, latestBackupManifest, sqlDescs, err := loadBackupSQLDescs(
 		ctx, p, details, details.Encryption,

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -976,8 +976,12 @@ func prepareNewTableDescsForIngestion(
 		}
 		seqVals[id] = tableDesc.SeqVal
 	}
-
-	if err := backupccl.RewriteTableDescs(newMutableTableDescriptors, tableRewrites, ""); err != nil {
+	// TODO(ajwerner): Remove this in 21.1.
+	canResetModTime := p.ExecCfg().Settings.Version.IsActive(
+		ctx, clusterversion.VersionLeasedDatabaseDescriptors)
+	if err := backupccl.RewriteTableDescs(
+		newMutableTableDescriptors, tableRewrites, "", canResetModTime,
+	); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
In #54296 we began resetting the version and modification time for all newly
added descriptors. This is fine for the descriptors which did not exist or
have those fields in 20.1 (schema, type, db). For tables however, this is not
okay because code in release 20.1 is missing a check added in the 20.2 cycle
to allow a missing modification time for version 1. This breaks restore and
import in the mixed version state.

This PR gates the resetting of modification time on the cluster version. I
have verified that this fixes the jobs/mixed-version roachtest which previously
failed deterministically due to this bug.

No release note because we haven't shipped this bug.

Fixes #54319.

Release note: None