### PR TITLE
sql: fix error for rename of constraint over an index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1384,3 +1384,21 @@ primary                         rowid
 regression_54196_col2_col3_idx  col2
 regression_54196_col2_col3_idx  col3
 regression_54196_col2_col3_idx  rowid
+
+# Test to ensure that renaming a constraint on top of an existing index
+# fails with the correct error.
+
+statement ok
+CREATE TABLE t_cannot_rename_constraint_over_index (
+    k INT PRIMARY KEY,
+    v INT,
+    CONSTRAINT v_unique UNIQUE (v),
+    INDEX idx_v (v)
+);
+
+statement error relation idx_v already exists
+ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT v_unique TO idx_v;
+
+statement error relation idx_v already exists
+ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO idx_v;
+


### PR DESCRIPTION
With #54354 and this we should be able to flip off tolerate-errors on the
schemachange workload.

Before this change:

```
root@127.0.0.1:35629/movr> ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO idx_v;
ERROR: internal error: duplicate index name: "idx_v"
SQLSTATE: XX000
DETAIL: stack trace:
github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc/structured.go:1926: validateTableIndexes()
github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc/structured.go:1767: ValidateTable()
github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc/structured.go:1111: AllocateIDs()
github.com/cockroachdb/cockroach/pkg/sql/alter_table.go:758: startExec()
github.com/cockroachdb/cockroach/pkg/sql/plan.go:514: func2()
github.com/cockroachdb/cockroach/pkg/sql/walk.go:119: func1()
github.com/cockroachdb/cockroach/pkg/sql/walk.go:298: visitInternal()
github.com/cockroachdb/cockroach/pkg/sql/walk.go:86: visit()
github.com/cockroachdb/cockroach/pkg/sql/walk.go:50: walkPlan()
github.com/cockroachdb/cockroach/pkg/sql/plan.go:517: startExec()
github.com/cockroachdb/cockroach/pkg/sql/plan_node_to_row_source.go:125: Start()
github.com/cockroachdb/cockroach/pkg/sql/execinfra/processorsbase.go:762: Run()
github.com/cockroachdb/cockroach/pkg/sql/flowinfra/flow.go:380: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:422: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:991: PlanAndRun()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:1058: execWithDistSQLEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:929: dispatchToExecutionEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:609: execStmtInOpenState()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:116: execStmt()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:1459: execCmd()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:1388: run()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:510: ServeConn()
github.com/cockroachdb/cockroach/pkg/sql/pgwire/conn.go:626: func1()
runtime/asm_amd64.s:1357: goexit()

HINT: You have encountered an unexpected error.

Please check the public issue tracker to check whether this problem is
already tracked. If you cannot find it there, please report the error
with details by creating a new issue.

If you would rather not post publicly, please contact us directly
using the support form.

We appreciate your feedback.
```

Release note (bug fix): Cockroach now properly returns an appropriate error
when the user attempts to rename a constraint to a name which conflicts with
an existing index.