### PR TITLE
opt: build constraint for containment operator

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -167,7 +167,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ·           distribution         local                        ·       ·
 ·           vectorized           true                         ·       ·
 index join  ·                    ·                            (a, b)  ·
- │          estimated row count  111 (missing stats)          ·       ·
+ │          estimated row count  110 (missing stats)          ·       ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
@@ -181,7 +181,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ·           distribution         local                                    ·       ·
 ·           vectorized           true                                     ·       ·
 index join  ·                    ·                                        (a, b)  ·
- │          estimated row count  111 (missing stats)                      ·       ·
+ │          estimated row count  110 (missing stats)                      ·       ·
  │          table                d@primary                                ·       ·
  │          key columns          a                                        ·       ·
  └── scan   ·                    ·                                        (a)     ·
@@ -195,7 +195,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ·           distribution         local                                            ·       ·
 ·           vectorized           true                                             ·       ·
 index join  ·                    ·                                                (a, b)  ·
- │          estimated row count  111 (missing stats)                              ·       ·
+ │          estimated row count  110 (missing stats)                              ·       ·
  │          table                d@primary                                        ·       ·
  │          key columns          a                                                ·       ·
  └── scan   ·                    ·                                                (a)     ·
@@ -209,7 +209,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ·           distribution         local                         ·       ·
 ·           vectorized           true                          ·       ·
 index join  ·                    ·                             (a, b)  ·
- │          estimated row count  111 (missing stats)           ·       ·
+ │          estimated row count  110 (missing stats)           ·       ·
  │          table                d@primary                     ·       ·
  │          key columns          a                             ·       ·
  └── scan   ·                    ·                             (a)     ·
@@ -223,7 +223,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ·           distribution         local                    ·       ·
 ·           vectorized           true                     ·       ·
 index join  ·                    ·                        (a, b)  ·
- │          estimated row count  111 (missing stats)      ·       ·
+ │          estimated row count  110 (missing stats)      ·       ·
  │          table                d@primary                ·       ·
  │          key columns          a                        ·       ·
  └── scan   ·                    ·                        (a)     ·
@@ -237,7 +237,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ·           distribution         local                                            ·       ·
 ·           vectorized           true                                             ·       ·
 index join  ·                    ·                                                (a, b)  ·
- │          estimated row count  111 (missing stats)                              ·       ·
+ │          estimated row count  110 (missing stats)                              ·       ·
  │          table                d@primary                                        ·       ·
  │          key columns          a                                                ·       ·
  └── scan   ·                    ·                                                (a)     ·
@@ -251,7 +251,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ·          distribution         local                 ·       ·
 ·          vectorized           true                  ·       ·
 filter     ·                    ·                     (a, b)  ·
- │         estimated row count  111 (missing stats)   ·       ·
+ │         estimated row count  110 (missing stats)   ·       ·
  │         filter               b @> '[]'             ·       ·
  └── scan  ·                    ·                     (a, b)  ·
 ·          estimated row count  1000 (missing stats)  ·       ·
@@ -265,7 +265,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ·          distribution         local                 ·       ·
 ·          vectorized           true                  ·       ·
 filter     ·                    ·                     (a, b)  ·
- │         estimated row count  111 (missing stats)   ·       ·
+ │         estimated row count  110 (missing stats)   ·       ·
  │         filter               b @> '{}'             ·       ·
  └── scan  ·                    ·                     (a, b)  ·
 ·          estimated row count  1000 (missing stats)  ·       ·
@@ -279,7 +279,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ·           distribution         local                        ·       ·
 ·           vectorized           true                         ·       ·
 index join  ·                    ·                            (a, b)  ·
- │          estimated row count  111 (missing stats)          ·       ·
+ │          estimated row count  110 (missing stats)          ·       ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
@@ -293,7 +293,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ·           distribution         local                                ·       ·
 ·           vectorized           true                                 ·       ·
 index join  ·                    ·                                    (a, b)  ·
- │          estimated row count  111 (missing stats)                  ·       ·
+ │          estimated row count  110 (missing stats)                  ·       ·
  │          table                d@primary                            ·       ·
  │          key columns          a                                    ·       ·
  └── scan   ·                    ·                                    (a)     ·
@@ -314,7 +314,7 @@ EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ·           distribution         local                        ·       ·
 ·           vectorized           true                         ·       ·
 index join  ·                    ·                            (a, b)  ·
- │          estimated row count  111 (missing stats)          ·       ·
+ │          estimated row count  110 (missing stats)          ·       ·
  │          table                d@primary                    ·       ·
  │          key columns          a                            ·       ·
  └── scan   ·                    ·                            (a)     ·
@@ -524,7 +524,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1]
 ·           distribution         local                ·       ·
 ·           vectorized           true                 ·       ·
 index join  ·                    ·                    (a, b)  ·
- │          estimated row count  333 (missing stats)  ·       ·
+ │          estimated row count  330 (missing stats)  ·       ·
  │          table                e@primary            ·       ·
  │          key columns          a                    ·       ·
  └── scan   ·                    ·                    (a)     ·
@@ -538,7 +538,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
 ·          distribution         local                 ·       ·
 ·          vectorized           true                  ·       ·
 filter     ·                    ·                     (a, b)  ·
- │         estimated row count  333 (missing stats)   ·       ·
+ │         estimated row count  330 (missing stats)   ·       ·
  │         filter               b @> ARRAY[]          ·       ·
  └── scan  ·                    ·                     (a, b)  ·
 ·          estimated row count  1000 (missing stats)  ·       ·
@@ -552,7 +552,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
 ·            distribution         local                ·       ·
 ·            vectorized           true                 ·       ·
 index join   ·                    ·                    (a, b)  ·
- │           estimated row count  333 (missing stats)  ·       ·
+ │           estimated row count  330 (missing stats)  ·       ·
  │           table                e@primary            ·       ·
  │           key columns          a                    ·       ·
  └── norows  ·                    ·                    (a)     ·
@@ -583,7 +583,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ·                    distribution           local                ·       ·
 ·                    vectorized             true                 ·       ·
 lookup join (inner)  ·                      ·                    (a, b)  ·
- │                   estimated row count    333 (missing stats)  ·       ·
+ │                   estimated row count    330 (missing stats)  ·       ·
  │                   table                  e@primary            ·       ·
  │                   equality               (a) = (a)            ·       ·
  │                   equality cols are key  ·                    ·       ·
@@ -603,7 +603,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ·                    distribution           local                                ·       ·
 ·                    vectorized             true                                 ·       ·
 lookup join (inner)  ·                      ·                                    (a, b)  ·
- │                   estimated row count    111 (missing stats)                  ·       ·
+ │                   estimated row count    110 (missing stats)                  ·       ·
  │                   table                  e@primary                            ·       ·
  │                   equality               (a) = (a)                            ·       ·
  │                   equality cols are key  ·                                    ·       ·

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -204,6 +204,10 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 				return cb.makeStringPrefixSpan(col, prefix), false
 			}
 		}
+
+	case opt.ContainsOp:
+		// NULL cannot contain anything, so a non-tight, not-null span is built.
+		return cb.notNullSpan(col), false
 	}
 	return unconstrained, false
 }

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1366,3 +1366,57 @@ select
                 └── eq [type=bool]
                      ├── variable: x:1 [type=int]
                      └── const: 3 [type=int]
+
+# Tests for the containment operator.
+
+exec-ddl
+CREATE TABLE f
+(
+    k INT PRIMARY KEY,
+    j JSON,
+    a INT[]
+)
+----
+
+# Containment implies the column is not null.
+opt
+SELECT 1 FROM f WHERE j @> '{"x": "y"}'
+----
+project
+ ├── columns: "?column?":5(int!null)
+ ├── immutable
+ ├── fd: ()-->(5)
+ ├── prune: (5)
+ ├── select
+ │    ├── columns: j:2(jsonb!null)
+ │    ├── immutable
+ │    ├── scan f
+ │    │    ├── columns: j:2(jsonb)
+ │    │    └── prune: (2)
+ │    └── filters
+ │         └── contains [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ])]
+ │              ├── variable: j:2 [type=jsonb]
+ │              └── const: '{"x": "y"}' [type=jsonb]
+ └── projections
+      └── const: 1 [as="?column?":5, type=int]
+
+opt
+SELECT 1 FROM f WHERE a @> ARRAY[1]
+----
+project
+ ├── columns: "?column?":5(int!null)
+ ├── immutable
+ ├── fd: ()-->(5)
+ ├── prune: (5)
+ ├── select
+ │    ├── columns: a:3(int[]!null)
+ │    ├── immutable
+ │    ├── scan f
+ │    │    ├── columns: a:3(int[])
+ │    │    └── prune: (3)
+ │    └── filters
+ │         └── contains [type=bool, outer=(3), immutable, constraints=(/3: (/NULL - ])]
+ │              ├── variable: a:3 [type=int[]]
+ │              └── const: ARRAY[1] [type=int[]]
+ └── projections
+      └── const: 1 [as="?column?":5, type=int]

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -775,3 +775,341 @@ scan hist@idx,partial
 exec-ddl
 DROP INDEX idx
 ----
+
+# ----------------------------------
+# Tests for partial inverted indexes
+# ----------------------------------
+
+exec-ddl
+CREATE TABLE inv (
+  k INT PRIMARY KEY,
+  i INT,
+  j JSON,
+  s STRING,
+  INVERTED INDEX partial (j) WHERE s IN ('foo', 'bar')
+)
+----
+
+exec-ddl
+ALTER TABLE inv INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 5000
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 500
+  },
+  {
+    "columns": ["j"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 500
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 500,
+    "null_count": 50
+  }
+]'
+----
+
+opt
+SELECT k FROM inv@partial WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar')
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=2.20440882]
+ ├── key: (1)
+ └── scan inv@partial,partial
+      ├── columns: k:1(int!null)
+      ├── constraint: /3/1: [/'{"x": "y"}' - /'{"x": "y"}']
+      ├── flags: force-index=partial
+      ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+      └── key: (1)
+
+opt
+SELECT * FROM inv@partial WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar')
+----
+index-join inv
+ ├── columns: k:1(int!null) i:2(int) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan inv@partial,partial
+      ├── columns: k:1(int!null)
+      ├── constraint: /3/1: [/'{"x": "y"}' - /'{"x": "y"}']
+      ├── flags: force-index=partial
+      ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+      └── key: (1)
+
+opt
+SELECT k FROM inv@partial WHERE j @> '{"x": "y"}' AND s = 'foo'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=1.10220441]
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) j:3(jsonb!null) s:4(string!null)
+      ├── immutable
+      ├── stats: [rows=1.10220441, distinct(4)=1, null(4)=0]
+      ├── key: (1)
+      ├── fd: ()-->(4), (1)-->(3)
+      ├── index-join inv
+      │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
+      │    ├── stats: [rows=2.20440882]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3,4)
+      │    └── scan inv@partial,partial
+      │         ├── columns: k:1(int!null)
+      │         ├── constraint: /3/1: [/'{"x": "y"}' - /'{"x": "y"}']
+      │         ├── flags: force-index=partial
+      │         ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+      │         └── key: (1)
+      └── filters
+           └── s:4 = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+opt
+SELECT * FROM inv@partial WHERE j @> '{"x": "y"}' AND s = 'foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=1.10220441, distinct(4)=1, null(4)=0]
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── index-join inv
+ │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
+ │    ├── stats: [rows=2.20440882]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan inv@partial,partial
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /3/1: [/'{"x": "y"}' - /'{"x": "y"}']
+ │         ├── flags: force-index=partial
+ │         ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+ │         └── key: (1)
+ └── filters
+      └── s:4 = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+opt
+SELECT * FROM inv@partial WHERE j @> '{"x": "y"}' AND s = 'foo' AND i > 0 AND i < 10
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=0.901983968, distinct(2)=0.901983968, null(2)=0, distinct(4)=0.901983968, null(4)=0, distinct(2,4)=0.901983968, null(2,4)=0]
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── index-join inv
+ │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
+ │    ├── stats: [rows=2.20440882]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan inv@partial,partial
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /3/1: [/'{"x": "y"}' - /'{"x": "y"}']
+ │         ├── flags: force-index=partial
+ │         ├── stats: [rows=2.20440882, distinct(4)=2, null(4)=0]
+ │         └── key: (1)
+ └── filters
+      ├── (i:2 > 0) AND (i:2 < 10) [type=bool, outer=(2), constraints=(/2: [/1 - /9]; tight)]
+      └── s:4 = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# --------------------------------------------------
+# Tests for partial inverted indexes with histograms
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE inv_hist (
+  k INT PRIMARY KEY,
+  i INT,
+  j JSON,
+  s STRING,
+  INVERTED INDEX partial (j) WHERE s IN ('apple', 'banana', 'cherry')
+)
+----
+
+# Histogram boundaries are from JSON values '{"a": 1}', '{"g": 7}', and '{"n":
+# 14}'.
+exec-ddl
+ALTER TABLE inv_hist INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 41,
+    "null_count": 30,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "100"},
+      {"num_eq": 10, "num_range": 180, "distinct_range": 9, "upper_bound": "200"},
+      {"num_eq": 20, "num_range": 270, "distinct_range": 9, "upper_bound": "300"},
+      {"num_eq": 30, "num_range": 360, "distinct_range": 9, "upper_bound": "400"}
+    ]
+  },
+  {
+    "columns": ["j"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 201,
+    "null_count": 200,
+    "histo_col_type": "bytes",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "\\\\x376100012a0200"},
+      {"num_eq": 100, "num_range": 200, "distinct_range": 99, "upper_bound": "\\\\x376700012a0e00"},
+      {"num_eq": 200, "num_range": 300, "distinct_range": 99, "upper_bound": "\\\\x376e00012a1c00"}
+    ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
+  }
+]'
+----
+
+opt
+SELECT k FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s IN ('apple', 'banana', 'cherry')
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=17.7777778]
+ ├── key: (1)
+ └── scan inv_hist@partial,partial
+      ├── columns: k:1(int!null)
+      ├── constraint: /3/1: [/'{"g": 7}' - /'{"g": 7}']
+      ├── flags: force-index=partial
+      ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+      │   histogram(4)=  0   8.8889   0   8.8889
+      │                <--- 'banana' --- 'cherry'
+      └── key: (1)
+
+opt
+SELECT * FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s IN ('apple', 'banana', 'cherry')
+----
+index-join inv_hist
+ ├── columns: k:1(int!null) i:2(int) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+ │   histogram(4)=  0   8.8889   0   8.8889
+ │                <--- 'banana' --- 'cherry'
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan inv_hist@partial,partial
+      ├── columns: k:1(int!null)
+      ├── constraint: /3/1: [/'{"g": 7}' - /'{"g": 7}']
+      ├── flags: force-index=partial
+      ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+      │   histogram(4)=  0   8.8889   0   8.8889
+      │                <--- 'banana' --- 'cherry'
+      └── key: (1)
+
+opt
+SELECT k FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s = 'banana'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=8.88888889]
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) j:3(jsonb!null) s:4(string!null)
+      ├── immutable
+      ├── stats: [rows=8.88888889, distinct(4)=1, null(4)=0]
+      │   histogram(4)=  0   8.8889
+      │                <--- 'banana'
+      ├── key: (1)
+      ├── fd: ()-->(4), (1)-->(3)
+      ├── index-join inv_hist
+      │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
+      │    ├── stats: [rows=17.7777778]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3,4)
+      │    └── scan inv_hist@partial,partial
+      │         ├── columns: k:1(int!null)
+      │         ├── constraint: /3/1: [/'{"g": 7}' - /'{"g": 7}']
+      │         ├── flags: force-index=partial
+      │         ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+      │         │   histogram(4)=  0   8.8889   0   8.8889
+      │         │                <--- 'banana' --- 'cherry'
+      │         └── key: (1)
+      └── filters
+           └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
+
+opt
+SELECT * FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s = 'banana'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=8.88888889, distinct(4)=1, null(4)=0]
+ │   histogram(4)=  0   8.8889
+ │                <--- 'banana'
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── index-join inv_hist
+ │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
+ │    ├── stats: [rows=17.7777778]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan inv_hist@partial,partial
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /3/1: [/'{"g": 7}' - /'{"g": 7}']
+ │         ├── flags: force-index=partial
+ │         ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+ │         │   histogram(4)=  0   8.8889   0   8.8889
+ │         │                <--- 'banana' --- 'cherry'
+ │         └── key: (1)
+ └── filters
+      └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
+
+opt
+SELECT * FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s IN ('apple', 'banana', 'cherry') AND i > 0 AND i <= 100
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) j:3(jsonb!null) s:4(string!null)
+ ├── immutable
+ ├── stats: [rows=2.81695304, distinct(2)=2.81695304, null(2)=0, distinct(4)=2, null(4)=0, distinct(2,4)=2.81695304, null(2,4)=0]
+ │   histogram(2)=  0  0  2.5353 0.2817
+ │                <--- 0 -------- 100 -
+ │   histogram(4)=  0   1.4085   0   1.4085
+ │                <--- 'banana' --- 'cherry'
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── index-join inv_hist
+ │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
+ │    ├── stats: [rows=17.7777778]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan inv_hist@partial,partial
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /3/1: [/'{"g": 7}' - /'{"g": 7}']
+ │         ├── flags: force-index=partial
+ │         ├── stats: [rows=17.7777778, distinct(4)=2, null(4)=0]
+ │         │   histogram(4)=  0   8.8889   0   8.8889
+ │         │                <--- 'banana' --- 'cherry'
+ │         └── key: (1)
+ └── filters
+      └── (i:2 > 0) AND (i:2 <= 100) [type=bool, outer=(2), constraints=(/2: [/1 - /100]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -841,7 +841,7 @@ opt
 SELECT * FROM tjson WHERE b @> '{"a":"b"}'
 ----
 index-join tjson
- ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── columns: a:1(int!null) b:2(jsonb!null) c:3(jsonb)
  ├── immutable
  ├── stats: [rows=555.555556]
  ├── key: (1)
@@ -858,7 +858,7 @@ opt
 SELECT * FROM tjson WHERE b @> '{"a":"b", "c":"d"}'
 ----
 inner-join (lookup tjson)
- ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── columns: a:1(int!null) b:2(jsonb!null) c:3(jsonb)
  ├── key columns: [1] = [1]
  ├── lookup columns are key
  ├── immutable
@@ -873,7 +873,7 @@ inner-join (lookup tjson)
  │    ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": "b", "c": "d"}' [type=bool, outer=(2), immutable]
+      └── b:2 @> '{"a": "b", "c": "d"}' [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 # Should generate a select on the table with a JSON filter, since c does not
 # have an inverted index.
@@ -881,18 +881,18 @@ opt
 SELECT * FROM tjson WHERE c @> '{"a":"b"}'
 ----
 select
- ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb!null)
  ├── immutable
  ├── stats: [rows=555.555556]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan tjson
  │    ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(3)=2500, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters
-      └── c:3 @> '{"a": "b"}' [type=bool, outer=(3), immutable]
+      └── c:3 @> '{"a": "b"}' [type=bool, outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
 # Should have a lower row count than the above case, due to a containment query
 # on 2 json paths.
@@ -900,18 +900,18 @@ opt
 SELECT * FROM tjson WHERE c @> '{"a":"b", "c":"d"}'
 ----
 select
- ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb!null)
  ├── immutable
  ├── stats: [rows=61.7283951]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan tjson
  │    ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(3)=2500, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters
-      └── c:3 @> '{"a": "b", "c": "d"}' [type=bool, outer=(3), immutable]
+      └── c:3 @> '{"a": "b", "c": "d"}' [type=bool, outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
 # Bump up null counts.
 exec-ddl

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -600,7 +600,7 @@ norm expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a' = '"b"'::JSON
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -609,13 +609,13 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": "b"}' [outer=(5), immutable]
+      └── j:5 @> '{"a": "b"}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 norm expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -624,7 +624,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable]
+      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # The transformation is not valid in this case.
 norm expect-not=NormalizeJSONFieldAccess
@@ -680,7 +680,7 @@ norm expect=NormalizeJSONContains
 SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -689,7 +689,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable]
+      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # --------------------------------------------------
 # SimplifyCaseWhenConstValue

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -177,7 +177,7 @@ delete kj
  ├── columns: <none>
  ├── fetch columns: k:5 j:6
  └── select
-      ├── columns: k:5!null j:6 crdb_internal_mvcc_timestamp:7
+      ├── columns: k:5!null j:6!null crdb_internal_mvcc_timestamp:7
       ├── scan kj
       │    └── columns: k:5!null j:6 crdb_internal_mvcc_timestamp:7
       └── filters

--- a/pkg/sql/opt/xform/testdata/external/fittings
+++ b/pkg/sql/opt/xform/testdata/external/fittings
@@ -2584,7 +2584,7 @@ project
       │    │    ├── ordering: -1
       │    │    └── limit hint: 900.00
       │    └── filters
-      │         └── items:10 @> '[32880]' [outer=(10), immutable]
+      │         └── items:10 @> '[32880]' [outer=(10), immutable, constraints=(/10: (/NULL - ])]
       └── 100
 
 # Find the 100 most recent Skybreakers. A Skybreaker is a very rare ship,
@@ -2639,5 +2639,5 @@ project
       │    │    ├── ordering: -1
       │    │    └── limit hint: 900.00
       │    └── filters
-      │         └── items:10 @> '[54731]' [outer=(10), immutable]
+      │         └── items:10 @> '[54731]' [outer=(10), immutable, constraints=(/10: (/NULL - ])]
       └── 100

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4948,7 +4948,7 @@ opt
 SELECT b,a FROM t5 WHERE b @> '{"a":1}'
 ----
 index-join t5
- ├── columns: b:2 a:1!null
+ ├── columns: b:2!null a:1!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -4961,7 +4961,7 @@ opt
 SELECT b,a FROM t5 WHERE b @> '{"a":[[{"b":{"c":[{"d":"e"}]}}]]}'
 ----
 index-join t5
- ├── columns: b:2 a:1!null
+ ├── columns: b:2!null a:1!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -4975,7 +4975,7 @@ opt
 SELECT b,a FROM t5 WHERE b @> '{"a":1, "c":2}'
 ----
 inner-join (lookup t5)
- ├── columns: b:2 a:1!null
+ ├── columns: b:2!null a:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
  ├── immutable
@@ -4988,7 +4988,7 @@ inner-join (lookup t5)
  │    ├── right fixed columns: [2] = ['{"c": 2}']
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable]
+      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 memo
 SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
@@ -5030,7 +5030,7 @@ opt
 SELECT b,a FROM t5 WHERE b @> '{"a":[{"b":"c", "d":3}, 5]}'
 ----
 inner-join (lookup t5)
- ├── columns: b:2 a:1!null
+ ├── columns: b:2!null a:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
  ├── immutable
@@ -5043,7 +5043,7 @@ inner-join (lookup t5)
  │    ├── right fixed columns: [2] = ['{"a": [{"d": 3}]}']
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(2), immutable]
+      └── b:2 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 # Regression test for issue where zero-column expressions could exist multiple
 # times in the tree, causing collisions.
@@ -5544,7 +5544,7 @@ opt
 SELECT b,a FROM t5 WHERE b @> '{"a":1, "c":2}' FOR UPDATE
 ----
 select
- ├── columns: b:2 a:1!null
+ ├── columns: b:2!null a:1!null
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -5560,7 +5560,7 @@ select
  │         ├── volatile
  │         └── key: (1)
  └── filters
-      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable]
+      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 # -----------------------------------------------------
 # ConvertSemiToInnerJoin

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -116,7 +116,7 @@ opt expect-not=EliminateIndexJoinInsideProject
 SELECT j FROM a WHERE j @> '{"a": "b"}'
 ----
 index-join a
- ├── columns: j:5
+ ├── columns: j:5!null
  ├── immutable
  └── scan a@j
       ├── columns: k:1!null

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1220,7 +1220,7 @@ memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k) (project G4 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G4 G3 k)
- │         └── cost: 118.43
+ │         └── cost: 118.42
  ├── G2: (select G5 G6) (index-join G4 b,cols=(1,4))
  │    └── []
  │         ├── best: (index-join G4 b,cols=(1,4))
@@ -1249,7 +1249,7 @@ project
  ├── immutable
  ├── key: (1)
  └── inner-join (lookup b)
-      ├── columns: k:1!null j:4
+      ├── columns: k:1!null j:4!null
       ├── key columns: [1] = [1]
       ├── lookup columns are key
       ├── immutable
@@ -1262,7 +1262,7 @@ project
       │    ├── right fixed columns: [4] = ['{"c": "d"}']
       │    └── filters (true)
       └── filters
-           └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable]
+           └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Query requiring an index join with no remaining filter.
 opt
@@ -1274,7 +1274,7 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── index-join b
-      ├── columns: k:1!null u:2 j:4
+      ├── columns: k:1!null u:2 j:4!null
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,4)
@@ -1287,7 +1287,7 @@ opt
 SELECT j, k FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
- ├── columns: j:4 k:1!null
+ ├── columns: j:4!null k:1!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
@@ -1300,7 +1300,7 @@ opt
 SELECT * FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1315,7 +1315,7 @@ opt
 SELECT j, k FROM b WHERE j @> '{"a": "b", "c": "d"}'
 ----
 inner-join (lookup b)
- ├── columns: j:4 k:1!null
+ ├── columns: j:4!null k:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
  ├── immutable
@@ -1328,13 +1328,13 @@ inner-join (lookup b)
  │    ├── right fixed columns: [4] = ['{"c": "d"}']
  │    └── filters (true)
  └── filters
-      └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable]
+      └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
 inner-join (lookup b)
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
  ├── immutable
@@ -1347,13 +1347,13 @@ inner-join (lookup b)
  │    ├── right fixed columns: [4] = ['{"a": {"d": "e"}}']
  │    └── filters (true)
  └── filters
-      └── j:4 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [outer=(4), immutable]
+      └── j:4 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '{}'
 ----
 select
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1362,13 +1362,13 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{}' [outer=(4), immutable]
+      └── j:4 @> '{}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '[]'
 ----
 select
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1377,13 +1377,13 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '[]' [outer=(4), immutable]
+      └── j:4 @> '[]' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '2'
 ----
 index-join b
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1398,7 +1398,7 @@ opt
 SELECT * FROM b WHERE j @> '[{}]'
 ----
 select
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1407,13 +1407,13 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '[{}]' [outer=(4), immutable]
+      └── j:4 @> '[{}]' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": {}}'
 ----
 select
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1422,13 +1422,13 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{"a": {}}' [outer=(4), immutable]
+      └── j:4 @> '{"a": {}}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": []}'
 ----
 select
- ├── columns: k:1!null u:2 v:3 j:4
+ ├── columns: k:1!null u:2 v:3 j:4!null
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -1437,7 +1437,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{"a": []}' [outer=(4), immutable]
+      └── j:4 @> '{"a": []}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # GenerateInvertedIndexScans propagates row-level locking information.
 opt
@@ -1475,7 +1475,7 @@ project
  ├── immutable
  ├── key: (1)
  └── inner-join (lookup c)
-      ├── columns: k:1!null a:2
+      ├── columns: k:1!null a:2!null
       ├── key columns: [1] = [1]
       ├── lookup columns are key
       ├── immutable
@@ -1488,7 +1488,7 @@ project
       │    ├── right fixed columns: [2] = [ARRAY[3]]
       │    └── filters (true)
       └── filters
-           └── a:2 @> ARRAY[1,3,1,5] [outer=(2), immutable]
+           └── a:2 @> ARRAY[1,3,1,5] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 opt
 SELECT k FROM c WHERE a @> ARRAY[]::INT[]
@@ -1498,7 +1498,7 @@ project
  ├── immutable
  ├── key: (1)
  └── select
-      ├── columns: k:1!null a:2
+      ├── columns: k:1!null a:2!null
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
@@ -1507,7 +1507,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
-           └── a:2 @> ARRAY[] [outer=(2), immutable]
+           └── a:2 @> ARRAY[] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
 
 opt
 SELECT k FROM c WHERE a IS NULL
@@ -2397,7 +2397,7 @@ opt
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'foo'
 ----
 index-join pi
- ├── columns: k:1!null s:2!null j:3
+ ├── columns: k:1!null s:2!null j:3!null
  ├── immutable
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3)
@@ -2420,7 +2420,7 @@ opt
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND j @> '{"group": 1}' AND s = 'foo'
 ----
 select
- ├── columns: k:1!null s:2!null j:3
+ ├── columns: k:1!null s:2!null j:3!null
  ├── immutable
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3)
@@ -2433,7 +2433,7 @@ select
  │         ├── constraint: /3/1: [/'{"a": "b"}' - /'{"a": "b"}']
  │         └── key: (1)
  └── filters
-      ├── j:3 @> '{"group": 1}' [outer=(3), immutable]
+      ├── j:3 @> '{"group": 1}' [outer=(3), immutable, constraints=(/3: (/NULL - ])]
       └── s:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
 
 exec-ddl
@@ -2811,7 +2811,7 @@ project
       │    │    ├── key: ()
       │    │    └── fd: ()-->(1,4)
       │    └── index-join b
-      │         ├── columns: k:7!null j:10
+      │         ├── columns: k:7!null j:10!null
       │         ├── immutable
       │         ├── key: (7)
       │         ├── fd: (7)-->(10)
@@ -2849,7 +2849,7 @@ project
       │    │    ├── key: ()
       │    │    └── fd: ()-->(1,2)
       │    └── index-join c
-      │         ├── columns: k:6!null a:7
+      │         ├── columns: k:6!null a:7!null
       │         ├── immutable
       │         ├── key: (6)
       │         ├── fd: (6)-->(7)
@@ -3843,7 +3843,7 @@ project
       │    │         ├── key: (1)
       │    │         └── fd: ()-->(2)
       │    └── index-join b
-      │         ├── columns: k:7!null u:8 j:10
+      │         ├── columns: k:7!null u:8 j:10!null
       │         ├── immutable
       │         ├── key: (7)
       │         ├── fd: (7)-->(8,10)
@@ -3885,7 +3885,7 @@ project
       │    │         ├── key: (1)
       │    │         └── fd: ()-->(3)
       │    └── index-join c
-      │         ├── columns: k:6!null a:7 u:8
+      │         ├── columns: k:6!null a:7!null u:8
       │         ├── immutable
       │         ├── key: (6)
       │         ├── fd: (6)-->(7,8)


### PR DESCRIPTION
This commit builds a non-tight, non-null constraint for containment
operators. This is valid because `NULL` cannot contain any elements.

This fixes a minor issue with the statistics of partial inverted index
scans. Tests for these scans have been added for in this commit.

Release note: None