### PR TITLE
backupccl: unskip TestBackupRestoreAppend

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -446,8 +446,6 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// TODO(adityamaru): Unskip once #53727 is merged.
-	skip.WithIssue(t, 54039, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 1000


### PR DESCRIPTION
This test was previously flaking with #54039, which has been reworked in
issue #53727.

Release note: None