### PR TITLE
kv: prevent rangelog span from being backpressured

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -284,6 +284,11 @@ var (
 	// NamespaceTableMax is the end key of system.namespace.
 	NamespaceTableMax = SystemSQLCodec.TablePrefix(NamespaceTableID + 1)
 	//
+	// RangeEventTableMin is the start key of system.rangelog.
+	RangeEventTableMin = SystemSQLCodec.TablePrefix(RangeEventTableID)
+	// RangeEventTableMax is the end key of system.rangelog.
+	RangeEventTableMax = SystemSQLCodec.TablePrefix(RangeEventTableID + 1)
+	//
 	// UserTableDataMin is the start key of user structured data.
 	UserTableDataMin = SystemSQLCodec.TablePrefix(MinUserDescID)
 


### PR DESCRIPTION
Previously, there was no check for for ensuring rangelog range is not backpressurable.
This needed to change because the rangelong range should not be backpressured.
To address this, a notBackpressurableSpans key span and a check within canBackpressureBatch for keys in this key span were added.

Release note (bug fix): None