### PR TITLE
sql: allow parsing of REASSIGN OWNED BY ... TO ...

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -14,6 +14,7 @@ stmt ::=
 	| prepare_stmt
 	| revoke_stmt
 	| savepoint_stmt
+	| reassign_owned_stmt
 	| release_stmt
 	| refresh_stmt
 	| nonpreparable_set_stmt
@@ -88,6 +89,9 @@ revoke_stmt ::=
 
 savepoint_stmt ::=
 	'SAVEPOINT' name
+
+reassign_owned_stmt ::=
+	'REASSIGN' 'OWNED' 'BY' role_spec_list 'TO' role_spec
 
 release_stmt ::=
 	'RELEASE' savepoint_name
@@ -298,6 +302,14 @@ schema_name_list ::=
 prep_type_clause ::=
 	'(' type_list ')'
 	| 
+
+role_spec_list ::=
+	( role_spec ) ( ( ',' role_spec ) )*
+
+role_spec ::=
+	non_reserved_word_or_sconst
+	| 'CURRENT_USER'
+	| 'SESSION_USER'
 
 savepoint_name ::=
 	'SAVEPOINT' name
@@ -947,6 +959,7 @@ unreserved_keyword ::=
 	| 'RANGE'
 	| 'RANGES'
 	| 'READ'
+	| 'REASSIGN'
 	| 'RECURRING'
 	| 'RECURSIVE'
 	| 'REF'
@@ -1134,6 +1147,10 @@ schema_name ::=
 
 type_list ::=
 	( typename ) ( ( ',' typename ) )*
+
+non_reserved_word_or_sconst ::=
+	non_reserved_word
+	| 'SCONST'
 
 transaction_mode_list ::=
 	( transaction_mode ) ( ( opt_comma transaction_mode ) )*
@@ -1349,10 +1366,6 @@ drop_type_stmt ::=
 explain_option_name ::=
 	non_reserved_word
 
-non_reserved_word_or_sconst ::=
-	non_reserved_word
-	| 'SCONST'
-
 kv_option_list ::=
 	( kv_option ) ( ( ',' kv_option ) )*
 
@@ -1504,6 +1517,12 @@ typename ::=
 	simple_typename opt_array_bounds
 	| simple_typename 'ARRAY'
 
+non_reserved_word ::=
+	'identifier'
+	| unreserved_keyword
+	| col_name_keyword
+	| type_func_name_keyword
+
 transaction_mode ::=
 	transaction_user_priority
 	| transaction_read_mode
@@ -1607,11 +1626,6 @@ alter_zone_partition_stmt ::=
 	'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_index_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_name '@' '*' set_zone_config
-
-role_spec ::=
-	non_reserved_word_or_sconst
-	| 'CURRENT_USER'
-	| 'SESSION_USER'
 
 opt_add_val_placement ::=
 	'BEFORE' 'SCONST'
@@ -1798,12 +1812,6 @@ table_index_name_list ::=
 
 table_name_list ::=
 	( table_name ) ( ( ',' table_name ) )*
-
-non_reserved_word ::=
-	'identifier'
-	| unreserved_keyword
-	| col_name_keyword
-	| type_func_name_keyword
 
 kv_option ::=
 	name '=' string_or_placeholder

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -1,0 +1,22 @@
+statement ok
+CREATE TABLE t()
+
+# Ensure old role must exist.
+# statement error pq: role/user "fake_role" does not exist
+statement error unimplemented
+REASSIGN OWNED BY fake_role TO new_role
+
+statement ok
+CREATE ROLE old_role
+
+# Ensure new role must exist.
+# statement error pq: role/user "fake_role" does not exist
+statement error unimplemented
+REASSIGN OWNED BY old_role TO fake_role
+
+statement ok
+CREATE ROLE new_role
+
+# statement ok
+statement error unimplemented
+REASSIGN OWNED BY old_role TO fake_role

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -113,6 +113,8 @@ func buildOpaque(
 		plan, err = p.Grant(ctx, n)
 	case *tree.GrantRole:
 		plan, err = p.GrantRole(ctx, n)
+	case *tree.ReassignOwnedBy:
+		plan, err = p.ReassignOwnedBy(ctx, n)
 	case *tree.RefreshMaterializedView:
 		plan, err = p.RefreshMaterializedView(ctx, n)
 	case *tree.RenameColumn:
@@ -213,6 +215,7 @@ func init() {
 		&tree.DropSequence{},
 		&tree.Grant{},
 		&tree.GrantRole{},
+		&tree.ReassignOwnedBy{},
 		&tree.RefreshMaterializedView{},
 		&tree.RenameColumn{},
 		&tree.RenameDatabase{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -242,6 +242,9 @@ func TestContextualHelp(t *testing.T) {
 		{`PAUSE SCHEDULE ??`, `PAUSE SCHEDULES`},
 		{`PAUSE SCHEDULES ??`, `PAUSE SCHEDULES`},
 
+		{`REASSIGN OWNED BY ?? TO ??`, `REASSIGN OWNED BY`},
+		{`REASSIGN OWNED BY foo, bar TO ??`, `REASSIGN OWNED BY`},
+
 		{`RESUME ??`, `RESUME`},
 		{`RESUME JOB ??`, `RESUME JOBS`},
 		{`RESUME JOBS ??`, `RESUME JOBS`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1505,6 +1505,9 @@ func TestParse(t *testing.T) {
 		{`ALTER TYPE t SET SCHEMA newschema`},
 		{`ALTER TYPE t OWNER TO foo`},
 
+		{`REASSIGN OWNED BY foo TO bar`},
+		{`REASSIGN OWNED BY foo, bar TO third`},
+
 		{`COMMENT ON COLUMN a.b IS 'a'`},
 		{`COMMENT ON COLUMN a.b IS NULL`},
 		{`COMMENT ON COLUMN a.b.c IS 'a'`},
@@ -2593,8 +2596,11 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 		{`SELECT 1::db.int4.typ array`, `SELECT 1::db.int4.typ[]`},
 		{`CREATE TABLE t (x int4.type array [1])`, `CREATE TABLE t (x int4.type[])`},
 
-		{`ALTER TYPE t OWNER TO CURRENT_USER`, "ALTER TYPE t OWNER TO \"current_user\""},
-		{`ALTER TYPE t OWNER TO SESSION_USER`, "ALTER TYPE t OWNER TO \"session_user\""},
+		{`ALTER TYPE t OWNER TO CURRENT_USER`, `ALTER TYPE t OWNER TO "current_user"`},
+		{`ALTER TYPE t OWNER TO SESSION_USER`, `ALTER TYPE t OWNER TO "session_user"`},
+
+		{`REASSIGN OWNED BY CURRENT_USER TO foo`, `REASSIGN OWNED BY "current_user" TO foo`},
+		{`REASSIGN OWNED BY SESSION_USER TO foo`, `REASSIGN OWNED BY "session_user" TO foo`},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -644,7 +644,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 
 %token <str> QUERIES QUERY
 
-%token <str> RANGE RANGES READ REAL RECURSIVE RECURRING REF REFERENCES REFRESH
+%token <str> RANGE RANGES READ REAL REASSIGN RECURSIVE RECURRING REF REFERENCES REFRESH
 %token <str> REGCLASS REGPROC REGPROCEDURE REGNAMESPACE REGTYPE REINDEX
 %token <str> REMOVE_PATH RENAME REPEATABLE REPLACE
 %token <str> RELEASE RESET RESTORE RESTRICT RESUME RETURNING RETRY REVISION_HISTORY REVOKE RIGHT
@@ -818,6 +818,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 %type <tree.Statement> import_stmt
 %type <tree.Statement> pause_stmt pause_jobs_stmt pause_schedules_stmt
 %type <*tree.Select>   for_schedules_clause
+%type <tree.Statement> reassign_owned_stmt
 %type <tree.Statement> release_stmt
 %type <tree.Statement> reset_stmt reset_session_stmt reset_csetting_stmt
 %type <tree.Statement> resume_stmt resume_jobs_stmt resume_schedules_stmt
@@ -1097,6 +1098,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 %type <str> non_reserved_word
 %type <str> non_reserved_word_or_sconst
 %type <str> role_spec
+%type <[]string> role_spec_list
 %type <tree.Expr> zone_value
 %type <tree.Expr> string_or_placeholder
 %type <tree.Expr> string_or_placeholder_list
@@ -1246,6 +1248,7 @@ stmt:
 | prepare_stmt      // EXTEND WITH HELP: PREPARE
 | revoke_stmt       // EXTEND WITH HELP: REVOKE
 | savepoint_stmt    // EXTEND WITH HELP: SAVEPOINT
+| reassign_owned_stmt // EXTEND WITH HELP: REASSIGN OWNED BY
 | release_stmt      // EXTEND WITH HELP: RELEASE
 | refresh_stmt      // EXTEND WITH HELP: REFRESH
 | nonpreparable_set_stmt // help texts in sub-rule
@@ -2074,6 +2077,15 @@ opt_add_val_placement:
   {
     $$.val = (*tree.AlterTypeAddValuePlacement)(nil)
   }
+
+role_spec_list:
+	role_spec {
+		$$.val = []string{$1}
+	}
+| role_spec_list ',' role_spec
+	{
+		$$.val = append($1.strs(), $3)
+	}
 
 role_spec:
   non_reserved_word_or_sconst
@@ -7514,6 +7526,20 @@ multiple_set_clause:
     $$.val = &tree.UpdateExpr{Tuple: true, Names: $2.nameList(), Expr: $5.expr()}
   }
 
+// %Help: REASSIGN OWNED BY - change ownership of all objects
+// %Category: Priv
+// %Text: REASSIGN OWNED BY {<name> | CURRENT_USER | SESSION_USER}[,...]
+// TO {<name> | CURRENT_USER | SESSION_USER}
+reassign_owned_stmt:
+	REASSIGN OWNED BY role_spec_list TO role_spec
+{
+	$$.val = &tree.ReassignOwnedBy{
+      OldRoles: $4.strs(),
+      NewRole: $6,
+	}
+}
+| REASSIGN OWNED BY error // SHOW HELP: REASSIGN OWNED BY
+
 // A complete SELECT statement looks like this.
 //
 // The rule returns either a single select_stmt node or a tree of them,
@@ -11612,6 +11638,7 @@ unreserved_keyword:
 | RANGE
 | RANGES
 | READ
+| REASSIGN
 | RECURRING
 | RECURSIVE
 | REF

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+// ReassignOwnedByNode represents a REASSIGN OWNED BY <name> TO <name> statement.
+// TODO(angelaw): to implement
+//type reassignOwnedByNode struct {
+//}
+
+func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) (planNode, error) {
+	return nil, unimplemented.NewWithIssue(52022, "reassign owned by is not yet implemented")
+}

--- a/pkg/sql/sem/tree/reassign_owned_by.go
+++ b/pkg/sql/sem/tree/reassign_owned_by.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// ReassignOwnedBy represents a REASSIGN OWNED BY <name> TO <name> statement.
+type ReassignOwnedBy struct {
+	OldRoles []string
+	NewRole  string
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ReassignOwnedBy) Format(ctx *FmtCtx) {
+	ctx.WriteString("REASSIGN OWNED BY ")
+	for i := range node.OldRoles {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNameP(&node.OldRoles[i])
+	}
+	ctx.WriteString(" TO ")
+	ctx.FormatNameP(&node.NewRole)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -569,6 +569,12 @@ func (*Prepare) StatementType() StatementType { return Ack }
 func (*Prepare) StatementTag() string { return "PREPARE" }
 
 // StatementType implements the Statement interface.
+func (*ReassignOwnedBy) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ReassignOwnedBy) StatementTag() string { return "REASSIGN OWNED" }
+
+// StatementType implements the Statement interface.
 func (*RefreshMaterializedView) StatementType() StatementType { return DDL }
 
 // StatementTag implements the Statement interface.
@@ -1064,6 +1070,7 @@ func (n *Insert) String() string                         { return AsString(n) }
 func (n *Import) String() string                         { return AsString(n) }
 func (n *ParenSelect) String() string                    { return AsString(n) }
 func (n *Prepare) String() string                        { return AsString(n) }
+func (n *ReassignOwnedBy) String() string                { return AsString(n) }
 func (n *ReleaseSavepoint) String() string               { return AsString(n) }
 func (n *Relocate) String() string                       { return AsString(n) }
 func (n *RefreshMaterializedView) String() string        { return AsString(n) }


### PR DESCRIPTION
Part 1 of addressing #52022.

Add parsing for REASSIGN OWNED BY ... TO ... command. Plan to follow up with implementation of the command for feature parity with PostgresQL, which will resolve the issue linked.

Release note: None