### PR TITLE
sql: add parens around partial index in pg_catalog

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2084,12 +2084,12 @@ CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test USING btree 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_partial_idx'))
 ----
-CREATE INDEX pg_indexdef_partial_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE a > 0
+CREATE INDEX pg_indexdef_partial_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE (a > 0)
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_partial_enum_idx'))
 ----
-CREATE INDEX pg_indexdef_partial_enum_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE e IN ('foo'::public.testenum, 'bar'::public.testenum)
+CREATE INDEX pg_indexdef_partial_enum_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE (e IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 query T
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
@@ -2186,7 +2186,7 @@ FROM pg_catalog.pg_constraint
 WHERE conrelid='pg_constraintdef_test'::regclass
 ----
 UNIQUE (b ASC)
-UNIQUE (a ASC) WHERE d = 'foo'::STRING
+UNIQUE (a ASC) WHERE (d = 'foo'::STRING)
 FOREIGN KEY (a) REFERENCES pg_indexdef_test(a) ON DELETE CASCADE
 CHECK ((c > a))
 

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -226,9 +226,9 @@ CREATE UNIQUE INDEX t11_b_key ON t11 (b) WHERE a > 0
 query TTTTB colnames
 SHOW CONSTRAINTS FROM t11
 ----
-table_name  constraint_name  constraint_type  details                     validated
-t11         t11_a_key        UNIQUE           UNIQUE (a ASC) WHERE b > 0  true
-t11         t11_b_key        UNIQUE           UNIQUE (b ASC) WHERE a > 0  true
+table_name  constraint_name  constraint_type  details                       validated
+t11         t11_a_key        UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
+t11         t11_b_key        UNIQUE           UNIQUE (b ASC) WHERE (a > 0)  true
 
 # Update a non-indexed column referenced by the predicate.
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2557,8 +2557,8 @@ WHERE tablename = 'partial_index_table'
 ----
 indexname                   indexdef
 primary                     CREATE UNIQUE INDEX "primary" ON test.public.partial_index_table USING btree (rowid ASC)
-partial_index_table_a_key   CREATE UNIQUE INDEX partial_index_table_a_key ON test.public.partial_index_table USING btree (a ASC) WHERE a > 0
-partial_index_table_a_key1  CREATE UNIQUE INDEX partial_index_table_a_key1 ON test.public.partial_index_table USING btree (a ASC) WHERE b IN ('foo'::public.testenum, 'bar'::public.testenum)
+partial_index_table_a_key   CREATE UNIQUE INDEX partial_index_table_a_key ON test.public.partial_index_table USING btree (a ASC) WHERE (a > 0)
+partial_index_table_a_key1  CREATE UNIQUE INDEX partial_index_table_a_key1 ON test.public.partial_index_table USING btree (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 query TT colnames
 SELECT conname, condef
@@ -2568,8 +2568,8 @@ WHERE t.relname = 'partial_index_table'
 ORDER BY conname
 ----
 conname                     condef
-partial_index_table_a_key   UNIQUE (a ASC) WHERE a > 0
-partial_index_table_a_key1  UNIQUE (a ASC) WHERE b IN ('foo'::public.testenum, 'bar'::public.testenum)
+partial_index_table_a_key   UNIQUE (a ASC) WHERE (a > 0)
+partial_index_table_a_key1  UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 subtest regression_46799
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -967,8 +967,7 @@ func populateTableConstraints(
 				if err != nil {
 					return err
 				}
-				f.WriteString(" WHERE ")
-				f.WriteString(pred)
+				f.WriteString(fmt.Sprintf(" WHERE (%s)", pred))
 			}
 			condef = tree.NewDString(f.CloseAndGetString())
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -179,8 +179,14 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 		ctx.WriteString(")")
 	}
 	if node.Predicate != nil {
-		ctx.WriteString(" WHERE ")
-		ctx.FormatNode(node.Predicate)
+		if ctx.HasFlags(FmtPGCatalog) {
+			ctx.WriteString(" WHERE (")
+			ctx.FormatNode(node.Predicate)
+			ctx.WriteString(")")
+		} else {
+			ctx.WriteString(" WHERE ")
+			ctx.FormatNode(node.Predicate)
+		}
 	}
 }
 


### PR DESCRIPTION
This improves compatibility with tools that inspect pg_catalog to get
index definitions. Some, like activerecord, rely on regexps that expect
these parens.

Release note (sql change): Partial index definitions in pg_catalog are
now formatted with parentheses around the WHERE clause.