### PR TITLE
release-20.2: backupccl,importccl: only reset ModificationTime on tables after upgrade

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -975,8 +975,12 @@ func prepareNewTableDescsForIngestion(
 		}
 		seqVals[id] = tableDesc.SeqVal
 	}
-
-	if err := backupccl.RewriteTableDescs(newMutableTableDescriptors, tableRewrites, ""); err != nil {
+	// TODO(ajwerner): Remove this in 21.1.
+	canResetModTime := p.ExecCfg().Settings.Version.IsActive(
+		ctx, clusterversion.VersionLeasedDatabaseDescriptors)
+	if err := backupccl.RewriteTableDescs(
+		newMutableTableDescriptors, tableRewrites, "", canResetModTime,
+	); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #54363.

/cc @cockroachdb/release

---

In #54296 we began resetting the version and modification time for all newly
added descriptors. This is fine for the descriptors which did not exist or
have those fields in 20.1 (schema, type, db). For tables however, this is not
okay because code in release 20.1 is missing a check added in the 20.2 cycle
to allow a missing modification time for version 1. This breaks restore and
import in the mixed version state.

This PR gates the resetting of modification time on the cluster version. I
have verified that this fixes the jobs/mixed-version roachtest which previously
failed deterministically due to this bug.

No release note because we haven't shipped this bug.

Fixes #54319.

Release note: None
