### PR TITLE
release-20.1: kvserver/rangefeed: use pointers for events

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -13,6 +13,7 @@ package rangefeed
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -116,9 +117,26 @@ type Processor struct {
 	lenResC    chan int
 	filterReqC chan struct{}
 	filterResC chan *Filter
-	eventC     chan event
+	eventC     chan *event
 	stopC      chan *roachpb.Error
 	stoppedC   chan struct{}
+}
+
+var eventSyncPool = sync.Pool{
+	New: func() interface{} {
+		return new(event)
+	},
+}
+
+func getPooledEvent(ev event) *event {
+	e := eventSyncPool.Get().(*event)
+	*e = ev
+	return e
+}
+
+func putPooledEvent(ev *event) {
+	*ev = event{}
+	eventSyncPool.Put(ev)
 }
 
 // event is a union of different event types that the Processor goroutine needs
@@ -152,7 +170,7 @@ func NewProcessor(cfg Config) *Processor {
 		lenResC:    make(chan int),
 		filterReqC: make(chan struct{}),
 		filterResC: make(chan *Filter),
-		eventC:     make(chan event, cfg.EventChanCap),
+		eventC:     make(chan *event, cfg.EventChanCap),
 		stopC:      make(chan *roachpb.Error, 1),
 		stoppedC:   make(chan struct{}),
 	}
@@ -251,6 +269,7 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIter storage.SimpleIterator)
 			// Transform and route events.
 			case e := <-p.eventC:
 				p.consumeEvent(ctx, e)
+				putPooledEvent(e)
 
 			// Check whether any unresolved intents need a push.
 			case <-txnPushTickerC:
@@ -448,20 +467,21 @@ func (p *Processor) ForwardClosedTS(closedTS hlc.Timestamp) bool {
 // the method will wait for no longer than that duration before giving up,
 // shutting down the Processor, and returning false. 0 for no timeout.
 func (p *Processor) sendEvent(e event, timeout time.Duration) bool {
+	ev := getPooledEvent(e)
 	if timeout == 0 {
 		select {
-		case p.eventC <- e:
+		case p.eventC <- ev:
 		case <-p.stoppedC:
 			// Already stopped. Do nothing.
 		}
 	} else {
 		select {
-		case p.eventC <- e:
+		case p.eventC <- ev:
 		case <-p.stoppedC:
 			// Already stopped. Do nothing.
 		default:
 			select {
-			case p.eventC <- e:
+			case p.eventC <- ev:
 			case <-p.stoppedC:
 				// Already stopped. Do nothing.
 			case <-time.After(timeout):
@@ -486,8 +506,9 @@ func (p *Processor) setResolvedTSInitialized() {
 // It does so by flushing the event pipeline.
 func (p *Processor) syncEventC() {
 	syncC := make(chan struct{})
+	ev := getPooledEvent(event{syncC: syncC})
 	select {
-	case p.eventC <- event{syncC: syncC}:
+	case p.eventC <- ev:
 		select {
 		case <-syncC:
 		// Synchronized.
@@ -499,7 +520,7 @@ func (p *Processor) syncEventC() {
 	}
 }
 
-func (p *Processor) consumeEvent(ctx context.Context, e event) {
+func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	switch {
 	case len(e.ops) > 0:
 		p.consumeLogicalOps(ctx, e.ops)

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -913,8 +913,9 @@ func (p *Processor) syncEventAndRegistrations() {
 // overlapping the given span to fully process their own internal buffers.
 func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
 	syncC := make(chan struct{})
+	ev := getPooledEvent(event{syncC: syncC, testRegCatchupSpan: span})
 	select {
-	case p.eventC <- event{syncC: syncC, testRegCatchupSpan: span}:
+	case p.eventC <- ev:
 		select {
 		case <-syncC:
 		// Synchronized.
@@ -922,6 +923,7 @@ func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
 			// Already stopped. Do nothing.
 		}
 	case <-p.stoppedC:
+		putPooledEvent(ev)
 		// Already stopped. Do nothing.
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -194,7 +194,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 				EndKey: roachpb.RKey("w"),
 			},
 		},
-		eventC: make(chan event, 100),
+		eventC: make(chan *event, 100),
 	}
 
 	// Run an init rts scan over a test iterator with the following keys.
@@ -230,7 +230,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 	require.True(t, iter.closed)
 
 	// Compare the event channel to the expected events.
-	expEvents := []event{
+	expEvents := []*event{
 		{ops: []enginepb.MVCCLogicalOp{
 			writeIntentOpWithKey(txn2, []byte("txnKey2"), hlc.Timestamp{WallTime: 21}),
 		}},
@@ -310,7 +310,7 @@ func TestTxnPushAttempt(t *testing.T) {
 	})
 
 	// Mock processor. We just needs its eventC.
-	p := Processor{eventC: make(chan event, 100)}
+	p := Processor{eventC: make(chan *event, 100)}
 	p.TxnPusher = &tp
 
 	txns := []enginepb.TxnMeta{txn1Meta, txn2Meta, txn3Meta}
@@ -320,7 +320,7 @@ func TestTxnPushAttempt(t *testing.T) {
 	<-doneC // check if closed
 
 	// Compare the event channel to the expected events.
-	expEvents := []event{
+	expEvents := []*event{
 		{ops: []enginepb.MVCCLogicalOp{
 			updateIntentOp(txn1, hlc.Timestamp{WallTime: 15}),
 			updateIntentOp(txn2, hlc.Timestamp{WallTime: 2}),


### PR DESCRIPTION
Backport 1/1 commits from #54526.

/cc @cockroachdb/release

---

Rangefeed processors allocate a bufferred channel for events. The default size
of this channel is 4KiB. An event struct is 104 bytes. That means that on the
server side we are allocating almost .5MiB per rangefeed client. This PR
changes the channel to instead use pointers and uses a sync.Pool to avoid
excessive allocations. This reduces the server-side overhead of a rangefeed
by ~10x. This should help in cases where changefeeds are run over large numbers
of ranges.

I imagine we can backport this to at least a few releases.

Release note (general change): Reduced the memory overhead of rangefeeds which
reduces the memory overhead for running CHANGEFEEDs over large tables.
