### PR TITLE
sql: add memory accounting for sqlStats

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -292,10 +292,12 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		Metrics:         makeMetrics(false /*internal*/),
 		InternalMetrics: makeMetrics(true /*internal*/),
 		// dbCache will be updated on Start().
-		dbCache:       newDatabaseCacheHolder(database.NewCache(cfg.Codec, systemCfg)),
-		pool:          pool,
-		sqlStats:      sqlStats{st: cfg.Settings, apps: make(map[string]*appStats)},
-		reportedStats: sqlStats{st: cfg.Settings, apps: make(map[string]*appStats)},
+		dbCache: newDatabaseCacheHolder(database.NewCache(cfg.Codec, systemCfg)),
+		pool:    pool,
+		// TODO(arul): Is it okay to hang this boundAccount off the pool or do we
+		// need another monitor that is a child of pool?
+		sqlStats:      sqlStats{st: cfg.Settings, apps: make(map[string]*appStats), sqlStatsMemAccount: pool.MakeBoundAccount()},
+		reportedStats: sqlStats{st: cfg.Settings, apps: make(map[string]*appStats), sqlStatsMemAccount: pool.MakeBoundAccount()},
 		reCache:       tree.NewRegexpCache(512),
 	}
 }

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -183,6 +183,10 @@ func (ex *connExecutor) recordStatementSummary(
 		parseLat, planLat, runLat, svcLat, execOverhead, stats,
 	)
 
+	// We just recorded some metrics to the server's sql stats, which may have
+	// resulted in the sqlStats datastructure to grow beyond the permitted amount.
+	ex.statsCollector.sqlStats.resetStatsIfUsingTooMuchMemory(ctx, &ex.server.reportedStats)
+
 	// Do some transaction level accounting for the transaction this statement is
 	// a part of.
 


### PR DESCRIPTION
sqlStats track statement/transaction level statistics which can grow
unboundedly larged based on the users' query patterns. To mitigate
this, we currenlty clear the sqlStats and reportedStats at regular
intervals. This doesn't guarentee that we won't run into trouble with
excess mem usage though. This patch adds memory accounting to these
datastructures to deterministically ensure that we keep the amount of
memory usage in check. If stats collection ends up using more memory
than allowed, the sqlStats datastructure is reset pre-emptively.

Closes #53749

Release note (general change): users may find statistics are cleared
more often than dictated by cluster settings if stats collection is
taking up too much memory.