### PR TITLE
pgwire: cleanup notice sending usage

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -123,7 +123,7 @@ func AlterColumnType(
 		if err := params.p.createOrUpdateSchemaChangeJob(params.ctx, tableDesc, tree.AsStringWithFQNames(t, params.Ann()), tableDesc.ClusterVersion.NextMutationID); err != nil {
 			return err
 		}
-		params.p.SendClientNotice(params.ctx, pgnotice.Newf("ALTER COLUMN TYPE changes are finalized asynchronously; "+
+		params.p.BufferClientNotice(params.ctx, pgnotice.Newf("ALTER COLUMN TYPE changes are finalized asynchronously; "+
 			"further schema changes on this table may be restricted until the job completes; "+
 			"some writes to the altered column may be rejected until the schema change is finalized"))
 	default:

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -315,7 +315,7 @@ func (p *planner) AlterPrimaryKey(
 
 	// Send a notice to users about the async cleanup jobs.
 	// TODO(knz): Mention the job ID in the client notice.
-	p.SendClientNotice(
+	p.BufferClientNotice(
 		ctx,
 		pgnotice.Newf(
 			"primary key changes are finalized asynchronously; "+

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -114,7 +114,7 @@ func (p *planner) addEnumValue(
 	for _, member := range n.desc.EnumMembers {
 		if member.LogicalRepresentation == node.NewVal {
 			if node.IfNotExists {
-				p.SendClientNotice(
+				p.BufferClientNotice(
 					ctx,
 					pgnotice.Newf("enum label %q already exists, skipping", node.NewVal),
 				)

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -688,13 +689,13 @@ type CommandResultClose interface {
 type RestrictedCommandResult interface {
 	CommandResultErrBase
 
-	// AppendParamStatusUpdate appends a parameter status update to the result.
+	// BufferParamStatusUpdate buffers a parameter status update to the result.
 	// This gets flushed only when the CommandResult is closed.
-	AppendParamStatusUpdate(string, string)
+	BufferParamStatusUpdate(string, string)
 
-	// AppendNotice appends a notice to the result.
+	// BufferNotice appends a notice to the result.
 	// This gets flushed only when the CommandResult is closed.
-	AppendNotice(noticeErr error)
+	BufferNotice(notice pgnotice.Notice)
 
 	// SetColumns informs the client about the schema of the result. The columns
 	// can be nil.
@@ -883,13 +884,13 @@ func (r *bufferedCommandResult) SetColumns(_ context.Context, cols colinfo.Resul
 	r.cols = cols
 }
 
-// AppendParamStatusUpdate is part of the RestrictedCommandResult interface.
-func (r *bufferedCommandResult) AppendParamStatusUpdate(key string, val string) {
+// BufferParamStatusUpdate is part of the RestrictedCommandResult interface.
+func (r *bufferedCommandResult) BufferParamStatusUpdate(key string, val string) {
 	panic("unimplemented")
 }
 
-// AppendNotice is part of the RestrictedCommandResult interface.
-func (r *bufferedCommandResult) AppendNotice(noticeErr error) {
+// BufferNotice is part of the RestrictedCommandResult interface.
+func (r *bufferedCommandResult) BufferNotice(notice pgnotice.Notice) {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -373,7 +373,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	}
 
 	if n.n.Concurrently {
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			pgnotice.Newf("CONCURRENTLY is not required as all indexes are created concurrently"),
 		)
@@ -382,7 +382,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	// Warn against creating a non-partitioned index on a partitioned table,
 	// which is undesirable in most cases.
 	if n.n.PartitionBy == nil && n.tableDesc.PrimaryIndex.Partitioning.NumColumns > 0 {
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			errors.WithHint(
 				pgnotice.Newf("creating non-partitioned index on partitioned table may not be performant"),

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -196,7 +196,7 @@ func getTableCreateParams(
 
 	if persistence.IsUnlogged() {
 		telemetry.Inc(sqltelemetry.CreateUnloggedTableCounter)
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			pgnotice.Newf("UNLOGGED TABLE will behave as a regular table in CockroachDB"),
 		)
@@ -262,7 +262,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		for _, def := range n.n.Defs {
 			if d, ok := def.(*tree.IndexTableDef); ok {
 				if d.PartitionBy == nil {
-					params.p.SendClientNotice(
+					params.p.BufferClientNotice(
 						params.ctx,
 						errors.WithHint(
 							pgnotice.Newf("creating non-partitioned index on partitioned table may not be performant"),

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -74,7 +74,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		}
 		if !persistence.IsTemporary() && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
-			params.p.SendClientNotice(
+			params.p.BufferClientNotice(
 				params.ctx,
 				pgnotice.Newf(`view "%s" will be a temporary view`, viewName),
 			)

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -76,7 +76,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("index"))
 
 	if n.n.Concurrently {
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			pgnotice.Newf("CONCURRENTLY is not required as all indexes are dropped concurrently"),
 		)
@@ -514,7 +514,7 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID, jobDesc); err != nil {
 		return err
 	}
-	p.SendClientNotice(
+	p.BufferClientNotice(
 		ctx,
 		errors.WithHint(
 			pgnotice.Newf("the data for dropped indexes is reclaimed asynchronously"),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1983,7 +1983,7 @@ type spanWithIndex struct {
 // paramStatusUpdater is a subset of RestrictedCommandResult which allows sending
 // status updates.
 type paramStatusUpdater interface {
-	AppendParamStatusUpdate(string, string)
+	BufferParamStatusUpdate(string, string)
 }
 
 // noopParamStatusUpdater implements paramStatusUpdater by performing a no-op.
@@ -1991,7 +1991,7 @@ type noopParamStatusUpdater struct{}
 
 var _ paramStatusUpdater = (*noopParamStatusUpdater)(nil)
 
-func (noopParamStatusUpdater) AppendParamStatusUpdate(string, string) {}
+func (noopParamStatusUpdater) BufferParamStatusUpdate(string, string) {}
 
 // sessionDataMutator is the interface used by sessionVars to change the session
 // state. It mostly mutates the Session's SessionData, but not exclusively (e.g.
@@ -2030,7 +2030,7 @@ func (m *sessionDataMutator) notifyOnDataChangeListeners(key string, val string)
 func (m *sessionDataMutator) SetApplicationName(appName string) {
 	m.data.ApplicationName = appName
 	m.notifyOnDataChangeListeners("application_name", appName)
-	m.paramStatusUpdater.AppendParamStatusUpdate("application_name", appName)
+	m.paramStatusUpdater.BufferParamStatusUpdate("application_name", appName)
 }
 
 func (m *sessionDataMutator) SetBytesEncodeFormat(val lex.BytesEncodeFormat) {
@@ -2150,7 +2150,7 @@ func (m *sessionDataMutator) UpdateSearchPath(paths []string) {
 
 func (m *sessionDataMutator) SetLocation(loc *time.Location) {
 	m.data.DataConversion.Location = loc
-	m.paramStatusUpdater.AppendParamStatusUpdate("TimeZone", sessionDataTimeZoneFormat(loc))
+	m.paramStatusUpdater.BufferParamStatusUpdate("TimeZone", sessionDataTimeZoneFormat(loc))
 }
 
 func (m *sessionDataMutator) SetReadOnly(val bool) {

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -191,8 +192,8 @@ type DummyClientNoticeSender struct{}
 
 var _ tree.ClientNoticeSender = &DummyClientNoticeSender{}
 
-// SendClientNotice is part of the tree.ClientNoticeSender interface.
-func (c *DummyClientNoticeSender) SendClientNotice(context.Context, error) {}
+// BufferClientNotice is part of the tree.ClientNoticeSender interface.
+func (c *DummyClientNoticeSender) BufferClientNotice(context.Context, pgnotice.Notice) {}
 
 // DummyTenantOperator implements the tree.TenantOperator interface.
 type DummyTenantOperator struct{}

--- a/pkg/sql/notice.go
+++ b/pkg/sql/notice.go
@@ -30,15 +30,15 @@ var NoticesEnabled = settings.RegisterPublicBoolSetting(
 // noticeSender is a subset of RestrictedCommandResult which allows
 // sending notices.
 type noticeSender interface {
-	AppendNotice(error)
+	BufferNotice(pgnotice.Notice)
 }
 
-// SendClientNotice implements the tree.ClientNoticeSender interface.
-func (p *planner) SendClientNotice(ctx context.Context, err error) {
+// BufferClientNotice implements the tree.ClientNoticeSender interface.
+func (p *planner) BufferClientNotice(ctx context.Context, notice pgnotice.Notice) {
 	if log.V(2) {
-		log.Infof(ctx, "out-of-band notice: %+v", err)
+		log.Infof(ctx, "buffered notice: %+v", notice)
 	}
-	noticeSeverity, ok := pgnotice.ParseDisplaySeverity(pgerror.GetSeverity(err))
+	noticeSeverity, ok := pgnotice.ParseDisplaySeverity(pgerror.GetSeverity(notice))
 	if !ok {
 		noticeSeverity = pgnotice.DisplaySeverityNotice
 	}
@@ -51,5 +51,5 @@ func (p *planner) SendClientNotice(ctx context.Context, err error) {
 		// * the notice protocol was disabled
 		return
 	}
-	p.noticeSender.AppendNotice(err)
+	p.noticeSender.BufferNotice(notice)
 }

--- a/pkg/sql/paramparse/paramobserver.go
+++ b/pkg/sql/paramparse/paramobserver.go
@@ -81,7 +81,7 @@ func applyFillFactorStorageParam(evalCtx *tree.EvalContext, key string, datum tr
 		return errors.Newf("%q must be between 0 and 100", key)
 	}
 	if evalCtx != nil {
-		evalCtx.ClientNoticeSender.SendClientNotice(
+		evalCtx.ClientNoticeSender.BufferClientNotice(
 			evalCtx.Context,
 			pgnotice.Newf("storage parameter %q is ignored", key),
 		)
@@ -116,7 +116,7 @@ func (a *TableStorageParamObserver) Apply(
 			boolVal = bool(*s)
 		}
 		if !boolVal && evalCtx != nil {
-			evalCtx.ClientNoticeSender.SendClientNotice(
+			evalCtx.ClientNoticeSender.BufferClientNotice(
 				evalCtx.Context,
 				pgnotice.Newf(`storage parameter "%s = %s" is ignored`, key, datum.String()),
 			)

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -642,7 +643,7 @@ func (c *conn) bufferParamStatus(param, value string) error {
 	return c.msgBuilder.finishMsg(&c.writerState.buf)
 }
 
-func (c *conn) bufferNotice(ctx context.Context, noticeErr error) error {
+func (c *conn) bufferNotice(ctx context.Context, noticeErr pgnotice.Notice) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgNoticeResponse)
 	return writeErrFields(ctx, c.sv, noticeErr, &c.msgBuilder, &c.writerState.buf)
 }

--- a/pkg/sql/pgwire/pgnotice/pgnotice.go
+++ b/pkg/sql/pgwire/pgnotice/pgnotice.go
@@ -16,18 +16,21 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Notice is an wrapper around errors that are intended to be notices.
+type Notice error
+
 // Newf generates a Notice with a format string.
-func Newf(format string, args ...interface{}) error {
+func Newf(format string, args ...interface{}) Notice {
 	err := errors.NewWithDepthf(1, format, args...)
 	err = pgerror.WithCandidateCode(err, pgcode.SuccessfulCompletion)
 	err = pgerror.WithSeverity(err, "NOTICE")
-	return err
+	return Notice(err)
 }
 
 // NewWithSeverityf generates a Notice with a format string and severity.
-func NewWithSeverityf(severity string, format string, args ...interface{}) error {
+func NewWithSeverityf(severity string, format string, args ...interface{}) Notice {
 	err := errors.NewWithDepthf(1, format, args...)
 	err = pgerror.WithCandidateCode(err, pgcode.SuccessfulCompletion)
 	err = pgerror.WithSeverity(err, severity)
-	return err
+	return Notice(err)
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -212,7 +212,7 @@ type planner struct {
 	optPlanningCtx optPlanningCtx
 
 	// noticeSender allows the sending of notices.
-	// Do not use this object directly; use the SendClientNotice() method
+	// Do not use this object directly; use the BufferClientNotice() method
 	// instead.
 	noticeSender noticeSender
 

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -61,7 +61,7 @@ func (n *refreshMaterializedViewNode) startExec(params runParams) error {
 
 	// Inform the user that CONCURRENTLY is not needed.
 	if n.n.Concurrently {
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			pgnotice.Newf("CONCURRENTLY is not required as views are refreshed concurrently"),
 		)

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -113,7 +113,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		// process of deprecating qualified rename targets, so issue a notice.
 		// TODO (rohany): Convert this to take in an unqualified name after 20.2
 		//  is released (#51445).
-		params.p.noticeSender.AppendNotice(
+		params.p.noticeSender.BufferNotice(
 			errors.WithHintf(
 				pgnotice.Newf("renaming tables with a qualification is deprecated"),
 				"use ALTER TABLE %s RENAME TO %s instead",

--- a/pkg/sql/sem/builtins/notice.go
+++ b/pkg/sql/sem/builtins/notice.go
@@ -27,7 +27,7 @@ func crdbInternalSendNotice(
 	if ctx.ClientNoticeSender == nil {
 		return nil, errors.AssertionFailedf("notice sender not set")
 	}
-	ctx.ClientNoticeSender.SendClientNotice(
+	ctx.ClientNoticeSender.BufferClientNotice(
 		ctx.Context,
 		pgnotice.NewWithSeverityf(strings.ToUpper(severity), "%s", msg),
 	)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -3027,8 +3028,9 @@ type EvalSessionAccessor interface {
 // interface only work on the gateway node (i.e. not from
 // distributed processors).
 type ClientNoticeSender interface {
-	// SendClientNotice sends a notice out-of-band to the client.
-	SendClientNotice(ctx context.Context, notice error)
+	// BufferClientNotice buffers the notice to send to the client.
+	// This is flushed before the connection is closed.
+	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
 }
 
 // InternalExecutor is a subset of sqlutil.InternalExecutor (which, in turn, is

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -102,7 +102,7 @@ func (n *setVarNode) startExec(params runParams) error {
 
 	if _, ok := DummyVars[n.name]; ok {
 		telemetry.Inc(sqltelemetry.DummySessionVarValueCounter(n.name))
-		params.p.SendClientNotice(
+		params.p.BufferClientNotice(
 			params.ctx,
 			pgnotice.NewWithSeverityf("WARNING", "setting session var %q is a no-op", n.name),
 		)


### PR DESCRIPTION
* Replace the `flushBeforeCloseFuncs` closure with the raw data types that
  need to be flushed.
* Rename SendClientNotice to BufferClientNotice to clear up semantics.
* Rename AppendNotice to BufferNotice.

This was desired in #49190.

Release note: None

