### PR TITLE
release-20.2: sql: don't allow cross-database sequence owners

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -47,6 +47,7 @@
 <tr><td><code>server.user_login.timeout</code></td><td>duration</td><td><code>10s</code></td><td>timeout after which client authentication times out if some system range is unavailable (0 = no timeout)</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
+<tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_views.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating views that refer to other databases is allowed</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.disallow_full_table_scans.enabled</code></td><td>boolean</td><td><code>false</code></td><td>setting to true rejects queries that have planned a full table scan</td></tr>

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5216,6 +5216,7 @@ func TestBackupRestoreSequenceOwnership(t *testing.T) {
 
 	// Setup for sequence ownership backup/restore tests in the same database.
 	backupLoc := LocalFoo + `/d`
+	origDB.Exec(t, "SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = TRUE")
 	origDB.Exec(t, `CREATE DATABASE d`)
 	origDB.Exec(t, `CREATE TABLE d.t(a int)`)
 	origDB.Exec(t, `CREATE SEQUENCE d.seq OWNED BY d.t.a`)

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -54,7 +54,9 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("sequence"))
 	desc := n.seqDesc
 
-	err := assignSequenceOptions(desc.SequenceOpts, n.n.Options, false /* setDefaults */, &params, desc.GetID())
+	err := assignSequenceOptions(
+		desc.SequenceOpts, n.n.Options, false /* setDefaults */, &params, desc.GetID(), desc.ParentID,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -217,7 +217,7 @@ func NewSequenceTableDesc(
 	opts := &descpb.TableDescriptor_SequenceOpts{
 		Increment: 1,
 	}
-	err := assignSequenceOptions(opts, sequenceOptions, true /* setDefaults */, params, id)
+	err := assignSequenceOptions(opts, sequenceOptions, true /* setDefaults */, params, id, parentID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -137,6 +137,14 @@ var allowCrossDatabaseViews = settings.RegisterPublicBoolSetting(
 	false,
 )
 
+const allowCrossDatabaseSeqOwnerSetting = "sql.cross_db_sequence_owners.enabled"
+
+var allowCrossDatabaseSeqOwner = settings.RegisterPublicBoolSetting(
+	allowCrossDatabaseSeqOwnerSetting,
+	"if true, creating sequences owned by tables from other databases is allowed",
+	false,
+)
+
 // traceTxnThreshold can be used to log SQL transactions that take
 // longer than duration to complete. For example, traceTxnThreshold=1s
 // will log the trace for any transaction that takes 1s or longer. To

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -4,6 +4,9 @@
 # (at the top because it requires a session in which `lastval` has never been called)
 
 statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = TRUE
+
+statement ok
 SET DATABASE = test
 
 statement ok
@@ -1229,3 +1232,41 @@ ALTER TABLE t_50711 DROP COLUMN a
 
 statement ok
 ALTER TABLE t_50711 DROP COLUMN b
+
+# Verify that we don't allow OWNED BY to refer to other databases (depending on
+# the cluster setting).
+statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = FALSE
+
+statement ok
+CREATE DATABASE db1
+
+statement ok
+CREATE DATABASE db2
+
+statement ok
+CREATE TABLE db1.t (a INT)
+
+statement ok
+CREATE SEQUENCE db1.seq OWNED BY db1.t.a
+
+statement error OWNED BY cannot refer to other databases
+CREATE SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+CREATE TABLE db2.t (a INT)
+
+statement ok
+CREATE SEQUENCE db2.seq OWNED BY db2.t.a
+
+statement error OWNED BY cannot refer to other databases
+ALTER SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = TRUE
+
+statement ok
+ALTER SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+CREATE SEQUENCE db2.seq2 OWNED BY db1.t.a

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -794,6 +794,18 @@ CREATE VIEW db1.public.v2 AS SELECT a+b FROM db1.public.ab
 statement error the view cannot refer to other databases
 CREATE VIEW db2.v AS SELECT a+b FROM db1.public.ab
 
+statement ok
+CREATE VIEW db2.replace AS SELECT 1
+
+statement error the view cannot refer to other databases
+CREATE OR REPLACE VIEW db2.replace AS SELECT a+b FROM db1.public.ab
+
+statement ok
+CREATE SEQUENCE db2.seq
+
+statement error the view cannot refer to other databases
+CREATE VIEW v2 AS SELECT last_value FROM db2.seq
+
 # Verify that cross-schema views are allowed.
 statement ok
 CREATE SCHEMA sc2

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -236,6 +236,7 @@ func assignSequenceOptions(
 	setDefaults bool,
 	params *runParams,
 	sequenceID descpb.ID,
+	sequenceParentID descpb.ID,
 ) error {
 	// All other defaults are dependent on the value of increment,
 	// i.e. whether the sequence is ascending or descending.
@@ -324,6 +325,13 @@ func assignSequenceOptions(
 				)
 				if err != nil {
 					return err
+				}
+				if tableDesc.ParentID != sequenceParentID &&
+					!allowCrossDatabaseSeqOwner.Get(&params.p.execCfg.Settings.SV) {
+					return pgerror.Newf(pgcode.FeatureNotSupported,
+						"OWNED BY cannot refer to other databases; (see the '%s' cluster setting)",
+						allowCrossDatabaseSeqOwnerSetting,
+					)
 				}
 				// We only want to trigger schema changes if the owner is not what we
 				// want it to be.


### PR DESCRIPTION
Backport 2/2 commits from #54531.

/cc @cockroachdb/release

---

#### sql: add more tests for cross-db views

Follow-up to #54475, a few more tests around views:
 - reference to sequence from another database
 - CREATE OR REPLACE

Release note: None

#### sql: don't allow cross-database sequence owners

A sequence can be "owned" by a column. This change disallows setting
owners from tables in other databases and adds a cluster setting to
allow them (false by default).

Informs #54126.

Release note (sql change): creating sequences that are OWNED BY
columns in tables in other databases is now disallowed (and can be
re-enabled via a cluster setting).

