### PR TITLE
sql: add telemetry for partial indexes

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -350,6 +350,7 @@ func MakeIndexDescriptor(
 
 	if n.Predicate != nil {
 		if n.Inverted {
+			telemetry.Inc(sqltelemetry.PartialInvertedIndexErrorCounter)
 			return nil, unimplemented.NewWithIssue(50952, "partial inverted indexes not supported")
 		}
 
@@ -359,6 +360,7 @@ func MakeIndexDescriptor(
 			return nil, err
 		}
 		indexDesc.Predicate = expr
+		telemetry.Inc(sqltelemetry.PartialIndexCounter)
 	}
 
 	if err := indexDesc.FillColumns(n.Columns); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1555,6 +1555,7 @@ func NewTableDesc(
 			}
 			if d.Predicate != nil {
 				if d.Inverted {
+					telemetry.Inc(sqltelemetry.PartialInvertedIndexErrorCounter)
 					return nil, unimplemented.NewWithIssue(50952, "partial inverted indexes not supported")
 				}
 
@@ -1563,6 +1564,7 @@ func NewTableDesc(
 					return nil, err
 				}
 				idx.Predicate = expr
+				telemetry.Inc(sqltelemetry.PartialIndexCounter)
 			}
 			if err := applyStorageParameters(
 				ctx,
@@ -1611,6 +1613,7 @@ func NewTableDesc(
 					return nil, err
 				}
 				idx.Predicate = expr
+				telemetry.Inc(sqltelemetry.PartialIndexCounter)
 			}
 			if err := desc.AddIndex(idx, d.PrimaryKey); err != nil {
 				return nil, err

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -649,6 +649,13 @@ func (s *ScanPrivate) PartialIndexPredicate(md *opt.Metadata) FiltersExpr {
 	return PartialIndexPredicate(tabMeta, s.Index)
 }
 
+// UsesPartialIndex returns true if the the LookupJoinPrivate looks-up via a
+// partial index.
+func (lj *LookupJoinPrivate) UsesPartialIndex(md *opt.Metadata) bool {
+	_, isPartialIndex := md.Table(lj.Table).Index(lj.Index).Predicate()
+	return isPartialIndex
+}
+
 // NeedResults returns true if the mutation operator can return the rows that
 // were mutated.
 func (m *MutationPrivate) NeedResults() bool {

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -150,6 +150,14 @@ var JoinTypeSemiUseCounter = telemetry.GetCounterOnce("sql.plan.opt.node.join.ty
 // planned.
 var JoinTypeAntiUseCounter = telemetry.GetCounterOnce("sql.plan.opt.node.join.type.anti")
 
+// PartialIndexScanUseCounter is to be incremented whenever a partial index scan
+// node is planned.
+var PartialIndexScanUseCounter = telemetry.GetCounterOnce("sql.plan.opt.partial-index.scan")
+
+// PartialIndexLookupJoinUseCounter is to be incremented whenever a lookup join
+// on a partial index is planned.
+var PartialIndexLookupJoinUseCounter = telemetry.GetCounterOnce("sql.plan.opt.partial-index.lookup-join")
+
 // CancelQueriesUseCounter is to be incremented whenever CANCEL QUERY or
 // CANCEL QUERIES is run.
 var CancelQueriesUseCounter = telemetry.GetCounterOnce("sql.session.cancel-queries")

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -66,6 +66,15 @@ var (
 	// geometry inverted index is created. These are a subset of the
 	// indexes counted in InvertedIndexCounter.
 	GeometryInvertedIndexCounter = telemetry.GetCounterOnce("sql.schema.geometry_inverted_index")
+
+	// PartialIndexCounter is to be incremented every time a partial index is
+	// created.
+	PartialIndexCounter = telemetry.GetCounterOnce("sql.schema.partial_index")
+
+	// PartialInvertedIndexErrorCounter is to be incremented every time a
+	// partial inverted index is attempted to be created, but fails because it
+	// is not yet supported.
+	PartialInvertedIndexErrorCounter = telemetry.GetCounterOnce("sql.schema.partial_inverted_index_error")
 )
 
 var (

--- a/pkg/sql/testdata/telemetry/partial_index
+++ b/pkg/sql/testdata/telemetry/partial_index
@@ -1,0 +1,38 @@
+# This file contains telemetry tests for sql.schema partial index creation
+# counters.
+
+feature-allowlist
+sql.schema.partial_index
+sql.schema.partial_inverted_index_error
+----
+
+feature-usage
+CREATE TABLE a (i INT, INDEX (i) WHERE i > 0)
+----
+sql.schema.partial_index
+
+feature-usage
+CREATE TABLE b (i INT, UNIQUE INDEX (i) WHERE i > 0)
+----
+sql.schema.partial_index
+
+feature-usage
+CREATE INDEX i ON b (i) WHERE i < 0
+----
+sql.schema.partial_index
+
+feature-usage
+CREATE TABLE c (i INT, j JSON, INVERTED INDEX (j) WHERE i > 0)
+----
+error: pq: unimplemented: partial inverted indexes not supported
+sql.schema.partial_inverted_index_error
+
+exec
+CREATE TABLE c (i INT, j JSON)
+----
+
+feature-usage
+CREATE INVERTED INDEX i ON c (j) WHERE i > 0
+----
+error: pq: unimplemented: partial inverted indexes not supported
+sql.schema.partial_inverted_index_error

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -222,3 +222,25 @@ NATURAL INNER MERGE JOIN (SELECT * FROM x WHERE a > 0) AS x2
 ----
 sql.plan.opt.node.join.algo.merge
 sql.plan.opt.node.join.type.inner
+
+# Tests for partial index counters.
+
+feature-allowlist
+sql.plan.opt.partial-index.scan
+sql.plan.opt.partial-index.lookup-join
+----
+
+exec
+CREATE INDEX i ON x (a) WHERE a > 0
+----
+
+feature-usage
+SELECT a FROM x@i WHERE a > 0
+----
+sql.plan.opt.partial-index.scan
+
+feature-usage
+SELECT x1.a FROM x x1 INNER LOOKUP JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0
+----
+sql.plan.opt.partial-index.lookup-join
+sql.plan.opt.partial-index.scan


### PR DESCRIPTION
#### sql: add telemetry for partial index creation

This commit adds telemetry counters for the creation of partial index. A
counter is also added for the failed creation of a partial inverted
index.

Release note: None

#### opt: add telemetry for partial index usage

This commit adds telemetry counters for the usage of a partial index,
either in a scan or a lookup join.

Release note: None
