### PR TITLE
release-20.2: sql: update search_path semantics to match pg now that we support UDS

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -10,14 +10,7 @@
 
 package catconstants
 
-import (
-	"math"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-)
-
-// DefaultSearchPath is the search path used by virgin sessions.
-var DefaultSearchPath = sessiondata.MakeSearchPath([]string{"public"})
+import "math"
 
 // ReportableAppNamePrefix indicates that the application name can be
 // reported in telemetry without scrubbing. (Note this only applies to

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/database"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -544,7 +543,7 @@ func (s *Server) populateMinimalSessionData(sd *sessiondata.SessionData) {
 		}
 	}
 	if len(sd.SearchPath.GetPathArray()) == 0 {
-		sd.SearchPath = catconstants.DefaultSearchPath
+		sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User)
 	}
 }
 

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -284,8 +284,12 @@ func (ds *ServerImpl) setupFlow(
 			ApplicationName: req.EvalContext.ApplicationName,
 			Database:        req.EvalContext.Database,
 			User:            req.EvalContext.User,
-			SearchPath:      sessiondata.MakeSearchPath(req.EvalContext.SearchPath).WithTemporarySchemaName(req.EvalContext.TemporarySchemaName),
-			SequenceState:   sessiondata.NewSequenceState(),
+			SearchPath: sessiondata.MakeSearchPath(
+				req.EvalContext.SearchPath,
+			).WithTemporarySchemaName(
+				req.EvalContext.TemporarySchemaName,
+			).WithUserSchemaName(req.EvalContext.User),
+			SequenceState: sessiondata.NewSequenceState(),
 			DataConversion: sessiondata.DataConversionConfig{
 				Location:          location,
 				BytesEncodeFormat: be,

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -12,7 +12,7 @@ DISCARD ALL
 query T
 SHOW SEARCH_PATH
 ----
-public
+$user,public
 
 query T
 SET timezone = 'Europe/Amsterdam'; SHOW TIMEZONE

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1856,7 +1856,7 @@ reorder_joins_limit                            8                   NULL      NUL
 require_explicit_primary_keys                  off                 NULL      NULL        NULL        string
 results_buffer_size                            16384               NULL      NULL        NULL        string
 row_security                                   off                 NULL      NULL        NULL        string
-search_path                                    public              NULL      NULL        NULL        string
+search_path                                    $user,public        NULL      NULL        NULL        string
 serial_normalization                           rowid               NULL      NULL        NULL        string
 server_encoding                                UTF8                NULL      NULL        NULL        string
 server_version                                 9.5.0               NULL      NULL        NULL        string
@@ -1927,7 +1927,7 @@ reorder_joins_limit                            8                   NULL  user   
 require_explicit_primary_keys                  off                 NULL  user     NULL      off                 off
 results_buffer_size                            16384               NULL  user     NULL      16384               16384
 row_security                                   off                 NULL  user     NULL      off                 off
-search_path                                    public              NULL  user     NULL      public              public
+search_path                                    $user,public        NULL  user     NULL      $user,public        $user,public
 serial_normalization                           rowid               NULL  user     NULL      rowid               rowid
 server_encoding                                UTF8                NULL  user     NULL      UTF8                UTF8
 server_version                                 9.5.0               NULL  user     NULL      9.5.0               9.5.0

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -15,7 +15,7 @@ RESET SEARCH_PATH
 query T
 SHOW SEARCH_PATH
 ----
-public
+$user,public
 
 statement error parameter "server_version" cannot be changed
 RESET SERVER_VERSION
@@ -39,7 +39,7 @@ RESET search_path
 query T
 SHOW search_path
 ----
-public
+$user,public
 
 statement ok
 RESET client_encoding; RESET NAMES

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -459,3 +459,77 @@ CREATE TABLE new_db.public.bar()
 
 statement ok
 CREATE TABLE new_db.testuser.bar()
+
+# cleanup the testuser schema created as part of the CREATE SCHEMA AUTHORIZATION
+# command above
+statement ok
+DROP SCHEMA testuser CASCADE
+
+# If a schema with a username exists, then that should be the first entry in
+# the search path.
+subtest user_schema_search_path
+
+# Test setup
+user root
+
+statement ok
+CREATE SCHEMA testuser
+
+statement ok
+GRANT ALL ON SCHEMA testuser TO testuser
+
+statement ok
+CREATE TABLE public.public_table(a INT)
+
+statement ok
+GRANT SELECT ON public.public_table TO testuser
+
+user testuser
+
+statement ok
+CREATE TABLE test_table(a INT);
+
+statement error pq: relation "public.test_table" does not exist
+SELECT * FROM public.test_table
+
+statement ok
+SELECT * FROM testuser.test_table
+
+# Only root has privs to create inside public
+user root
+
+statement ok
+CREATE TABLE public.test_table(a INT, b INT)
+
+statement ok
+GRANT SELECT ON public.test_table TO testuser
+
+user testuser
+
+query I colnames
+SELECT * FROM test_table
+----
+a
+
+query II colnames
+SELECT * FROM public.test_table
+----
+a  b
+
+query I colnames
+SELECT * FROM public_table
+----
+a
+
+# The search path is configured to be user specific.
+user root
+
+query II colnames
+SELECT * FROM test_table
+----
+a  b
+
+query I colnames
+SELECT * FROM testuser.test_table
+----
+a

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -68,7 +68,7 @@ reorder_joins_limit                            8
 require_explicit_primary_keys                  off
 results_buffer_size                            16384
 row_security                                   off
-search_path                                    public
+search_path                                    $user,public
 serial_normalization                           rowid
 server_encoding                                UTF8
 server_version                                 9.5.0

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -263,7 +262,7 @@ func newInternalPlanner(
 	ctx := logtags.AddTag(context.Background(), opName, "")
 
 	sd := &sessiondata.SessionData{
-		SearchPath:    catconstants.DefaultSearchPath,
+		SearchPath:    sessiondata.DefaultSearchPathForUser(user),
 		User:          user,
 		Database:      "system",
 		SequenceState: sessiondata.NewSequenceState(),

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -1898,7 +1897,6 @@ func createSchemaChangeEvalCtx(
 ) extendedEvalContext {
 
 	sd := newFakeSessionData()
-
 	evalCtx := extendedEvalContext{
 		// Make a session tracing object on-the-fly. This is OK
 		// because it sets "enabled: false" and thus none of the
@@ -1942,7 +1940,7 @@ func createSchemaChangeEvalCtx(
 
 func newFakeSessionData() *sessiondata.SessionData {
 	sd := &sessiondata.SessionData{
-		SearchPath: catconstants.DefaultSearchPath,
+		SearchPath: sessiondata.DefaultSearchPathForUser(security.NodeUser),
 		// The database is not supposed to be needed in schema changes, as there
 		// shouldn't be unqualified identifiers in backfills, and the pure functions
 		// that need it should have already been evaluated.

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -229,7 +228,7 @@ func cleanupSchemaObjects(
 	}
 	a := catalogkv.UncachedPhysicalAccessor{}
 
-	searchPath := catconstants.DefaultSearchPath.WithTemporarySchemaName(schemaName)
+	searchPath := sessiondata.DefaultSearchPathForUser(security.RootUser).WithTemporarySchemaName(schemaName)
 	override := sessiondata.InternalExecutorOverride{
 		SearchPath: &searchPath,
 		User:       security.RootUser,

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
@@ -846,7 +845,7 @@ var varGen = map[string]sessionVar{
 			return evalCtx.SessionData.SearchPath.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return catconstants.DefaultSearchPath.String()
+			return sessiondata.DefaultSearchPath.String()
 		},
 	},
 


### PR DESCRIPTION
Backport 1/1 commits from #54538.

/cc @cockroachdb/release

---

Postgres semantics dictate that the default search_path should be
`$user, public`, where `$user` expands to the current user's username.
This wasn't a problem until now as we lacked support for user defined
schemas, which meant a schema by the name of `$user` wouldn't ever
exist. This however had changed now and this patch brings us in line
with the PG semantics.

Fixes #53560

Release note (sql change): The default search path for all sessions is
now `$user, public` (as opposed to just `public`). This affects our
name resolution semantics -- now, if a table is present in both the
public schema and the schema named the current user's username, an
unqualified object name will be searched/placed in the user's schema.
This doesn't impact the search semantics of tables in
pg_catalog/information_schema/temp_schema -- these continued to be
searched before checking the $user schema and the public schema.
