### PR TITLE
sql: increase statement_timeout in sequences logictest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -890,7 +890,7 @@ DROP SEQUENCE sv
 subtest generator_timeout
 
 statement ok
-SET statement_timeout = 1
+SET statement_timeout = 10
 
 statement error pq: query execution canceled due to statement timeout
 select * from generate_series(1,10000000) where generate_series = 0;


### PR DESCRIPTION
Previously the statement timeout in a logic test was set to 1ms, which
was sometimes not enough to complete resetting the statement timeout
after the test, causing it to flake. This PR increases the timeout
from 1ms to 10ms so that we don't flake on the cleanup.

Release note: None