### PR TITLE
logictest: switch high vmodule nightly tests to use make test

### DIFF
--- a/build/teamcity-testlogic-verbose.sh
+++ b/build/teamcity-testlogic-verbose.sh
@@ -16,5 +16,5 @@ tc_end_block "Compile C dependencies"
 tc_start_block "Run TestLogic tests under verbose"
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make testlogic GOTESTFLAGS=-json TESTTIMEOUT=1h TESTFLAGS='--vmodule=*=10 -show-sql -test.v'
+  make test GOTESTFLAGS=-json TESTFLAGS='--vmodule=*=10 -show-sql -test.v' TESTTIMEOUT='1h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$'
 tc_end_block "Run TestLogic tests under verbose"


### PR DESCRIPTION
make testlogic would build the testing binary first and then invoke it
manually, losing test JSON output and therefore creating parsing issues. The
switch to make test changes this nightly test to emit expected JSON output.

Release note: None

Fixes #50136