### PR TITLE
cli/sql: improve the display of statement timings

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -229,6 +229,9 @@ var sqlCtx = struct {
 
 	// Determines whether to display server execution timings in the CLI.
 	enableServerExecutionTimings bool
+
+	// Determine whether to show raw durations.
+	verboseTimings bool
 }{cliContext: &cliCtx}
 
 // setSQLContextDefaults set the default values in sqlCtx.  This
@@ -243,6 +246,7 @@ func setSQLContextDefaults() {
 	sqlCtx.debugMode = false
 	sqlCtx.echo = false
 	sqlCtx.enableServerExecutionTimings = false
+	sqlCtx.verboseTimings = false
 }
 
 // zipCtx captures the command-line parameters of the `zip` command.

--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -10,8 +10,8 @@ eexpect root@
 start_test "Test that server execution time and network latency are printed by default."
 send "SELECT * FROM vehicles LIMIT 1;\r"
 eexpect "1 row"
-eexpect "Server Execution Time:"
-eexpect "Network Latency:"
+eexpect "/ net"
+eexpect "/ other"
 
 # Ditto with multiple statements on one line
 send "SELECT * FROM vehicles LIMIT 1; CREATE TABLE t(a int);\r"
@@ -25,6 +25,6 @@ send "SELECT * FROM vehicles LIMIT 1;\r"
 eexpect "\nTime:"
 send "\\set show_server_times=true\r"
 send "SELECT * FROM vehicles LIMIT 1;\r"
-eexpect "Server Execution Time:"
-eexpect "Network Latency:"
+eexpect "/ net"
+eexpect "/ other"
 end_test

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -371,6 +371,14 @@ var options = map[string]struct {
 		reset:                     func(_ *cliState) error { sqlCtx.enableServerExecutionTimings = false; return nil },
 		display:                   func(_ *cliState) string { return strconv.FormatBool(sqlCtx.enableServerExecutionTimings) },
 	},
+	`verbose_times`: {
+		description:               "display execution times with more precision (requires show_times to be set)",
+		isBoolean:                 true,
+		validDuringMultilineEntry: true,
+		set:                       func(_ *cliState, _ string) error { sqlCtx.verboseTimings = true; return nil },
+		reset:                     func(_ *cliState) error { sqlCtx.verboseTimings = false; return nil },
+		display:                   func(_ *cliState) string { return strconv.FormatBool(sqlCtx.verboseTimings) },
+	},
 	`smart_prompt`: {
 		description:               "deprecated",
 		isBoolean:                 true,

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -926,66 +926,86 @@ func runQueryAndFormatResults(conn *sqlConn, w io.Writer, fn queryFunc) (err err
 			return err
 		}
 
-		if sqlCtx.showTimes {
-			clientSideQueryTime := queryCompleteTime.Sub(startTime)
-			// We don't print timings for multi-statement queries as we don't have an
-			// accurate way to measure them currently. See #48180.
-			if isMultiStatementQuery {
-				// No need to print if no one's watching.
-				if sqlCtx.isInteractive {
-					fmt.Fprintf(stderr, "Note: timings for multiple statements on a single line are not supported. See %s.\n",
-						unimplemented.MakeURL(48180))
-				}
-			} else {
-				// Print a newline early. This provides a discreet visual
-				// feedback that execution finished, and that the next line of
-				// output will be execution time(s).
-				fmt.Fprintln(w)
-
-				if sqlCtx.verboseTimings {
-					fmt.Fprintf(w, "Time: %s", clientSideQueryTime)
-				} else {
-					// Simplified displays: human users typically can't
-					// distinguish sub-millisecond latencies.
-					fmt.Fprintf(w, "Time: %.3fs", clientSideQueryTime.Seconds())
-				}
-				if sqlCtx.enableServerExecutionTimings {
-					// If discrete server/network timings are available, also print them.
-					execLatency, serviceLatency, err := conn.getLastQueryStatistics()
-					if err != nil {
-						fmt.Fprintf(stderr, "\nwarning: %v", err)
-					} else {
-						networkLatency := clientSideQueryTime - serviceLatency
-						if sqlCtx.verboseTimings {
-							fmt.Fprintf(w, " total (exec %s / net %s / other %s)",
-								execLatency, networkLatency, serviceLatency-execLatency)
-						} else {
-							// Simplified display: just show percentages.
-							totalSeconds := clientSideQueryTime.Seconds()
-							fmt.Fprintf(w, " total (exec %.1f%% / net %.1f%% / other %.1f%%)",
-								execLatency.Seconds()*100/totalSeconds,
-								networkLatency.Seconds()*100/totalSeconds,
-								(serviceLatency-execLatency).Seconds()*100/totalSeconds)
-						}
-					}
-				}
-				fmt.Fprintln(w)
-			}
-			renderDelay := timeutil.Now().Sub(queryCompleteTime)
-			if renderDelay >= 1*time.Second && sqlCtx.isInteractive {
-				fmt.Fprintf(stderr,
-					"Note: an additional delay of %s was spent formatting the results.\n"+
-						"You can use \\set display_format to change the formatting.\n",
-					renderDelay)
-			}
-			fmt.Fprintln(w)
-		}
+		maybeShowTimes(conn, w, isMultiStatementQuery, startTime, queryCompleteTime)
 
 		if more, err := rows.NextResultSet(); err != nil {
 			return err
 		} else if !more {
 			return nil
 		}
+	}
+}
+
+// maybeShowTimes displays the execution time if show_times has been set.
+func maybeShowTimes(
+	conn *sqlConn, w io.Writer, isMultiStatementQuery bool, startTime,
+	queryCompleteTime time.Time,
+) {
+	if !sqlCtx.showTimes {
+		return
+	}
+
+	defer func() {
+		// If there was noticeable overhead, let the user know.
+		renderDelay := timeutil.Now().Sub(queryCompleteTime)
+		if renderDelay >= 1*time.Second && sqlCtx.isInteractive {
+			fmt.Fprintf(stderr,
+				"\nNote: an additional delay of %s was spent formatting the results.\n"+
+					"You can use \\set display_format to change the formatting.\n",
+				renderDelay)
+		}
+		// An additional empty line as separator.
+		fmt.Fprintln(w)
+	}()
+
+	clientSideQueryTime := queryCompleteTime.Sub(startTime)
+	// We don't print timings for multi-statement queries as we don't have an
+	// accurate way to measure them currently. See #48180.
+	if isMultiStatementQuery {
+		// No need to print if no one's watching.
+		if sqlCtx.isInteractive {
+			fmt.Fprintf(stderr, "\nNote: timings for multiple statements on a single line are not supported. See %s.\n",
+				unimplemented.MakeURL(48180))
+		}
+		return
+	}
+
+	// Print a newline early. This provides a discreet visual
+	// feedback that execution finished, and that the next line of
+	// output will be execution time(s).
+	fmt.Fprintln(w)
+
+	if sqlCtx.verboseTimings {
+		fmt.Fprintf(w, "Time: %s", clientSideQueryTime)
+	} else {
+		// Simplified displays: human users typically can't
+		// distinguish sub-millisecond latencies.
+		fmt.Fprintf(w, "Time: %.3fs", clientSideQueryTime.Seconds())
+	}
+
+	if !sqlCtx.enableServerExecutionTimings {
+		fmt.Fprintln(w)
+		return
+	}
+
+	// If discrete server/network timings are available, also print them.
+	execLatency, serviceLatency, err := conn.getLastQueryStatistics()
+	if err != nil {
+		fmt.Fprintf(stderr, "\nwarning: %v", err)
+		return
+	}
+
+	networkLatency := clientSideQueryTime - serviceLatency
+	if sqlCtx.verboseTimings {
+		fmt.Fprintf(w, " total (exec %s / net %s / other %s)\n",
+			execLatency, networkLatency, serviceLatency-execLatency)
+	} else {
+		// Simplified display: just show percentages.
+		totalSeconds := clientSideQueryTime.Seconds()
+		fmt.Fprintf(w, " total (exec %.1f%% / net %.1f%% / other %.1f%%)\n",
+			execLatency.Seconds()*100/totalSeconds,
+			networkLatency.Seconds()*100/totalSeconds,
+			(serviceLatency-execLatency).Seconds()*100/totalSeconds)
 	}
 }
 


### PR DESCRIPTION
Requested/recommended by @jordanlewis 

2 changes:
- bug fix: include the parse and planning times too
- aesthetics: make the display clearer and more compact

Example:
```
root@:26257/defaultdb> delete from t where true;
DELETE 12

Time: 0.003s total (exec 40.5% / net 37.5% / other 22.0%)

root@:26257/defaultdb> insert into t select uuid_v4()::uuid from generate_series(1,10000);
INSERT 10000

Time: 0.108s total (exec 99.5% / net 0.3% / other 0.2%)
```