### PR TITLE
rowexec: fix a crash with json_object_agg used as a window function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3838,3 +3838,27 @@ statement ok
 SELECT max(b::INT8) OVER (PARTITION BY b ORDER BY a RANGE 1 PRECEDING)
 FROM t53442_b NATURAL JOIN t53442_a
 WHERE false
+
+# Regression test for a crash with json_object_agg used as a window function
+# (#54604).
+statement ok
+CREATE TABLE t54604 (s STRING);
+INSERT INTO t54604 SELECT g::STRING FROM generate_series(1, 5) AS g
+
+query T rowsort
+SELECT json_object_agg(s, s) OVER (ORDER BY s DESC) FROM t54604
+----
+{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5"}
+{"2": "2", "3": "3", "4": "4", "5": "5"}
+{"3": "3", "4": "4", "5": "5"}
+{"4": "4", "5": "5"}
+{"5": "5"}
+
+query T rowsort
+SELECT jsonb_object_agg(s, s) OVER (ORDER BY s RANGE UNBOUNDED PRECEDING) FROM t54604
+----
+{"1": "1"}
+{"1": "1", "2": "2"}
+{"1": "1", "2": "2", "3": "3"}
+{"1": "1", "2": "2", "3": "3", "4": "4"}
+{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5"}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -449,6 +449,10 @@ func (w *windower) processPartition(
 	for _, windowFnIdx := range w.orderOfWindowFnsProcessing {
 		windowFn := w.windowFns[windowFnIdx]
 
+		// TODO(yuzefovich): creating a new WindowFrameRun object for each
+		// partition and populating it below for a custom window frame is
+		// suboptimal. Consider extracting this logic into the constructor of
+		// the windower and reusing the same objects between partitions.
 		frameRun := &tree.WindowFrameRun{
 			ArgsIdxs:     windowFn.argsIdxs,
 			FilterColIdx: windowFn.filterColIdx,


### PR DESCRIPTION
In 20.2 we added a new aggregate function `json_object_agg`
implementation of which violates some assumptions that are built into
the window functions code which would result in a panic. Namely,
`framableAggregateWindowFunc` (which is a helper for handling different
window frames) needs to be told whether it needs to reset the aggregate
function, and not resetting it result in an optimization that we don't
need to start from scratch (think "running sum" behavior). This
optimization can be used when the window frame is the default one;
however, `json_object_agg` internally uses
`json.ObjectBuilderWithCounter` which prohibits calls to `Add` and
`Build` once `Build` has already been called. This breaks the
optimization (in which we have something like `Add -> Build -> Add -> Build -> ...`
sequence of calls on the same object). To go around this
issue we disable the optimization for this aggregate function.

Fixes: #54604.

Release note (bug fix): CockroachDB could crash when `json_object_agg`
and `jsonb_object_agg` aggregate functions were used as window
functions. Those functions were added only in 20.2 release, so only
testing 20.2 releases are affected.