### PR TITLE
sql: implement REASSIGN OWNED BY ... TO ...

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -27,36 +28,51 @@ type alterDatabaseOwnerNode struct {
 func (p *planner) AlterDatabaseOwner(
 	ctx context.Context, n *tree.AlterDatabaseOwner,
 ) (planNode, error) {
-	dbDesc, err := p.ResolveMutableDatabaseDescriptor(ctx, n.Name.String(), true)
+	dbDesc, err := p.ResolveMutableDatabaseDescriptor(ctx, n.Name.String(), true /* required */)
 	if err != nil {
 		return nil, err
 	}
-	privs := dbDesc.GetPrivileges()
 
-	newOwner := string(n.Owner)
-	if err := p.checkCanAlterToNewOwner(ctx, dbDesc, newOwner); err != nil {
-		return nil, err
-	}
-
-	// To alter the owner, the user also has to have CREATEDB privilege.
-	if err := p.CheckRoleOption(ctx, roleoption.CREATEDB); err != nil {
-		return nil, err
-	}
-
-	// If the owner we want to set to is the current owner, do a no-op.
-	if newOwner == privs.Owner {
-		return nil, nil
-	}
 	return &alterDatabaseOwnerNode{n: n, desc: dbDesc}, nil
 }
 
 func (n *alterDatabaseOwnerNode) startExec(params runParams) error {
-	n.desc.GetPrivileges().SetOwner(string(n.n.Owner))
+	privs := n.desc.GetPrivileges()
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	newOwner := string(n.n.Owner)
+	if newOwner == privs.Owner {
+		return nil
+	}
+	if err := params.p.checkCanAlterDatabaseAndSetNewOwner(params.ctx, n.desc, newOwner); err != nil {
+		return err
+	}
+
 	return params.p.writeNonDropDatabaseChange(
 		params.ctx,
 		n.desc,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
 	)
+}
+
+// checkCanAlterDatabaseAndSetNewOwner handles privilege checking and setting new owner.
+// Called in ALTER DATABASE and REASSIGN OWNED BY.
+func (p *planner) checkCanAlterDatabaseAndSetNewOwner(
+	ctx context.Context, desc catalog.MutableDescriptor, newOwner string,
+) error {
+	if err := p.checkCanAlterToNewOwner(ctx, desc, newOwner); err != nil {
+		return err
+	}
+
+	// To alter the owner, the user also has to have CREATEDB privilege.
+	if err := p.CheckRoleOption(ctx, roleoption.CREATEDB); err != nil {
+		return err
+	}
+
+	privs := desc.GetPrivileges()
+	privs.SetOwner(newOwner)
+
+	return nil
 }
 
 func (n *alterDatabaseOwnerNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -2,21 +2,307 @@ statement ok
 CREATE TABLE t()
 
 # Ensure old role must exist.
-# statement error pq: role/user "fake_role" does not exist
-statement error unimplemented
-REASSIGN OWNED BY fake_role TO new_role
+statement error pq: role/user "fake_old_role" does not exist
+REASSIGN OWNED BY fake_old_role TO new_role
 
 statement ok
-CREATE ROLE old_role
+CREATE ROLE old_role;
+GRANT CREATE ON DATABASE test TO old_role;
+ALTER TABLE t OWNER TO old_role
+
+# Make testuser a member of old_role.
+statement ok
+GRANT old_role TO testuser
+
+user testuser
 
 # Ensure new role must exist.
-# statement error pq: role/user "fake_role" does not exist
-statement error unimplemented
-REASSIGN OWNED BY old_role TO fake_role
+statement error pq: role/user "fake_new_role" does not exist
+REASSIGN OWNED BY old_role TO fake_new_role
+
+user root
 
 statement ok
-CREATE ROLE new_role
+CREATE ROLE new_role;
+GRANT CREATE ON DATABASE test TO new_role
 
-# statement ok
-statement error unimplemented
-REASSIGN OWNED BY old_role TO fake_role
+user testuser
+
+# Ensure the current user is a member of the role we're setting to.
+statement error pq: must be member of role "new_role"
+REASSIGN OWNED BY old_role TO new_role
+
+user root
+
+# Make testuser a member of new_role.
+statement ok
+GRANT new_role TO testuser
+
+user testuser
+
+# All checks passed - reassign table.
+statement ok
+REASSIGN OWNED BY old_role TO new_role
+
+statement ok
+DROP TABLE t
+
+user root
+
+statement ok
+GRANT testuser TO root
+
+statement ok
+CREATE ROLE testuser2 WITH LOGIN;
+GRANT testuser2 TO root
+
+# Create database for old role
+statement ok
+CREATE DATABASE d;
+ALTER DATABASE d OWNER TO testuser
+
+# Check ownership - testuser should own all objects just created
+query TT
+SELECT datname, datdba FROM pg_database WHERE datname='d'
+----
+d  2264919399
+
+# Switch to database d so it can reassign from current db
+statement ok
+use d
+
+statement ok
+REASSIGN OWNED BY testuser TO testuser2
+
+# Check ownership - testuser2 should now own all objects just created
+query TT
+SELECT datname, datdba FROM pg_database WHERE datname='d'
+----
+d  3957504279
+
+user testuser2
+
+# Ensure new_role is owner by dropping db as testuser2.
+statement ok
+DROP DATABASE d
+
+user root
+
+# Ensure old_role no longer owns anything.
+statement ok
+DROP ROLE testuser
+
+# ------------------------------------------------------------------------------
+# Can reassign from more than one old role to new role.
+statement ok
+use test;
+CREATE ROLE testuser;
+GRANT testuser TO root
+
+# Create schema for testuser and one for root.
+statement ok
+CREATE SCHEMA s1;
+ALTER SCHEMA s1 OWNER TO testuser
+
+statement ok
+CREATE SCHEMA s2
+
+# Check ownership for testuser and root
+query TT
+SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s1' OR nspname='s2'
+----
+s1  2264919399
+s2  1546506610
+
+statement ok
+REASSIGN OWNED BY testuser, root TO testuser2
+
+user testuser2
+
+# Check ownership - testuser2 should own both objects
+query TT
+SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s1' OR nspname='s2'
+----
+s1  3957504279
+s2  3957504279
+
+# Ensure testuser2 is new owner by dropping.
+statement ok
+DROP SCHEMA s1;
+DROP SCHEMA s2
+
+user root
+
+statement ok
+ALTER DATABASE test OWNER TO root
+
+# Ensure testuser no longer owns anything.
+statement ok
+DROP ROLE testuser
+
+# ------------------------------------------------------------------------------
+# Confirm tables, schemas, types are reassigned together.
+
+user root
+
+statement ok
+use test
+
+statement ok
+CREATE ROLE testuser
+
+statement ok
+GRANT CREATE ON DATABASE test TO testuser, testuser2
+
+statement ok
+CREATE SCHEMA s;
+ALTER SCHEMA s OWNER TO testuser
+
+statement ok
+CREATE TABLE s.t();
+ALTER TABLE s.t OWNER TO testuser
+
+statement ok
+CREATE TYPE s.typ AS ENUM ();
+ALTER TYPE s.typ OWNER to testuser
+
+# Check ownership - testuser should own all objects just created
+query TT
+SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s'
+----
+s  2264919399
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t'
+----
+t  testuser
+
+query TT
+SELECT typname, typowner FROM pg_type WHERE typname='_typ' OR typname='typ'
+----
+typ   2264919399
+_typ  2264919399
+
+statement ok
+REASSIGN OWNED BY testuser TO testuser2
+
+# testuser2 should own everything now
+query TT
+SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s'
+----
+s  3957504279
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t'
+----
+t  testuser2
+
+query TT
+SELECT typname, typowner FROM pg_type WHERE typname='_typ' OR typname='typ'
+----
+typ   3957504279
+_typ  3957504279
+
+# Ensure testuser2 is owner by dropping as member of testuser2.
+user testuser2
+
+statement ok
+DROP TABLE s.t;
+DROP TYPE s.typ;
+DROP SCHEMA s;
+
+# Ensure testuser no longer owns anything.
+user root
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM testuser, testuser2;
+DROP ROLE testuser;
+DROP ROLE testuser2
+
+# ------------------------------------------------------------------------------
+# Make sure only objects in the current database are reassigned
+
+user root
+
+statement ok
+CREATE ROLE testuser;
+GRANT CREATE ON DATABASE test TO testuser;
+
+statement ok
+CREATE DATABASE d;
+ALTER DATABASE d OWNER TO testuser
+
+# Create table t in test database
+statement ok
+CREATE TABLE t1();
+ALTER TABLE t1 OWNER TO testuser
+
+# Create table t2 in d database
+statement ok
+CREATE TABLE d.t2();
+ALTER TABLE d.t2 OWNER TO testuser
+
+# Confirm ownership - testuser should own all objects just created
+query TT
+SELECT datname, datdba FROM pg_database WHERE datname='d' OR datname='test'
+----
+d     2264919399
+test  1546506610
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t1'
+----
+t1  testuser
+
+statement ok
+use d
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t2'
+----
+t2  testuser
+
+statement ok
+CREATE ROLE testuser2;
+GRANT testuser2 TO root;
+GRANT CREATE ON DATABASE test TO testuser2
+
+statement ok
+use test
+
+# Only reassign objects in test database to testuser2
+statement ok
+REASSIGN OWNED BY testuser TO testuser2
+
+# Confirm ownership - testuser2 should own just table t1
+query TT
+SELECT datname, datdba FROM pg_database WHERE datname='d' OR datname='test'
+----
+d     2264919399
+test  1546506610
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t1'
+----
+t1  testuser2
+
+statement ok
+use d
+
+query TT
+SELECT tablename, tableowner FROM pg_tables WHERE tablename='t2'
+----
+t2  testuser
+
+# Confirm d, d.t2 still belongs to testuser
+user testuser
+
+statement ok
+DROP TABLE d.t2;
+DROP DATABASE d;
+
+# Confirm test.t1 was reassigned to testuser2
+user testuser2
+
+statement ok
+DROP TABLE t1;

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -185,6 +185,7 @@ var _ planNode = &limitNode{}
 var _ planNode = &max1RowNode{}
 var _ planNode = &ordinalityNode{}
 var _ planNode = &projectSetNode{}
+var _ planNode = &reassignOwnedByNode{}
 var _ planNode = &refreshMaterializedViewNode{}
 var _ planNode = &recursiveCTENode{}
 var _ planNode = &relocateNode{}

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -13,15 +13,183 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 // ReassignOwnedByNode represents a REASSIGN OWNED BY <name> TO <name> statement.
-// TODO(angelaw): to implement
-//type reassignOwnedByNode struct {
-//}
+type reassignOwnedByNode struct {
+	n *tree.ReassignOwnedBy
+}
 
 func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) (planNode, error) {
-	return nil, unimplemented.NewWithIssue(52022, "reassign owned by is not yet implemented")
+	// Check all roles in old roles exist. Checks in authorization.go will confirm that current user
+	// is a member of old roles and new roles and has CREATE privilege.
+	for _, oldRole := range n.OldRoles {
+		roleExists, err := p.RoleExists(ctx, oldRole)
+		if err != nil {
+			return nil, err
+		}
+		if !roleExists {
+			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", oldRole)
+		}
+	}
+	return &reassignOwnedByNode{n: n}, nil
 }
+
+func (n *reassignOwnedByNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.CreateReassignOwnedByCounter())
+
+	allDescs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn, true /* validate */)
+	if err != nil {
+		return err
+	}
+
+	// Filter for all objects in current database.
+	currentDatabase := params.p.CurrentDatabase()
+	currentDbDesc, err := params.p.ResolveMutableDatabaseDescriptor(params.ctx, currentDatabase, true)
+	if err != nil {
+		return err
+	}
+
+	lCtx := newInternalLookupCtx(params.ctx, allDescs,
+		currentDbDesc.ImmutableCopy().(*dbdesc.Immutable), nil /* fallback */)
+
+	// Iterate through each object, check for ownership by an old role.
+	for _, oldRole := range n.n.OldRoles {
+		// There should only be one database (current).
+		for _, dbID := range lCtx.dbIDs {
+			if IsOwner(lCtx.dbDescs[dbID], oldRole) {
+				if err := n.reassignDatabaseOwner(lCtx.dbDescs[dbID], params); err != nil {
+					return err
+				}
+			}
+		}
+		for _, schemaID := range lCtx.schemaIDs {
+			if IsOwner(lCtx.schemaDescs[schemaID], oldRole) {
+				if err := n.reassignSchemaOwner(lCtx.schemaDescs[schemaID], params); err != nil {
+					return err
+				}
+			}
+		}
+		for _, tbID := range lCtx.tbIDs {
+			if IsOwner(lCtx.tbDescs[tbID], oldRole) {
+				if err := n.reassignTableOwner(lCtx.tbDescs[tbID], params); err != nil {
+					return err
+				}
+			}
+		}
+		for _, typID := range lCtx.typIDs {
+			if IsOwner(lCtx.typDescs[typID], oldRole) && (lCtx.typDescs[typID].Kind != descpb.TypeDescriptor_ALIAS) {
+				if err := n.reassignTypeOwner(lCtx.typDescs[typID], params); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (n *reassignOwnedByNode) reassignDatabaseOwner(
+	dbDesc *dbdesc.Immutable, params runParams,
+) error {
+	mutableDbDesc, err := params.p.Descriptors().GetMutableDescriptorByID(params.ctx, dbDesc.ID, params.p.txn)
+	if err != nil {
+		return err
+	}
+	if err := params.p.checkCanAlterDatabaseAndSetNewOwner(params.ctx,
+		mutableDbDesc.(*dbdesc.Mutable), n.n.NewRole); err != nil {
+		return err
+	}
+	if err := params.p.writeNonDropDatabaseChange(
+		params.ctx,
+		mutableDbDesc.(*dbdesc.Mutable),
+		tree.AsStringWithFQNames(n.n, params.p.Ann()),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *reassignOwnedByNode) reassignSchemaOwner(
+	schemaDesc *schemadesc.Immutable, params runParams,
+) error {
+	mutableSchemaDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+		params.ctx, schemaDesc.ID, params.p.txn)
+	if err != nil {
+		return err
+	}
+	if err := params.p.checkCanAlterSchemaAndSetNewOwner(
+		params.ctx, mutableSchemaDesc.(*schemadesc.Mutable), n.n.NewRole); err != nil {
+		return err
+	}
+	if err := params.p.writeSchemaDescChange(params.ctx,
+		mutableSchemaDesc.(*schemadesc.Mutable),
+		tree.AsStringWithFQNames(n.n, params.p.Ann()),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *reassignOwnedByNode) reassignTableOwner(
+	tbDesc *tabledesc.Immutable, params runParams,
+) error {
+	mutableTbDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+		params.ctx, tbDesc.ID, params.p.txn)
+	if err != nil {
+		return err
+	}
+	if err := params.p.checkCanAlterTableAndSetNewOwner(
+		params.ctx, mutableTbDesc.(*tabledesc.Mutable), n.n.NewRole); err != nil {
+		return err
+	}
+	if err := params.p.writeSchemaChange(
+		params.ctx, mutableTbDesc.(*tabledesc.Mutable), descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *reassignOwnedByNode) reassignTypeOwner(
+	typDesc *typedesc.Immutable, params runParams,
+) error {
+	mutableTypDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+		params.ctx, typDesc.ID, params.p.txn)
+	if err != nil {
+		return err
+	}
+	arrayDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
+		params.ctx, params.p.txn, typDesc.ArrayTypeID)
+	if err != nil {
+		return err
+	}
+	if err := params.p.checkCanAlterTypeAndSetNewOwner(
+		params.ctx, mutableTypDesc.(*typedesc.Mutable), arrayDesc, n.n.NewRole); err != nil {
+		return err
+	}
+	if err := params.p.writeTypeSchemaChange(
+		params.ctx, mutableTypDesc.(*typedesc.Mutable), tree.AsStringWithFQNames(n.n, params.p.Ann()),
+	); err != nil {
+		return err
+	}
+	if err := params.p.writeTypeSchemaChange(
+		params.ctx, arrayDesc, tree.AsStringWithFQNames(n.n, params.p.Ann()),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *reassignOwnedByNode) Next(runParams) (bool, error) { return false, nil }
+func (n *reassignOwnedByNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *reassignOwnedByNode) Close(context.Context)        {}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -638,6 +638,7 @@ type internalLookupCtx struct {
 	dbIDs       []descpb.ID
 	dbDescs     map[descpb.ID]*dbdesc.Immutable
 	schemaDescs map[descpb.ID]*schemadesc.Immutable
+	schemaIDs   []descpb.ID
 	tbDescs     map[descpb.ID]*tabledesc.Immutable
 	tbIDs       []descpb.ID
 	typDescs    map[descpb.ID]*typedesc.Immutable
@@ -725,7 +726,7 @@ func newInternalLookupCtx(
 	schemaDescs := make(map[descpb.ID]*schemadesc.Immutable)
 	tbDescs := make(map[descpb.ID]*tabledesc.Immutable)
 	typDescs := make(map[descpb.ID]*typedesc.Immutable)
-	var tbIDs, typIDs, dbIDs []descpb.ID
+	var tbIDs, typIDs, dbIDs, schemaIDs []descpb.ID
 	// Record descriptors for name lookups.
 	for i := range descs {
 		switch desc := descs[i].(type) {
@@ -733,6 +734,7 @@ func newInternalLookupCtx(
 			dbNames[desc.GetID()] = desc.GetName()
 			dbDescs[desc.GetID()] = desc
 			if prefix == nil || prefix.GetID() == desc.GetID() {
+				// Only make the database visible for iteration if the prefix was included.
 				dbIDs = append(dbIDs, desc.GetID())
 			}
 		case *tabledesc.Immutable:
@@ -749,6 +751,10 @@ func newInternalLookupCtx(
 			}
 		case *schemadesc.Immutable:
 			schemaDescs[desc.GetID()] = desc
+			if prefix == nil || prefix.GetID() == desc.ParentID {
+				// Only make the schema visible for iteration if the prefix was included.
+				schemaIDs = append(schemaIDs, desc.GetID())
+			}
 		}
 	}
 
@@ -756,6 +762,7 @@ func newInternalLookupCtx(
 		dbNames:     dbNames,
 		dbDescs:     dbDescs,
 		schemaDescs: schemaDescs,
+		schemaIDs:   schemaIDs,
 		tbDescs:     tbDescs,
 		typDescs:    typDescs,
 		tbIDs:       tbIDs,

--- a/pkg/sql/sqltelemetry/reassign_owned_by.go
+++ b/pkg/sql/sqltelemetry/reassign_owned_by.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// CreateReassignOwnedByCounter returns a counter to increment for the REASSIGN OWNED BY command.
+func CreateReassignOwnedByCounter() telemetry.Counter {
+	return telemetry.GetCounter("sql.reassign_owned_by")
+}

--- a/pkg/sql/testdata/telemetry/reassign_owned_by
+++ b/pkg/sql/testdata/telemetry/reassign_owned_by
@@ -1,0 +1,19 @@
+# This file contains telemetry tests for the sql.reassign_owned_by counter.
+
+feature-allowlist
+sql.reassign_owned_by.*
+----
+
+exec
+CREATE ROLE testuser;
+CREATE ROLE testuser2;
+CREATE TABLE t();
+GRANT testuser, testuser2 TO root;
+GRANT CREATE ON DATABASE defaultdb TO testuser, testuser2;
+ALTER TABLE t OWNER TO testuser
+----
+
+feature-usage
+REASSIGN OWNED BY testuser TO testuser2
+----
+sql.reassign_owned_by

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -394,6 +394,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&max1RowNode{}):                 "max1row",
 	reflect.TypeOf(&ordinalityNode{}):              "ordinality",
 	reflect.TypeOf(&projectSetNode{}):              "project set",
+	reflect.TypeOf(&reassignOwnedByNode{}):         "reassign owned by",
 	reflect.TypeOf(&recursiveCTENode{}):            "recursive cte",
 	reflect.TypeOf(&refreshMaterializedViewNode{}): "refresh materialized view",
 	reflect.TypeOf(&relocateNode{}):                "relocate",


### PR DESCRIPTION
Resolves #52022. 

The command should change ownerships of all database objects in the
current database owned by any roles in the first argument to the new role
in second argument. It requires the current user be a member of
both source role(s) and target role.

Release note (sql change): Implement the REASSIGN OWNED BY ... TO
... command, which changes ownership of all database objects in
the current database, owned by any roles in the first argument, to the
new role in the second argument.