### PR TITLE
sql: add a test for the internal executor

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -665,6 +665,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			return ev, payload, nil
 		}
+		log.VEventf(ctx, 2, "push detected for non-refreshable txn but auto-retry not possible")
 	}
 	// No event was generated.
 	return nil, nil, nil


### PR DESCRIPTION
Make sure that the internal executor does not eagerly generate retriable
errors for pushed txns when running in a higher-level txn.

Release note: None