### PR TITLE
release-20.2: parser: fix drop schedule help message

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6996,7 +6996,7 @@ resume_schedules_stmt:
 // DROP SCHEDULES <selectclause>
 //  selectclause: select statement returning schedule IDs to resume.
 //
-// DROP SCHEDULES <jobid>
+// DROP SCHEDULE <scheduleid>
 //
 // %SeeAlso: PAUSE SCHEDULES, SHOW JOBS, CANCEL JOBS
 drop_schedule_stmt:


### PR DESCRIPTION
Backport 1/1 commits from #54359.

/cc @cockroachdb/release

---

Updates the help message for `DROP SCHEDULE JOBID`.

Fixes:  #54209

Release note: None
