### PR TITLE
kvclient: seed the random num generator for tests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/main_test.go
+++ b/pkg/kv/kvclient/kvcoord/main_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 //go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
@@ -46,5 +47,6 @@ func TestForbiddenDeps(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	randutil.SeedForTests()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This package wasn't seeding it with a random number, so we were always
using the same default seed of 1.
It's good to get actual randomness, cause otherwise you still get it by
virtue of the number of calls to the rng itself being random, except you
get it less (particularly when running a single test). Which means that
when you have a failure that doesn't happen with the default seed, you
get it really rarely.

Release note: None