### PR TITLE
sql: randomize max mutation batch size in logic tests

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -400,7 +401,8 @@ func TestHalloweenProblemAvoidance(t *testing.T) {
 	const smallerKvBatchSize = 10
 	defer row.TestingSetKVBatchSize(smallerKvBatchSize)()
 	const smallerInsertBatchSize = 5
-	defer sql.TestingSetInsertBatchSize(smallerInsertBatchSize)()
+	mutations.SetMaxBatchSizeForTests(smallerInsertBatchSize)
+	defer mutations.ResetMaxBatchSizeForTests()
 	numRows := smallerKvBatchSize + smallerInsertBatchSize + 10
 
 	params, _ := tests.CreateTestServerParams()

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -63,12 +63,6 @@ type deleteRun struct {
 	rowIdxToRetIdx []int
 }
 
-// maxDeleteBatchSize is the max number of entries in the KV batch for
-// the delete operation (including secondary index updates, FK
-// cascading updates, etc), before the current KV batch is executed
-// and a new batch is started.
-const maxDeleteBatchSize = 10000
-
 func (d *deleteNode) startExec(params runParams) error {
 	// cache traceKV during execution, to avoid re-evaluating it for every row.
 	d.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
@@ -124,7 +118,7 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if d.run.td.currentBatchSize >= maxDeleteBatchSize {
+		if d.run.td.currentBatchSize >= d.run.td.maxBatchSize {
 			break
 		}
 	}

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -178,6 +179,17 @@ func (f *FlowBase) Setup(
 	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
 	f.ctxDone = ctx.Done()
 	f.spec = spec
+
+	mutationsTestingMaxBatchSize := int64(0)
+	if f.FlowCtx.Cfg.Settings != nil {
+		mutationsTestingMaxBatchSize = mutations.MutationsTestingMaxBatchSize.Get(&f.FlowCtx.Cfg.Settings.SV)
+	}
+	if mutationsTestingMaxBatchSize != 0 {
+		mutations.SetMaxBatchSizeForTests(int(mutationsTestingMaxBatchSize))
+	} else {
+		mutations.ResetMaxBatchSizeForTests()
+	}
+
 	return ctx, nil
 }
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -181,12 +181,6 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	return nil
 }
 
-// maxInsertBatchSize is the max number of entries in the KV batch for
-// the insert operation (including secondary index updates, FK
-// cascading updates, etc), before the current KV batch is executed
-// and a new batch is started.
-var maxInsertBatchSize = 10000
-
 func (n *insertNode) startExec(params runParams) error {
 	// Cache traceKV during execution, to avoid re-evaluating it for every row.
 	n.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
@@ -246,7 +240,7 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.ti.currentBatchSize >= maxInsertBatchSize {
+		if n.run.ti.currentBatchSize >= n.run.ti.maxBatchSize {
 			break
 		}
 	}
@@ -291,11 +285,4 @@ func (n *insertNode) Close(ctx context.Context) {
 // See planner.autoCommit.
 func (n *insertNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()
-}
-
-// TestingSetInsertBatchSize exports a constant for testing only.
-func TestingSetInsertBatchSize(val int) func() {
-	oldVal := maxInsertBatchSize
-	maxInsertBatchSize = val
-	return func() { maxInsertBatchSize = oldVal }
 }

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -37,9 +38,9 @@ var insertFastPathNodePool = sync.Pool{
 }
 
 // Check that exec.InsertFastPathMaxRows does not exceed the default
-// maxInsertBatchSize.
+// mutations.MaxBatchSize.
 func init() {
-	if maxInsertBatchSize < exec.InsertFastPathMaxRows {
+	if mutations.MaxBatchSize() < exec.InsertFastPathMaxRows {
 		panic("decrease exec.InsertFastPathMaxRows")
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -364,7 +364,7 @@ WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
 AND info NOT LIKE '%sql.stats.automatic_collection.enabled%'
 AND info NOT LIKE '%sql.defaults.vectorize%'
-AND info NOT LIKE '%sql.testing.vectorize.batch_size%'
+AND info NOT LIKE '%sql.testing%'
 AND info NOT LIKE '%sql.defaults.experimental_distsql_planning%'
 ORDER BY "timestamp"
 ----

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -562,7 +562,7 @@ FROM system.settings
 WHERE name != 'sql.defaults.distsql'
 AND name != 'sql.stats.automatic_collection.enabled'
 AND name NOT LIKE '%sql.defaults.vectorize%'
-AND name NOT LIKE '%sql.testing.vectorize.batch_size%'
+AND name NOT LIKE '%sql.testing%'
 AND name NOT LIKE '%sql.defaults.experimental_distsql_planning%'
 ORDER BY name
 ----
@@ -582,7 +582,8 @@ WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
   'sql.stats.automatic_collection.enabled', 'sql.defaults.vectorize',
   'sql.defaults.vectorize_row_count_threshold',
   'sql.testing.vectorize.batch_size',
-  'sql.defaults.experimental_distsql_planning')
+  'sql.defaults.experimental_distsql_planning',
+  'sql.testing.mutations.max_batch_size')
 ORDER BY name
 ----
 diagnostics.reporting.enabled                  true

--- a/pkg/sql/mutations/mutations_util.go
+++ b/pkg/sql/mutations/mutations_util.go
@@ -1,0 +1,50 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mutations
+
+import (
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+)
+
+var maxBatchSize int64 = defaultMaxBatchSize
+
+const defaultMaxBatchSize = 10000
+
+// MaxBatchSize returns the max number of entries in the KV batch for a
+// mutation operation (delete, insert, update, upsert) - including secondary
+// index updates, FK cascading updates, etc - before the current KV batch is
+// executed and a new batch is started.
+func MaxBatchSize() int {
+	return int(atomic.LoadInt64(&maxBatchSize))
+}
+
+// SetMaxBatchSizeForTests modifies maxBatchSize variable. It
+// should only be used in tests.
+func SetMaxBatchSizeForTests(newMaxBatchSize int) {
+	atomic.SwapInt64(&maxBatchSize, int64(newMaxBatchSize))
+}
+
+// ResetMaxBatchSizeForTests resets the maxBatchSize variable to
+// the default mutation batch size. It should only be used in tests.
+func ResetMaxBatchSizeForTests() {
+	atomic.SwapInt64(&maxBatchSize, defaultMaxBatchSize)
+}
+
+// MutationsTestingMaxBatchSize is a testing cluster setting that sets the
+// default max mutation batch size. A low max batch size is useful to test
+// batching logic of the mutations.
+var MutationsTestingMaxBatchSize = settings.RegisterNonNegativeIntSetting(
+	"sql.testing.mutations.max_batch_size",
+	"the max number of rows that are processed by a single KV batch when performing a mutation operation (0=default)",
+	0,
+)

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -27,5 +27,11 @@ import (
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/[^.]*")
+	logictest.RunLogicTest(t, logictest.TestServerArgs{
+		// Several test files in execbuilder verify that mutations behave as
+		// expected; however, if we add the randomization of the mutations max
+		// batch size, then the output becomes non-deterministic, so we disable
+		// that randomization.
+		DisableMutationsMaxBatchSizeRandomization: true,
+	}, "testdata/[^.]*")
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_automatic_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_automatic_stats
@@ -1,3 +1,13 @@
+# Note that this file was moved from the regular logic tests as a part of
+# introducing the randomization of the max batch size of mutations. That
+# randomization needs to be disabled for these queries because they become
+# non-deterministic. However, there is no easy to do so just for a single file,
+# so the file was moved into execbuilder tests which disable that
+# randomization.
+# The file didn't explicitly specify the configs to run with, and it wasn't
+# changed, but if later it becomes a concern, it should be ok to restrict the
+# number of configs here.
+
 # Disable automatic stats
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -119,12 +119,6 @@ type updateRun struct {
 	numPassthrough int
 }
 
-// maxUpdateBatchSize is the max number of entries in the KV batch for
-// the update operation (including secondary index updates, FK
-// cascading updates, etc), before the current KV batch is executed
-// and a new batch is started.
-const maxUpdateBatchSize = 10000
-
 func (u *updateNode) startExec(params runParams) error {
 	// cache traceKV during execution, to avoid re-evaluating it for every row.
 	u.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
@@ -182,7 +176,7 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if u.run.tu.currentBatchSize >= maxUpdateBatchSize {
+		if u.run.tu.currentBatchSize >= u.run.tu.maxBatchSize {
 			break
 		}
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -71,12 +71,6 @@ func (n *upsertNode) Next(params runParams) (bool, error) { panic("not valid") }
 // in plan_batch.go.
 func (n *upsertNode) Values() tree.Datums { panic("not valid") }
 
-// maxUpsertBatchSize is the max number of entries in the KV batch for
-// the upsert operation (including secondary index updates, FK
-// cascading updates, etc), before the current KV batch is executed
-// and a new batch is started.
-const maxUpsertBatchSize = 10000
-
 // BatchedNext implements the batchedPlanNode interface.
 func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 	if n.run.done {
@@ -111,7 +105,7 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.tw.currentBatchSize >= maxUpsertBatchSize {
+		if n.run.tw.currentBatchSize >= n.run.tw.maxBatchSize {
 			break
 		}
 	}


### PR DESCRIPTION
Previously, all mutation operations (delete, insert, update, upsert)
used the same constant value 10000 which was stored separately. Such
a large number makes it difficult to test multi-batch logic in our logic
tests because they tend to not modify many rows, so usually we would
have a single KV batch. This testing gap turned out to be unfortunate
because it allowed a pretty severe bug to slip into a point release.

In order to close this gap and increase the testing coverage of the
mutations, this commit removes separate constants and introduces
a shared `MaxBatchSize` function (which uses an atomic) that all
mutations now use to determine when to start a new KV batch. The value
can be modified by a setter function as well as via a new private
cluster setting `sql.testing.mutations.max_batch_size`. The latter way
is now utilized by the logic tests.

Note that some of the tests (mostly in execbuilder) rely on the fact
that are batches are of predetermined size, so we disable this
randomization for execbuilder tests. `distsql_automatic_stats` logic
test was moved into `execbuilder` tests because of this.

Informs: #54456.

Release note: None