### PR TITLE
sql: set planner database scope of SchemaChanger to descriptor db

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -362,3 +362,13 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Regression test for #53819
+statement ok
+CREATE SEQUENCE regression_53819_seq;
+CREATE TABLE regression_53819_table AS SELECT nextval('regression_53819_seq')
+
+query I
+SELECT * FROM regression_53819_table
+----
+2

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -149,3 +149,21 @@ REFRESH MATERIALIZED VIEW with_options WITH NO DATA
 
 query I
 SELECT * FROM with_options
+
+# Regression test for #53819
+statement ok
+CREATE SEQUENCE regression_53819_seq;
+CREATE MATERIALIZED VIEW regression_53819_mat_view AS SELECT nextval('regression_53819_seq')
+
+query I
+SELECT * FROM regression_53819_mat_view
+----
+1
+
+statement ok
+REFRESH MATERIALIZED VIEW regression_53819_mat_view WITH DATA
+
+query I
+SELECT * FROM regression_53819_mat_view
+----
+2

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -249,6 +249,16 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			return err
 		}
 
+		// Set the database in SessionData to the database in the descriptor.
+		// This is otherwise the system table which can result with issues in functions such as nextval,
+		// which relies on the planner scope being the same as the scope that ran the initial schema
+		// query.
+		db, err := catalogkv.GetDatabaseDescByID(ctx, txn, sc.execCfg.Codec, table.GetParentID())
+		if err != nil {
+			return err
+		}
+		localPlanner.sessionDataMutator.SetDatabase(db.Name)
+
 		// Construct an optimized logical plan of the AS source stmt.
 		localPlanner.stmt = &Statement{Statement: stmt}
 		localPlanner.optPlanningCtx.init(localPlanner)


### PR DESCRIPTION
Resolves #53819. Unsure about whether we should backport this.

Release note (bug fix): Previously, using builtins which referenced
other tables (e.g. nextval) in a CREATE TABLE AS or CREATE MATERIALIZED
VIEW would error. This has been resolved.