### PR TITLE
release-20.2: backport various standalone geospatial builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1653,6 +1653,12 @@ Bottom Left.</p>
 </span></td></tr>
 <tr><td><a name="st_forcepolygoncw"></a><code>st_forcepolygoncw(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry where all Polygon objects have exterior rings in the clockwise orientation and interior rings in the counter-clockwise orientation. Non-Polygon objects are unchanged.</p>
 </span></td></tr>
+<tr><td><a name="st_frechetdistance"></a><code>st_frechetdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Frechet distance between the given geometries.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_frechetdistance"></a><code>st_frechetdistance(geometry_a: geometry, geometry_b: geometry, densify_frac: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Frechet distance between the given geometries, with the given segment densification (range 0.0-1.0, -1 to disable).</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkt"></a><code>st_geogfromewkt(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKT representation.</p>
@@ -1717,6 +1723,12 @@ Bottom Left.</p>
 <tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(bytes: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation with the given SRID set.</p>
 </span></td></tr>
 <tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation.</p>
+</span></td></tr>
+<tr><td><a name="st_hausdorffdistance"></a><code>st_hausdorffdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Hausdorff distance between the given geometries.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_hausdorffdistance"></a><code>st_hausdorffdistance(geometry_a: geometry, geometry_b: geometry, densify_frac: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Hausdorff distance between the given geometries, with the given segment densification (range 0.0-1.0).</p>
+<p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_interiorringn"></a><code>st_interiorringn(geometry: geometry, n: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the n-th (1-indexed) interior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon, or the ring does not exist.</p>
 </span></td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1377,6 +1377,9 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_azimuth"></a><code>st_azimuth(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the azimuth in radians of the segment defined by the given point geometries, or NULL if the two points are coincident.</p>
 <p>The azimuth is angle is referenced from north, and is positive clockwise: North = 0; East = π/2; South = π; West = 3π/2.</p>
 </span></td></tr>
+<tr><td><a name="st_boundary"></a><code>st_boundary(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the closure of the combinatorial boundary of this Geometry.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
 <tr><td><a name="st_box2dfromgeohash"></a><code>st_box2dfromgeohash(geohash: <a href="string.html">string</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Return a Box2D from a GeoHash string with max precision.</p>
 </span></td></tr>
 <tr><td><a name="st_box2dfromgeohash"></a><code>st_box2dfromgeohash(geohash: <a href="string.html">string</a>, precision: <a href="int.html">int</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Return a Box2D from a GeoHash string with supplied precision.</p>
@@ -1548,6 +1551,9 @@ from the given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_dfullywithinexclusive"></a><code>st_dfullywithinexclusive(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units, exclusive. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than distance units.</p>
 <p>This function variant will attempt to utilize any available spatial index.</p>
+</span></td></tr>
+<tr><td><a name="st_difference"></a><code>st_difference(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the difference of two Geometries.</p>
+<p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_dimension"></a><code>st_dimension(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of topological dimensions of a given Geometry.</p>
 </span></td></tr>
@@ -1985,6 +1991,9 @@ East is azimuth π/2 (90 degrees); south is azimuth π (180 degrees); west is az
 Negative azimuth values and values greater than 2π (360 degrees) are supported.</p>
 </span></td></tr>
 <tr><td><a name="st_relate"></a><code>st_relate(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the DE-9IM spatial relation between geometry_a and geometry_b.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_relate"></a><code>st_relate(geometry_a: geometry, geometry_b: geometry, bnr: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the DE-9IM spatial relation between geometry_a and geometry_b using the given boundary node rule (1:OGC/MOD2, 2:Endpoint, 3:MultivalentEndpoint, 4:MonovalentEndpoint).</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_relate"></a><code>st_relate(geometry_a: geometry, geometry_b: geometry, pattern: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the DE-9IM spatial relation between geometry_a and geometry_b matches the DE-9IM pattern.</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1844,6 +1844,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_maxdistance"></a><code>st_maxdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the maximum distance across every pair of points comprising the given geometries. Note if the geometries are the same, it will return the maximum distance between the geometry’s vertexes.</p>
 </span></td></tr>
+<tr><td><a name="st_minimumclearance"></a><code>st_minimumclearance(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the minimum distance a vertex can move before producing an invalid geometry. Returns Infinity if no minimum clearance can be found (e.g. for a single point).</p>
+</span></td></tr>
+<tr><td><a name="st_minimumclearanceline"></a><code>st_minimumclearanceline(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a LINESTRING spanning the minimum distance a vertex can move before producing an invalid geometry. If no minimum clearance can be found (e.g. for a single point), an empty LINESTRING is returned.</p>
+</span></td></tr>
 <tr><td><a name="st_mlinefromtext"></a><code>st_mlinefromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not MultiLineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_mlinefromtext"></a><code>st_mlinefromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not MultiLineString, NULL is returned.</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1979,6 +1979,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_polyfromwkb"></a><code>st_polyfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation with an SRID. If the shape underneath is not Polygon, NULL is returned.</p>
 </span></td></tr>
+<tr><td><a name="st_polygon"></a><code>st_polygon(geometry: geometry, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Polygon from the given LineString and sets its SRID. It is equivalent to ST_MakePolygon with a single argument followed by ST_SetSRID.</p>
+</span></td></tr>
 <tr><td><a name="st_polygonfromtext"></a><code>st_polygonfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not Polygon, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_polygonfromtext"></a><code>st_polygonfromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not Polygon, NULL is returned.</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1241,6 +1241,12 @@ has no relationship with the commit order of concurrent transactions.</p>
 | d  e  y_off |  | y |
 \ 0  0      1 /  \ 0 /</p>
 </span></td></tr>
+<tr><td><a name="st_angle"></a><code>st_angle(line1: geometry, line2: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the clockwise angle between two LINESTRING geometries, treating them as vectors between their start- and endpoints. Returns NULL if any vectors have 0 length.</p>
+</span></td></tr>
+<tr><td><a name="st_angle"></a><code>st_angle(point1: geometry, point2: geometry, point3: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the clockwise angle between the vectors formed by point2,point1 and point2,point3. The arguments must be POINT geometries. Returns NULL if any vectors have 0 length.</p>
+</span></td></tr>
+<tr><td><a name="st_angle"></a><code>st_angle(point1: geometry, point2: geometry, point3: geometry, point4: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the clockwise angle between the vectors formed by point1,point2 and point3,point4. The arguments must be POINT geometries. Returns NULL if any vectors have 0 length.</p>
+</span></td></tr>
 <tr><td><a name="st_area"></a><code>st_area(geography: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the area of the given geography in meters^2. Uses a spheroid to perform the operation.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/angle.go
+++ b/pkg/geo/geomfn/angle.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// Angle calculates the clockwise angle between two vectors given by points
+// p1,p2 and p3,p4. If p4 is an empty geometry (of any type, to follow PostGIS
+// behavior), it instead calculates the clockwise angle between p2,p1 and p2,p3.
+func Angle(g1, g2, g3, g4 geo.Geometry) (*float64, error) {
+	if g4.Empty() {
+		g1, g2, g3, g4 = g2, g1, g2, g3
+	}
+
+	if g1.SRID() != g2.SRID() {
+		return nil, geo.NewMismatchingSRIDsError(g1.SpatialObject(), g2.SpatialObject())
+	}
+	if g1.SRID() != g3.SRID() {
+		return nil, geo.NewMismatchingSRIDsError(g1.SpatialObject(), g3.SpatialObject())
+	}
+	if g1.SRID() != g4.SRID() {
+		return nil, geo.NewMismatchingSRIDsError(g1.SpatialObject(), g4.SpatialObject())
+	}
+
+	t1, err := g1.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	t2, err := g2.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	t3, err := g3.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	t4, err := g4.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	p1, p1ok := t1.(*geom.Point)
+	p2, p2ok := t2.(*geom.Point)
+	p3, p3ok := t3.(*geom.Point)
+	p4, p4ok := t4.(*geom.Point)
+
+	if !p1ok || !p2ok || !p3ok || !p4ok {
+		return nil, errors.New("arguments must be POINT geometries")
+	}
+	if p1.Empty() || p2.Empty() || p3.Empty() || p4.Empty() {
+		return nil, errors.New("received EMPTY geometry")
+	}
+
+	return angleFromCoords(p1.Coords(), p2.Coords(), p3.Coords(), p4.Coords()), nil
+}
+
+// AngleLineString calculates the clockwise angle between two linestrings,
+// treating them as vectors between the start- and endpoints. Type conflicts
+// or empty geometries return nil (as opposed to Angle which errors), to
+// follow PostGIS behavior.
+func AngleLineString(g1, g2 geo.Geometry) (*float64, error) {
+	if g1.SRID() != g2.SRID() {
+		return nil, geo.NewMismatchingSRIDsError(g1.SpatialObject(), g2.SpatialObject())
+	}
+	t1, err := g1.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	t2, err := g2.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	l1, l1ok := t1.(*geom.LineString)
+	l2, l2ok := t2.(*geom.LineString)
+	if !l1ok || !l2ok || l1.Empty() || l2.Empty() {
+		return nil, nil // follow PostGIS behavior
+	}
+	return angleFromCoords(
+		l1.Coord(0), l1.Coord(l1.NumCoords()-1), l2.Coord(0), l2.Coord(l2.NumCoords()-1)), nil
+}
+
+// angleFromCoords returns the clockwise angle between the vectors c1,c2 and
+// c3,c4. For compatibility with PostGIS, it returns nil if any vectors have
+// length 0.
+func angleFromCoords(c1, c2, c3, c4 geom.Coord) *float64 {
+	a := coordSub(c2, c1)
+	b := coordSub(c4, c3)
+	if (a.X() == 0 && a.Y() == 0) || (b.X() == 0 && b.Y() == 0) {
+		return nil
+	}
+	// We want the clockwise angle, not the smallest interior angle, so can't use cosine formula.
+	angle := math.Atan2(-coordDet(a, b), coordDot(a, b))
+	// We want the angle in the interval [0,2π), while Atan2 returns [-π,π]
+	if angle == -0.0 {
+		angle = 0.0
+	} else if angle < 0 {
+		angle += 2 * math.Pi
+	}
+	return &angle
+}

--- a/pkg/geo/geomfn/angle_test.go
+++ b/pkg/geo/geomfn/angle_test.go
@@ -1,0 +1,148 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAngle(t *testing.T) {
+	pf := func(f float64) *float64 {
+		return &f
+	}
+	testCases := []struct {
+		wkt1     string
+		wkt2     string
+		wkt3     string
+		wkt4     string
+		expected *float64
+	}{
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (0 1)", pf(0)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (1 1)", pf(1.0 / 4.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (1 0)", pf(2.0 / 4.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (1 -1)", pf(3.0 / 4.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (0 -1)", pf(math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (-1 -1)", pf(5.0 / 4.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (-1 0)", pf(6.0 / 4.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 0)", "POINT (-1 1)", pf(7.0 / 4.0 * math.Pi)},
+		{"POINT (10 10)", "POINT (10 11)", "POINT (-100 -100)", "POINT (-99 -99)", pf(1.0 / 4.0 * math.Pi)},
+		{"POINT (1.2 -3.4)", "POINT (-5.6 7.8)", "POINT (-0.12 0.34)", "POINT (0.56 -0.78)", pf(math.Pi)},
+		{"POINT (56 76)", "POINT (-34 -71)", "POINT (-3 27)", "POINT (-81 -36)", pf(0.3420080366154973)},
+		{"POINT (0 0)", "POINT (1 0)", "POINT (1 1)", "POINT EMPTY", pf(1.0 / 2.0 * math.Pi)},
+		{"POINT (0 0)", "POINT (0 1)", "POINT (0 -1)", "POINT EMPTY", pf(0)},
+		// Ignore type of final empty geometry, following PostGIS.
+		{"POINT (0 0)", "POINT (1 0)", "POINT (1 -1)", "MULTIPOLYGON EMPTY", pf(3.0 / 2.0 * math.Pi)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v, %v, %v, %v", tc.wkt1, tc.wkt2, tc.wkt3, tc.wkt4), func(t *testing.T) {
+			srid := geopb.SRID(4000)
+			g1, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt1), srid, true)
+			require.NoError(t, err)
+			g2, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt2), srid, true)
+			require.NoError(t, err)
+			g3, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt3), srid, true)
+			require.NoError(t, err)
+			g4, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt4), srid, true)
+			require.NoError(t, err)
+
+			angle, err := Angle(g1, g2, g3, g4)
+			require.NoError(t, err)
+			if tc.expected != nil && angle != nil {
+				require.Equal(t, *tc.expected, *angle)
+			} else {
+				require.Equal(t, tc.expected, angle)
+			}
+		})
+	}
+
+	errorTestCases := []struct {
+		wkt1 string
+		wkt2 string
+		wkt3 string
+		wkt4 string
+	}{
+		{"POINT EMPTY", "POINT EMPTY", "POINT EMPTY", "POINT EMPTY"},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 1)"},
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", "LINESTRING EMPTY", "LINESTRING EMPTY"},
+	}
+	t.Run("errors on invalid arguments", func(t *testing.T) {
+		for _, tc := range errorTestCases {
+			t.Run(fmt.Sprintf("%v, %v, %v, %v", tc.wkt1, tc.wkt2, tc.wkt3, tc.wkt4), func(t *testing.T) {
+				srid := geopb.SRID(4000)
+				g1, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt1), srid, true)
+				require.NoError(t, err)
+				g2, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt2), srid, true)
+				require.NoError(t, err)
+				g3, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt3), srid, true)
+				require.NoError(t, err)
+				g4, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt4), srid, true)
+				require.NoError(t, err)
+
+				_, err = Angle(g1, g2, g3, g4)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestAngleLineString(t *testing.T) {
+	pf := func(f float64) *float64 {
+		return &f
+	}
+	testCases := []struct {
+		wkt1     string
+		wkt2     string
+		expected *float64
+	}{
+		{"LINESTRING (0 0, 0 0)", "LINESTRING (0 0, 0 1)", nil},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 0)", nil},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 1)", pf(0)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 1 1)", pf(1.0 / 4.0 * math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 1 0)", pf(2.0 / 4.0 * math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 1 -1)", pf(3.0 / 4.0 * math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, 0 -1)", pf(math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, -1 -1)", pf(5.0 / 4.0 * math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, -1 0)", pf(6.0 / 4.0 * math.Pi)},
+		{"LINESTRING (0 0, 0 1)", "LINESTRING (0 0, -1 1)", pf(7.0 / 4.0 * math.Pi)},
+		{"LINESTRING (10 10, 10 11)", "LINESTRING (-100 -100, -99 -99)", pf(1.0 / 4.0 * math.Pi)},
+		{"LINESTRING (1.2 -3.4, -5.6 7.8)", "LINESTRING (-0.12 0.34, 0.56 -0.78)", pf(math.Pi)},
+		{"LINESTRING (56 76, -34 -71)", "LINESTRING (-3 27, -81 -36)", pf(0.3420080366154973)},
+		// Returns nil on type errors, to follow PostGIS behavior.
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", nil},
+		{"GEOMETRYCOLLECTION EMPTY", "MULTIPOLYGON EMPTY", nil},
+		{"POINT (0 1)", "POINT(1 0)", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v, %v", tc.wkt1, tc.wkt2), func(t *testing.T) {
+			srid := geopb.SRID(4000)
+			g1, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt1), srid, true)
+			require.NoError(t, err)
+			g2, err := geo.ParseGeometryFromEWKT(geopb.EWKT(tc.wkt2), srid, true)
+			require.NoError(t, err)
+
+			angle, err := AngleLineString(g1, g2)
+			require.NoError(t, err)
+			if tc.expected != nil && angle != nil {
+				require.Equal(t, *tc.expected, *angle)
+			} else {
+				require.Equal(t, tc.expected, angle)
+			}
+		})
+	}
+}

--- a/pkg/geo/geomfn/coord.go
+++ b/pkg/geo/geomfn/coord.go
@@ -31,6 +31,11 @@ func coordMul(a geom.Coord, s float64) geom.Coord {
 	return geom.Coord{a.X() * s, a.Y() * s}
 }
 
+// coordDet returns the determinant of the 2x2 matrix formed by the vectors a and b.
+func coordDet(a geom.Coord, b geom.Coord) float64 {
+	return a.X()*b.Y() - b.X()*a.Y()
+}
+
 // coordDot returns the dot product of two coords if the coord was a vector.
 func coordDot(a geom.Coord, b geom.Coord) float64 {
 	return a.X()*b.X() + a.Y()*b.Y()

--- a/pkg/geo/geomfn/de9im.go
+++ b/pkg/geo/geomfn/de9im.go
@@ -25,6 +25,15 @@ func Relate(a geo.Geometry, b geo.Geometry) (string, error) {
 	return geos.Relate(a.EWKB(), b.EWKB())
 }
 
+// RelateBoundaryNodeRule returns the DE-9IM relation between A and B using
+// the given boundary node rule (as specified by GEOS).
+func RelateBoundaryNodeRule(a, b geo.Geometry, bnr int) (string, error) {
+	if a.SRID() != b.SRID() {
+		return "", geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	return geos.RelateBoundaryNodeRule(a.EWKB(), b.EWKB(), bnr)
+}
+
 // RelatePattern returns whether the DE-9IM relation between A and B matches.
 func RelatePattern(a geo.Geometry, b geo.Geometry, pattern string) (bool, error) {
 	if a.SRID() != b.SRID() {

--- a/pkg/geo/geomfn/de9im_test.go
+++ b/pkg/geo/geomfn/de9im_test.go
@@ -36,6 +36,40 @@ func TestRelate(t *testing.T) {
 	}
 }
 
+func TestRelateBoundaryNodeRule(t *testing.T) {
+	testCases := []struct {
+		a        geo.Geometry
+		b        geo.Geometry
+		bnr      int
+		expected string
+	}{
+		{leftRect, rightRect, 1, "FF2F11212"},
+		{leftRect, rightRect, 2, "FF2F11212"},
+		{leftRect, rightRect, 3, "1F2F002F2"},
+		{leftRect, rightRect, 4, "FF2F11212"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			ret, err := RelateBoundaryNodeRule(tc.a, tc.b, tc.bnr)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+
+	t.Run("errors on invalid BNR", func(t *testing.T) {
+		_, err := RelateBoundaryNodeRule(leftRect, rightRect, 0)
+		require.Error(t, err)
+		_, err = RelateBoundaryNodeRule(leftRect, rightRect, 5)
+		require.Error(t, err)
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := RelateBoundaryNodeRule(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 1)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
 func TestMatchesDE9IM(t *testing.T) {
 	testCases := []struct {
 		str           string

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -700,3 +700,192 @@ func TestShortestLineString(t *testing.T) {
 		requireMismatchingSRIDError(t, err)
 	})
 }
+
+func TestFrechetDistance(t *testing.T) {
+	pf := func(f float64) *float64 { return &f }
+
+	testCases := []struct {
+		a        string
+		b        string
+		expected *float64
+	}{
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING EMPTY", nil},
+		{"LINESTRING EMPTY", "LINESTRING (0 0, 9 1, 2 2)", nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", pf(7.615773105863909)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v %v", tc.a, tc.b), func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := FrechetDistance(a, b)
+			require.NoError(t, err)
+			if tc.expected != nil && ret != nil {
+				require.Equal(t, *tc.expected, *ret)
+			} else {
+				require.Equal(t, tc.expected, ret)
+			}
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := FrechetDistance(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestFrechetDistanceDensify(t *testing.T) {
+	pf := func(f float64) *float64 { return &f }
+
+	testCases := []struct {
+		a        string
+		b        string
+		densify  float64
+		expected *float64
+	}{
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", 0.5, nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING EMPTY", 0.5, nil},
+		{"LINESTRING EMPTY", "LINESTRING (0 0, 9 1, 2 2)", 0.5, nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", -1, pf(7.615773105863909)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", -0.1, pf(7.615773105863909)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 0.0, pf(7.615773105863909)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 0.2, pf(6.627216610312356)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 0.4, pf(6.666666666666667)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 0.6, pf(6.670832032063167)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 0.8, pf(7.615773105863909)},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", 1.0, pf(7.615773105863909)},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%v %v densify %v", tc.a, tc.b, tc.densify), func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := FrechetDistanceDensify(a, b, tc.densify)
+			require.NoError(t, err)
+			if tc.expected != nil && ret != nil {
+				require.Equal(t, *tc.expected, *ret)
+			} else {
+				require.Equal(t, tc.expected, ret)
+			}
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := FrechetDistanceDensify(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 0.5)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestHausdorffDistance(t *testing.T) {
+	pf := func(f float64) *float64 { return &f }
+
+	testCases := []struct {
+		a        string
+		b        string
+		expected *float64
+	}{
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING EMPTY", nil},
+		{"LINESTRING EMPTY", "LINESTRING (0 0, 9 1, 2 2)", nil},
+		{"LINESTRING (0 0, 3 7, 5 5)", "LINESTRING (0 0, 9 1, 2 2)", pf(5.656854249492381)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v %v", tc.a, tc.b), func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := HausdorffDistance(a, b)
+			require.NoError(t, err)
+			if tc.expected != nil && ret != nil {
+				require.Equal(t, *tc.expected, *ret)
+			} else {
+				require.Equal(t, tc.expected, ret)
+			}
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := HausdorffDistance(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestHausdorffDistanceDensify(t *testing.T) {
+	pf := func(f float64) *float64 { return &f }
+
+	testCases := []struct {
+		a        string
+		b        string
+		densify  float64
+		expected *float64
+	}{
+		{"LINESTRING EMPTY", "LINESTRING EMPTY", 0.5, nil},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING EMPTY", 0.5, nil},
+		{"LINESTRING EMPTY", "LINESTRING (10 10, 10 150, 130 10)", 0.5, nil},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.2, pf(66)},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.4, pf(56.66666666666667)},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.6, pf(70)},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.8, pf(14.142135623730951)},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1.0, pf(14.142135623730951)},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%v %v densify %v", tc.a, tc.b, tc.densify), func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := HausdorffDistanceDensify(a, b, tc.densify)
+			require.NoError(t, err)
+			if tc.expected != nil && ret != nil {
+				require.Equal(t, *tc.expected, *ret)
+			} else {
+				require.Equal(t, tc.expected, ret)
+			}
+		})
+	}
+
+	errorTestCases := []struct {
+		a       string
+		b       string
+		densify float64
+	}{
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", -1},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", -0.1},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.0},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1.1},
+	}
+
+	t.Run("errors on invalid densify fraction", func(t *testing.T) {
+		for _, tc := range errorTestCases {
+			tc := tc
+			t.Run(fmt.Sprintf("%v %v densify %v", tc.a, tc.b, tc.densify), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+
+				_, err = HausdorffDistanceDensify(a, b, tc.densify)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := HausdorffDistanceDensify(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 0.5)
+		requireMismatchingSRIDError(t, err)
+	})
+}

--- a/pkg/geo/geomfn/make_geometry.go
+++ b/pkg/geo/geomfn/make_geometry.go
@@ -12,6 +12,7 @@ package geomfn
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/errors"
 	"github.com/twpayne/go-geom"
 )
@@ -51,4 +52,18 @@ func MakePolygon(outer geo.Geometry, interior ...geo.Geometry) (geo.Geometry, er
 		return geo.Geometry{}, err
 	}
 	return geo.MakeGeometryFromGeomT(polygon)
+}
+
+// MakePolygonWithSRID is like MakePolygon but also sets the SRID, like ST_Polygon.
+func MakePolygonWithSRID(g geo.Geometry, srid int) (geo.Geometry, error) {
+	polygon, err := MakePolygon(g)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	t, err := polygon.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	geo.AdjustGeomTSRID(t, geopb.SRID(srid))
+	return geo.MakeGeometryFromGeomT(t)
 }

--- a/pkg/geo/geomfn/make_geometry_test.go
+++ b/pkg/geo/geomfn/make_geometry_test.go
@@ -263,3 +263,42 @@ func TestMakePolygon(t *testing.T) {
 		})
 	}
 }
+
+func TestMakePolygonWithSRID(t *testing.T) {
+	testCases := []struct {
+		name     string
+		g        string
+		srid     int
+		expected string
+	}{
+		{
+			"Single input variant - 2D",
+			"LINESTRING(75 29,77 29,77 29, 75 29)",
+			int(geopb.DefaultGeometrySRID),
+			"SRID=0;POLYGON((75 29,77 29,77 29,75 29))",
+		},
+		{
+			"Single input variant - 2D with SRID",
+			"LINESTRING(75 29,77 29,77 29, 75 29)",
+			4326,
+			"SRID=4326;POLYGON((75 29,77 29,77 29,75 29))",
+		},
+		{
+			"Single input variant - 2D square with SRID",
+			"LINESTRING(40 80, 80 80, 80 40, 40 40, 40 80)",
+			4000,
+			"SRID=4000;POLYGON((40 80, 80 80, 80 40, 40 40, 40 80))",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := geo.MustParseGeometry(tc.g)
+			polygon, err := MakePolygonWithSRID(g, tc.srid)
+			require.NoError(t, err)
+			expected := geo.MustParseGeometry(tc.expected)
+			require.Equal(t, expected, polygon)
+			require.EqualValues(t, tc.srid, polygon.SRID())
+		})
+	}
+}

--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -15,6 +15,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 )
 
+// Boundary returns the boundary of a given Geometry.
+func Boundary(g geo.Geometry) (geo.Geometry, error) {
+	// follow PostGIS behavior
+	if g.Empty() {
+		return g, nil
+	}
+	boundaryEWKB, err := geos.Boundary(g.EWKB())
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	return geo.ParseGeometryFromEWKB(boundaryEWKB)
+}
+
 // Centroid returns the Centroid of a given Geometry.
 func Centroid(g geo.Geometry) (geo.Geometry, error) {
 	centroidEWKB, err := geos.Centroid(g.EWKB())
@@ -43,6 +56,22 @@ func ConvexHull(g geo.Geometry) (geo.Geometry, error) {
 		return geo.Geometry{}, err
 	}
 	return geo.ParseGeometryFromEWKB(convexHullEWKB)
+}
+
+// Difference returns the difference between two given Geometries.
+func Difference(a, b geo.Geometry) (geo.Geometry, error) {
+	// follow PostGIS behavior
+	if a.Empty() || b.Empty() {
+		return a, nil
+	}
+	if a.SRID() != b.SRID() {
+		return geo.Geometry{}, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	diffEWKB, err := geos.Difference(a.EWKB(), b.EWKB())
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	return geo.ParseGeometryFromEWKB(diffEWKB)
 }
 
 // Simplify returns a simplified Geometry.

--- a/pkg/geo/geomfn/unary_operators.go
+++ b/pkg/geo/geomfn/unary_operators.go
@@ -215,3 +215,20 @@ func Normalize(g geo.Geometry) (geo.Geometry, error) {
 	}
 	return geo.ParseGeometryFromEWKB(retEWKB)
 }
+
+// MinimumClearance returns the minimum distance a vertex can move to produce
+// an invalid geometry, or infinity if no clearance was found.
+func MinimumClearance(g geo.Geometry) (float64, error) {
+	return geos.MinimumClearance(g.EWKB())
+}
+
+// MinimumClearanceLine returns the line spanning the minimum distance a vertex
+// can move to produce an invalid geometry, or an empty line if no clearance was
+// found.
+func MinimumClearanceLine(g geo.Geometry) (geo.Geometry, error) {
+	retEWKB, err := geos.MinimumClearanceLine(g.EWKB())
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	return geo.ParseGeometryFromEWKB(retEWKB)
+}

--- a/pkg/geo/geos/geos.cc
+++ b/pkg/geo/geos/geos.cc
@@ -97,8 +97,11 @@ typedef int (*CR_GEOS_Length_r)(CR_GEOS_Handle, CR_GEOS_Geometry, double*);
 typedef int (*CR_GEOS_Normalize_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 typedef CR_GEOS_Geometry (*CR_GEOS_LineMerge_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 
+typedef CR_GEOS_Geometry (*CR_GEOS_Boundary_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 typedef CR_GEOS_Geometry (*CR_GEOS_Centroid_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 typedef CR_GEOS_Geometry (*CR_GEOS_ConvexHull_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
+typedef CR_GEOS_Geometry (*CR_GEOS_Difference_r)(CR_GEOS_Handle, CR_GEOS_Geometry,
+                                                 CR_GEOS_Geometry);
 typedef CR_GEOS_Geometry (*CR_GEOS_Simplify_r)(CR_GEOS_Handle, CR_GEOS_Geometry, double);
 typedef CR_GEOS_Geometry (*CR_GEOS_TopologyPreserveSimplify_r)(CR_GEOS_Handle, CR_GEOS_Geometry,
                                                                double);
@@ -125,6 +128,8 @@ typedef char (*CR_GEOS_Touches_r)(CR_GEOS_Handle, CR_GEOS_Geometry, CR_GEOS_Geom
 typedef char (*CR_GEOS_Within_r)(CR_GEOS_Handle, CR_GEOS_Geometry, CR_GEOS_Geometry);
 
 typedef char* (*CR_GEOS_Relate_r)(CR_GEOS_Handle, CR_GEOS_Geometry, CR_GEOS_Geometry);
+typedef char* (*CR_GEOS_RelateBoundaryNodeRule_r)(CR_GEOS_Handle, CR_GEOS_Geometry,
+                                                  CR_GEOS_Geometry, int);
 typedef char (*CR_GEOS_RelatePattern_r)(CR_GEOS_Handle, CR_GEOS_Geometry, CR_GEOS_Geometry,
                                         const char*);
 
@@ -190,8 +195,10 @@ struct CR_GEOS {
   CR_GEOS_Normalize_r GEOSNormalize_r;
   CR_GEOS_LineMerge_r GEOSLineMerge_r;
 
+  CR_GEOS_Boundary_r GEOSBoundary_r;
   CR_GEOS_Centroid_r GEOSGetCentroid_r;
   CR_GEOS_ConvexHull_r GEOSConvexHull_r;
+  CR_GEOS_Difference_r GEOSDifference_r;
   CR_GEOS_Simplify_r GEOSSimplify_r;
   CR_GEOS_TopologyPreserveSimplify_r GEOSTopologyPreserveSimplify_r;
   CR_GEOS_Union_r GEOSUnion_r;
@@ -215,6 +222,7 @@ struct CR_GEOS {
   CR_GEOS_Within_r GEOSWithin_r;
 
   CR_GEOS_Relate_r GEOSRelate_r;
+  CR_GEOS_RelateBoundaryNodeRule_r GEOSRelateBoundaryNodeRule_r;
   CR_GEOS_RelatePattern_r GEOSRelatePattern_r;
 
   CR_GEOS_WKBWriter_create_r GEOSWKBWriter_create_r;
@@ -276,6 +284,8 @@ struct CR_GEOS {
     INIT(GEOSNormalize_r);
     INIT(GEOSLineMerge_r);
     INIT(GEOSisSimple_r);
+    INIT(GEOSBoundary_r);
+    INIT(GEOSDifference_r);
     INIT(GEOSGetCentroid_r);
     INIT(GEOSConvexHull_r);
     INIT(GEOSSimplify_r);
@@ -297,6 +307,7 @@ struct CR_GEOS {
     INIT(GEOSTouches_r);
     INIT(GEOSWithin_r);
     INIT(GEOSRelate_r);
+    INIT(GEOSRelateBoundaryNodeRule_r);
     INIT(GEOSRelatePattern_r);
     INIT(GEOSSharedPaths_r);
     INIT(GEOSWKTReader_create_r);
@@ -705,6 +716,24 @@ CR_GEOS_Status CR_GEOS_MakeValid(CR_GEOS* lib, CR_GEOS_Slice g, CR_GEOS_String* 
 // Topology operators.
 //
 
+CR_GEOS_Status CR_GEOS_Boundary(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* boundaryEWKB) {
+  std::string error;
+  auto handle = initHandleWithErrorBuffer(lib, &error);
+  auto geom = CR_GEOS_GeometryFromSlice(lib, handle, a);
+  *boundaryEWKB = {.data = NULL, .len = 0};
+  if (geom != nullptr) {
+    auto boundaryGeom = lib->GEOSBoundary_r(handle, geom);
+    if (boundaryGeom != nullptr) {
+      auto srid = lib->GEOSGetSRID_r(handle, geom);
+      CR_GEOS_writeGeomToEWKB(lib, handle, boundaryGeom, boundaryEWKB, srid);
+      lib->GEOSGeom_destroy_r(handle, boundaryGeom);
+    }
+    lib->GEOSGeom_destroy_r(handle, geom);
+  }
+  lib->GEOS_finish_r(handle);
+  return toGEOSString(error.data(), error.length());
+}
+
 CR_GEOS_Status CR_GEOS_Centroid(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* centroidEWKB) {
   std::string error;
   auto handle = initHandleWithErrorBuffer(lib, &error);
@@ -736,6 +765,31 @@ CR_GEOS_Status CR_GEOS_ConvexHull(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String*
       lib->GEOSGeom_destroy_r(handle, convexHullGeom);
     }
     lib->GEOSGeom_destroy_r(handle, geom);
+  }
+  lib->GEOS_finish_r(handle);
+  return toGEOSString(error.data(), error.length());
+}
+
+CR_GEOS_Status CR_GEOS_Difference(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                  CR_GEOS_String* diffEWKB) {
+  std::string error;
+  auto handle = initHandleWithErrorBuffer(lib, &error);
+  auto geomA = CR_GEOS_GeometryFromSlice(lib, handle, a);
+  auto geomB = CR_GEOS_GeometryFromSlice(lib, handle, b);
+  *diffEWKB = {.data = NULL, .len = 0};
+  if (geomA != nullptr && geomB != nullptr) {
+    auto diffGeom = lib->GEOSDifference_r(handle, geomA, geomB);
+    if (diffGeom != nullptr) {
+      auto srid = lib->GEOSGetSRID_r(handle, geomA);
+      CR_GEOS_writeGeomToEWKB(lib, handle, diffGeom, diffEWKB, srid);
+      lib->GEOSGeom_destroy_r(handle, diffGeom);
+    }
+  }
+  if (geomA != nullptr) {
+    lib->GEOSGeom_destroy_r(handle, geomA);
+  }
+  if (geomB != nullptr) {
+    lib->GEOSGeom_destroy_r(handle, geomB);
   }
   lib->GEOS_finish_r(handle);
   return toGEOSString(error.data(), error.length());
@@ -1002,6 +1056,33 @@ CR_GEOS_Status CR_GEOS_Relate(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, CR
 
   if (geomA != nullptr && geomB != nullptr) {
     auto r = lib->GEOSRelate_r(handle, geomA, geomB);
+    if (r != NULL) {
+      *ret = toGEOSString(r, strlen(r));
+      lib->GEOSFree_r(handle, r);
+    }
+  }
+  if (geomA != nullptr) {
+    lib->GEOSGeom_destroy_r(handle, geomA);
+  }
+  if (geomB != nullptr) {
+    lib->GEOSGeom_destroy_r(handle, geomB);
+  }
+  lib->GEOS_finish_r(handle);
+  return toGEOSString(error.data(), error.length());
+}
+
+CR_GEOS_Status CR_GEOS_RelateBoundaryNodeRule(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                              int bnr, CR_GEOS_String* ret) {
+  std::string error;
+  auto handle = initHandleWithErrorBuffer(lib, &error);
+
+  auto wkbReader = lib->GEOSWKBReader_create_r(handle);
+  auto geomA = lib->GEOSWKBReader_read_r(handle, wkbReader, a.data, a.len);
+  auto geomB = lib->GEOSWKBReader_read_r(handle, wkbReader, b.data, b.len);
+  lib->GEOSWKBReader_destroy_r(handle, wkbReader);
+
+  if (geomA != nullptr && geomB != nullptr) {
+    auto r = lib->GEOSRelateBoundaryNodeRule_r(handle, geomA, geomB, bnr);
     if (r != NULL) {
       *ret = toGEOSString(r, strlen(r));
       lib->GEOSFree_r(handle, r);

--- a/pkg/geo/geos/geos.cc
+++ b/pkg/geo/geos/geos.cc
@@ -94,6 +94,8 @@ typedef CR_GEOS_Geometry (*CR_GEOS_MakeValid_r)(CR_GEOS_Handle, CR_GEOS_Geometry
 
 typedef int (*CR_GEOS_Area_r)(CR_GEOS_Handle, CR_GEOS_Geometry, double*);
 typedef int (*CR_GEOS_Length_r)(CR_GEOS_Handle, CR_GEOS_Geometry, double*);
+typedef int (*CR_GEOS_MinimumClearance_r)(CR_GEOS_Handle, CR_GEOS_Geometry, double*);
+typedef CR_GEOS_Geometry (*CR_GEOS_MinimumClearanceLine_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 typedef int (*CR_GEOS_Normalize_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 typedef CR_GEOS_Geometry (*CR_GEOS_LineMerge_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 
@@ -192,6 +194,8 @@ struct CR_GEOS {
 
   CR_GEOS_Area_r GEOSArea_r;
   CR_GEOS_Length_r GEOSLength_r;
+  CR_GEOS_MinimumClearance_r GEOSMinimumClearance_r;
+  CR_GEOS_MinimumClearanceLine_r GEOSMinimumClearanceLine_r;
   CR_GEOS_Normalize_r GEOSNormalize_r;
   CR_GEOS_LineMerge_r GEOSLineMerge_r;
 
@@ -281,6 +285,8 @@ struct CR_GEOS {
     INIT(GEOSMakeValid_r);
     INIT(GEOSArea_r);
     INIT(GEOSLength_r);
+    INIT(GEOSMinimumClearance_r);
+    INIT(GEOSMinimumClearanceLine_r);
     INIT(GEOSNormalize_r);
     INIT(GEOSLineMerge_r);
     INIT(GEOSisSimple_r);
@@ -547,6 +553,42 @@ CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double* ret) {
 
 CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double* ret) {
   return CR_GEOS_UnaryOperator(lib, lib->GEOSLength_r, a, ret);
+}
+
+CR_GEOS_Status CR_GEOS_MinimumClearance(CR_GEOS* lib, CR_GEOS_Slice g, double* ret) {
+  std::string error;
+  auto handle = initHandleWithErrorBuffer(lib, &error);
+  auto geom = CR_GEOS_GeometryFromSlice(lib, handle, g);
+  *ret = 0;
+  if (geom != nullptr) {
+    auto r = lib->GEOSMinimumClearance_r(handle, geom, ret);
+    if (r == 2) {
+      if (error.length() == 0) {
+        error.assign(CR_GEOS_NO_ERROR_DEFINED_MESSAGE);
+      }
+    }
+    lib->GEOSGeom_destroy_r(handle, geom);
+  }
+  lib->GEOS_finish_r(handle);
+  return toGEOSString(error.data(), error.length());
+}
+
+CR_GEOS_Status CR_GEOS_MinimumClearanceLine(CR_GEOS* lib, CR_GEOS_Slice g,
+                                            CR_GEOS_String* clearanceEWKB) {
+  std::string error;
+  auto handle = initHandleWithErrorBuffer(lib, &error);
+  *clearanceEWKB = {.data = NULL, .len = 0};
+
+  auto geom = CR_GEOS_GeometryFromSlice(lib, handle, g);
+  if (geom != nullptr) {
+    auto clearance = lib->GEOSMinimumClearanceLine_r(handle, geom);
+    auto srid = lib->GEOSGetSRID_r(handle, clearance);
+    CR_GEOS_writeGeomToEWKB(lib, handle, clearance, clearanceEWKB, srid);
+    lib->GEOSGeom_destroy_r(handle, geom);
+  }
+
+  lib->GEOS_finish_r(handle);
+  return toGEOSString(error.data(), error.length());
 }
 
 CR_GEOS_Status CR_GEOS_Normalize(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* normalizedEWKB) {

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -719,6 +719,66 @@ func Within(a geopb.EWKB, b geopb.EWKB) (bool, error) {
 	return ret == 1, nil
 }
 
+// FrechetDistance returns the Frechet distance between the geometries.
+func FrechetDistance(a, b geopb.EWKB) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(
+		C.CR_GEOS_FrechetDistance(g, goToCSlice(a), goToCSlice(b), &distance),
+	); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
+// FrechetDistanceDensify returns the Frechet distance between the geometries.
+func FrechetDistanceDensify(a, b geopb.EWKB, densifyFrac float64) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(
+		C.CR_GEOS_FrechetDistanceDensify(g, goToCSlice(a), goToCSlice(b), C.double(densifyFrac), &distance),
+	); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
+// HausdorffDistance returns the Hausdorff distance between the geometries.
+func HausdorffDistance(a, b geopb.EWKB) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(
+		C.CR_GEOS_HausdorffDistance(g, goToCSlice(a), goToCSlice(b), &distance),
+	); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
+// HausdorffDistanceDensify returns the Hausdorff distance between the geometries.
+func HausdorffDistanceDensify(a, b geopb.EWKB, densifyFrac float64) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(
+		C.CR_GEOS_HausdorffDistanceDensify(g, goToCSlice(a), goToCSlice(b), C.double(densifyFrac), &distance),
+	); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
 //
 // DE-9IM related
 //

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -326,6 +326,32 @@ func Area(ewkb geopb.EWKB) (float64, error) {
 	return float64(area), nil
 }
 
+// Boundary returns the boundary of an EWKB.
+func Boundary(ewkb geopb.EWKB) (geopb.EWKB, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, err
+	}
+	var cEWKB C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_Boundary(g, goToCSlice(ewkb), &cEWKB)); err != nil {
+		return nil, err
+	}
+	return cStringToSafeGoBytes(cEWKB), nil
+}
+
+// Difference returns the difference between two EWKB.
+func Difference(ewkb1 geopb.EWKB, ewkb2 geopb.EWKB) (geopb.EWKB, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, err
+	}
+	var diffEWKB C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_Difference(g, goToCSlice(ewkb1), goToCSlice(ewkb2), &diffEWKB)); err != nil {
+		return nil, err
+	}
+	return cStringToSafeGoBytes(diffEWKB), nil
+}
+
 // Length returns the length of an EWKB.
 func Length(ewkb geopb.EWKB) (float64, error) {
 	g, err := ensureInitInternal()
@@ -677,6 +703,22 @@ func Relate(a geopb.EWKB, b geopb.EWKB) (string, error) {
 	}
 	var ret C.CR_GEOS_String
 	if err := statusToError(C.CR_GEOS_Relate(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return "", err
+	}
+	if ret.data == nil {
+		return "", errors.Newf("expected DE-9IM string but found nothing")
+	}
+	return string(cStringToSafeGoBytes(ret)), nil
+}
+
+// RelateBoundaryNodeRule returns the DE-9IM relation between A and B given a boundary node rule.
+func RelateBoundaryNodeRule(a geopb.EWKB, b geopb.EWKB, bnr int) (string, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return "", err
+	}
+	var ret C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_RelateBoundaryNodeRule(g, goToCSlice(a), goToCSlice(b), C.int(bnr), &ret)); err != nil {
 		return "", err
 	}
 	if ret.data == nil {

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -545,6 +545,34 @@ func MinDistance(a geopb.EWKB, b geopb.EWKB) (float64, error) {
 	return float64(distance), nil
 }
 
+// MinimumClearance returns the minimum distance a vertex can move to result in an
+// invalid geometry.
+func MinimumClearance(ewkb geopb.EWKB) (float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return 0, err
+	}
+	var distance C.double
+	if err := statusToError(C.CR_GEOS_MinimumClearance(g, goToCSlice(ewkb), &distance)); err != nil {
+		return 0, err
+	}
+	return float64(distance), nil
+}
+
+// MinimumClearanceLine returns the line spanning the minimum clearance a vertex can
+// move before producing an invalid geometry.
+func MinimumClearanceLine(ewkb geopb.EWKB) (geopb.EWKB, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, err
+	}
+	var clearanceEWKB C.CR_GEOS_String
+	if err := statusToError(C.CR_GEOS_MinimumClearanceLine(g, goToCSlice(ewkb), &clearanceEWKB)); err != nil {
+		return nil, err
+	}
+	return cStringToSafeGoBytes(clearanceEWKB), nil
+}
+
 // ClipByRect clips a EWKB to the specified rectangle.
 func ClipByRect(
 	ewkb geopb.EWKB, xMin float64, yMin float64, xMax float64, yMax float64,

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -131,6 +131,13 @@ CR_GEOS_Status CR_GEOS_Interpolate(CR_GEOS* lib, CR_GEOS_Slice a, double distanc
 //
 
 CR_GEOS_Status CR_GEOS_Distance(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, double* ret);
+CR_GEOS_Status CR_GEOS_FrechetDistance(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, double* ret);
+CR_GEOS_Status CR_GEOS_FrechetDistanceDensify(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                              double densifyFrac, double* ret);
+CR_GEOS_Status CR_GEOS_HausdorffDistance(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                         double* ret);
+CR_GEOS_Status CR_GEOS_HausdorffDistanceDensify(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                                double densifyFrac, double* ret);
 
 //
 // Binary predicates.

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -97,8 +97,11 @@ CR_GEOS_Status CR_GEOS_IsSimple(CR_GEOS* lib, CR_GEOS_Slice a, char* ret);
 // Topology operators.
 //
 
+CR_GEOS_Status CR_GEOS_Boundary(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* boundaryEWKB);
 CR_GEOS_Status CR_GEOS_Centroid(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* centroidEWKB);
 CR_GEOS_Status CR_GEOS_ConvexHull(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* convexHullEWKB);
+CR_GEOS_Status CR_GEOS_Difference(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                  CR_GEOS_String* diffEWKB);
 CR_GEOS_Status CR_GEOS_Simplify(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* simplifyEWKB,
                                 double tolerance);
 CR_GEOS_Status CR_GEOS_TopologyPreserveSimplify(CR_GEOS* lib, CR_GEOS_Slice a,
@@ -146,6 +149,8 @@ CR_GEOS_Status CR_GEOS_Within(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, ch
 //
 
 CR_GEOS_Status CR_GEOS_Relate(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, CR_GEOS_String* ret);
+CR_GEOS_Status CR_GEOS_RelateBoundaryNodeRule(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                              int bnr, CR_GEOS_String* ret);
 CR_GEOS_Status CR_GEOS_RelatePattern(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
                                      CR_GEOS_Slice pattern, char* ret);
 

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -86,6 +86,9 @@ CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
 CR_GEOS_Status CR_GEOS_Normalize(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* normalizedEWKB);
 CR_GEOS_Status CR_GEOS_LineMerge(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* ewkb);
+CR_GEOS_Status CR_GEOS_MinimumClearance(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
+CR_GEOS_Status CR_GEOS_MinimumClearanceLine(CR_GEOS* lib, CR_GEOS_Slice a,
+                                            CR_GEOS_String* clearanceEWKB);
 
 //
 // Unary predicates.

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1821,6 +1821,317 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            0                 0
 Square overlapping left and right square  Square overlapping left and right square  0                 0
 
+query TTRRR
+SELECT
+  a.dsc,
+  b.dsc,
+  ST_FrechetDistance(a.geom, b.geom),
+  ST_FrechetDistance(a.geom, b.geom, 0.2),
+  ST_FrechetDistance(a.geom, b.geom, -1)
+FROM geom_operators_test a
+JOIN geom_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  NULL               NULL               NULL
+Empty GeometryCollection                  Empty LineString                          NULL               NULL               NULL
+Empty GeometryCollection                  Empty Point                               NULL               NULL               NULL
+Empty GeometryCollection                  Faraway point                             NULL               NULL               NULL
+Empty GeometryCollection                  Line going through left and right square  NULL               NULL               NULL
+Empty GeometryCollection                  NULL                                      NULL               NULL               NULL
+Empty GeometryCollection                  Nested Geometry Collection                NULL               NULL               NULL
+Empty GeometryCollection                  Point middle of Left Square               NULL               NULL               NULL
+Empty GeometryCollection                  Point middle of Right Square              NULL               NULL               NULL
+Empty GeometryCollection                  Square (left)                             NULL               NULL               NULL
+Empty GeometryCollection                  Square (right)                            NULL               NULL               NULL
+Empty GeometryCollection                  Square overlapping left and right square  NULL               NULL               NULL
+Empty LineString                          Empty GeometryCollection                  NULL               NULL               NULL
+Empty LineString                          Empty LineString                          NULL               NULL               NULL
+Empty LineString                          Empty Point                               NULL               NULL               NULL
+Empty LineString                          Faraway point                             NULL               NULL               NULL
+Empty LineString                          Line going through left and right square  NULL               NULL               NULL
+Empty LineString                          NULL                                      NULL               NULL               NULL
+Empty LineString                          Nested Geometry Collection                NULL               NULL               NULL
+Empty LineString                          Point middle of Left Square               NULL               NULL               NULL
+Empty LineString                          Point middle of Right Square              NULL               NULL               NULL
+Empty LineString                          Square (left)                             NULL               NULL               NULL
+Empty LineString                          Square (right)                            NULL               NULL               NULL
+Empty LineString                          Square overlapping left and right square  NULL               NULL               NULL
+Empty Point                               Empty GeometryCollection                  NULL               NULL               NULL
+Empty Point                               Empty LineString                          NULL               NULL               NULL
+Empty Point                               Empty Point                               NULL               NULL               NULL
+Empty Point                               Faraway point                             NULL               NULL               NULL
+Empty Point                               Line going through left and right square  NULL               NULL               NULL
+Empty Point                               NULL                                      NULL               NULL               NULL
+Empty Point                               Nested Geometry Collection                NULL               NULL               NULL
+Empty Point                               Point middle of Left Square               NULL               NULL               NULL
+Empty Point                               Point middle of Right Square              NULL               NULL               NULL
+Empty Point                               Square (left)                             NULL               NULL               NULL
+Empty Point                               Square (right)                            NULL               NULL               NULL
+Empty Point                               Square overlapping left and right square  NULL               NULL               NULL
+Faraway point                             Empty GeometryCollection                  NULL               NULL               NULL
+Faraway point                             Empty LineString                          NULL               NULL               NULL
+Faraway point                             Empty Point                               NULL               NULL               NULL
+Faraway point                             Faraway point                             NaN                NaN                NaN
+Faraway point                             Line going through left and right square  6.36396103067893   6.95269731830748   6.36396103067893
+Faraway point                             NULL                                      NULL               NULL               NULL
+Faraway point                             Nested Geometry Collection                NaN                NaN                NaN
+Faraway point                             Point middle of Left Square               NaN                NaN                NaN
+Faraway point                             Point middle of Right Square              NaN                NaN                NaN
+Faraway point                             Square (left)                             7.81024967590665   7.81024967590665   7.81024967590665
+Faraway point                             Square (right)                            7.07106781186548   7.07106781186548   7.07106781186548
+Faraway point                             Square overlapping left and right square  7.14212853426764   7.14212853426764   7.14212853426764
+Line going through left and right square  Empty GeometryCollection                  NULL               NULL               NULL
+Line going through left and right square  Empty LineString                          NULL               NULL               NULL
+Line going through left and right square  Empty Point                               NULL               NULL               NULL
+Line going through left and right square  Faraway point                             6.36396103067893   6.95269731830748   6.36396103067893
+Line going through left and right square  Line going through left and right square  0                  0                  0
+Line going through left and right square  NULL                                      NULL               NULL               NULL
+Line going through left and right square  Nested Geometry Collection                0.707106781186548  0.707106781186548  0.707106781186548
+Line going through left and right square  Point middle of Left Square               1                  1                  1
+Line going through left and right square  Point middle of Right Square              0                  0.8                0
+Line going through left and right square  Square (left)                             1.58113883008419   1.58113883008419   1.58113883008419
+Line going through left and right square  Square (right)                            0.707106781186548  0.707106781186548  0.707106781186548
+Line going through left and right square  Square overlapping left and right square  0.781024967590665  0.781024967590665  0.781024967590665
+NULL                                      Empty GeometryCollection                  NULL               NULL               NULL
+NULL                                      Empty LineString                          NULL               NULL               NULL
+NULL                                      Empty Point                               NULL               NULL               NULL
+NULL                                      Faraway point                             NULL               NULL               NULL
+NULL                                      Line going through left and right square  NULL               NULL               NULL
+NULL                                      NULL                                      NULL               NULL               NULL
+NULL                                      Nested Geometry Collection                NULL               NULL               NULL
+NULL                                      Point middle of Left Square               NULL               NULL               NULL
+NULL                                      Point middle of Right Square              NULL               NULL               NULL
+NULL                                      Square (left)                             NULL               NULL               NULL
+NULL                                      Square (right)                            NULL               NULL               NULL
+NULL                                      Square overlapping left and right square  NULL               NULL               NULL
+Nested Geometry Collection                Empty GeometryCollection                  NULL               NULL               NULL
+Nested Geometry Collection                Empty LineString                          NULL               NULL               NULL
+Nested Geometry Collection                Empty Point                               NULL               NULL               NULL
+Nested Geometry Collection                Faraway point                             NaN                NaN                NaN
+Nested Geometry Collection                Line going through left and right square  0.707106781186548  0.707106781186548  0.707106781186548
+Nested Geometry Collection                NULL                                      NULL               NULL               NULL
+Nested Geometry Collection                Nested Geometry Collection                NaN                NaN                NaN
+Nested Geometry Collection                Point middle of Left Square               NaN                NaN                NaN
+Nested Geometry Collection                Point middle of Right Square              NaN                NaN                NaN
+Nested Geometry Collection                Square (left)                             1.4142135623731    1.4142135623731    1.4142135623731
+Nested Geometry Collection                Square (right)                            1.4142135623731    1.4142135623731    1.4142135623731
+Nested Geometry Collection                Square overlapping left and right square  1.4142135623731    1.4142135623731    1.4142135623731
+Point middle of Left Square               Empty GeometryCollection                  NULL               NULL               NULL
+Point middle of Left Square               Empty LineString                          NULL               NULL               NULL
+Point middle of Left Square               Empty Point                               NULL               NULL               NULL
+Point middle of Left Square               Faraway point                             NaN                NaN                NaN
+Point middle of Left Square               Line going through left and right square  1                  1                  1
+Point middle of Left Square               NULL                                      NULL               NULL               NULL
+Point middle of Left Square               Nested Geometry Collection                NaN                NaN                NaN
+Point middle of Left Square               Point middle of Left Square               NaN                NaN                NaN
+Point middle of Left Square               Point middle of Right Square              NaN                NaN                NaN
+Point middle of Left Square               Square (left)                             0.707106781186548  0.707106781186548  0.707106781186548
+Point middle of Left Square               Square (right)                            1.58113883008419   1.58113883008419   1.58113883008419
+Point middle of Left Square               Square overlapping left and right square  1.58113883008419   1.58113883008419   1.58113883008419
+Point middle of Right Square              Empty GeometryCollection                  NULL               NULL               NULL
+Point middle of Right Square              Empty LineString                          NULL               NULL               NULL
+Point middle of Right Square              Empty Point                               NULL               NULL               NULL
+Point middle of Right Square              Faraway point                             NaN                NaN                NaN
+Point middle of Right Square              Line going through left and right square  0                  0.8                0
+Point middle of Right Square              NULL                                      NULL               NULL               NULL
+Point middle of Right Square              Nested Geometry Collection                NaN                NaN                NaN
+Point middle of Right Square              Point middle of Left Square               NaN                NaN                NaN
+Point middle of Right Square              Point middle of Right Square              NaN                NaN                NaN
+Point middle of Right Square              Square (left)                             1.58113883008419   1.58113883008419   1.58113883008419
+Point middle of Right Square              Square (right)                            0.707106781186548  0.707106781186548  0.707106781186548
+Point middle of Right Square              Square overlapping left and right square  0.781024967590665  0.781024967590665  0.781024967590665
+Square (left)                             Empty GeometryCollection                  NULL               NULL               NULL
+Square (left)                             Empty LineString                          NULL               NULL               NULL
+Square (left)                             Empty Point                               NULL               NULL               NULL
+Square (left)                             Faraway point                             7.81024967590665   7.81024967590665   7.81024967590665
+Square (left)                             Line going through left and right square  1.58113883008419   1.58113883008419   1.58113883008419
+Square (left)                             NULL                                      NULL               NULL               NULL
+Square (left)                             Nested Geometry Collection                1.4142135623731    1.4142135623731    1.4142135623731
+Square (left)                             Point middle of Left Square               0.707106781186548  0.707106781186548  0.707106781186548
+Square (left)                             Point middle of Right Square              1.58113883008419   1.58113883008419   1.58113883008419
+Square (left)                             Square (left)                             0                  0                  0
+Square (left)                             Square (right)                            1                  1                  1
+Square (left)                             Square overlapping left and right square  1                  1                  1
+Square (right)                            Empty GeometryCollection                  NULL               NULL               NULL
+Square (right)                            Empty LineString                          NULL               NULL               NULL
+Square (right)                            Empty Point                               NULL               NULL               NULL
+Square (right)                            Faraway point                             7.07106781186548   7.07106781186548   7.07106781186548
+Square (right)                            Line going through left and right square  0.707106781186548  0.707106781186548  0.707106781186548
+Square (right)                            NULL                                      NULL               NULL               NULL
+Square (right)                            Nested Geometry Collection                1.4142135623731    1.4142135623731    1.4142135623731
+Square (right)                            Point middle of Left Square               1.58113883008419   1.58113883008419   1.58113883008419
+Square (right)                            Point middle of Right Square              0.707106781186548  0.707106781186548  0.707106781186548
+Square (right)                            Square (left)                             1                  1                  1
+Square (right)                            Square (right)                            0                  0                  0
+Square (right)                            Square overlapping left and right square  0.1                0.1                0.1
+Square overlapping left and right square  Empty GeometryCollection                  NULL               NULL               NULL
+Square overlapping left and right square  Empty LineString                          NULL               NULL               NULL
+Square overlapping left and right square  Empty Point                               NULL               NULL               NULL
+Square overlapping left and right square  Faraway point                             7.14212853426764   7.14212853426764   7.14212853426764
+Square overlapping left and right square  Line going through left and right square  0.781024967590665  0.781024967590665  0.781024967590665
+Square overlapping left and right square  NULL                                      NULL               NULL               NULL
+Square overlapping left and right square  Nested Geometry Collection                1.4142135623731    1.4142135623731    1.4142135623731
+Square overlapping left and right square  Point middle of Left Square               1.58113883008419   1.58113883008419   1.58113883008419
+Square overlapping left and right square  Point middle of Right Square              0.781024967590665  0.781024967590665  0.781024967590665
+Square overlapping left and right square  Square (left)                             1                  1                  1
+Square overlapping left and right square  Square (right)                            0.1                0.1                0.1
+Square overlapping left and right square  Square overlapping left and right square  0                  0                  0
+
+query TTRR
+SELECT
+  a.dsc,
+  b.dsc,
+  ST_HausdorffDistance(a.geom, b.geom),
+  ST_HausdorffDistance(a.geom, b.geom, 0.4)
+FROM geom_operators_test a
+JOIN geom_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  NULL               NULL
+Empty GeometryCollection                  Empty LineString                          NULL               NULL
+Empty GeometryCollection                  Empty Point                               NULL               NULL
+Empty GeometryCollection                  Faraway point                             NULL               NULL
+Empty GeometryCollection                  Line going through left and right square  NULL               NULL
+Empty GeometryCollection                  NULL                                      NULL               NULL
+Empty GeometryCollection                  Nested Geometry Collection                NULL               NULL
+Empty GeometryCollection                  Point middle of Left Square               NULL               NULL
+Empty GeometryCollection                  Point middle of Right Square              NULL               NULL
+Empty GeometryCollection                  Square (left)                             NULL               NULL
+Empty GeometryCollection                  Square (right)                            NULL               NULL
+Empty GeometryCollection                  Square overlapping left and right square  NULL               NULL
+Empty LineString                          Empty GeometryCollection                  NULL               NULL
+Empty LineString                          Empty LineString                          NULL               NULL
+Empty LineString                          Empty Point                               NULL               NULL
+Empty LineString                          Faraway point                             NULL               NULL
+Empty LineString                          Line going through left and right square  NULL               NULL
+Empty LineString                          NULL                                      NULL               NULL
+Empty LineString                          Nested Geometry Collection                NULL               NULL
+Empty LineString                          Point middle of Left Square               NULL               NULL
+Empty LineString                          Point middle of Right Square              NULL               NULL
+Empty LineString                          Square (left)                             NULL               NULL
+Empty LineString                          Square (right)                            NULL               NULL
+Empty LineString                          Square overlapping left and right square  NULL               NULL
+Empty Point                               Empty GeometryCollection                  NULL               NULL
+Empty Point                               Empty LineString                          NULL               NULL
+Empty Point                               Empty Point                               NULL               NULL
+Empty Point                               Faraway point                             NULL               NULL
+Empty Point                               Line going through left and right square  NULL               NULL
+Empty Point                               NULL                                      NULL               NULL
+Empty Point                               Nested Geometry Collection                NULL               NULL
+Empty Point                               Point middle of Left Square               NULL               NULL
+Empty Point                               Point middle of Right Square              NULL               NULL
+Empty Point                               Square (left)                             NULL               NULL
+Empty Point                               Square (right)                            NULL               NULL
+Empty Point                               Square overlapping left and right square  NULL               NULL
+Faraway point                             Empty GeometryCollection                  NULL               NULL
+Faraway point                             Empty LineString                          NULL               NULL
+Faraway point                             Empty Point                               NULL               NULL
+Faraway point                             Faraway point                             0                  0
+Faraway point                             Line going through left and right square  7.10633520177595   7.10633520177595
+Faraway point                             NULL                                      NULL               NULL
+Faraway point                             Nested Geometry Collection                7.07106781186548   7.07106781186548
+Faraway point                             Point middle of Left Square               7.10633520177595   7.10633520177595
+Faraway point                             Point middle of Right Square              6.36396103067893   6.36396103067893
+Faraway point                             Square (left)                             7.81024967590665   7.81024967590665
+Faraway point                             Square (right)                            7.07106781186548   7.07106781186548
+Faraway point                             Square overlapping left and right square  7.14212853426764   7.14212853426764
+Line going through left and right square  Empty GeometryCollection                  NULL               NULL
+Line going through left and right square  Empty LineString                          NULL               NULL
+Line going through left and right square  Empty Point                               NULL               NULL
+Line going through left and right square  Faraway point                             7.10633520177595   7.10633520177595
+Line going through left and right square  Line going through left and right square  0                  0
+Line going through left and right square  NULL                                      NULL               NULL
+Line going through left and right square  Nested Geometry Collection                0.707106781186548  0.707106781186548
+Line going through left and right square  Point middle of Left Square               1                  1
+Line going through left and right square  Point middle of Right Square              1                  1
+Line going through left and right square  Square (left)                             0.707106781186548  0.707106781186548
+Line going through left and right square  Square (right)                            0.707106781186548  0.707106781186548
+Line going through left and right square  Square overlapping left and right square  0.707106781186548  0.707106781186548
+NULL                                      Empty GeometryCollection                  NULL               NULL
+NULL                                      Empty LineString                          NULL               NULL
+NULL                                      Empty Point                               NULL               NULL
+NULL                                      Faraway point                             NULL               NULL
+NULL                                      Line going through left and right square  NULL               NULL
+NULL                                      NULL                                      NULL               NULL
+NULL                                      Nested Geometry Collection                NULL               NULL
+NULL                                      Point middle of Left Square               NULL               NULL
+NULL                                      Point middle of Right Square              NULL               NULL
+NULL                                      Square (left)                             NULL               NULL
+NULL                                      Square (right)                            NULL               NULL
+NULL                                      Square overlapping left and right square  NULL               NULL
+Nested Geometry Collection                Empty GeometryCollection                  NULL               NULL
+Nested Geometry Collection                Empty LineString                          NULL               NULL
+Nested Geometry Collection                Empty Point                               NULL               NULL
+Nested Geometry Collection                Faraway point                             7.07106781186548   7.07106781186548
+Nested Geometry Collection                Line going through left and right square  0.707106781186548  0.707106781186548
+Nested Geometry Collection                NULL                                      NULL               NULL
+Nested Geometry Collection                Nested Geometry Collection                0                  0
+Nested Geometry Collection                Point middle of Left Square               0.707106781186548  0.707106781186548
+Nested Geometry Collection                Point middle of Right Square              0.707106781186548  0.707106781186548
+Nested Geometry Collection                Square (left)                             1.4142135623731    1.4142135623731
+Nested Geometry Collection                Square (right)                            1.4142135623731    1.4142135623731
+Nested Geometry Collection                Square overlapping left and right square  1.4142135623731    1.4142135623731
+Point middle of Left Square               Empty GeometryCollection                  NULL               NULL
+Point middle of Left Square               Empty LineString                          NULL               NULL
+Point middle of Left Square               Empty Point                               NULL               NULL
+Point middle of Left Square               Faraway point                             7.10633520177595   7.10633520177595
+Point middle of Left Square               Line going through left and right square  1                  1
+Point middle of Left Square               NULL                                      NULL               NULL
+Point middle of Left Square               Nested Geometry Collection                0.707106781186548  0.707106781186548
+Point middle of Left Square               Point middle of Left Square               0                  0
+Point middle of Left Square               Point middle of Right Square              1                  1
+Point middle of Left Square               Square (left)                             0.707106781186548  0.707106781186548
+Point middle of Left Square               Square (right)                            1.58113883008419   1.58113883008419
+Point middle of Left Square               Square overlapping left and right square  1.58113883008419   1.58113883008419
+Point middle of Right Square              Empty GeometryCollection                  NULL               NULL
+Point middle of Right Square              Empty LineString                          NULL               NULL
+Point middle of Right Square              Empty Point                               NULL               NULL
+Point middle of Right Square              Faraway point                             6.36396103067893   6.36396103067893
+Point middle of Right Square              Line going through left and right square  1                  1
+Point middle of Right Square              NULL                                      NULL               NULL
+Point middle of Right Square              Nested Geometry Collection                0.707106781186548  0.707106781186548
+Point middle of Right Square              Point middle of Left Square               1                  1
+Point middle of Right Square              Point middle of Right Square              0                  0
+Point middle of Right Square              Square (left)                             1.58113883008419   1.58113883008419
+Point middle of Right Square              Square (right)                            0.707106781186548  0.707106781186548
+Point middle of Right Square              Square overlapping left and right square  0.781024967590665  0.781024967590665
+Square (left)                             Empty GeometryCollection                  NULL               NULL
+Square (left)                             Empty LineString                          NULL               NULL
+Square (left)                             Empty Point                               NULL               NULL
+Square (left)                             Faraway point                             7.81024967590665   7.81024967590665
+Square (left)                             Line going through left and right square  0.707106781186548  0.707106781186548
+Square (left)                             NULL                                      NULL               NULL
+Square (left)                             Nested Geometry Collection                1.4142135623731    1.4142135623731
+Square (left)                             Point middle of Left Square               0.707106781186548  0.707106781186548
+Square (left)                             Point middle of Right Square              1.58113883008419   1.58113883008419
+Square (left)                             Square (left)                             0                  5.55111512312578e-17
+Square (left)                             Square (right)                            1                  1
+Square (left)                             Square overlapping left and right square  1                  1
+Square (right)                            Empty GeometryCollection                  NULL               NULL
+Square (right)                            Empty LineString                          NULL               NULL
+Square (right)                            Empty Point                               NULL               NULL
+Square (right)                            Faraway point                             7.07106781186548   7.07106781186548
+Square (right)                            Line going through left and right square  0.707106781186548  0.707106781186548
+Square (right)                            NULL                                      NULL               NULL
+Square (right)                            Nested Geometry Collection                1.4142135623731    1.4142135623731
+Square (right)                            Point middle of Left Square               1.58113883008419   1.58113883008419
+Square (right)                            Point middle of Right Square              0.707106781186548  0.707106781186548
+Square (right)                            Square (left)                             1                  1
+Square (right)                            Square (right)                            0                  5.55111512312578e-17
+Square (right)                            Square overlapping left and right square  0.1                0.1
+Square overlapping left and right square  Empty GeometryCollection                  NULL               NULL
+Square overlapping left and right square  Empty LineString                          NULL               NULL
+Square overlapping left and right square  Empty Point                               NULL               NULL
+Square overlapping left and right square  Faraway point                             7.14212853426764   7.14212853426764
+Square overlapping left and right square  Line going through left and right square  0.707106781186548  0.707106781186548
+Square overlapping left and right square  NULL                                      NULL               NULL
+Square overlapping left and right square  Nested Geometry Collection                1.4142135623731    1.4142135623731
+Square overlapping left and right square  Point middle of Left Square               1.58113883008419   1.58113883008419
+Square overlapping left and right square  Point middle of Right Square              0.781024967590665  0.781024967590665
+Square overlapping left and right square  Square (left)                             1                  1
+Square overlapping left and right square  Square (right)                            0.1                0.1
+Square overlapping left and right square  Square overlapping left and right square  0                  5.55111512312578e-17
+
 # ST_LongestLine, ST_ShortestLine
 query TTTT
 SELECT

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -211,6 +211,18 @@ SELECT ST_Azimuth(ST_Point(0, 0), ST_Point(0, 0))
 ----
 NULL
 
+query RRRRRRR
+SELECT
+	degrees(ST_Angle('POINT (0 0)', 'POINT (0 1)', 'POINT (0 0)', 'POINT (1 0)')),
+	degrees(ST_Angle('POINT (0 0)', 'POINT (0 1)', 'POINT (0 0)')),
+	degrees(ST_Angle('POINT (0 0)', 'POINT (0 1)', 'POINT (1 1)')),
+	degrees(ST_Angle('POINT (0 0)', 'POINT (0 0)', 'POINT (0 0)', 'POINT (0 0)')),
+	degrees(ST_Angle('LINESTRING (0 0, 0 1)', 'LINESTRING (0 0, 1 0)')),
+	degrees(ST_Angle('LINESTRING (0 0, 0 1)', 'LINESTRING (0 0, 0 1)')),
+	degrees(ST_Angle('LINESTRING (0 0, 0 0)', 'LINESTRING (0 0, 0 0)'))
+----
+90  0  270  NULL  90  0  NULL
+
 subtest json_test
 
 # All values here should be true.

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3221,6 +3221,11 @@ SELECT ST_AsEWKT(ST_MakePolygon(
 ----
 SRID=4326;POLYGON ((40 80, 80 80, 80 40, 40 40, 40 80), (50 70, 70 70, 70 50, 50 50, 50 70))
 
+query T
+SELECT ST_AsEWKT(ST_Polygon( ST_GeomFromText('LINESTRING(75 29,77 29,77 29, 75 29)'), 4326))
+----
+SRID=4326;POLYGON ((75 29, 77 29, 77 29, 75 29))
+
 # Multi-Geometry related operations.
 query ITTT
 SELECT

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -942,7 +942,7 @@ invalid polygon            false  false  false  Self-intersection[1.5 1.5]     S
 self-intersecting polygon  false  false  true   Ring Self-intersection[14 20]  Ring Self-intersection  Valid Geometry     POLYGON ((14 20, 8 45, 20 35, 14 20), (14 20, 16 30, 12 30, 14 20))
 
 # Unary operators
-query TRRRRRR
+query TRRRRRRRT
 SELECT
   a.dsc,
   ST_Area(a.geom),
@@ -950,22 +950,24 @@ SELECT
   ST_Length(a.geom),
   ST_Length2D(a.geom),
   ST_Perimeter(a.geom),
-  ST_Perimeter2D(a.geom)
+  ST_Perimeter2D(a.geom),
+  ST_MinimumClearance(a.geom),
+  ST_AsText(ST_MinimumClearanceLine(a.geom))
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  0     0     0     0     0     0
-Empty LineString                          0     0     0     0     0     0
-Empty Point                               0     0     0     0     0     0
-Faraway point                             0     0     0     0     0     0
-Line going through left and right square  0     0     1     1     0     0
-NULL                                      NULL  NULL  NULL  NULL  NULL  NULL
-Nested Geometry Collection                0     0     0     0     0     0
-Point middle of Left Square               0     0     0     0     0     0
-Point middle of Right Square              0     0     0     0     0     0
-Square (left)                             1     1     0     0     4     4
-Square (right)                            1     1     0     0     4     4
-Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2
+Empty GeometryCollection                  0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Empty LineString                          0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Empty Point                               0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Faraway point                             0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Line going through left and right square  0     0     1     1     0     0     1     LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                      NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+Nested Geometry Collection                0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Point middle of Left Square               0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Point middle of Right Square              0     0     0     0     0     0     +Inf  LINESTRING EMPTY
+Square (left)                             1     1     0     0     4     4     1     LINESTRING (-1 0, 0 0)
+Square (right)                            1     1     0     0     4     4     1     LINESTRING (0 0, 1 0)
+Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2   1     LINESTRING (-0.1 0, -0.1 1)
 
 # Unary predicates
 query TBBBB

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1190,6 +1190,24 @@ Square (left)                             POINT (-0.5 0.5)  POINT (-0.5 0.5)  PO
 Square (right)                            POINT (0.5 0.5)   POINT (0.5 0.5)   POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
 Square overlapping left and right square  POINT (0.45 0.5)  POINT (0.45 0.5)  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 
+query TT
+SELECT
+  a.dsc,
+  ST_AsEWKT(ST_Boundary(a.geom))
+FROM geom_operators_test a
+WHERE NOT ST_IsCollection(a.geom)
+ORDER BY a.dsc
+----
+Empty LineString                          LINESTRING EMPTY
+Empty Point                               POINT EMPTY
+Faraway point                             GEOMETRYCOLLECTION EMPTY
+Line going through left and right square  MULTIPOINT (-0.5 0.5, 0.5 0.5)
+Point middle of Left Square               GEOMETRYCOLLECTION EMPTY
+Point middle of Right Square              GEOMETRYCOLLECTION EMPTY
+Square (left)                             LINESTRING (-1 0, 0 0, 0 1, -1 1, -1 0)
+Square (right)                            LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)
+Square overlapping left and right square  LINESTRING (-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0)
+
 query TTT
 SELECT
   a.dsc,
@@ -1945,6 +1963,160 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            LINESTRING (-0.1 0, 1 1)         LINESTRING (0 0, 0 0)
 Square overlapping left and right square  Square overlapping left and right square  LINESTRING (-0.1 0, 1 1)         LINESTRING (-0.1 0, -0.1 0)
 
+# ST_Difference
+query TTT
+SELECT
+  a.dsc,
+  b.dsc,
+  ST_AsText(ST_Difference(a.geom, b.geom))
+FROM geom_operators_test a, geom_operators_test b
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Empty LineString                          GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Empty Point                               GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Faraway point                             GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Line going through left and right square  GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  NULL                                      NULL
+Empty GeometryCollection                  Nested Geometry Collection                GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Point middle of Left Square               GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Point middle of Right Square              GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Square (left)                             GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Square (right)                            GEOMETRYCOLLECTION EMPTY
+Empty GeometryCollection                  Square overlapping left and right square  GEOMETRYCOLLECTION EMPTY
+Empty LineString                          Empty GeometryCollection                  LINESTRING EMPTY
+Empty LineString                          Empty LineString                          LINESTRING EMPTY
+Empty LineString                          Empty Point                               LINESTRING EMPTY
+Empty LineString                          Faraway point                             LINESTRING EMPTY
+Empty LineString                          Line going through left and right square  LINESTRING EMPTY
+Empty LineString                          NULL                                      NULL
+Empty LineString                          Nested Geometry Collection                LINESTRING EMPTY
+Empty LineString                          Point middle of Left Square               LINESTRING EMPTY
+Empty LineString                          Point middle of Right Square              LINESTRING EMPTY
+Empty LineString                          Square (left)                             LINESTRING EMPTY
+Empty LineString                          Square (right)                            LINESTRING EMPTY
+Empty LineString                          Square overlapping left and right square  LINESTRING EMPTY
+Empty Point                               Empty GeometryCollection                  POINT EMPTY
+Empty Point                               Empty LineString                          POINT EMPTY
+Empty Point                               Empty Point                               POINT EMPTY
+Empty Point                               Faraway point                             POINT EMPTY
+Empty Point                               Line going through left and right square  POINT EMPTY
+Empty Point                               NULL                                      NULL
+Empty Point                               Nested Geometry Collection                POINT EMPTY
+Empty Point                               Point middle of Left Square               POINT EMPTY
+Empty Point                               Point middle of Right Square              POINT EMPTY
+Empty Point                               Square (left)                             POINT EMPTY
+Empty Point                               Square (right)                            POINT EMPTY
+Empty Point                               Square overlapping left and right square  POINT EMPTY
+Faraway point                             Empty GeometryCollection                  POINT (5 5)
+Faraway point                             Empty LineString                          POINT (5 5)
+Faraway point                             Empty Point                               POINT (5 5)
+Faraway point                             Faraway point                             POINT EMPTY
+Faraway point                             Line going through left and right square  POINT (5 5)
+Faraway point                             NULL                                      NULL
+Faraway point                             Nested Geometry Collection                POINT (5 5)
+Faraway point                             Point middle of Left Square               POINT (5 5)
+Faraway point                             Point middle of Right Square              POINT (5 5)
+Faraway point                             Square (left)                             POINT (5 5)
+Faraway point                             Square (right)                            POINT (5 5)
+Faraway point                             Square overlapping left and right square  POINT (5 5)
+Line going through left and right square  Empty GeometryCollection                  LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Empty LineString                          LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Empty Point                               LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Faraway point                             LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Line going through left and right square  LINESTRING EMPTY
+Line going through left and right square  NULL                                      NULL
+Line going through left and right square  Nested Geometry Collection                LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Point middle of Left Square               LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Point middle of Right Square              LINESTRING (-0.5 0.5, 0.5 0.5)
+Line going through left and right square  Square (left)                             LINESTRING (0 0.5, 0.5 0.5)
+Line going through left and right square  Square (right)                            LINESTRING (-0.5 0.5, 0 0.5)
+Line going through left and right square  Square overlapping left and right square  LINESTRING (-0.5 0.5, -0.1 0.5)
+NULL                                      Empty GeometryCollection                  NULL
+NULL                                      Empty LineString                          NULL
+NULL                                      Empty Point                               NULL
+NULL                                      Faraway point                             NULL
+NULL                                      Line going through left and right square  NULL
+NULL                                      NULL                                      NULL
+NULL                                      Nested Geometry Collection                NULL
+NULL                                      Point middle of Left Square               NULL
+NULL                                      Point middle of Right Square              NULL
+NULL                                      Square (left)                             NULL
+NULL                                      Square (right)                            NULL
+NULL                                      Square overlapping left and right square  NULL
+Nested Geometry Collection                Empty GeometryCollection                  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+Nested Geometry Collection                Empty LineString                          GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+Nested Geometry Collection                Empty Point                               GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+Nested Geometry Collection                Faraway point                             POINT (0 0)
+Nested Geometry Collection                Line going through left and right square  POINT (0 0)
+Nested Geometry Collection                NULL                                      NULL
+Nested Geometry Collection                Nested Geometry Collection                POINT EMPTY
+Nested Geometry Collection                Point middle of Left Square               POINT (0 0)
+Nested Geometry Collection                Point middle of Right Square              POINT (0 0)
+Nested Geometry Collection                Square (left)                             POINT EMPTY
+Nested Geometry Collection                Square (right)                            POINT EMPTY
+Nested Geometry Collection                Square overlapping left and right square  POINT EMPTY
+Point middle of Left Square               Empty GeometryCollection                  POINT (-0.5 0.5)
+Point middle of Left Square               Empty LineString                          POINT (-0.5 0.5)
+Point middle of Left Square               Empty Point                               POINT (-0.5 0.5)
+Point middle of Left Square               Faraway point                             POINT (-0.5 0.5)
+Point middle of Left Square               Line going through left and right square  POINT EMPTY
+Point middle of Left Square               NULL                                      NULL
+Point middle of Left Square               Nested Geometry Collection                POINT (-0.5 0.5)
+Point middle of Left Square               Point middle of Left Square               POINT EMPTY
+Point middle of Left Square               Point middle of Right Square              POINT (-0.5 0.5)
+Point middle of Left Square               Square (left)                             POINT EMPTY
+Point middle of Left Square               Square (right)                            POINT (-0.5 0.5)
+Point middle of Left Square               Square overlapping left and right square  POINT (-0.5 0.5)
+Point middle of Right Square              Empty GeometryCollection                  POINT (0.5 0.5)
+Point middle of Right Square              Empty LineString                          POINT (0.5 0.5)
+Point middle of Right Square              Empty Point                               POINT (0.5 0.5)
+Point middle of Right Square              Faraway point                             POINT (0.5 0.5)
+Point middle of Right Square              Line going through left and right square  POINT EMPTY
+Point middle of Right Square              NULL                                      NULL
+Point middle of Right Square              Nested Geometry Collection                POINT (0.5 0.5)
+Point middle of Right Square              Point middle of Left Square               POINT (0.5 0.5)
+Point middle of Right Square              Point middle of Right Square              POINT EMPTY
+Point middle of Right Square              Square (left)                             POINT (0.5 0.5)
+Point middle of Right Square              Square (right)                            POINT EMPTY
+Point middle of Right Square              Square overlapping left and right square  POINT EMPTY
+Square (left)                             Empty GeometryCollection                  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+Square (left)                             Empty LineString                          POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+Square (left)                             Empty Point                               POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+Square (left)                             Faraway point                             POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (left)                             Line going through left and right square  POLYGON ((0 0.5, 0 0, -1 0, -1 1, 0 1, 0 0.5))
+Square (left)                             NULL                                      NULL
+Square (left)                             Nested Geometry Collection                POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (left)                             Point middle of Left Square               POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (left)                             Point middle of Right Square              POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (left)                             Square (left)                             POLYGON EMPTY
+Square (left)                             Square (right)                            POLYGON ((0 0, -1 0, -1 1, 0 1, 0 0))
+Square (left)                             Square overlapping left and right square  POLYGON ((-0.1 0, -1 0, -1 1, -0.1 1, -0.1 0))
+Square (right)                            Empty GeometryCollection                  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+Square (right)                            Empty LineString                          POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+Square (right)                            Empty Point                               POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+Square (right)                            Faraway point                             POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+Square (right)                            Line going through left and right square  POLYGON ((0 0.5, 0 1, 1 1, 1 0, 0 0, 0 0.5))
+Square (right)                            NULL                                      NULL
+Square (right)                            Nested Geometry Collection                POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+Square (right)                            Point middle of Left Square               POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+Square (right)                            Point middle of Right Square              POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+Square (right)                            Square (left)                             POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))
+Square (right)                            Square (right)                            POLYGON EMPTY
+Square (right)                            Square overlapping left and right square  POLYGON EMPTY
+Square overlapping left and right square  Empty GeometryCollection                  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+Square overlapping left and right square  Empty LineString                          POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+Square overlapping left and right square  Empty Point                               POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+Square overlapping left and right square  Faraway point                             POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+Square overlapping left and right square  Line going through left and right square  POLYGON ((-0.1 0.5, -0.1 1, 1 1, 1 0, -0.1 0, -0.1 0.5))
+Square overlapping left and right square  NULL                                      NULL
+Square overlapping left and right square  Nested Geometry Collection                POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+Square overlapping left and right square  Point middle of Left Square               POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+Square overlapping left and right square  Point middle of Right Square              POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+Square overlapping left and right square  Square (left)                             POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))
+Square overlapping left and right square  Square (right)                            POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))
+Square overlapping left and right square  Square overlapping left and right square  POLYGON EMPTY
+
 # Binary predicates
 query TTBBBBBBBBBBB
 SELECT
@@ -2625,160 +2797,161 @@ FROM ( VALUES
 true
 false
 
-query TTTB
+query TTTTB
 SELECT
   a.dsc,
   b.dsc,
   ST_Relate(a.geom, b.geom),
+  ST_Relate(a.geom, b.geom, 3),
   ST_Relate(a.geom, b.geom, 'T**FF*FF*')
 FROM geom_operators_test a
 JOIN geom_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc
 ----
-Empty GeometryCollection                  Empty GeometryCollection                  FFFFFFFF2  false
-Empty GeometryCollection                  Empty LineString                          FFFFFFFF2  false
-Empty GeometryCollection                  Empty Point                               FFFFFFFF2  false
-Empty GeometryCollection                  Faraway point                             FFFFFF0F2  false
-Empty GeometryCollection                  Line going through left and right square  FFFFFF102  false
-Empty GeometryCollection                  NULL                                      NULL       NULL
-Empty GeometryCollection                  Nested Geometry Collection                FFFFFF0F2  false
-Empty GeometryCollection                  Point middle of Left Square               FFFFFF0F2  false
-Empty GeometryCollection                  Point middle of Right Square              FFFFFF0F2  false
-Empty GeometryCollection                  Square (left)                             FFFFFF212  false
-Empty GeometryCollection                  Square (right)                            FFFFFF212  false
-Empty GeometryCollection                  Square overlapping left and right square  FFFFFF212  false
-Empty LineString                          Empty GeometryCollection                  FFFFFFFF2  false
-Empty LineString                          Empty LineString                          FFFFFFFF2  false
-Empty LineString                          Empty Point                               FFFFFFFF2  false
-Empty LineString                          Faraway point                             FFFFFF0F2  false
-Empty LineString                          Line going through left and right square  FFFFFF102  false
-Empty LineString                          NULL                                      NULL       NULL
-Empty LineString                          Nested Geometry Collection                FFFFFF0F2  false
-Empty LineString                          Point middle of Left Square               FFFFFF0F2  false
-Empty LineString                          Point middle of Right Square              FFFFFF0F2  false
-Empty LineString                          Square (left)                             FFFFFF212  false
-Empty LineString                          Square (right)                            FFFFFF212  false
-Empty LineString                          Square overlapping left and right square  FFFFFF212  false
-Empty Point                               Empty GeometryCollection                  FFFFFFFF2  false
-Empty Point                               Empty LineString                          FFFFFFFF2  false
-Empty Point                               Empty Point                               FFFFFFFF2  false
-Empty Point                               Faraway point                             FFFFFF0F2  false
-Empty Point                               Line going through left and right square  FFFFFF102  false
-Empty Point                               NULL                                      NULL       NULL
-Empty Point                               Nested Geometry Collection                FFFFFF0F2  false
-Empty Point                               Point middle of Left Square               FFFFFF0F2  false
-Empty Point                               Point middle of Right Square              FFFFFF0F2  false
-Empty Point                               Square (left)                             FFFFFF212  false
-Empty Point                               Square (right)                            FFFFFF212  false
-Empty Point                               Square overlapping left and right square  FFFFFF212  false
-Faraway point                             Empty GeometryCollection                  FF0FFFFF2  false
-Faraway point                             Empty LineString                          FF0FFFFF2  false
-Faraway point                             Empty Point                               FF0FFFFF2  false
-Faraway point                             Faraway point                             0FFFFFFF2  true
-Faraway point                             Line going through left and right square  FF0FFF102  false
-Faraway point                             NULL                                      NULL       NULL
-Faraway point                             Nested Geometry Collection                FF0FFF0F2  false
-Faraway point                             Point middle of Left Square               FF0FFF0F2  false
-Faraway point                             Point middle of Right Square              FF0FFF0F2  false
-Faraway point                             Square (left)                             FF0FFF212  false
-Faraway point                             Square (right)                            FF0FFF212  false
-Faraway point                             Square overlapping left and right square  FF0FFF212  false
-Line going through left and right square  Empty GeometryCollection                  FF1FF0FF2  false
-Line going through left and right square  Empty LineString                          FF1FF0FF2  false
-Line going through left and right square  Empty Point                               FF1FF0FF2  false
-Line going through left and right square  Faraway point                             FF1FF00F2  false
-Line going through left and right square  Line going through left and right square  1FFF0FFF2  false
-Line going through left and right square  NULL                                      NULL       NULL
-Line going through left and right square  Nested Geometry Collection                FF1FF00F2  false
-Line going through left and right square  Point middle of Left Square               FF10F0FF2  false
-Line going through left and right square  Point middle of Right Square              FF10F0FF2  false
-Line going through left and right square  Square (left)                             1010F0212  false
-Line going through left and right square  Square (right)                            1010F0212  false
-Line going through left and right square  Square overlapping left and right square  1010F0212  false
-NULL                                      Empty GeometryCollection                  NULL       NULL
-NULL                                      Empty LineString                          NULL       NULL
-NULL                                      Empty Point                               NULL       NULL
-NULL                                      Faraway point                             NULL       NULL
-NULL                                      Line going through left and right square  NULL       NULL
-NULL                                      NULL                                      NULL       NULL
-NULL                                      Nested Geometry Collection                NULL       NULL
-NULL                                      Point middle of Left Square               NULL       NULL
-NULL                                      Point middle of Right Square              NULL       NULL
-NULL                                      Square (left)                             NULL       NULL
-NULL                                      Square (right)                            NULL       NULL
-NULL                                      Square overlapping left and right square  NULL       NULL
-Nested Geometry Collection                Empty GeometryCollection                  FF0FFFFF2  false
-Nested Geometry Collection                Empty LineString                          FF0FFFFF2  false
-Nested Geometry Collection                Empty Point                               FF0FFFFF2  false
-Nested Geometry Collection                Faraway point                             FF0FFF0F2  false
-Nested Geometry Collection                Line going through left and right square  FF0FFF102  false
-Nested Geometry Collection                NULL                                      NULL       NULL
-Nested Geometry Collection                Nested Geometry Collection                0FFFFFFF2  true
-Nested Geometry Collection                Point middle of Left Square               FF0FFF0F2  false
-Nested Geometry Collection                Point middle of Right Square              FF0FFF0F2  false
-Nested Geometry Collection                Square (left)                             F0FFFF212  false
-Nested Geometry Collection                Square (right)                            F0FFFF212  false
-Nested Geometry Collection                Square overlapping left and right square  F0FFFF212  false
-Point middle of Left Square               Empty GeometryCollection                  FF0FFFFF2  false
-Point middle of Left Square               Empty LineString                          FF0FFFFF2  false
-Point middle of Left Square               Empty Point                               FF0FFFFF2  false
-Point middle of Left Square               Faraway point                             FF0FFF0F2  false
-Point middle of Left Square               Line going through left and right square  F0FFFF102  false
-Point middle of Left Square               NULL                                      NULL       NULL
-Point middle of Left Square               Nested Geometry Collection                FF0FFF0F2  false
-Point middle of Left Square               Point middle of Left Square               0FFFFFFF2  true
-Point middle of Left Square               Point middle of Right Square              FF0FFF0F2  false
-Point middle of Left Square               Square (left)                             0FFFFF212  false
-Point middle of Left Square               Square (right)                            FF0FFF212  false
-Point middle of Left Square               Square overlapping left and right square  FF0FFF212  false
-Point middle of Right Square              Empty GeometryCollection                  FF0FFFFF2  false
-Point middle of Right Square              Empty LineString                          FF0FFFFF2  false
-Point middle of Right Square              Empty Point                               FF0FFFFF2  false
-Point middle of Right Square              Faraway point                             FF0FFF0F2  false
-Point middle of Right Square              Line going through left and right square  F0FFFF102  false
-Point middle of Right Square              NULL                                      NULL       NULL
-Point middle of Right Square              Nested Geometry Collection                FF0FFF0F2  false
-Point middle of Right Square              Point middle of Left Square               FF0FFF0F2  false
-Point middle of Right Square              Point middle of Right Square              0FFFFFFF2  true
-Point middle of Right Square              Square (left)                             FF0FFF212  false
-Point middle of Right Square              Square (right)                            0FFFFF212  false
-Point middle of Right Square              Square overlapping left and right square  0FFFFF212  false
-Square (left)                             Empty GeometryCollection                  FF2FF1FF2  false
-Square (left)                             Empty LineString                          FF2FF1FF2  false
-Square (left)                             Empty Point                               FF2FF1FF2  false
-Square (left)                             Faraway point                             FF2FF10F2  false
-Square (left)                             Line going through left and right square  1020F1102  false
-Square (left)                             NULL                                      NULL       NULL
-Square (left)                             Nested Geometry Collection                FF20F1FF2  false
-Square (left)                             Point middle of Left Square               0F2FF1FF2  true
-Square (left)                             Point middle of Right Square              FF2FF10F2  false
-Square (left)                             Square (left)                             2FFF1FFF2  false
-Square (left)                             Square (right)                            FF2F11212  false
-Square (left)                             Square overlapping left and right square  212111212  false
-Square (right)                            Empty GeometryCollection                  FF2FF1FF2  false
-Square (right)                            Empty LineString                          FF2FF1FF2  false
-Square (right)                            Empty Point                               FF2FF1FF2  false
-Square (right)                            Faraway point                             FF2FF10F2  false
-Square (right)                            Line going through left and right square  1020F1102  false
-Square (right)                            NULL                                      NULL       NULL
-Square (right)                            Nested Geometry Collection                FF20F1FF2  false
-Square (right)                            Point middle of Left Square               FF2FF10F2  false
-Square (right)                            Point middle of Right Square              0F2FF1FF2  true
-Square (right)                            Square (left)                             FF2F11212  false
-Square (right)                            Square (right)                            2FFF1FFF2  false
-Square (right)                            Square overlapping left and right square  2FF11F212  false
-Square overlapping left and right square  Empty GeometryCollection                  FF2FF1FF2  false
-Square overlapping left and right square  Empty LineString                          FF2FF1FF2  false
-Square overlapping left and right square  Empty Point                               FF2FF1FF2  false
-Square overlapping left and right square  Faraway point                             FF2FF10F2  false
-Square overlapping left and right square  Line going through left and right square  1020F1102  false
-Square overlapping left and right square  NULL                                      NULL       NULL
-Square overlapping left and right square  Nested Geometry Collection                FF20F1FF2  false
-Square overlapping left and right square  Point middle of Left Square               FF2FF10F2  false
-Square overlapping left and right square  Point middle of Right Square              0F2FF1FF2  true
-Square overlapping left and right square  Square (left)                             212111212  false
-Square overlapping left and right square  Square (right)                            212F11FF2  false
-Square overlapping left and right square  Square overlapping left and right square  2FFF1FFF2  false
+Empty GeometryCollection                  Empty GeometryCollection                  FFFFFFFF2  FFFFFFFF2  false
+Empty GeometryCollection                  Empty LineString                          FFFFFFFF2  FFFFFFFF2  false
+Empty GeometryCollection                  Empty Point                               FFFFFFFF2  FFFFFFFF2  false
+Empty GeometryCollection                  Faraway point                             FFFFFF0F2  FFFFFF0F2  false
+Empty GeometryCollection                  Line going through left and right square  FFFFFF102  FFFFFF102  false
+Empty GeometryCollection                  NULL                                      NULL       NULL       NULL
+Empty GeometryCollection                  Nested Geometry Collection                FFFFFF0F2  FFFFFF0F2  false
+Empty GeometryCollection                  Point middle of Left Square               FFFFFF0F2  FFFFFF0F2  false
+Empty GeometryCollection                  Point middle of Right Square              FFFFFF0F2  FFFFFF0F2  false
+Empty GeometryCollection                  Square (left)                             FFFFFF212  FFFFFF212  false
+Empty GeometryCollection                  Square (right)                            FFFFFF212  FFFFFF212  false
+Empty GeometryCollection                  Square overlapping left and right square  FFFFFF212  FFFFFF212  false
+Empty LineString                          Empty GeometryCollection                  FFFFFFFF2  FFFFFFFF2  false
+Empty LineString                          Empty LineString                          FFFFFFFF2  FFFFFFFF2  false
+Empty LineString                          Empty Point                               FFFFFFFF2  FFFFFFFF2  false
+Empty LineString                          Faraway point                             FFFFFF0F2  FFFFFF0F2  false
+Empty LineString                          Line going through left and right square  FFFFFF102  FFFFFF102  false
+Empty LineString                          NULL                                      NULL       NULL       NULL
+Empty LineString                          Nested Geometry Collection                FFFFFF0F2  FFFFFF0F2  false
+Empty LineString                          Point middle of Left Square               FFFFFF0F2  FFFFFF0F2  false
+Empty LineString                          Point middle of Right Square              FFFFFF0F2  FFFFFF0F2  false
+Empty LineString                          Square (left)                             FFFFFF212  FFFFFF212  false
+Empty LineString                          Square (right)                            FFFFFF212  FFFFFF212  false
+Empty LineString                          Square overlapping left and right square  FFFFFF212  FFFFFF212  false
+Empty Point                               Empty GeometryCollection                  FFFFFFFF2  FFFFFFFF2  false
+Empty Point                               Empty LineString                          FFFFFFFF2  FFFFFFFF2  false
+Empty Point                               Empty Point                               FFFFFFFF2  FFFFFFFF2  false
+Empty Point                               Faraway point                             FFFFFF0F2  FFFFFF0F2  false
+Empty Point                               Line going through left and right square  FFFFFF102  FFFFFF102  false
+Empty Point                               NULL                                      NULL       NULL       NULL
+Empty Point                               Nested Geometry Collection                FFFFFF0F2  FFFFFF0F2  false
+Empty Point                               Point middle of Left Square               FFFFFF0F2  FFFFFF0F2  false
+Empty Point                               Point middle of Right Square              FFFFFF0F2  FFFFFF0F2  false
+Empty Point                               Square (left)                             FFFFFF212  FFFFFF212  false
+Empty Point                               Square (right)                            FFFFFF212  FFFFFF212  false
+Empty Point                               Square overlapping left and right square  FFFFFF212  FFFFFF212  false
+Faraway point                             Empty GeometryCollection                  FF0FFFFF2  FF0FFFFF2  false
+Faraway point                             Empty LineString                          FF0FFFFF2  FF0FFFFF2  false
+Faraway point                             Empty Point                               FF0FFFFF2  FF0FFFFF2  false
+Faraway point                             Faraway point                             0FFFFFFF2  0FFFFFFF2  true
+Faraway point                             Line going through left and right square  FF0FFF102  FF0FFF102  false
+Faraway point                             NULL                                      NULL       NULL       NULL
+Faraway point                             Nested Geometry Collection                FF0FFF0F2  FF0FFF0F2  false
+Faraway point                             Point middle of Left Square               FF0FFF0F2  FF0FFF0F2  false
+Faraway point                             Point middle of Right Square              FF0FFF0F2  FF0FFF0F2  false
+Faraway point                             Square (left)                             FF0FFF212  FF0FFF212  false
+Faraway point                             Square (right)                            FF0FFF212  FF0FFF212  false
+Faraway point                             Square overlapping left and right square  FF0FFF212  FF0FFF212  false
+Line going through left and right square  Empty GeometryCollection                  FF1FF0FF2  FF1FF0FF2  false
+Line going through left and right square  Empty LineString                          FF1FF0FF2  FF1FF0FF2  false
+Line going through left and right square  Empty Point                               FF1FF0FF2  FF1FF0FF2  false
+Line going through left and right square  Faraway point                             FF1FF00F2  FF1FF00F2  false
+Line going through left and right square  Line going through left and right square  1FFF0FFF2  1FFFFFFF2  false
+Line going through left and right square  NULL                                      NULL       NULL       NULL
+Line going through left and right square  Nested Geometry Collection                FF1FF00F2  FF1FF00F2  false
+Line going through left and right square  Point middle of Left Square               FF10F0FF2  0F1FFFFF2  false
+Line going through left and right square  Point middle of Right Square              FF10F0FF2  0F1FFFFF2  false
+Line going through left and right square  Square (left)                             1010F0212  101FFF202  false
+Line going through left and right square  Square (right)                            1010F0212  101FFF202  false
+Line going through left and right square  Square overlapping left and right square  1010F0212  101FFF202  false
+NULL                                      Empty GeometryCollection                  NULL       NULL       NULL
+NULL                                      Empty LineString                          NULL       NULL       NULL
+NULL                                      Empty Point                               NULL       NULL       NULL
+NULL                                      Faraway point                             NULL       NULL       NULL
+NULL                                      Line going through left and right square  NULL       NULL       NULL
+NULL                                      NULL                                      NULL       NULL       NULL
+NULL                                      Nested Geometry Collection                NULL       NULL       NULL
+NULL                                      Point middle of Left Square               NULL       NULL       NULL
+NULL                                      Point middle of Right Square              NULL       NULL       NULL
+NULL                                      Square (left)                             NULL       NULL       NULL
+NULL                                      Square (right)                            NULL       NULL       NULL
+NULL                                      Square overlapping left and right square  NULL       NULL       NULL
+Nested Geometry Collection                Empty GeometryCollection                  FF0FFFFF2  FF0FFFFF2  false
+Nested Geometry Collection                Empty LineString                          FF0FFFFF2  FF0FFFFF2  false
+Nested Geometry Collection                Empty Point                               FF0FFFFF2  FF0FFFFF2  false
+Nested Geometry Collection                Faraway point                             FF0FFF0F2  FF0FFF0F2  false
+Nested Geometry Collection                Line going through left and right square  FF0FFF102  FF0FFF102  false
+Nested Geometry Collection                NULL                                      NULL       NULL       NULL
+Nested Geometry Collection                Nested Geometry Collection                0FFFFFFF2  0FFFFFFF2  true
+Nested Geometry Collection                Point middle of Left Square               FF0FFF0F2  FF0FFF0F2  false
+Nested Geometry Collection                Point middle of Right Square              FF0FFF0F2  FF0FFF0F2  false
+Nested Geometry Collection                Square (left)                             F0FFFF212  F0FFFF212  false
+Nested Geometry Collection                Square (right)                            F0FFFF212  F0FFFF212  false
+Nested Geometry Collection                Square overlapping left and right square  F0FFFF212  F0FFFF212  false
+Point middle of Left Square               Empty GeometryCollection                  FF0FFFFF2  FF0FFFFF2  false
+Point middle of Left Square               Empty LineString                          FF0FFFFF2  FF0FFFFF2  false
+Point middle of Left Square               Empty Point                               FF0FFFFF2  FF0FFFFF2  false
+Point middle of Left Square               Faraway point                             FF0FFF0F2  FF0FFF0F2  false
+Point middle of Left Square               Line going through left and right square  F0FFFF102  0FFFFF1F2  false
+Point middle of Left Square               NULL                                      NULL       NULL       NULL
+Point middle of Left Square               Nested Geometry Collection                FF0FFF0F2  FF0FFF0F2  false
+Point middle of Left Square               Point middle of Left Square               0FFFFFFF2  0FFFFFFF2  true
+Point middle of Left Square               Point middle of Right Square              FF0FFF0F2  FF0FFF0F2  false
+Point middle of Left Square               Square (left)                             0FFFFF212  0FFFFF212  false
+Point middle of Left Square               Square (right)                            FF0FFF212  FF0FFF212  false
+Point middle of Left Square               Square overlapping left and right square  FF0FFF212  FF0FFF212  false
+Point middle of Right Square              Empty GeometryCollection                  FF0FFFFF2  FF0FFFFF2  false
+Point middle of Right Square              Empty LineString                          FF0FFFFF2  FF0FFFFF2  false
+Point middle of Right Square              Empty Point                               FF0FFFFF2  FF0FFFFF2  false
+Point middle of Right Square              Faraway point                             FF0FFF0F2  FF0FFF0F2  false
+Point middle of Right Square              Line going through left and right square  F0FFFF102  0FFFFF1F2  false
+Point middle of Right Square              NULL                                      NULL       NULL       NULL
+Point middle of Right Square              Nested Geometry Collection                FF0FFF0F2  FF0FFF0F2  false
+Point middle of Right Square              Point middle of Left Square               FF0FFF0F2  FF0FFF0F2  false
+Point middle of Right Square              Point middle of Right Square              0FFFFFFF2  0FFFFFFF2  true
+Point middle of Right Square              Square (left)                             FF0FFF212  FF0FFF212  false
+Point middle of Right Square              Square (right)                            0FFFFF212  0FFFFF212  false
+Point middle of Right Square              Square overlapping left and right square  0FFFFF212  0FFFFF212  false
+Square (left)                             Empty GeometryCollection                  FF2FF1FF2  FF2FF1FF2  false
+Square (left)                             Empty LineString                          FF2FF1FF2  FF2FF1FF2  false
+Square (left)                             Empty Point                               FF2FF1FF2  FF2FF1FF2  false
+Square (left)                             Faraway point                             FF2FF10F2  FF2FF10F2  false
+Square (left)                             Line going through left and right square  1020F1102  1F20F01F2  false
+Square (left)                             NULL                                      NULL       NULL       NULL
+Square (left)                             Nested Geometry Collection                FF20F1FF2  FF20F1FF2  false
+Square (left)                             Point middle of Left Square               0F2FF1FF2  0F2FF1FF2  true
+Square (left)                             Point middle of Right Square              FF2FF10F2  FF2FF10F2  false
+Square (left)                             Square (left)                             2FFF1FFF2  2FFF0FFF2  false
+Square (left)                             Square (right)                            FF2F11212  1F2F002F2  false
+Square (left)                             Square overlapping left and right square  212111212  2F2F002F2  false
+Square (right)                            Empty GeometryCollection                  FF2FF1FF2  FF2FF1FF2  false
+Square (right)                            Empty LineString                          FF2FF1FF2  FF2FF1FF2  false
+Square (right)                            Empty Point                               FF2FF1FF2  FF2FF1FF2  false
+Square (right)                            Faraway point                             FF2FF10F2  FF2FF10F2  false
+Square (right)                            Line going through left and right square  1020F1102  1F20F01F2  false
+Square (right)                            NULL                                      NULL       NULL       NULL
+Square (right)                            Nested Geometry Collection                FF20F1FF2  FF20F1FF2  false
+Square (right)                            Point middle of Left Square               FF2FF10F2  FF2FF10F2  false
+Square (right)                            Point middle of Right Square              0F2FF1FF2  0F2FF1FF2  true
+Square (right)                            Square (left)                             FF2F11212  1F2F0F202  false
+Square (right)                            Square (right)                            2FFF1FFF2  2FFF0FFF2  false
+Square (right)                            Square overlapping left and right square  2FF11F212  2FFF0F202  false
+Square overlapping left and right square  Empty GeometryCollection                  FF2FF1FF2  FF2FF1FF2  false
+Square overlapping left and right square  Empty LineString                          FF2FF1FF2  FF2FF1FF2  false
+Square overlapping left and right square  Empty Point                               FF2FF1FF2  FF2FF1FF2  false
+Square overlapping left and right square  Faraway point                             FF2FF10F2  FF2FF10F2  false
+Square overlapping left and right square  Line going through left and right square  1020F1102  1F20F01F2  false
+Square overlapping left and right square  NULL                                      NULL       NULL       NULL
+Square overlapping left and right square  Nested Geometry Collection                FF20F1FF2  FF20F1FF2  false
+Square overlapping left and right square  Point middle of Left Square               FF2FF10F2  FF2FF10F2  false
+Square overlapping left and right square  Point middle of Right Square              0F2FF1FF2  0F2FF1FF2  true
+Square overlapping left and right square  Square (left)                             212111212  2F2F0F202  false
+Square overlapping left and right square  Square (right)                            212F11FF2  2F2F00FF2  false
+Square overlapping left and right square  Square overlapping left and right square  2FFF1FFF2  2FFF0FFF2  false
 
 # ST_Envelope
 query TT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2758,6 +2758,104 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_frechetdistance": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.FrechetDistance(a.Geometry, b.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				if ret == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info:         `Returns the Frechet distance between the given geometries.`,
+				libraryUsage: usesGEOS,
+			},
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_a", types.Geometry},
+				{"geometry_b", types.Geometry},
+				{"densify_frac", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				densifyFrac := tree.MustBeDFloat(args[2])
+
+				ret, err := geomfn.FrechetDistanceDensify(a.Geometry, b.Geometry, float64(densifyFrac))
+				if err != nil {
+					return nil, err
+				}
+				if ret == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*ret)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Frechet distance between the given geometries, with the given ` +
+					`segment densification (range 0.0-1.0, -1 to disable).`,
+				libraryUsage: usesGEOS,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_hausdorffdistance": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.HausdorffDistance(a.Geometry, b.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				if ret == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info:         `Returns the Hausdorff distance between the given geometries.`,
+				libraryUsage: usesGEOS,
+			},
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_a", types.Geometry},
+				{"geometry_b", types.Geometry},
+				{"densify_frac", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				densifyFrac := tree.MustBeDFloat(args[2])
+
+				ret, err := geomfn.HausdorffDistanceDensify(a.Geometry, b.Geometry, float64(densifyFrac))
+				if err != nil {
+					return nil, err
+				}
+				if ret == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*ret)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Hausdorff distance between the given geometries, with the given ` +
+					`segment densification (range 0.0-1.0).`,
+				libraryUsage: usesGEOS,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_maxdistance": makeBuiltin(
 		defProps(),
 		geometryOverload2(
@@ -5014,10 +5112,8 @@ Bottom Left.`,
 	"st_dump":                    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49785}),
 	"st_dumppoints":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49786}),
 	"st_dumprings":               makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49787}),
-	"st_frechetdistance":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48940}),
 	"st_generatepoints":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48941}),
 	"st_geometricmedian":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48944}),
-	"st_hausdorffdistance":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48947}),
 	"st_interpolatepoint":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48950}),
 	"st_isvaliddetail":           makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48962}),
 	"st_length2dspheroid":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48967}),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -596,6 +596,30 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_polygon": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"srid", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				srid := tree.MustBeDInt(args[1])
+				polygon, err := geomfn.MakePolygonWithSRID(g.Geometry, int(srid))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(polygon), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a new Polygon from the given LineString and sets its SRID. It is equivalent ` +
+					`to ST_MakePolygon with a single argument followed by ST_SetSRID.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
 	"st_geomcollfromtext":        geometryFromTextCheckShapeBuiltin(geopb.ShapeType_GeometryCollection),
 	"st_geomcollfromwkb":         geometryFromWKBCheckShapeBuiltin(geopb.ShapeType_GeometryCollection),
@@ -4923,7 +4947,6 @@ Bottom Left.`,
 	"st_orderingequals":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49002}),
 	"st_orientedenvelope":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49003}),
 	"st_pointinsidecircle":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49007}),
-	"st_polygon":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49010}),
 	"st_polygonize":              makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49011}),
 	"st_quantizecoordinates":     makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49012}),
 	"st_seteffectivearea":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49030}),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4455,6 +4455,92 @@ Bottom Left.`,
 		},
 	),
 
+	"st_angle": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"point1", types.Geometry},
+				{"point2", types.Geometry},
+				{"point3", types.Geometry},
+				{"point4", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g1 := tree.MustBeDGeometry(args[0]).Geometry
+				g2 := tree.MustBeDGeometry(args[1]).Geometry
+				g3 := tree.MustBeDGeometry(args[2]).Geometry
+				g4 := tree.MustBeDGeometry(args[3]).Geometry
+				angle, err := geomfn.Angle(g1, g2, g3, g4)
+				if err != nil {
+					return nil, err
+				}
+				if angle == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*angle)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the clockwise angle between the vectors formed by point1,point2 and point3,point4. ` +
+					`The arguments must be POINT geometries. Returns NULL if any vectors have 0 length.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"point1", types.Geometry},
+				{"point2", types.Geometry},
+				{"point3", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g1 := tree.MustBeDGeometry(args[0]).Geometry
+				g2 := tree.MustBeDGeometry(args[1]).Geometry
+				g3 := tree.MustBeDGeometry(args[2]).Geometry
+				g4, err := geo.MakeGeometryFromGeomT(geom.NewPointEmpty(geom.XY))
+				if err != nil {
+					return nil, err
+				}
+				angle, err := geomfn.Angle(g1, g2, g3, g4)
+				if err != nil {
+					return nil, err
+				}
+				if angle == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*angle)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the clockwise angle between the vectors formed by point2,point1 and point2,point3. ` +
+					`The arguments must be POINT geometries. Returns NULL if any vectors have 0 length.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"line1", types.Geometry},
+				{"line2", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g1 := tree.MustBeDGeometry(args[0]).Geometry
+				g2 := tree.MustBeDGeometry(args[1]).Geometry
+				angle, err := geomfn.AngleLineString(g1, g2)
+				if err != nil {
+					return nil, err
+				}
+				if angle == nil {
+					return tree.DNull, nil
+				}
+				return tree.NewDFloat(tree.DFloat(*angle)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the clockwise angle between two LINESTRING geometries, treating them as vectors ` +
+					`between their start- and endpoints. Returns NULL if any vectors have 0 length.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
 	//
 	// BoundingBox
 	//
@@ -4909,7 +4995,6 @@ Bottom Left.`,
 	// Unimplemented.
 	//
 
-	"st_angle":                   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48866}),
 	"st_asencodedpolyline":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48872}),
 	"st_asgml":                   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48877}),
 	"st_aslatlontext":            makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48882}),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1962,6 +1962,43 @@ Flags shown square brackets after the geometry type have the following meaning:
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_minimumclearance": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MinimumClearance(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: `Returns the minimum distance a vertex can move before producing an invalid geometry. ` +
+					`Returns Infinity if no minimum clearance can be found (e.g. for a single point).`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_minimumclearanceline": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MinimumClearanceLine(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Returns a LINESTRING spanning the minimum distance a vertex can move before producing ` +
+					`an invalid geometry. If no minimum clearance can be found (e.g. for a single point), an ` +
+					`empty LINESTRING is returned.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_numinteriorrings": makeBuiltin(
 		defProps(),
 		geometryOverload1(
@@ -4882,8 +4919,6 @@ Bottom Left.`,
 	"st_memsize":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48985}),
 	"st_minimumboundingcircle":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48987}),
 	"st_minimumboundingradius":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48988}),
-	"st_minimumclearance":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48989}),
-	"st_minimumclearanceline":    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48990}),
 	"st_node":                    makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48993}),
 	"st_orderingequals":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49002}),
 	"st_orientedenvelope":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49003}),


### PR DESCRIPTION
Backport:
  * 1/1 commits from "builtins: implement ST_Boundary, ST_Difference, and ST_Relate with BNR" (#54310)
  * 1/1 commits from "builtins: implement ST_MinimumClearance and ST_MinimumClearanceLine" (#54315)
  * 1/1 commits from "builtins: implement ST_Polygon" (#54318)
  * 1/1 commits from "builtins: implement ST_Angle" (#54307)
  * 1/1 commits from "builtins: implement ST_FrechetDistance and ST_HausdorffDistance" (#54314)

Please see individual PRs for details.

/cc @cockroachdb/release
