### PR TITLE
release-20.2: sql: fix internal executor usage in leaf txn

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1122,10 +1122,6 @@ func (tc *TxnCoordSender) PrepareRetryableError(ctx context.Context, msg string)
 
 // Step is part of the TxnSender interface.
 func (tc *TxnCoordSender) Step(ctx context.Context) error {
-	if tc.typ != kv.RootTxn {
-		return errors.WithContextTags(
-			errors.AssertionFailedf("cannot call Step() in leaf txn"), ctx)
-	}
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.interceptorAlloc.txnSeqNumAllocator.stepLocked(ctx)
@@ -1135,10 +1131,6 @@ func (tc *TxnCoordSender) Step(ctx context.Context) error {
 func (tc *TxnCoordSender) ConfigureStepping(
 	ctx context.Context, mode kv.SteppingMode,
 ) (prevMode kv.SteppingMode) {
-	if tc.typ != kv.RootTxn {
-		panic(errors.WithContextTags(
-			errors.AssertionFailedf("cannot call ConfigureStepping() in leaf txn"), ctx))
-	}
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.interceptorAlloc.txnSeqNumAllocator.configureSteppingLocked(mode)

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1199,10 +1199,6 @@ func (txn *Txn) ManualRestart(ctx context.Context, ts hlc.Timestamp) {
 // operation (usually, but not exclusively, by a high-priority txn with
 // conflicting writes).
 func (txn *Txn) IsSerializablePushAndRefreshNotPossible() bool {
-	if txn.typ != RootTxn {
-		panic(
-			errors.AssertionFailedf("IsSerializablePushAndRefreshNotPossible() called on leaf txn"))
-	}
 	return txn.mu.sender.IsSerializablePushAndRefreshNotPossible()
 }
 
@@ -1246,10 +1242,6 @@ func (txn *Txn) Active() bool {
 // In step-wise execution, reads operate at a snapshot established at
 // the last step, instead of the latest write if not yet enabled.
 func (txn *Txn) Step(ctx context.Context) error {
-	if txn.typ != RootTxn {
-		return errors.WithContextTags(
-			errors.AssertionFailedf("txn.Step() only allowed in RootTxn"), ctx)
-	}
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	return txn.mu.sender.Step(ctx)
@@ -1258,10 +1250,6 @@ func (txn *Txn) Step(ctx context.Context) error {
 // ConfigureStepping configures step-wise execution in the
 // transaction.
 func (txn *Txn) ConfigureStepping(ctx context.Context, mode SteppingMode) (prevMode SteppingMode) {
-	if txn.typ != RootTxn {
-		panic(errors.WithContextTags(
-			errors.AssertionFailedf("txn.ConfigureStepping() only allowed in RootTxn"), ctx))
-	}
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	return txn.mu.sender.ConfigureStepping(ctx, mode)


### PR DESCRIPTION
Backport 1/1 commits from #45966.

/cc @cockroachdb/release

---

Internal executors use a conn executor under the hood, which sets a priority
and configures stepping on the transaction it is provided with. Both operations
would previously cause panics when used with a leaf transaction.

This commit reworks setting transaction priority on leaf transactions to avoid
crashing when the new priority is the same as the old one, and allows stepping
to be configured on a leaf transaction since doing so is a noop.

Fixes #45924

Release note: None

Release justification: crash fix
