### PR TITLE
release-20.2: backupccl: redact storage URIs printed in error messages during BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -167,7 +167,8 @@ func getBackupManifests(
 				ctx, uri, user, makeCloudStorage, encryption,
 			)
 			if err != nil {
-				return errors.Wrapf(err, "failed to read backup from %q", uri)
+				return errors.Wrapf(err, "failed to read backup from %q",
+					RedactURIForErrorMessage(uri))
 			}
 			manifests[i] = desc
 			return nil

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -422,16 +422,17 @@ func (b *backupResumer) Resume(
 
 	// EncryptionInfo is non-nil only when new encryption information has been
 	// generated during BACKUP planning.
+	redactedURI := RedactURIForErrorMessage(details.URI)
 	if details.EncryptionInfo != nil {
 		if err := writeEncryptionInfoIfNotExists(ctx, details.EncryptionInfo,
 			defaultStore); err != nil {
-			return errors.Wrapf(err, "creating encryption info file to %s", details.URI)
+			return errors.Wrapf(err, "creating encryption info file to %s", redactedURI)
 		}
 	}
 
 	if err := createCheckpointIfNotExists(ctx, p.ExecCfg().Settings, defaultStore,
 		details.EncryptionOptions); err != nil {
-		return errors.Wrapf(err, "creating checkpoint to %s", details.URI)
+		return errors.Wrapf(err, "creating checkpoint to %s", redactedURI)
 	}
 
 	ptsID := details.ProtectedTimestampRecord


### PR DESCRIPTION
Backport 1/1 commits from #54466.

/cc @cockroachdb/release

---

Certain user sensitive information such as AWS secret keys are printed
back to the client in certain error conditions. We now redact sensitive
information before returning the string to the client.

Fixes: #41998 

Release note: None
