### PR TITLE
jobs: ensure that the StartedMicros field is populated

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1068,6 +1068,11 @@ func (r *Registry) stepThroughStateMachine(
 				"job %d: resuming with non-nil error", *job.ID())
 		}
 		resumeCtx := logtags.AddTag(ctx, "job", *job.ID())
+		if payload.StartedMicros == 0 {
+			if err := job.started(ctx); err != nil {
+				return err
+			}
+		}
 		err := resumer.Resume(resumeCtx, phs, resultsCh)
 		if err == nil {
 			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusSucceeded, nil)


### PR DESCRIPTION
This commit ensures that when jobs of the new sqlliveness leases are started
for they first time, they populate their StartedMicros field.

Release note (bug fix): Fixed bug from earlier alphas whereby jobs would not
properly populate their `started` timestamp.