### PR TITLE
release-20.1: backupccl: show schema privileges in SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -391,6 +391,9 @@ func showPrivileges(descriptor *descpb.Descriptor) string {
 	} else if table := descpb.TableFromDescriptor(descriptor, hlc.Timestamp{}); table != nil {
 		privDesc = table.GetPrivileges()
 		objectType = privilege.Table
+	} else if schema := descriptor.GetSchema(); schema != nil {
+		privDesc = schema.GetPrivileges()
+		objectType = privilege.Schema
 	}
 	if privDesc == nil {
 		return ""
@@ -398,10 +401,10 @@ func showPrivileges(descriptor *descpb.Descriptor) string {
 	for _, userPriv := range privDesc.Show(objectType) {
 		user := userPriv.User
 		privs := userPriv.Privileges
-		privStringBuilder.WriteString("GRANT ")
 		if len(privs) == 0 {
 			continue
 		}
+		privStringBuilder.WriteString("GRANT ")
 
 		for j, priv := range privs {
 			if j != 0 {


### PR DESCRIPTION
Previously, privileges for schemas were not displayed in SHOW BACKUP.

Part of #53548 (release blocker).

Release note: None