### PR TITLE
release-19.2: sql: fix bug in cascader which updated columns in index rather than fk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2712,3 +2712,63 @@ SELECT * FROM fk_ref LEFT JOIN xyz ON a = x
 statement ok
 DROP TABLE fk_ref;
 DROP TABLE xyz;
+
+
+# This tests behavior of foreign key cascades in the presence of covering
+# indexes which contain additional columns in their suffix. This is a regression
+# test for #54208.
+
+subtest secondary_index_overlaps_with_fk_prefix
+
+statement ok
+CREATE TABLE fk_54208_referenced (
+    j INT PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE fk_54208_origin_default (
+    i INT PRIMARY KEY,
+    j INT,
+    k INT NOT NULL DEFAULT -1,
+    INDEX (j, k),
+    INDEX (j)
+)
+
+statement ok
+CREATE TABLE fk_54208_origin_null (
+    i INT PRIMARY KEY,
+    j INT,
+    k INT NOT NULL,
+    INDEX (j, k),
+    INDEX (j)
+)
+
+statement ok
+ALTER TABLE fk_54208_origin_default
+    ADD CONSTRAINT fk_54208_default FOREIGN KEY (j) REFERENCES fk_54208_referenced(j) ON DELETE SET DEFAULT;
+
+statement ok
+ALTER TABLE fk_54208_origin_null
+    ADD CONSTRAINT fk_54208_null FOREIGN KEY (j) REFERENCES fk_54208_referenced(j) ON DELETE SET NULL;
+
+statement ok
+INSERT INTO fk_54208_referenced VALUES (1);
+
+statement ok
+INSERT INTO fk_54208_origin_default VALUES (1, 1, 1);
+
+statement ok
+INSERT INTO fk_54208_origin_null VALUES (1, 1, 1);
+
+statement ok
+DELETE FROM fk_54208_referenced WHERE j = 1;
+
+query III
+SELECT * FROM fk_54208_origin_default;
+----
+1 NULL 1
+
+query III
+SELECT * FROM fk_54208_origin_null;
+----
+1 NULL 1

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -672,6 +672,7 @@ func (c *cascader) updateRows(
 	match sqlbase.ForeignKeyReference_Match,
 	values cascadeQueueElement,
 	action sqlbase.ForeignKeyReference_Action,
+	fk *sqlbase.ForeignKeyConstraint,
 	traceKV bool,
 ) (*rowcontainer.RowContainer, *rowcontainer.RowContainer, map[sqlbase.ColumnID]int, int, error) {
 	// Create the span to search for index values.
@@ -717,12 +718,12 @@ func (c *cascader) updateRows(
 	switch action {
 	case sqlbase.ForeignKeyReference_SET_NULL:
 		referencingIndexValuesByColIDs = make(map[sqlbase.ColumnID]tree.Datum)
-		for _, columnID := range referencingIndex.ColumnIDs {
+		for _, columnID := range fk.OriginColumnIDs {
 			referencingIndexValuesByColIDs[columnID] = tree.DNull
 		}
 	case sqlbase.ForeignKeyReference_SET_DEFAULT:
 		referencingIndexValuesByColIDs = make(map[sqlbase.ColumnID]tree.Datum)
-		for _, columnID := range referencingIndex.ColumnIDs {
+		for _, columnID := range fk.OriginColumnIDs {
 			column, err := referencingTable.FindColumnByID(columnID)
 			if err != nil {
 				return nil, nil, nil, 0, err
@@ -1099,6 +1100,7 @@ func (c *cascader) cascadeAll(
 						sqlbase.ForeignKeyReference_SIMPLE,
 						elem,
 						foundFK.OnDelete,
+						foundFK,
 						traceKV,
 					)
 					if err != nil {
@@ -1130,6 +1132,7 @@ func (c *cascader) cascadeAll(
 						sqlbase.ForeignKeyReference_SIMPLE,
 						elem,
 						foundFK.OnUpdate,
+						foundFK,
 						traceKV,
 					)
 					if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #54543.

/cc @cockroachdb/release

---

This bug is quite old and I suppose was due to an assumption that the index
columns would be identical to the reference columns, but in fact, they are
not.

Fixes #54208.
Fixes #54547.

Release note (bug fix): Fixed a bug which could cause columns used in an
index which contains the columns of a foreign key as a prefix could lead
to all of the index columns being set to null or default on cascade
