### PR TITLE
sql: add support for partial inverted indexes

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -225,11 +224,6 @@ func MakeIndexDescriptor(
 	}
 
 	if n.Predicate != nil {
-		if n.Inverted {
-			telemetry.Inc(sqltelemetry.PartialInvertedIndexErrorCounter)
-			return nil, unimplemented.NewWithIssue(50952, "partial inverted indexes not supported")
-		}
-
 		idxValidator := schemaexpr.MakeIndexPredicateValidator(params.ctx, n.Table, tableDesc, &params.p.semaCtx)
 		expr, err := idxValidator.Validate(n.Predicate)
 		if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1458,11 +1458,6 @@ func NewTableDesc(
 				idx.Partitioning = partitioning
 			}
 			if d.Predicate != nil {
-				if d.Inverted {
-					telemetry.Inc(sqltelemetry.PartialInvertedIndexErrorCounter)
-					return nil, unimplemented.NewWithIssue(50952, "partial inverted indexes not supported")
-				}
-
 				expr, err := idxValidator.Validate(d.Predicate)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -254,6 +254,9 @@ SELECT * FROM a@idx_c_b_gt_1 WHERE b > 1
 ----
 1  2  1
 
+statement error index "idx_c_b_gt_1" is a partial index that does not contain all the rows needed to execute this query
+SELECT * FROM a@idx_c_b_gt_1 WHERE b = 0
+
 # Return error if evaluating the predicate errs and do not insert or update the
 # row.
 
@@ -1128,6 +1131,7 @@ enum_table_show  CREATE TABLE public.enum_table_show (
 )
 
 # Inverted partial indexes.
+subtest inverted
 
 statement ok
 CREATE TABLE inv (j JSON, i INT, INVERTED INDEX (j) WHERE i > 0);
@@ -1135,7 +1139,85 @@ DROP TABLE inv;
 
 statement ok
 CREATE TABLE inv (k INT PRIMARY KEY, j JSON, s STRING);
-CREATE INVERTED INDEX ON inv (j) WHERE s IN ('foo', 'bar');
+CREATE INVERTED INDEX i ON inv (j) WHERE s IN ('foo', 'bar');
+
+statement ok
+INSERT INTO inv VALUES
+    (1, '{"x": "y", "num": 1}', 'foo'),
+    (2, '{"x": "y", "num": 2}', 'baz'),
+    (3, '{"x": "y", "num": 3}', 'bar')
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s = 'foo'
+----
+1  {"num": 1, "x": "y"}  foo
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"num": 1}' AND s IN ('foo', 'bar')
+----
+1  {"num": 1, "x": "y"}  foo
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar') ORDER BY k
+----
+1  {"num": 1, "x": "y"}  foo
+3  {"num": 3, "x": "y"}  bar
+
+statement ok
+DELETE FROM inv WHERE k = 3
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar')
+----
+1  {"num": 1, "x": "y"}  foo
+
+statement ok
+UPDATE inv SET j = '{"x": "y", "num": 10}' WHERE k = 1
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"num": 10}' AND s = 'foo'
+----
+1  {"num": 10, "x": "y"}  foo
+
+statement ok
+UPDATE inv SET k = 10 WHERE k = 1
+
+statement ok
+UPDATE inv SET s = 'bar' WHERE k = 2
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar') ORDER BY k
+----
+2   {"num": 2, "x": "y"}   bar
+10  {"num": 10, "x": "y"}  foo
+
+statement ok
+UPDATE inv SET s = 'baz' WHERE k = 10
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar')
+----
+2  {"num": 2, "x": "y"}  bar
+
+statement ok
+UPSERT INTO inv VALUES (3, '{"x": "y", "num": 3}', 'bar')
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s = 'bar' ORDER BY k
+----
+2  {"num": 2, "x": "y"}  bar
+3  {"num": 3, "x": "y"}  bar
+
+statement ok
+UPSERT INTO inv VALUES (3, '{"x": "y", "num": 4}', 'bar')
+
+query ITT
+SELECT * FROM inv@i WHERE j @> '{"num": 4}' AND s = 'bar'
+----
+3  {"num": 4, "x": "y"}  bar
+
+statement error index "i" is a partial inverted index and cannot be used for this query
+SELECT * FROM inv@i WHERE j @> '{"num": 2}' AND s = 'baz'
 
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1129,14 +1129,13 @@ enum_table_show  CREATE TABLE public.enum_table_show (
 
 # Inverted partial indexes.
 
-statement error pgcode 0A000 unimplemented: partial inverted indexes not supported
-CREATE TABLE inv (j JSON, i INT, INVERTED INDEX (j) WHERE i > 0)
+statement ok
+CREATE TABLE inv (j JSON, i INT, INVERTED INDEX (j) WHERE i > 0);
+DROP TABLE inv;
 
 statement ok
-CREATE TABLE inv (j JSON, i INT)
-
-statement error pgcode 0A000 unimplemented: partial inverted indexes not supported
-CREATE INVERTED INDEX ON inv (j) WHERE i > 0
+CREATE TABLE inv (k INT PRIMARY KEY, j JSON, s STRING);
+CREATE INVERTED INDEX ON inv (j) WHERE s IN ('foo', 'bar');
 
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -672,6 +672,199 @@ Del /Table/54/2/3/2/0
 CPut /Table/54/2/4/2/0 -> /BYTES/ (expecting does not exist)
 
 # ---------------------------------------------------------
+# INSERT partial inverted index
+# ---------------------------------------------------------
+
+# INVERTED INDEX (b) WHERE c IN ('foo', 'bar')
+statement ok
+CREATE TABLE inv (
+    a INT PRIMARY KEY,
+    b JSON,
+    c STRING,
+    INVERTED INDEX (b) WHERE c IN ('foo', 'bar'),
+    FAMILY (a, b, c)
+)
+
+query T kvtrace
+INSERT INTO inv VALUES (1, '{"x": "y", "num": 1}', 'foo')
+----
+CPut /Table/55/1/1/0 -> /TUPLE/
+InitPut /Table/55/2/"num"/1/1/0 -> /BYTES/
+InitPut /Table/55/2/"x"/"y"/1/0 -> /BYTES/
+
+query T kvtrace
+INSERT INTO inv VALUES (2, '{"x": "y", "num": 2}', 'baz')
+----
+CPut /Table/55/1/2/0 -> /TUPLE/
+
+# ---------------------------------------------------------
+# DELETE partial inverted index
+# ---------------------------------------------------------
+
+query T kvtrace
+DELETE FROM inv WHERE a = 1
+----
+Scan /Table/55/1/1{-/#}
+Del /Table/55/2/"num"/1/1/0
+Del /Table/55/2/"x"/"y"/1/0
+Del /Table/55/1/1/0
+
+query T kvtrace
+DELETE FROM inv WHERE a = 2
+----
+Scan /Table/55/1/2{-/#}
+Del /Table/55/1/2/0
+
+# ---------------------------------------------------------
+# UPDATE partial inverted index
+# ---------------------------------------------------------
+
+statement ok
+INSERT INTO inv VALUES (1, '{"x": "y", "num": 1}', 'foo');
+INSERT INTO inv VALUES (2, '{"x": "y", "num": 2}', 'baz');
+
+# Update a non-JSON column so that the row remains in the partial index.
+query T kvtrace
+UPDATE inv SET c = 'bar' WHERE a = 1
+----
+Scan /Table/55/1/1{-/#}
+Put /Table/55/1/1/0 -> /TUPLE/
+
+# Update the JSON of a row in the partial index.
+query T kvtrace
+UPDATE inv SET b = '{"x": "y", "num": 3}' WHERE a = 1
+----
+Scan /Table/55/1/1{-/#}
+Put /Table/55/1/1/0 -> /TUPLE/
+Del /Table/55/2/"num"/1/1/0
+InitPut /Table/55/2/"num"/3/1/0 -> /BYTES/
+
+# Update a non-JSON column so that the row is removed from the partial index.
+query T kvtrace
+UPDATE inv SET c = 'fud' WHERE a = 1
+----
+Scan /Table/55/1/1{-/#}
+Put /Table/55/1/1/0 -> /TUPLE/
+Del /Table/55/2/"num"/3/1/0
+Del /Table/55/2/"x"/"y"/1/0
+
+# Update a non-JSON column so that the row remains not in the partial index.
+query T kvtrace
+UPDATE inv SET c = 'boo' WHERE a = 2
+----
+Scan /Table/55/1/2{-/#}
+Put /Table/55/1/2/0 -> /TUPLE/
+
+# Update the JSON of a row not in the partial index.
+query T kvtrace
+UPDATE inv SET b = '{"x": "y", "num": 4}' WHERE a = 2
+----
+Scan /Table/55/1/2{-/#}
+Put /Table/55/1/2/0 -> /TUPLE/
+
+# Update a non-JSON column so that the row is added to the partial index.
+query T kvtrace
+UPDATE inv SET c = 'bar' WHERE a = 2
+----
+Scan /Table/55/1/2{-/#}
+Put /Table/55/1/2/0 -> /TUPLE/
+InitPut /Table/55/2/"num"/4/2/0 -> /BYTES/
+InitPut /Table/55/2/"x"/"y"/2/0 -> /BYTES/
+
+# Update the primary key of a row in the partial index.
+query T kvtrace
+UPDATE inv SET a = 4 WHERE a = 2
+----
+Scan /Table/55/1/2{-/#}
+Del /Table/55/2/"num"/4/2/0
+Del /Table/55/2/"x"/"y"/2/0
+Del /Table/55/1/2/0
+CPut /Table/55/1/4/0 -> /TUPLE/
+InitPut /Table/55/2/"num"/4/4/0 -> /BYTES/
+InitPut /Table/55/2/"x"/"y"/4/0 -> /BYTES/
+
+# Update the primary key of a row not in the partial index.
+query T kvtrace
+UPDATE inv SET a = 3 WHERE a = 1
+----
+Scan /Table/55/1/1{-/#}
+Del /Table/55/1/1/0
+CPut /Table/55/1/3/0 -> /TUPLE/
+
+# Update to multiple rows (one in and one not in the partial index) so that both
+# are in the partial index.
+statement ok
+INSERT INTO inv VALUES (10, '{"a": "b"}', 'foo'), (11, '{"a": "b"}', 'baz')
+
+query T kvtrace
+UPDATE inv SET c = 'foo' WHERE a IN (10, 11)
+----
+Scan /Table/55/1/1{0-1/#}
+Put /Table/55/1/10/0 -> /TUPLE/
+Put /Table/55/1/11/0 -> /TUPLE/
+InitPut /Table/55/2/"a"/"b"/11/0 -> /BYTES/
+
+# Update to multiple rows (one in and one not in the partial index) so that both
+# are not in the partial index.
+statement ok
+INSERT INTO inv VALUES (12, '{"a": "b"}', 'foo'), (13, '{"a": "b"}', 'baz')
+
+query T kvtrace
+UPDATE inv SET c = 'fud' WHERE a IN (12, 13)
+----
+Scan /Table/55/1/1{2-3/#}
+Put /Table/55/1/12/0 -> /TUPLE/
+Del /Table/55/2/"a"/"b"/12/0
+Put /Table/55/1/13/0 -> /TUPLE/
+
+# ---------------------------------------------------------
+# UPSERT partial inverted index
+# ---------------------------------------------------------
+
+# Upsert a conflicting row with the same JSON as the existing row in the partial
+# index so that it remains in the partial index.
+query T kvtrace
+UPSERT INTO inv VALUES (4, '{"x": "y", "num": 4}', 'foo')
+----
+Scan /Table/55/1/4{-/#}
+Put /Table/55/1/4/0 -> /TUPLE/
+
+# Upsert a conflicting row with different JSON from the existing row in the
+# partial index.
+query T kvtrace
+UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'foo')
+----
+Scan /Table/55/1/4{-/#}
+Put /Table/55/1/4/0 -> /TUPLE/
+Del /Table/55/2/"num"/4/4/0
+InitPut /Table/55/2/"num"/6/4/0 -> /BYTES/
+
+# Upsert a conflicting row so that it is removed from the partial index.
+query T kvtrace
+UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'fud')
+----
+Scan /Table/55/1/4{-/#}
+Put /Table/55/1/4/0 -> /TUPLE/
+Del /Table/55/2/"num"/6/4/0
+Del /Table/55/2/"x"/"y"/4/0
+
+# Upsert a non-conflicting row that is added to the partial index.
+query T kvtrace
+UPSERT INTO inv VALUES (5, '{"x": "y", "num": 7}', 'bar')
+----
+Scan /Table/55/1/5{-/#}
+CPut /Table/55/1/5/0 -> /TUPLE/
+InitPut /Table/55/2/"num"/7/5/0 -> /BYTES/
+InitPut /Table/55/2/"x"/"y"/5/0 -> /BYTES/
+
+# Upsert a non-conflicting row that is not added to the partial index.
+query T kvtrace
+UPSERT INTO inv VALUES (6, '{"x": "y", "num": 8}', 'baz')
+----
+Scan /Table/55/1/6{-/#}
+CPut /Table/55/1/6/0 -> /TUPLE/
+
+# ---------------------------------------------------------
 # EXPLAIN
 # ---------------------------------------------------------
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -671,19 +671,37 @@ Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
 Del /Table/54/2/3/2/0
 CPut /Table/54/2/4/2/0 -> /BYTES/ (expecting does not exist)
 
-# ---------------------------------------------------------
-# INSERT partial inverted index
-# ---------------------------------------------------------
+# Tests for partial inverted indexes.
 
-# INVERTED INDEX (b) WHERE c IN ('foo', 'bar')
 statement ok
 CREATE TABLE inv (
     a INT PRIMARY KEY,
     b JSON,
     c STRING,
-    INVERTED INDEX (b) WHERE c IN ('foo', 'bar'),
+    INVERTED INDEX i (b) WHERE c IN ('foo', 'bar'),
     FAMILY (a, b, c)
 )
+
+# ---------------------------------------------------------
+# SELECT
+# ---------------------------------------------------------
+
+query T kvtrace
+SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
+----
+Scan /Table/55/2/"x"/"y"{-/PrefixEnd}
+
+query T kvtrace
+SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
+----
+Scan /Table/55/2/"x"/"y"{-/PrefixEnd}
+
+statement error index "i" is a partial inverted index and cannot be used for this query
+SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'baz'
+
+# ---------------------------------------------------------
+# INSERT partial inverted index
+# ---------------------------------------------------------
 
 query T kvtrace
 INSERT INTO inv VALUES (1, '{"x": "y", "num": 1}', 'foo')
@@ -878,3 +896,39 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t@b_partial (partial index)
 ·     spans          FULL SCAN
+
+query TTT
+EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
+----
+·     distribution   local
+·     vectorized     true
+scan  ·              ·
+·     missing stats  ·
+·     table          inv@i (partial index)
+·     spans          [/'{"x": "y"}' - /'{"x": "y"}']
+
+query TTT
+EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
+----
+·                distribution   local
+·                vectorized     true
+filter           ·              ·
+ │               filter         c = 'foo'
+ └── index join  ·              ·
+      │          table          inv@primary
+      └── scan   ·              ·
+·                missing stats  ·
+·                table          inv@i (partial index)
+·                spans          [/'{"x": "y"}' - /'{"x": "y"}']
+
+query TTT
+EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
+----
+·           distribution   local
+·           vectorized     true
+index join  ·              ·
+ │          table          inv@primary
+ └── scan   ·              ·
+·           missing stats  ·
+·           table          inv@i (partial index)
+·           spans          [/'{"x": "y"}' - /'{"x": "y"}']

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -487,6 +487,15 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 	// Add the geoConfig if applicable.
 	notNullIndex := true
 	for i, colDef := range def.Columns {
+		ordinal := tt.FindOrdinal(string(colDef.Column))
+		colType := tt.Columns[ordinal].DatumType()
+		if !def.Inverted && !colinfo.ColumnTypeIsIndexable(colType) {
+			panic(fmt.Errorf("column %s of type %s is not indexable", colDef.Column, colType))
+		}
+		if def.Inverted && i == 0 && !colinfo.ColumnTypeIsInvertedIndexable(colType) {
+			panic(fmt.Errorf("column %s of type %s is not inverted indexable", colDef.Column, colType))
+		}
+
 		col := idx.addColumn(tt, string(colDef.Column), colDef.Direction, keyCol)
 
 		if typ == primaryIndex && col.IsNullable() {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -345,9 +345,8 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 		// If the index is a partial index, check whether or not the filter
 		// implies the predicate.
 		_, isPartialIndex := md.Table(scanPrivate.Table).Index(iter.IndexOrdinal()).Predicate()
-		var pred memo.FiltersExpr
 		if isPartialIndex {
-			pred = memo.PartialIndexPredicate(tabMeta, iter.IndexOrdinal())
+			pred := memo.PartialIndexPredicate(tabMeta, iter.IndexOrdinal())
 			remainingFilters, ok := c.im.FiltersImplyPredicate(explicitFilters, pred)
 			if !ok {
 				// The filters do not imply the predicate, so the partial index
@@ -974,7 +973,7 @@ func (c *CustomFuncs) partitionValuesFilters(
 // the Scan operator's table.
 func (c *CustomFuncs) HasInvertedIndexes(scanPrivate *memo.ScanPrivate) bool {
 	// Don't bother matching unless there's an inverted index.
-	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonInvertedIndexes|rejectPartialIndexes)
+	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonInvertedIndexes)
 	return iter.Next()
 }
 
@@ -993,27 +992,42 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	sb.init(c, scanPrivate.Table)
 
 	// Iterate over all inverted indexes.
-	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonInvertedIndexes|rejectPartialIndexes)
+	md := c.e.mem.Metadata()
+	tabMeta := md.TableMeta(scanPrivate.Table)
+	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonInvertedIndexes)
 	for iter.Next() {
 		var spanExpr *invertedexpr.SpanExpression
 		var spansToRead invertedexpr.InvertedSpans
 		var constraint *constraint.Constraint
-		var remaining memo.FiltersExpr
 		var geoOk, nonGeoOk bool
+		remaining := filters
+
+		// If the index is a partial index, check whether or not the filter
+		// implies the predicate.
+		_, isPartialIndex := md.Table(scanPrivate.Table).Index(iter.IndexOrdinal()).Predicate()
+		if isPartialIndex {
+			pred := memo.PartialIndexPredicate(tabMeta, iter.IndexOrdinal())
+			remainingFilters, ok := c.im.FiltersImplyPredicate(remaining, pred)
+			if !ok {
+				// The filters do not imply the predicate, so the partial index
+				// cannot be used.
+				continue
+			}
+			remaining = remainingFilters
+		}
 
 		// Check whether the filter can constrain the index.
 		// TODO(rytaft): Unify these two cases so both return a spanExpr.
 		spanExpr, geoOk = invertedidx.TryConstrainGeoIndex(
-			c.e.evalCtx.Context, c.e.f, filters, scanPrivate.Table, iter.Index(),
+			c.e.evalCtx.Context, c.e.f, remaining, scanPrivate.Table, iter.Index(),
 		)
 		if geoOk {
-			// Geo index scans can never be tight, so remaining filters is always the
-			// same as filters.
-			remaining = filters
+			// Geo index scans can never be tight, so the remaining filters do
+			// not change.
 			spansToRead = spanExpr.SpansToRead
 		} else {
 			constraint, remaining, nonGeoOk = c.tryConstrainIndex(
-				filters,
+				remaining,
 				nil, /* optionalFilters */
 				scanPrivate.Table,
 				iter.IndexOrdinal(),

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2333,6 +2333,196 @@ project
       └── filters
            └── geom:3 ~ '01040000000200000001010000009A999999999901409A99999999990140010100000000000000000008400000000000000840' [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
+# Tests for partial inverted indexes.
+
+exec-ddl
+CREATE TABLE pi (
+    k INT PRIMARY KEY,
+    s STRING,
+    j JSON
+)
+----
+
+# Partial inverted index scan.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE s = 'foo'
+----
+
+opt
+SELECT k FROM pi WHERE j @> '{"a": "b"}' AND s = 'foo'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan pi@idx,partial
+      ├── columns: k:1!null
+      ├── constraint: /3/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Partial inverted index scan with indexed column in predicate.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE j @> '{"group": 1}'
+----
+
+opt
+SELECT k FROM pi WHERE j @> '{"a": "b"}' AND j @> '{"group": 1}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan pi@idx,partial
+      ├── columns: k:1!null
+      ├── constraint: /3/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Partial inverted index scan with index-join.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE s = 'foo'
+----
+
+opt
+SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'foo'
+----
+index-join pi
+ ├── columns: k:1!null s:2!null j:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ └── scan pi@idx,partial
+      ├── columns: k:1!null
+      ├── constraint: /3/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Partial inverted index scan with additional filters.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
+----
+
+opt
+SELECT * FROM pi WHERE j @> '{"a": "b"}' AND j @> '{"group": 1}' AND s = 'foo'
+----
+select
+ ├── columns: k:1!null s:2!null j:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join pi
+ │    ├── columns: k:1!null s:2 j:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan pi@idx,partial
+ │         ├── columns: k:1!null
+ │         ├── constraint: /3/1: [/'{"a": "b"}' - /'{"a": "b"}']
+ │         └── key: (1)
+ └── filters
+      ├── j:3 @> '{"group": 1}' [outer=(3), immutable]
+      └── s:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Generate multiple partial inverted index scans in the memo when the filter
+# implies multiple partial index predicates.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
+----
+
+exec-ddl
+CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
+----
+
+memo
+SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
+----
+memo (optimized, ~8KB, required=[presentation: k:1,s:2,j:3])
+ ├── G1: (select G2 G3) (select G4 G5) (index-join G6 pi,cols=(1-3))
+ │    └── [presentation: k:1,s:2,j:3]
+ │         ├── best: (index-join G6 pi,cols=(1-3))
+ │         └── cost: 9.63
+ ├── G2: (scan pi,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan pi,cols=(1-3))
+ │         └── cost: 1064.02
+ ├── G3: (filters G7 G8)
+ ├── G4: (index-join G9 pi,cols=(1-3))
+ │    └── []
+ │         ├── best: (index-join G9 pi,cols=(1-3))
+ │         └── cost: 15.24
+ ├── G5: (filters G8)
+ ├── G6: (scan pi@idx2,partial,cols=(1),constrained)
+ │    └── []
+ │         ├── best: (scan pi@idx2,partial,cols=(1),constrained)
+ │         └── cost: 5.14
+ ├── G7: (contains G10 G11)
+ ├── G8: (eq G12 G13)
+ ├── G9: (scan pi@idx,partial,cols=(1),constrained)
+ │    └── []
+ │         ├── best: (scan pi@idx,partial,cols=(1),constrained)
+ │         └── cost: 6.28
+ ├── G10: (variable j)
+ ├── G11: (const '{"a": "b"}')
+ ├── G12: (variable s)
+ └── G13: (const 'bar')
+
+exec-ddl
+DROP INDEX idx
+----
+
+exec-ddl
+DROP INDEX idx2
+----
+
+# Do not generate a partial inverted index scan when the predicate is not
+# implied by the filter.
+
+exec-ddl
+CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
+----
+
+memo expect-not=GenerateInvertedIndexScans
+SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'baz'
+----
+memo (optimized, ~5KB, required=[presentation: k:1,s:2,j:3])
+ ├── G1: (select G2 G3)
+ │    └── [presentation: k:1,s:2,j:3]
+ │         ├── best: (select G2 G3)
+ │         └── cost: 1074.05
+ ├── G2: (scan pi,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan pi,cols=(1-3))
+ │         └── cost: 1064.02
+ ├── G3: (filters G4 G5)
+ ├── G4: (contains G6 G7)
+ ├── G5: (eq G8 G9)
+ ├── G6: (variable j)
+ ├── G7: (const '{"a": "b"}')
+ ├── G8: (variable s)
+ └── G9: (const 'baz')
+
+exec-ddl
+DROP INDEX idx
+----
+
 # --------------------------------------------------
 # SplitDisjunction
 # --------------------------------------------------

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -70,11 +70,6 @@ var (
 	// PartialIndexCounter is to be incremented every time a partial index is
 	// created.
 	PartialIndexCounter = telemetry.GetCounterOnce("sql.schema.partial_index")
-
-	// PartialInvertedIndexErrorCounter is to be incremented every time a
-	// partial inverted index is attempted to be created, but fails because it
-	// is not yet supported.
-	PartialInvertedIndexErrorCounter = telemetry.GetCounterOnce("sql.schema.partial_inverted_index_error")
 )
 
 var (

--- a/pkg/sql/testdata/telemetry/partial_index
+++ b/pkg/sql/testdata/telemetry/partial_index
@@ -24,15 +24,13 @@ sql.schema.partial_index
 feature-usage
 CREATE TABLE c (i INT, j JSON, INVERTED INDEX (j) WHERE i > 0)
 ----
-error: pq: unimplemented: partial inverted indexes not supported
-sql.schema.partial_inverted_index_error
+sql.schema.partial_index
 
 exec
-CREATE TABLE c (i INT, j JSON)
+CREATE TABLE d (i INT, j JSON)
 ----
 
 feature-usage
-CREATE INVERTED INDEX i ON c (j) WHERE i > 0
+CREATE INVERTED INDEX i ON d (j) WHERE i > 0
 ----
-error: pq: unimplemented: partial inverted indexes not supported
-sql.schema.partial_inverted_index_error
+sql.schema.partial_index


### PR DESCRIPTION
#### sql: enable partial inverted indexes and add mutation tests

This commit allows partial inverted indexes to be created. It also adds
exec-builder tests for mutations.

Note that the optimizer does not currently generate query plans that
scan partial inverted indexes. This is left for a future commit.

Release note: None

#### testcat: panic when creating indexes on invalid column types

Attempting to create indexes on invalid column types in opt tests will
now panic. Previously, it was possible to create an inverted index on
columns that could only be indexed by a non-inverted index. It was also
possible to create a non-inverted index on columns that could only be
indexed by an inverted index.

If a contributor wrote a test with an invalid index, the optimizer would
not error and produce invalid plans, which could lead to confusion.
Panicking should help prevent future confusion.

Release note: None

#### opt: generate partial inverted index scans

This commit updates the GenerateInvertedIndexScans transformation rule
so that inverted index scans are generated over partial indexes when the
filters imply the partial index predicate.

Informs #50952

Release note (sql change): It is now possible to create partial inverted
indexes. The optimizer will choose to scan partial inverted indexes when
the partial index predicate is implied and scanning the inverted index
has the lowest estimated cost.
