### PR TITLE
opt: fix st_distance -> st_dwithin rule to cast distance param as float

### DIFF
--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -119,6 +119,9 @@ func FindFunction(
 	props, overloads := builtins.GetBuiltinProperties(name)
 	for o := range overloads {
 		overload = &overloads[o]
+		if overload.Types.Length() != e.ChildCount() {
+			continue
+		}
 		matches := true
 		for i, n := 0, e.ChildCount(); i < n; i++ {
 			typ := e.Child(i).(opt.ScalarExpr).DataType()

--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -236,11 +236,14 @@ func (c *CustomFuncs) makeSTDWithin(
 			name = incName
 		}
 	}
-	props, overload, ok := memo.FindFunction(&args, name)
+
+	// The distance parameter must be type float.
+	newArgs := append(args, c.f.ConstructCast(bound, types.Float))
+	props, overload, ok := memo.FindFunction(&newArgs, name)
 	if !ok {
 		panic(errors.AssertionFailedf("could not find overload for %s", name))
 	}
-	within := c.f.ConstructFunction(append(args, bound), &memo.FunctionPrivate{
+	within := c.f.ConstructFunction(newArgs, &memo.FunctionPrivate{
 		Name:       name,
 		Typ:        types.Bool,
 		Properties: props,

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -844,6 +844,37 @@ select
  └── filters
       └── st_dwithinexclusive(geog:2, '0101000020E610000000000000000000000000000000000000', 5.0) [outer=(2), immutable]
 
+# Regression test for #54326. Ensure the distance param is cast to a float.
+norm expect=FoldCmpSTDistanceLeft format=(show-scalars,show-types)
+SELECT * FROM geom_geog WHERE st_distance(geog, 'point(0.0 0.0)') < 5::int
+----
+select
+ ├── columns: geom:1(geometry) geog:2(geography) val:3(float)
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1(geometry) geog:2(geography) val:3(float)
+ └── filters
+      └── function: st_dwithinexclusive [type=bool, outer=(2), immutable]
+           ├── variable: geog:2 [type=geography]
+           ├── const: '0101000020E610000000000000000000000000000000000000' [type=geography]
+           └── const: 5.0 [type=float]
+
+norm expect=FoldCmpSTDistanceLeft format=(show-scalars,show-types)
+SELECT * FROM geom_geog WHERE st_distance(geog, 'point(0.0 0.0)') < val::int
+----
+select
+ ├── columns: geom:1(geometry) geog:2(geography) val:3(float)
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1(geometry) geog:2(geography) val:3(float)
+ └── filters
+      └── function: st_dwithinexclusive [type=bool, outer=(2,3), immutable]
+           ├── variable: geog:2 [type=geography]
+           ├── const: '0101000020E610000000000000000000000000000000000000' [type=geography]
+           └── cast: FLOAT8 [type=float]
+                └── cast: INT8 [type=int]
+                     └── variable: val:3 [type=float]
+
 # --------------------------------------------------
 # FoldCmpSTDistanceRight
 # --------------------------------------------------


### PR DESCRIPTION
Release justification: low-risk updates to new functionality

This commit fixes an error that could occur when the normalization rule was
applied that converts `st_distance(g1, g2) <= d` to `st_dwithin(g1, g2, d)`.
The error occurred when `d`, the distance parameter, was some type other than
`float`. Since `st_dwithin` requires the distance parameter to have type `float`,
this commit fixes the problem by casting the parameter to type `float`.

Fixes #54326

Release note (bug fix): fixed an internal error and/or panic that could occur
when the ST_Distance or ST_MaxDistance functions were compared against a
constant or variable with any type other than float. For example, previously,
a query with the predicate `WHERE ST_Distance(g1, g2) < 10::int` could cause an
error.