### PR TITLE
kvserver/rangefeed: use pointers for events

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -926,8 +926,9 @@ func (p *Processor) syncEventAndRegistrations() {
 // overlapping the given span to fully process their own internal buffers.
 func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
 	syncC := make(chan struct{})
+	ev := getPooledEvent(event{syncC: syncC, testRegCatchupSpan: span})
 	select {
-	case p.eventC <- event{syncC: syncC, testRegCatchupSpan: span}:
+	case p.eventC <- ev:
 		select {
 		case <-syncC:
 		// Synchronized.
@@ -935,6 +936,7 @@ func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
 			// Already stopped. Do nothing.
 		}
 	case <-p.stoppedC:
+		putPooledEvent(ev)
 		// Already stopped. Do nothing.
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -194,7 +194,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 				EndKey: roachpb.RKey("w"),
 			},
 		},
-		eventC: make(chan event, 100),
+		eventC: make(chan *event, 100),
 	}
 
 	// Run an init rts scan over a test iterator with the following keys.
@@ -230,7 +230,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 	require.True(t, iter.closed)
 
 	// Compare the event channel to the expected events.
-	expEvents := []event{
+	expEvents := []*event{
 		{ops: []enginepb.MVCCLogicalOp{
 			writeIntentOpWithKey(txn2, []byte("txnKey2"), hlc.Timestamp{WallTime: 21}),
 		}},
@@ -346,7 +346,7 @@ func TestTxnPushAttempt(t *testing.T) {
 	})
 
 	// Mock processor. We just needs its eventC.
-	p := Processor{eventC: make(chan event, 100)}
+	p := Processor{eventC: make(chan *event, 100)}
 	p.TxnPusher = &tp
 
 	txns := []enginepb.TxnMeta{txn1Meta, txn2Meta, txn3Meta, txn4Meta}
@@ -356,7 +356,7 @@ func TestTxnPushAttempt(t *testing.T) {
 	<-doneC // check if closed
 
 	// Compare the event channel to the expected events.
-	expEvents := []event{
+	expEvents := []*event{
 		{ops: []enginepb.MVCCLogicalOp{
 			updateIntentOp(txn1, hlc.Timestamp{WallTime: 15}),
 			updateIntentOp(txn2, hlc.Timestamp{WallTime: 2}),


### PR DESCRIPTION
Rangefeed processors allocate a bufferred channel for events. The default size
of this channel is 4KiB. An event struct is 104 bytes. That means that on the
server side we are allocating almost .5MiB per rangefeed client. This PR
changes the channel to instead use pointers and uses a sync.Pool to avoid
excessive allocations. This reduces the server-side overhead of a rangefeed
by ~10x. This should help in cases where changefeeds are run over large numbers
of ranges.

I imagine we can backport this to at least a few releases.

Release note (general change): Reduced the memory overhead of rangefeeds which
reduces the memory overhead for running CHANGEFEEDs over large tables.