### PR TITLE
release-20.2: sql/catalog/descs: don't hydrate dropped tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1162,6 +1162,25 @@ uds    typ        schema
 statement error pq: cannot create "fakedb.typ" because the target database or schema does not exist
 CREATE TYPE fakedb.typ AS ENUM ('schema')
 
+# Regression test that hydrating descriptors does not happen on dropped
+# descriptors. See #54343.
+
+subtest dropped_database_with_enum
+
+statement ok
+CREATE DATABASE to_drop;
+USE to_drop;
+CREATE TYPE greeting AS ENUM ('hi');
+CREATE TABLE t(a greeting);
+USE defaultdb;
+DROP DATABASE to_drop CASCADE;
+
+# Before the bug-fix which introduced this test, this call would load all
+# descriptors, including dropped ones, and hydrate them, causing a panic as
+# the referenced type no longer exists.
+statement ok
+SELECT * FROM crdb_internal.tables;
+
 # Test the behavior of dropping a not-null enum colums
 
 subtest drop_not_null


### PR DESCRIPTION
Backport 1/1 commits from #54358.

/cc @cockroachdb/release

---

The invariant that types referenced by tables only exists for non-dropped
tables. We were not checking the state of the table when choosing to hydrate.
This lead to pretty catastropic failures when the invariant was violated.

Fixes #54343.

Release note (bug fix): Fixed bug from earlier alphas where dropping a database
which contained tables using user-defined types could result in panics.
