### PR TITLE
release-20.2: sql: fix large UPSERTs with RETURNING

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1231,3 +1231,19 @@ statement ok
 RESET CLUSTER SETTING kv.raft.command.max_size;
 DROP TABLE src;
 DROP TABLE dest
+
+# Regression test for finishing UPSERT too early (#54456).
+statement ok
+CREATE TABLE t54456 (c INT PRIMARY KEY);
+UPSERT INTO t54456 SELECT i FROM generate_series(1, 25000) AS i
+
+query I
+SELECT count(*) FROM t54456
+----
+25000
+
+# Regression test for clearing up upserted rows too early (#54465).
+query I
+WITH cte(c) AS (UPSERT INTO t54456 SELECT i FROM generate_series(25001, 40000) AS i RETURNING c) SELECT count(*) FROM cte
+----
+15000

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1531,7 +1531,7 @@ func (ef *execFactory) ConstructUpsert(
 		// in the table.
 		ups.run.tw.tabColIdxToRetIdx = row.ColMapping(tabDesc.Columns, returnColDescs)
 		ups.run.tw.returnCols = returnColDescs
-		ups.run.tw.collectRows = true
+		ups.run.tw.rowsNeeded = true
 	}
 
 	if autoCommit {

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -195,7 +195,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 func (n *upsertNode) BatchedCount() int { return n.run.tw.lastBatchSize }
 
 // BatchedValues implements the batchedPlanNode interface.
-func (n *upsertNode) BatchedValues(rowIdx int) tree.Datums { return n.run.tw.batchedValues(rowIdx) }
+func (n *upsertNode) BatchedValues(rowIdx int) tree.Datums { return n.run.tw.rows.At(rowIdx) }
 
 func (n *upsertNode) Close(ctx context.Context) {
 	n.source.Close(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #54478.

/cc @cockroachdb/release

---

In #51608 we fixed a bug with pagination of UPSERTs (now it is possible
to have multiple batches when performing an UPSERT of over 10k rows),
and it exposed another bug in how we're handling an UPSERT with
RETURNING clause - we were clearing the row container too early which
would result in an index of bounds crash. This is now fixed.

Fixes: #54465.

Release note (bug fix): Starting from v20.2.0-alpha.3 CockroachDB would
crash when performing an UPSERT with RETURNING clause of more than 10k
rows, and this is now fixed.
