### PR TITLE
release-20.1: util/tracing: fix timing info on Recording.String()

### DIFF
--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -293,7 +293,7 @@ type traceLogData struct {
 // SessionTracing.generateSessionTraceVTable().
 func (r Recording) String() string {
 	var buf strings.Builder
-	var start time.Time
+	start := r[0].StartTime
 	writeLogs := func(logs []traceLogData) {
 		for _, entry := range logs {
 			fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",


### PR DESCRIPTION
Backport 1/1 commits from #53858.

/cc @cockroachdb/release

---

Release justification: bug fix

Each line coming out of Recording.String() is supposed to start with the
time elapsed since the start of the trace. That first column was broken.
I think this used to be broken, then fixed for a while, then it broke
again.

Release note: The first timing column in the trace.txt file collected as
part of a statement diagnostics bundle is no longer bogus.
