### PR TITLE
release-20.2: sql: fix dropping of NOT NULL enum columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1161,3 +1161,44 @@ uds    typ        schema
 
 statement error pq: cannot create "fakedb.typ" because the target database or schema does not exist
 CREATE TYPE fakedb.typ AS ENUM ('schema')
+
+# Test the behavior of dropping a not-null enum colums
+
+subtest drop_not_null
+
+statement ok
+CREATE TYPE enum_with_vals AS ENUM ('val', 'other_val');
+
+statement ok
+CREATE TABLE table_with_not_null_enum (i INT PRIMARY KEY, v enum_with_vals NOT NULL);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE table_with_not_null_enum DROP COLUMN v;
+
+statement ok
+INSERT INTO table_with_not_null_enum VALUES (1);
+
+statement ok
+COMMIT; DROP TABLE table_with_not_null_enum; DROP TYPE enum_with_vals;
+
+statement ok
+CREATE TYPE enum_with_no_vals AS ENUM ();
+
+statement ok
+CREATE TABLE table_with_not_null_enum_no_vals (i INT PRIMARY KEY, v enum_with_no_vals NOT NULL);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE table_with_not_null_enum_no_vals DROP COLUMN v;
+
+statement error enum_with_no_vals has no values which can be used to satisfy the NOT NULL constraint while adding or dropping
+INSERT INTO table_with_not_null_enum_no_vals VALUES (1);
+
+statement ok
+ROLLBACK; DROP TABLE table_with_not_null_enum_no_vals; DROP TYPE enum_with_no_vals;
+


### PR DESCRIPTION
Backport 1/1 commits from #54354.

/cc @cockroachdb/release

---

I added enums to the random schemachange workload and it hit a fun scenario.
If we recall https://github.com/cockroachdb/cockroach/issues/42459#issuecomment-600139293
we decided to have default "zero" values for columns which are in the process
of being dropped (being added is fine because you have to have a default). We
didn't extend this for enums. Enums are a bit awkward here. Given that we know
the column is going to be dropped, I'm thinking it is okay to put an arbitrary
value, the smallest one. Alternatively we could return an error. Error seems
worse but I'd love somebody to tell me writing the smallest value seems sane.

Unfortunately there's an edge case when dealing with an enum that has no
values. In that case, we have to return an error, but it's sort of okay (sort
of) because nobody could write to the table.

Release note (bug fix): Fixed a bug which would cause an internal error when
writing to a table with a recently (concurrent or in the same transaction)
NOT NULL enum column.
