### PR TITLE
ui: s/"query"/"statement"/ in sessions page

### DIFF
--- a/pkg/ui/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/src/views/sessions/sessionsPage.tsx
@@ -60,7 +60,7 @@ export class SessionsPage extends React.Component<SessionsPageProps, SessionsPag
     super(props);
     const defaultState = {
       sortSetting: {
-        sortKey: 2, // Sort by Query Age column as default option.
+        sortKey: 2, // Sort by Statement Age column as default option.
         ascending: false,
       },
       pagination: {

--- a/pkg/ui/src/views/sessions/sessionsTable.tsx
+++ b/pkg/ui/src/views/sessions/sessionsTable.tsx
@@ -67,7 +67,7 @@ export function makeSessionsColumns(
         if (session.session.active_queries?.length > 0) {
           return AgeLabel({
             start: TimestampToMoment(session.session.active_queries[0].start),
-            thingName: "Query",
+            thingName: "Statement",
           });
         }
         return "N/A";
@@ -124,7 +124,7 @@ export function makeSessionsColumns(
                   }
                 }}
               >
-                Terminate Query
+                Terminate Statement
               </Anchor>
             </Menu.Item>
             <Menu.Item>

--- a/pkg/ui/src/views/sessions/sessionsTableContent.tsx
+++ b/pkg/ui/src/views/sessions/sessionsTableContent.tsx
@@ -97,7 +97,7 @@ export const SessionTableTitle = {
         </div>
       }
     >
-      Query Age
+      Statement Age
     </Tooltip>
   ),
   memUsage: (

--- a/pkg/ui/src/views/sessions/terminateQueryModal.tsx
+++ b/pkg/ui/src/views/sessions/terminateQueryModal.tsx
@@ -55,10 +55,10 @@ const TerminateQueryModal = (props: TerminateQueryModalProps, ref: React.RefObje
       onCancel={onCancelHandler}
       okText="Yes"
       cancelText="No"
-      title="Terminate the Query?"
+      title="Terminate the Statement?"
     >
       <Text>
-        Terminating a query ends the query, returning an error to the session.
+        Terminating a statement ends the statement, returning an error to the session.
       </Text>
     </Modal>
   );


### PR DESCRIPTION
Remove unclear use of "query" when "statement" is more appropriate, on
the new sessions page

cc @vy-ton 

Release note: None
Release justification: low risk change to new functionality