### PR TITLE
roachtest: improve Ctrl+C behavior

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -372,10 +372,11 @@ func CtrlC(ctx context.Context, l *logger, cancel func(), cr *clusterRegistry) {
 		// If we get a second CTRL-C, exit immediately.
 		select {
 		case <-sig:
-			shout(ctx, l, os.Stderr, "Second SIGINT received. Quitting.")
+			shout(ctx, l, os.Stderr, "Second SIGINT received. Quitting. Cluster might be left behind.")
 			os.Exit(2)
 		case <-destroyCh:
 			shout(ctx, l, os.Stderr, "Done destroying all clusters.")
+			os.Exit(2)
 		}
 	}()
 }


### PR DESCRIPTION
A Ctrl+C is supposed to kill all the cluster and exit. Prior to this
patch it was waiting for all the tests to finish before actually
exiting. In practice tests are supposed to react quickly to their
cluster being shut down from under them, but nothing guarantees that to
be the case. Now the Ctrl-C handler takes killing the process upon
itself.

Release note: None