### PR TITLE
sql: enable partial inverted indexes in randomized tests

### DIFF
--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -1390,12 +1390,6 @@ func PartialIndexMutator(rng *rand.Rand, stmts []tree.Statement) ([]tree.Stateme
 	for _, stmt := range stmts {
 		switch ast := stmt.(type) {
 		case *tree.CreateIndex:
-			// TODO(mgartner): Create partial inverted indexes when they are
-			// fully supported.
-			if ast.Inverted {
-				continue
-			}
-
 			tableInfo, ok := tables[ast.Table.ObjectName]
 			if !ok {
 				continue
@@ -1424,9 +1418,7 @@ func PartialIndexMutator(rng *rand.Rand, stmts []tree.Statement) ([]tree.Stateme
 					}
 				}
 
-				// TODO(mgartner): Create partial inverted indexes when they are
-				// fully supported.
-				if idx == nil || idx.Inverted {
+				if idx == nil {
 					continue
 				}
 


### PR DESCRIPTION
Now that partial inverted indexes can be created, they can be generated
in randomized tests.

Release note: None