### PR TITLE
release-20.2: sql/catalog: disallow uncached resolution of draining names

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6206,3 +6206,58 @@ CREATE INDEX i ON t.test (a) WHERE b > 2
 		t.Errorf("partial index contains an incorrect number of keys: expected %d, but found %d", expectedNumKeys, numKeys)
 	}
 }
+
+// TestDrainingNamesCannotBeResolved tests that during the draining names state
+// for renamed descriptors, old names cannot be used via the uncached name
+// resolution path.
+func TestDrainingNamesCannotBeResolved(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		// Don't drain names. This also means that we don't wait for leases to
+		// drain before returning, which is fine since we're testing the non-
+		// leased name resolution path.
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			SchemaChangeJobNoOp: func() bool { return true },
+		},
+		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+			TypeSchemaChangeJobNoOp: func() bool { return true },
+		},
+	}
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create descriptors and rename them so that the old names get stuck as
+	// draining names.
+	sqlRun.Exec(t, `
+CREATE TABLE tbl();
+ALTER TABLE tbl RENAME TO tbl2;
+
+CREATE TYPE typ AS ENUM();
+ALTER TYPE typ RENAME TO typ2;
+
+CREATE SCHEMA sc;
+ALTER SCHEMA sc RENAME TO sc2;
+
+CREATE DATABASE db;
+ALTER DATABASE db RENAME TO db2;
+`)
+
+	// Ensure that the old namespace entries still exist.
+	sqlRun.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'tbl'`, [][]string{{"1"}})
+	sqlRun.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'typ'`, [][]string{{"1"}})
+	sqlRun.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'sc'`, [][]string{{"1"}})
+	sqlRun.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'db'`, [][]string{{"1"}})
+
+	// Test uncached name resolution by attempting schema changes. As of 20.2 we
+	// have some internal inconsistency in error messages.
+	sqlRun.ExpectErr(t, `relation "tbl" does not exist`, `ALTER TABLE tbl RENAME TO tbl3`)
+	sqlRun.ExpectErr(t, `type "typ" does not exist`, `ALTER TYPE typ RENAME TO typ3`)
+	sqlRun.ExpectErr(t, `unknown schema "sc"`, `ALTER SCHEMA sc RENAME TO sc3`)
+	sqlRun.ExpectErr(t, `database "db" does not exist`, `ALTER DATABASE db RENAME TO db3`)
+}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -106,6 +106,8 @@ type typeSchemaChanger struct {
 
 // TypeSchemaChangerTestingKnobs contains testing knobs for the typeSchemaChanger.
 type TypeSchemaChangerTestingKnobs struct {
+	// TypeSchemaChangeJobNoOp returning true will cause the job to be a no-op.
+	TypeSchemaChangeJobNoOp func() bool
 	// RunBeforeExec runs at the start of the typeSchemaChanger.
 	RunBeforeExec func() error
 	// RunBeforeEnumMemberPromotion runs before enum members are promoted from
@@ -273,9 +275,15 @@ type typeChangeResumer struct {
 func (t *typeChangeResumer) Resume(
 	ctx context.Context, phs interface{}, _ chan<- tree.Datums,
 ) error {
+	p := phs.(*planner)
+	if p.execCfg.TypeSchemaChangerTestingKnobs.TypeSchemaChangeJobNoOp != nil {
+		if p.execCfg.TypeSchemaChangerTestingKnobs.TypeSchemaChangeJobNoOp() {
+			return nil
+		}
+	}
 	tc := &typeSchemaChanger{
 		typeID:  t.job.Details().(jobspb.TypeSchemaChangeDetails).TypeID,
-		execCfg: phs.(*planner).execCfg,
+		execCfg: p.execCfg,
 	}
 	return tc.execWithRetry(ctx)
 }


### PR DESCRIPTION
Backport 1/1 commits from #54213.

/cc @cockroachdb/release

---

Previously, when table descriptors were read from the store in the
`UncachedPhysicalAccessor`, we would reject the descriptor if the
requested name didn't match the current name, which happens when the
namespace entry for the old draining name still exists. This change
updates all other descriptor types to have the same behavior.

The old behavior for non-table descriptors is arguably not incorrect,
since both names are valid during the draining names state, but the
behavior should be consistent.

Release justification: Bug fixes to new functionality

Release note (sql change): This is a change from earlier 20.2 beta
releases. After renaming a database, schema, or type, the old names are
immediately inaccessible from other sessions when referred to in schema
change statements as soon as the new name is committed. This matches the
existing behavior for tables.
