### PR TITLE
release-20.2: invertedidx: don't do *types.T pointer comparison

### DIFF
--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -735,8 +735,8 @@ func (p *PreFilterer) PreFilter(
 	if err != nil {
 		return false, err
 	}
-	switch p.typ {
-	case types.Geometry:
+	switch p.typ.Family() {
+	case types.GeometryFamily:
 		var bb geo.CartesianBoundingBox
 		bb.LoX, bb.LoY, bb.HiX, bb.HiY = loX, loY, hiX, hiY
 		switch p.preFilterRelationship {
@@ -765,7 +765,7 @@ func (p *PreFilterer) PreFilter(
 			}
 		}
 		return rv, nil
-	case types.Geography:
+	case types.GeographyFamily:
 		bb := s2.Rect{
 			Lat: r1.Interval{Lo: loY, Hi: hiY},
 			Lng: s1.Interval{Lo: loX, Hi: hiX},


### PR DESCRIPTION
Backport 1/1 commits from #54523.

/cc @cockroachdb/release

---

Release note: None
Release justification: Bug fixes and low-risk updates to new functionality
