### PR TITLE
vendor: Bump pebble to 08b545a1f5403e31a76b48f46a780c8d59432f57

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200910205826-d7a278abeed4
+	github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540
 	github.com/cockroachdb/redact v1.0.6
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200910205826-d7a278abeed4 h1:7lCGHHElrKF6cNcDsZUPORkjqFOJfCgm3TtzqHogGaQ=
-github.com/cockroachdb/pebble v0.0.0-20200910205826-d7a278abeed4/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540 h1:eBX0kuZHgURpBqr23FWSnjrf9HQ1FJGZpJ4NbbbY1DM=
+github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=


### PR DESCRIPTION
Changes pulled in:

```
08b545a1f5403e31a76b48f46a780c8d59432f57 compaction: Invalidate limit when a splitter defers a split suggestion
6e5e695d8b1c33c0c4687bd7e804e9aaac66d9dd db: remove unused compaction.maxExpandedBytes
```

Fixes #54284.

Release note: None.