### PR TITLE
release-20.2: backupccl: change CREATE SCHEDULE output `name` column to `label`

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -558,7 +558,7 @@ func makeScheduledBackupEval(
 // scheduledBackupHeader is the header for "CREATE SCHEDULE..." statements results.
 var scheduledBackupHeader = colinfo.ResultColumns{
 	{Name: "schedule_id", Typ: types.Int},
-	{Name: "name", Typ: types.String},
+	{Name: "label", Typ: types.String},
 	{Name: "status", Typ: types.String},
 	{Name: "first_run", Typ: types.TimestampTZ},
 	{Name: "schedule", Typ: types.String},


### PR DESCRIPTION
Backport 1/1 commits from #54353.

/cc @cockroachdb/release

---

This change makes the output of the CREATE SCHEDULE statement more
in line with SHOW SCHEDULES. Since #53129 a scheduled job has a
"label" not a "name" to establish more accurate user expectations.

Fixes: #54210

Release note (sql change): CREATE SCHEDULE output now has a column
called `label` which was previously called `name`.
