### PR TITLE
backupccl: clear table stats from manifest on canceled backup

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -513,8 +513,7 @@ func (b *backupResumer) Resume(
 		return err
 	}
 
-	err = b.clearStats(ctx, p.ExecCfg().DB)
-	if err != nil {
+	if err := b.clearStats(ctx, p.ExecCfg().DB); err != nil {
 		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
 	}
 	b.deleteCheckpoint(ctx, p.ExecCfg(), p.User())
@@ -663,6 +662,9 @@ func (b *backupResumer) OnFailOrCancel(ctx context.Context, phs interface{}) err
 
 	p := phs.(sql.PlanHookState)
 	cfg := p.ExecCfg()
+	if err := b.clearStats(ctx, p.ExecCfg().DB); err != nil {
+		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
+	}
 	b.deleteCheckpoint(ctx, cfg, p.User())
 	return cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return b.releaseProtectedTimestamp(ctx, txn, cfg.ProtectedTimestampProvider)


### PR DESCRIPTION
The table statistics that are being backed up are stored in the backup
manifest, and thus the job description in v19.2 and v20.1. They are
cleared when the job completes successfully. This commit changes backup
to also clear the statistics when the job either fails or is canceled.
Failing to do this may leave behind unnecassarily large job rows.

Release note (bug fix): Clear table statistics from job description in
failed and canceled backup jobs.