### PR TITLE
backupccl: fix auto-append destination resolution

### DIFF
--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -1,0 +1,425 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStorageFactory(t *testing.T) (cloud.ExternalStorageFromURIFactory, func()) {
+	dir, dirCleanupFn := testutils.TempDir(t)
+	settings := cluster.MakeTestingClusterSettings()
+	settings.ExternalIODir = dir
+	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
+	externalStorageFromURI := func(ctx context.Context, uri, user string) (cloud.ExternalStorage,
+		error) {
+		conf, err := cloudimpl.ExternalStorageConfFromURI(uri, user)
+		require.NoError(t, err)
+		return cloudimpl.TestingMakeLocalStorage(ctx, conf.LocalFile, settings, clientFactory, base.ExternalIODirConfig{})
+	}
+	return externalStorageFromURI, dirCleanupFn
+}
+
+// TestBackupRestoreResolveDestination is an integration style tests that tests
+// all of the expected ways of organizing backups.
+func TestBackupRestoreResolveDestination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	emptyReader := bytes.NewReader([]byte{})
+
+	// Setup a storage factory.
+	externalStorageFromURI, cleanup := newTestStorageFactory(t)
+	defer cleanup()
+
+	// writeManifest writes an empty backup manifest file to the given URI.
+	writeManifest := func(t *testing.T, uri string) {
+		storage, err := externalStorageFromURI(ctx, uri, security.RootUser)
+		defer storage.Close()
+		require.NoError(t, err)
+		require.NoError(t, storage.WriteFile(ctx, backupManifestName, emptyReader))
+	}
+
+	// writeLatest writes latestBackupSuffix to the LATEST file in the given
+	// collection.
+	writeLatest := func(t *testing.T, collectionURI, latestBackupSuffix string) {
+		storage, err := externalStorageFromURI(ctx, collectionURI, security.RootUser)
+		defer storage.Close()
+		require.NoError(t, err)
+		require.NoError(t, storage.WriteFile(ctx, latestFileName, bytes.NewReader([]byte(latestBackupSuffix))))
+	}
+
+	// localizeURI returns a slice of just the base URI if localities is nil.
+	// Otherwise, it returns a slice of URIs. The first will be the URI for the
+	// default locality, and then one will be returned for each locality in
+	// `localities`. The path for each locality will be augmented with the
+	// locality to ensure that each locality references a different directory and
+	// the appropriate COCKROACH_LOCALITY argument will be added to the URI.
+	localizeURI := func(t *testing.T, baseURI string, localities []string) []string {
+		if localities == nil {
+			return []string{baseURI}
+		}
+		allLocalities := append([]string{defaultLocalityValue}, localities...)
+		localizedURIs := make([]string, len(allLocalities))
+		for i, locality := range allLocalities {
+			parsedURI, err := url.Parse(baseURI)
+			require.NoError(t, err)
+			if locality != defaultLocalityValue {
+				parsedURI.Path = path.Join(parsedURI.Path, locality)
+			}
+			q := parsedURI.Query()
+			q.Add(localityURLParam, locality)
+			parsedURI.RawQuery = q.Encode()
+			localizedURIs[i] = parsedURI.String()
+		}
+
+		return localizedURIs
+	}
+
+	for _, localityAware := range []bool{true, false} {
+		var localities []string
+		if localityAware {
+			localities = []string{"dc=EN", "dc=FR"}
+		}
+		t.Run(fmt.Sprintf("locality-aware-%t", localityAware), func(t *testing.T) {
+
+			// When testing explicit backup locations, we'll be testing the name
+			// resolution on backup directory structures created when running a
+			// sequence of backups like:
+			// - BACKUP TO full
+			// - BACKUP TO inc1 INCREMENTAL FROM full
+			// - BACKUP TO inc1 INCREMENTAL FROM full, inc1
+			//
+			// We write backup manifests as we test as if we were actually running the
+			// backup.
+			t.Run("explicit", func(t *testing.T) {
+				fullLoc := fmt.Sprintf("nodelocal://1/%s?AUTH=implicit", t.Name())
+				inc1Loc := fmt.Sprintf("nodelocal://1/%s/inc1?AUTH=implicit", t.Name())
+				inc2Loc := fmt.Sprintf("nodelocal://1/%s/inc2?AUTH=implicit", t.Name())
+
+				testExplicitBackup := func(t *testing.T, to []string, incrementalFrom []string) {
+					// Time doesn't matter for these since we don't create any date-based
+					// subdirectory. Let's just use now.
+					endTime := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+
+					expectedPrevBackups := make([]string, len(incrementalFrom))
+					for i, incrementalLoc := range incrementalFrom {
+						expectedPrevBackups[i] = localizeURI(t, incrementalLoc, localities)[0]
+					}
+					defaultDest, localitiesDest, err := getURIsByLocalityKV(to, "")
+					require.NoError(t, err)
+
+					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+						ctx, security.RootUser,
+						false /* nested */, false, /* appendToLatest */
+						defaultDest, localitiesDest,
+						externalStorageFromURI, endTime,
+						to, incrementalFrom, "", /* subdir */
+					)
+					require.NoError(t, err)
+
+					// Not an INTO backup, so no collection of suffix info.
+					require.Equal(t, "", collectionURI)
+					require.Equal(t, "", chosenSuffix)
+
+					require.Equal(t, defaultDest, defaultURI)
+					require.Equal(t, localitiesDest, urisByLocalityKV)
+					require.Equal(t, incrementalFrom, prevBackupURIs)
+				}
+
+				// The first initial full backup: BACKUP TO full.
+				{
+					incrementalFrom := []string(nil)
+					to := localizeURI(t, fullLoc, localities)
+					testExplicitBackup(t, to, incrementalFrom)
+
+					// Write the manifest files as if this backup succeeded.
+					writeManifest(t, fullLoc)
+				}
+
+				// An incremental on top if it: BACKUP TO inc1 INCREMENTAL FROM full.
+				{
+					incrementalFrom := []string{fullLoc}
+					to := localizeURI(t, inc1Loc, localities)
+					testExplicitBackup(t, to, incrementalFrom)
+
+					// Write the manifest files as if this backup succeeded.
+					writeManifest(t, inc1Loc)
+				}
+
+				// Another incremental on top of the incremental: BACKUP TO inc2
+				// INCREMENTAL FROM full, inc1.
+				{
+					incrementalFrom := []string{fullLoc, inc1Loc}
+					to := localizeURI(t, inc2Loc, localities)
+					testExplicitBackup(t, to, incrementalFrom)
+
+					writeManifest(t, inc2Loc)
+				}
+			})
+
+			// When testing auto-append backup locations, we'll be testing the name
+			// resolution on backup directory structures created when running a sequence
+			// of backups like:
+			// - BACKUP TO full
+			// - BACKUP TO full
+			// - BACKUP TO full
+			t.Run("auto-append", func(t *testing.T) {
+				baseDir := fmt.Sprintf("nodelocal://1/%s?AUTH=implicit", t.Name())
+				fullTime := time.Date(2020, 12, 25, 6, 0, 0, 0, time.UTC)
+				inc1Time := fullTime.Add(time.Minute * 30)
+				inc2Time := inc1Time.Add(time.Minute * 30)
+				prevBackups := []string(nil)
+
+				testAutoAppendBackup := func(t *testing.T, to []string, backupTime time.Time,
+					expectedDefault string, expectedLocalities map[string]string, expectedPrevBackups []string,
+				) {
+					endTime := hlc.Timestamp{WallTime: backupTime.UnixNano()}
+
+					dest, localitiesDest, err := getURIsByLocalityKV(to, "")
+					require.NoError(t, err)
+					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+						ctx, security.RootUser,
+						false /* nested */, false, /* appendToLatest */
+						dest, localitiesDest,
+						externalStorageFromURI, endTime,
+						to, nil /* incrementalFrom */, "", /* subdir */
+					)
+					require.NoError(t, err)
+
+					// Not a backup collection.
+					require.Equal(t, "", collectionURI)
+					require.Equal(t, "", chosenSuffix)
+					require.Equal(t, expectedDefault, defaultURI)
+					require.Equal(t, expectedLocalities, urisByLocalityKV)
+					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+				}
+
+				// Initial full backup: BACKUP TO baseDir.
+				{
+					to := localizeURI(t, baseDir, localities)
+					// The full backup should go into the baseDir.
+					expectedDefault := baseDir
+					expectedLocalities := make(map[string]string)
+					for _, locality := range localities {
+						expectedLocalities[locality] = fmt.Sprintf("nodelocal://1/%s/%s?AUTH=implicit", t.Name(), locality)
+					}
+
+					testAutoAppendBackup(t, to, fullTime, expectedDefault, expectedLocalities, prevBackups)
+
+					prevBackups = append(prevBackups, expectedDefault)
+					writeManifest(t, expectedDefault)
+				}
+
+				// Incremental: BACKUP TO baseDir.
+				{
+					to := localizeURI(t, baseDir, localities)
+					// The full backup should go into the baseDir.
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s/20201225/063000.00?AUTH=implicit", t.Name())
+					expectedLocalities := make(map[string]string)
+					for _, locality := range localities {
+						expectedLocalities[locality] = fmt.Sprintf("nodelocal://1/%s/%s/20201225/063000.00?AUTH=implicit", t.Name(), locality)
+					}
+
+					testAutoAppendBackup(t, to, inc1Time, expectedDefault, expectedLocalities, prevBackups)
+
+					prevBackups = append(prevBackups, expectedDefault)
+					writeManifest(t, expectedDefault)
+				}
+
+				// Another incremental: BACKUP TO baseDir.
+				{
+					to := localizeURI(t, baseDir, localities)
+					// We expect another incremental to go into the appropriate time
+					// formatted sub-directory.
+					expectedDefault := fmt.Sprintf(
+						"nodelocal://1/%s/20201225/070000.00?AUTH=implicit", t.Name())
+					expectedLocalities := make(map[string]string)
+					for _, locality := range localities {
+						expectedLocalities[locality] = fmt.Sprintf(
+							"nodelocal://1/%s/%s/20201225/070000.00?AUTH=implicit",
+							t.Name(), locality)
+					}
+
+					testAutoAppendBackup(t, to, inc2Time, expectedDefault, expectedLocalities, prevBackups)
+					writeManifest(t, expectedDefault)
+				}
+			})
+
+			// When testing auto-append backup locations, we'll be testing the name
+			// resolution on backup directory structures created when running a sequence
+			// of backups like:
+			// - BACKUP INTO collection
+			// - BACKUP INTO LATEST IN collection
+			// - BACKUP INTO LATEST IN collection
+			// - BACKUP INTO collection
+			// - BACKUP INTO LATEST IN collection
+			// - BACKUP INTO full1 IN collection
+			t.Run("collection", func(t *testing.T) {
+				collectionLoc := fmt.Sprintf("nodelocal://1/%s?AUTH=implicit", t.Name())
+				collectionTo := localizeURI(t, collectionLoc, localities)
+				fullTime := time.Date(2020, 12, 25, 6, 0, 0, 0, time.UTC)
+				inc1Time := fullTime.Add(time.Minute * 30)
+				inc2Time := inc1Time.Add(time.Minute * 30)
+				full2Time := inc2Time.Add(time.Minute * 30)
+				inc3Time := full2Time.Add(time.Minute * 30)
+				inc4Time := inc3Time.Add(time.Minute * 30)
+
+				// firstBackupChain is maintained throughout the tests as the history of
+				// backups that were taken based on the initial full backup.
+				firstBackupChain := []string(nil)
+				// An explicit sub-directory is used in backups of the form BACKUP INTO
+				// X IN Y. Otherwise, it should be empty string.
+				noExplicitSubDir := ""
+
+				testCollectionBackup := func(t *testing.T, backupTime time.Time,
+					expectedDefault, expectedSuffix, expectedIncDir string, expectedPrevBackups []string,
+					appendToLatest bool, subdir string) {
+
+					endTime := hlc.Timestamp{WallTime: backupTime.UnixNano()}
+					incrementalFrom := []string(nil)
+
+					defaultCollection, localityCollections, err := getURIsByLocalityKV(collectionTo, "")
+					require.NoError(t, err)
+					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+						ctx, security.RootUser,
+						true /* nested */, appendToLatest,
+						defaultCollection, localityCollections,
+						externalStorageFromURI, endTime,
+						collectionTo, incrementalFrom, subdir,
+					)
+
+					require.NoError(t, err)
+					localityDests := make(map[string]string, len(localityCollections))
+					for locality, localityDest := range localityCollections {
+						u, err := url.Parse(localityDest)
+						require.NoError(t, err)
+						u.Path = u.Path + expectedSuffix + expectedIncDir
+						localityDests[locality] = u.String()
+					}
+
+					require.Equal(t, collectionLoc, collectionURI)
+					require.Equal(t, expectedSuffix, chosenSuffix)
+
+					require.Equal(t, expectedDefault, defaultURI)
+					require.Equal(t, localityDests, urisByLocalityKV)
+
+					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+				}
+
+				// Initial: BACKUP INTO collection
+				{
+					expectedSuffix := "/2020/12/25-060000.00"
+					expectedIncDir := ""
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s?AUTH=implicit", t.Name(), expectedSuffix)
+
+					testCollectionBackup(t, fullTime,
+						expectedDefault, expectedSuffix, expectedIncDir, firstBackupChain,
+						false /* intoLatest */, noExplicitSubDir)
+					firstBackupChain = append(firstBackupChain, expectedDefault)
+					writeManifest(t, expectedDefault)
+					// We also wrote a new full backup, so let's update the latest.
+					writeLatest(t, collectionLoc, expectedSuffix)
+				}
+
+				// Incremental: BACKUP INTO LATEST IN collection
+				{
+					// We're backing up to the full backup at 6am.
+					expectedSuffix := "/2020/12/25-060000.00"
+					expectedIncDir := "/20201225/063000.00"
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s%s?AUTH=implicit", t.Name(), expectedSuffix, expectedIncDir)
+
+					testCollectionBackup(t, inc1Time,
+						expectedDefault, expectedSuffix, expectedIncDir, firstBackupChain,
+						true /* intoLatest */, noExplicitSubDir)
+					firstBackupChain = append(firstBackupChain, expectedDefault)
+					writeManifest(t, expectedDefault)
+				}
+
+				// Another incremental: BACKUP INTO LATEST IN collection
+				{
+					// We're backing up to the full backup at 6am.
+					expectedSuffix := "/2020/12/25-060000.00"
+					expectedIncDir := "/20201225/070000.00"
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s%s?AUTH=implicit", t.Name(), expectedSuffix, expectedIncDir)
+
+					testCollectionBackup(t, inc2Time,
+						expectedDefault, expectedSuffix, expectedIncDir, firstBackupChain,
+						true /* intoLatest */, noExplicitSubDir)
+					firstBackupChain = append(firstBackupChain, expectedDefault)
+					writeManifest(t, expectedDefault)
+				}
+
+				// A new full backup: BACKUP INTO collection
+				var backup2Location string
+				{
+					expectedSuffix := "/2020/12/25-073000.00"
+					expectedIncDir := ""
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s?AUTH=implicit", t.Name(), expectedSuffix)
+					backup2Location = expectedDefault
+
+					testCollectionBackup(t, full2Time,
+						expectedDefault, expectedSuffix, expectedIncDir, []string(nil),
+						false /* intoLatest */, noExplicitSubDir)
+					writeManifest(t, expectedDefault)
+					// We also wrote a new full backup, so let's update the latest.
+					writeLatest(t, collectionLoc, expectedSuffix)
+				}
+
+				// An incremental into the new latest: BACKUP INTO LATEST IN collection
+				{
+					// We're backing up to the full backup at 7:30am.
+					expectedSuffix := "/2020/12/25-073000.00"
+					expectedIncDir := "/20201225/080000.00"
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s%s?AUTH=implicit", t.Name(), expectedSuffix, expectedIncDir)
+
+					testCollectionBackup(t, inc3Time,
+						expectedDefault, expectedSuffix, expectedIncDir, []string{backup2Location},
+						true /* intoLatest */, noExplicitSubDir)
+					writeManifest(t, expectedDefault)
+				}
+
+				// An explicit incremental into the first full: BACKUP INTO full1 IN collection
+				{
+					expectedSuffix := "/2020/12/25-060000.00"
+					expectedIncDir := "/20201225/083000.00"
+					expectedSubdir := expectedSuffix
+					expectedDefault := fmt.Sprintf("nodelocal://1/%s%s%s?AUTH=implicit", t.Name(), expectedSuffix, expectedIncDir)
+
+					testCollectionBackup(t, inc4Time,
+						expectedDefault, expectedSuffix, expectedIncDir, firstBackupChain,
+						false /* intoLatest */, expectedSubdir)
+					writeManifest(t, expectedDefault)
+				}
+			})
+		})
+	}
+}
+
+// TODO(pbardea): Add tests for resolveBackupCollection.

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -631,12 +631,12 @@ func backupPlanHook(
 		// TODO(pbardea): Refactor (defaultURI and urisByLocalityKV) pairs into a
 		// backupDestination struct.
 		collectionURI, defaultURI, resolvedSubdir, urisByLocalityKV, prevs, err :=
-			resolveDest(ctx, p, backupStmt, defaultURI, urisByLocalityKV, makeCloudStorage, endTime,
-				to, incrementalFrom, subdir)
+			resolveDest(ctx, p.User(), backupStmt.Nested, backupStmt.AppendToLatest, defaultURI,
+				urisByLocalityKV, makeCloudStorage, endTime, to, incrementalFrom, subdir)
 		if err != nil {
 			return err
 		}
-		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p, makeCloudStorage, prevs,
+		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p.User(), makeCloudStorage, prevs,
 			encryptionParams)
 		if err != nil {
 			return err

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -471,22 +471,22 @@ func TestBackupRestoreAppend(t *testing.T) {
 		`userfile:///bar/3`
 	makeBackups := func(b1, b2, b3 string) []interface{} {
 		return []interface{}{
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", b1, url.QueryEscape("default")),
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", b2, url.QueryEscape("dc=dc1")),
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", b3, url.QueryEscape("dc=dc2"))}
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", b1, url.QueryEscape("default")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", b2, url.QueryEscape("dc=dc1")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", b3, url.QueryEscape("dc=dc2"))}
 	}
 	makeCollections := func(c1, c2, c3 string) []interface{} {
 		return []interface{}{
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", c1, url.QueryEscape("default")),
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", c2, url.QueryEscape("dc=dc1")),
-			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", c3, url.QueryEscape("dc=dc2"))}
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c1, url.QueryEscape("default")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c2, url.QueryEscape("dc=dc1")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c3, url.QueryEscape("dc=dc2"))}
 	}
 
 	makeCollectionsWithSubdir := func(c1, c2, c3 string) []interface{} {
 		return []interface{}{
-			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s", c1, "foo", url.QueryEscape("default")),
-			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s", c2, "foo", url.QueryEscape("dc=dc1")),
-			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s", c3, "foo", url.QueryEscape("dc=dc2"))}
+			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c1, "foo", url.QueryEscape("default")),
+			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c2, "foo", url.QueryEscape("dc=dc1")),
+			fmt.Sprintf("%s/%s?COCKROACH_LOCALITY=%s&AUTH=implicit", c3, "foo", url.QueryEscape("dc=dc2"))}
 	}
 
 	// for testing backup *into* with specified subdirectory.

--- a/pkg/storage/cloudimpl/nodelocal_storage.go
+++ b/pkg/storage/cloudimpl/nodelocal_storage.go
@@ -49,6 +49,17 @@ func makeNodeLocalURIWithNodeID(nodeID roachpb.NodeID, path string) string {
 	return fmt.Sprintf("nodelocal://%d/%s", nodeID, path)
 }
 
+// TestingMakeLocalStorage is used by tests.
+func TestingMakeLocalStorage(
+	ctx context.Context,
+	cfg roachpb.ExternalStorage_LocalFilePath,
+	settings *cluster.Settings,
+	blobClientFactory blobs.BlobClientFactory,
+	ioConf base.ExternalIODirConfig,
+) (cloud.ExternalStorage, error) {
+	return makeLocalStorage(ctx, cfg, settings, blobClientFactory, ioConf)
+}
+
 func makeLocalStorage(
 	ctx context.Context,
 	cfg roachpb.ExternalStorage_LocalFilePath,


### PR DESCRIPTION
This commit fixes a bug where destination resolution to auto-appendable
backups would fail if the URI had authentication params specified.

Fixes #54455.

Release note (bug fix): In a previous beta, backing up to an
auto-appendable directory would not work if authentication parameters
were specified in the URI.