### PR TITLE
sql: exempt `SET` statements from the statement_timeout

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -400,7 +400,9 @@ func (ex *connExecutor) execStmtInOpenState(
 		return ev, payload, nil
 	}
 
-	if ex.sessionData.StmtTimeout > 0 {
+	// We exempt `SET` statements from the statement timeout, particularly so as
+	// not to block the `SET statement_timeout` command itself.
+	if ex.sessionData.StmtTimeout > 0 && stmt.AST.StatementTag() != "SET" {
 		timerDuration := ex.sessionData.StmtTimeout - timeutil.Since(ex.phaseTimes[sessionQueryReceived])
 		// There's no need to proceed with execution if the timer has already expired.
 		if timerDuration < 0 {

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -290,6 +290,25 @@ SHOW statement_timeout
 ----
 100
 
+# Set the statement timeout to something absurdly small, so that no query would
+# presumably be able to go through. It should still be possible to get out of
+# this "bad state" by resetting the statement timeout.
+subtest impossible_statement_timeout_recovery
+
+statement ok
+SET statement_timeout = '1us'
+
+statement error query execution canceled due to statement timeout
+SHOW statement_timeout
+
+statement ok
+SET statement_timeout = 0
+
+query T
+SHOW statement_timeout
+----
+0
+
 # Test that composite variable names get rejected properly, especially
 # when "tracing" is used as prefix.
 


### PR DESCRIPTION
Previously, if a user set a really low statement_timeout value, there
would be no way to reset it/remove the statement_timeout entirely. To
get around this, all `SET` statements are now exempt from the statement
timeout.This should also fix some of the flakes we were seeing in
checks were decoupled in #53968. `SET` statements aren't canceled as no
one checks for a canceled context, which meant this exemption existed
implicitly before #53968.

Closes #54372

Release note: None