### PR TITLE
release-20.1: backupccl: redact storage URIs printed in error messages during BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -433,7 +433,7 @@ func backupPlanHook(
 						ctx, uri, makeCloudStorage, encryption,
 					)
 					if err != nil {
-						return errors.Wrapf(err, "failed to read backup from %q", uri)
+						return errors.Wrapf(err, "failed to read backup from %q", RedactURIForErrorMessage(uri))
 					}
 					prevBackups[i] = desc
 					return nil


### PR DESCRIPTION
Backport 1/1 commits from #54466.

/cc @cockroachdb/release

---

Certain user sensitive information such as AWS secret keys are printed
back to the client in certain error conditions. We now redact sensitive
information before returning the string to the client.

Fixes: #41998 

Release note: None
