### PR TITLE
build: increase default TESTTIMEOUT for SQL Race Logic Tests

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,11 +8,14 @@ maybe_ccache
 
 mkdir -p artifacts
 
+TESTTIMEOUT=2h
+
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
   make testrace \
   GOTESTFLAGS=-json \
   PKG=./pkg/sql/logictest \
+  TESTTIMEOUT="${TESTTIMEOUT}" \
   TESTFLAGS='-v' \
   ENABLE_ROCKSDB_ASSERTIONS=1
 
@@ -25,6 +28,7 @@ run_json_test build/builder.sh \
   GOTESTFLAGS=-json \
   PKG=./pkg/sql/logictest \
   TESTS='^TestLogic/local$$' \
+  TESTTIMEOUT="${TESTTIMEOUT}" \
   TESTFLAGS='-optimizer-cost-perturbation=0.9 -v' \
   ENABLE_ROCKSDB_ASSERTIONS=1
 
@@ -43,9 +47,10 @@ for file in $LOGICTESTS; do
         run_json_test build/builder.sh \
           stdbuf -oL -eL \
           make testrace \
-    GOTESTFLAGS=-json \
+          GOTESTFLAGS=-json \
           PKG=./pkg/sql/logictest \
           TESTS='^TestLogic/local/'${file}'$$' \
+          TESTTIMEOUT="${TESTTIMEOUT}" \
           TESTFLAGS='-disable-opt-rule-probability=0.5 -v' \
           ENABLE_ROCKSDB_ASSERTIONS=1 \
     fi


### PR DESCRIPTION
This commit increases the test timeout to 1 hour, since the tests
have been failing by timing out after 30 minutes. We may need
to increase the timeout further, but this is a start.

Release note: None