### PR TITLE
sql: implement CREATE EXTENSION syntax

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -127,6 +127,7 @@ create_stmt ::=
 	| create_ddl_stmt
 	| create_stats_stmt
 	| create_schedule_for_backup_stmt
+	| create_extension_stmt
 
 delete_stmt ::=
 	opt_with_clause 'DELETE' 'FROM' table_expr_opt_alias_idx opt_where_clause opt_sort_clause opt_limit_clause returning_clause
@@ -410,6 +411,10 @@ create_stats_stmt ::=
 
 create_schedule_for_backup_stmt ::=
 	'CREATE' 'SCHEDULE' opt_description 'FOR' 'BACKUP' opt_backup_targets 'INTO' string_or_placeholder_opt_list opt_with_backup_options cron_expr opt_full_backup_clause opt_with_schedule_options
+
+create_extension_stmt ::=
+	'CREATE' 'EXTENSION' 'IF' 'NOT' 'EXISTS' name
+	| 'CREATE' 'EXTENSION' name
 
 opt_with_clause ::=
 	with_clause

--- a/pkg/sql/create_extension.go
+++ b/pkg/sql/create_extension.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+type createExtensionNode struct {
+	CreateExtension tree.CreateExtension
+}
+
+func (p *planner) CreateExtension(ctx context.Context, n *tree.CreateExtension) (planNode, error) {
+	return &createExtensionNode{
+		CreateExtension: *n,
+	}, nil
+}
+
+func (n *createExtensionNode) unimplementedExtensionError(issue int) error {
+	name := n.CreateExtension.Name
+	return unimplemented.NewWithIssueDetailf(
+		issue,
+		"CREATE EXTENSION "+name,
+		"extension %q is not yet supported",
+		name,
+	)
+}
+
+func (n *createExtensionNode) startExec(params runParams) error {
+	switch n.CreateExtension.Name {
+	case "postgis":
+		telemetry.Inc(sqltelemetry.CreateExtensionCounter(n.CreateExtension.Name))
+		return nil
+	case "postgis_raster",
+		"postgis_topology",
+		"postgis_sfcgal",
+		"fuzzystrmatch",
+		"address_standardizer",
+		"address_standardizer_data_us",
+		"postgis_tiger_geocoder":
+		// PostGIS specific extensions.
+		return n.unimplementedExtensionError(54514)
+	case "btree_gin":
+		return n.unimplementedExtensionError(51992)
+	case "btree_gist":
+		return n.unimplementedExtensionError(51993)
+	case "citext":
+		return n.unimplementedExtensionError(41276)
+	case "postgres_fdw":
+		return n.unimplementedExtensionError(20249)
+	case "pg_trgm":
+		return n.unimplementedExtensionError(51137)
+	case "adminpack",
+		"amcheck",
+		"auth_delay",
+		"auto_explain",
+		"bloom",
+		"cube",
+		"dblink",
+		"dict_int",
+		"dict_xsyn",
+		"earthdistance",
+		"file_fdw",
+		"hstore",
+		"intagg",
+		"intarray",
+		"isn",
+		"lo",
+		"ltree",
+		"pageinspect",
+		"passwordcheck",
+		"pg_buffercache",
+		"pgcrypto",
+		"pg_freespacemap",
+		"pg_prewarm",
+		"pgrowlocks",
+		"pg_stat_statements",
+		"pgstattuple",
+		"pg_visibility",
+		"seg",
+		"sepgsql",
+		"spi",
+		"sslinfo",
+		"tablefunc",
+		"tcn",
+		"test_decoding",
+		"tsm_system_rows",
+		"tsm_system_time",
+		"unaccent",
+		"uuid-ossp",
+		"xml2":
+		return n.unimplementedExtensionError(54516)
+	}
+	return pgerror.Newf(pgcode.UndefinedParameter, "unknown extension: %q", n.CreateExtension.Name)
+}
+
+func (n *createExtensionNode) Next(params runParams) (bool, error) { return false, nil }
+func (n *createExtensionNode) Values() tree.Datums                 { return tree.Datums{} }
+func (n *createExtensionNode) Close(ctx context.Context)           {}

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -89,6 +89,8 @@ func buildOpaque(
 		plan, err = p.CreateSequence(ctx, n)
 	case *tree.CreateStats:
 		plan, err = p.CreateStatistics(ctx, n)
+	case *tree.CreateExtension:
+		plan, err = p.CreateExtension(ctx, n)
 	case *tree.Deallocate:
 		plan, err = p.Deallocate(ctx, n)
 	case *tree.Discard:
@@ -195,6 +197,7 @@ func init() {
 		&tree.CommentOnIndex{},
 		&tree.CommentOnTable{},
 		&tree.CreateDatabase{},
+		&tree.CreateExtension{},
 		&tree.CreateIndex{},
 		&tree.CreateSchema{},
 		&tree.CreateSequence{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -117,6 +117,8 @@ func TestContextualHelp(t *testing.T) {
 		{`CREATE DATABASE IF NOT ??`, `CREATE DATABASE`},
 		{`CREATE DATABASE blih ??`, `CREATE DATABASE`},
 
+		{`CREATE EXTENSION ??`, `CREATE EXTENSION`},
+
 		{`CREATE USER blih ??`, `CREATE ROLE`},
 		{`CREATE USER blih WITH ??`, `CREATE ROLE`},
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -351,6 +351,9 @@ func TestParse(t *testing.T) {
 		{`CREATE SEQUENCE a OWNED BY b`},
 		{`CREATE SEQUENCE a OWNED BY NONE`},
 
+		{`CREATE EXTENSION bob`},
+		{`CREATE EXTENSION IF NOT EXISTS bob`},
+
 		{`CREATE STATISTICS a ON col1 FROM t`},
 		{`EXPLAIN CREATE STATISTICS a ON col1 FROM t`},
 		{`CREATE STATISTICS a FROM t`},
@@ -2945,7 +2948,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE CONSTRAINT TRIGGER a`, 28296, `create constraint`, ``},
 		{`CREATE CONVERSION a`, 0, `create conversion`, ``},
 		{`CREATE DEFAULT CONVERSION a`, 0, `create def conv`, ``},
-		{`CREATE EXTENSION a`, 0, `create extension a`, ``},
 		{`CREATE FOREIGN DATA WRAPPER a`, 0, `create fdw`, ``},
 		{`CREATE FOREIGN TABLE a`, 0, `create foreign table`, ``},
 		{`CREATE FUNCTION a`, 17511, `create`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -776,6 +776,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 %type <tree.Statement> create_changefeed_stmt
 %type <tree.Statement> create_ddl_stmt
 %type <tree.Statement> create_database_stmt
+%type <tree.Statement> create_extension_stmt
 %type <tree.Statement> create_index_stmt
 %type <tree.Statement> create_role_stmt
 %type <tree.Statement> create_schedule_for_backup_stmt
@@ -2908,14 +2909,28 @@ comment_text:
 // %Text:
 // CREATE DATABASE, CREATE TABLE, CREATE INDEX, CREATE TABLE AS,
 // CREATE USER, CREATE VIEW, CREATE SEQUENCE, CREATE STATISTICS,
-// CREATE ROLE, CREATE TYPE
+// CREATE ROLE, CREATE TYPE, CREATE EXTENSION
 create_stmt:
   create_role_stmt     // EXTEND WITH HELP: CREATE ROLE
 | create_ddl_stmt      // help texts in sub-rule
 | create_stats_stmt    // EXTEND WITH HELP: CREATE STATISTICS
 | create_schedule_for_backup_stmt   // EXTEND WITH HELP: CREATE SCHEDULE FOR BACKUP
+| create_extension_stmt // EXTEND WITH HELP: CREATE EXTENSION
 | create_unsupported   {}
 | CREATE error         // SHOW HELP: CREATE
+
+// %Help: CREATE EXTENSION
+// %Category: Cfg
+// %Text: CREATE EXTENSION [IF NOT EXISTS] name
+create_extension_stmt:
+  CREATE EXTENSION IF NOT EXISTS name
+  {
+    $$.val = &tree.CreateExtension{IfNotExists: true, Name: $6}
+  }
+| CREATE EXTENSION name {
+    $$.val = &tree.CreateExtension{Name: $3}
+  }
+| CREATE EXTENSION error // SHOW HELP: CREATE EXTENSION
 
 create_unsupported:
   CREATE AGGREGATE error { return unimplemented(sqllex, "create aggregate") }
@@ -2923,8 +2938,6 @@ create_unsupported:
 | CREATE CONSTRAINT TRIGGER error { return unimplementedWithIssueDetail(sqllex, 28296, "create constraint") }
 | CREATE CONVERSION error { return unimplemented(sqllex, "create conversion") }
 | CREATE DEFAULT CONVERSION error { return unimplemented(sqllex, "create def conv") }
-| CREATE EXTENSION IF NOT EXISTS name error { return unimplemented(sqllex, "create extension " + $6) }
-| CREATE EXTENSION name error { return unimplemented(sqllex, "create extension " + $3) }
 | CREATE FOREIGN TABLE error { return unimplemented(sqllex, "create foreign table") }
 | CREATE FOREIGN DATA error { return unimplemented(sqllex, "create fdw") }
 | CREATE FUNCTION error { return unimplementedWithIssueDetail(sqllex, 17511, "create function") }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1707,3 +1707,18 @@ func (o *CreateStatsOptions) CombineWith(other *CreateStatsOptions) error {
 	}
 	return nil
 }
+
+// CreateExtension represents a CREATE EXTENSION statement.
+type CreateExtension struct {
+	Name        string
+	IfNotExists bool
+}
+
+// Format implements the NodeFormatter interface.
+func (node *CreateExtension) Format(ctx *FmtCtx) {
+	ctx.WriteString("CREATE EXTENSION ")
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
+	ctx.WriteString(node.Name)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -364,6 +364,12 @@ func (*CreateDatabase) StatementType() StatementType { return DDL }
 func (*CreateDatabase) StatementTag() string { return "CREATE DATABASE" }
 
 // StatementType implements the Statement interface.
+func (*CreateExtension) StatementType() StatementType { return Ack }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateExtension) StatementTag() string { return "CREATE EXTENSION" }
+
+// StatementType implements the Statement interface.
 func (*CreateIndex) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -1037,6 +1043,7 @@ func (n *CommitTransaction) String() string              { return AsString(n) }
 func (n *CopyFrom) String() string                       { return AsString(n) }
 func (n *CreateChangefeed) String() string               { return AsString(n) }
 func (n *CreateDatabase) String() string                 { return AsString(n) }
+func (n *CreateExtension) String() string                { return AsString(n) }
 func (n *CreateIndex) String() string                    { return AsString(n) }
 func (n *CreateRole) String() string                     { return AsString(n) }
 func (n *CreateTable) String() string                    { return AsString(n) }

--- a/pkg/sql/sqltelemetry/extension.go
+++ b/pkg/sql/sqltelemetry/extension.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// CreateExtensionCounter returns a counter to increment for creating extensions.
+func CreateExtensionCounter(ext string) telemetry.Counter {
+	return telemetry.GetCounter("sql.extension.create." + ext)
+}

--- a/pkg/sql/testdata/telemetry/extension
+++ b/pkg/sql/testdata/telemetry/extension
@@ -1,0 +1,32 @@
+feature-allowlist
+sql.extension.*
+unimplemented.*
+----
+
+feature-usage
+CREATE EXTENSION postgis
+----
+sql.extension.create.postgis
+
+feature-usage
+CREATE EXTENSION postgis_raster
+----
+error: pq: unimplemented: extension "postgis_raster" is not yet supported
+unimplemented.#54514.CREATE EXTENSION postgis_raster
+
+feature-usage
+CREATE EXTENSION pg_trgm
+----
+error: pq: unimplemented: extension "pg_trgm" is not yet supported
+unimplemented.#51137.CREATE EXTENSION pg_trgm
+
+feature-usage
+CREATE EXTENSION xml2
+----
+error: pq: unimplemented: extension "xml2" is not yet supported
+unimplemented.#54516.CREATE EXTENSION xml2
+
+feature-usage
+CREATE EXTENSION asdf
+----
+error: pq: unknown extension: "asdf"

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -353,6 +353,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&controlJobsNode{}):             "control jobs",
 	reflect.TypeOf(&controlSchedulesNode{}):        "control schedules",
 	reflect.TypeOf(&createDatabaseNode{}):          "create database",
+	reflect.TypeOf(&createExtensionNode{}):         "create extension",
 	reflect.TypeOf(&createIndexNode{}):             "create index",
 	reflect.TypeOf(&createSequenceNode{}):          "create sequence",
 	reflect.TypeOf(&createSchemaNode{}):            "create schema",


### PR DESCRIPTION
Refs #51424, #51137 

Release note (sql change): Add support for the CREATE EXTENSION syntax.
This no-ops for PostGIS, and gives unimplemented errors for extensions
we do not yet support but may plan to.