### PR TITLE
opt: panic when calling InvertedSourceColumnOrdinal on a non-virtual column

### DIFF
--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -134,6 +134,9 @@ func (c *Column) ComputedExprStr() string {
 //
 // Must not be called if this is not a virtual column.
 func (c *Column) InvertedSourceColumnOrdinal() int {
+	if c.kind != Virtual {
+		panic(errors.AssertionFailedf("non-virtual columns have no inverted source column ordinal"))
+	}
 	return c.invertedSourceColumnOrdinal
 }
 


### PR DESCRIPTION
`Column.InvertedSourceColumnOrdinal` should not be called on a
non-virtual column. This commit adds a panic if this happens.

Release note: None