### PR TITLE
ui: Validate jobs duration calculation for DateRange component

### DIFF
--- a/pkg/ui/src/util/convert.ts
+++ b/pkg/ui/src/util/convert.ts
@@ -35,11 +35,15 @@ export function SecondsToNano(sec: number): number {
 
 /**
  * TimestampToMoment converts a Timestamp$Properties object, as seen in wire.proto, to
- * a Moment object. If timestamp is null, it returns the current time.
+ * a Moment object. If timestamp is null, it returns the `defaultsIfNull` value which is
+ * by default is current time.
  */
-export function TimestampToMoment(timestamp?: protos.google.protobuf.ITimestamp): moment.Moment {
+export function TimestampToMoment(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultsIfNull = moment.utc(),
+): moment.Moment {
   if (!timestamp) {
-    return moment.utc();
+    return defaultsIfNull;
   }
   return moment.utc((timestamp.seconds.toNumber() * 1e3) + NanoToMilli(timestamp.nanos));
 }


### PR DESCRIPTION
Resolves #52727

Jobs duration was calculated with the use of `TimestampToMoment` function which
parsed input `null` values to current date. It caused following issues:
- if `started` date is null, then it converted to date now and it became
bigger than `modified` or `finished` dates which are not possible. And as a result
duration became negative value;
- if `modified` or `finished` dates are null values, then with every page refresh
their values calculated with new current date and duration values increase.

With this fix, `TimestampToMoment` function accepts optional argument
`defaultsIfNull` to specify how to treat nullable input date values.
And then duration is calculated only if `started` is present and when
`modified`/`finished` dates are present depending on job status.

In addition, "Waiting for GG TCL" label is removed for jobs in pending status, the only badge is shown as a status indicator.
<img width="1412" alt="Screen Shot 2020-09-24 at 9 44 27 PM" src="https://user-images.githubusercontent.com/3106437/94186543-7e4e1600-feaf-11ea-93e8-7f8e8d3878be.png">
