### PR TITLE
sql/catalog: fix descs.Collection reuse on retries in descs.Txn

### DIFF
--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -16,11 +16,14 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -90,4 +93,68 @@ func TestCollectionWriteDescToBatch(t *testing.T) {
 		require.Equal(t, newTable, newTableResolved)
 		return txn.Run(ctx, b)
 	}))
+}
+
+// TestTxnClearsCollectionOnRetry tests that descs.Txn() correctly clears the
+// state of its associated descs.Collection on a retry error at commit time.
+// Regression test for #51197.
+func TestTxnClearsCollectionOnRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	const txnName = "descriptor update"
+	haveInjectedRetry := false
+	var serverArgs base.TestServerArgs
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+		TestingRequestFilter: func(ctx context.Context, r roachpb.BatchRequest) *roachpb.Error {
+			if r.Txn == nil || r.Txn.Name != txnName {
+				return nil
+			}
+			if _, ok := r.GetArg(roachpb.EndTxn); ok {
+				if !haveInjectedRetry {
+					haveInjectedRetry = true
+					// Force a retry error the first time.
+					return roachpb.NewError(roachpb.NewTransactionRetryError(roachpb.RETRY_REASON_UNKNOWN, "injected error"))
+				}
+			}
+			return nil
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 1, params)
+	defer tc.Stopper().Stop(ctx)
+
+	s := tc.Server(0)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `USE db`)
+	tdb.Exec(t, `CREATE SCHEMA schema`)
+	tdb.Exec(t, `CREATE TABLE db.schema.table()`)
+	tn := tree.MakeTableNameWithSchema("db", "schema", "table")
+
+	err := descs.Txn(
+		ctx,
+		s.ClusterSettings(),
+		s.LeaseManager().(*lease.Manager),
+		s.InternalExecutor().(sqlutil.InternalExecutor),
+		s.DB(),
+		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			txn.SetDebugName(txnName)
+
+			flags := tree.ObjectLookupFlagsWithRequired()
+			flags.RequireMutable = true
+			desc, err := descriptors.GetMutableTableDescriptor(ctx, txn, &tn, flags)
+			require.NoError(t, err)
+			// Verify that the descriptor version is always 1 prior to the write and 2
+			// after the write even after a retry.
+			require.Equal(t, descpb.DescriptorVersion(1), desc.Version)
+			require.NoError(t, descriptors.WriteDesc(ctx, false /* kvTrace */, desc, txn))
+			require.Equal(t, descpb.DescriptorVersion(2), desc.Version)
+			return nil
+		},
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Previously, in `descs.Txn()`, we weren't clearing the state of the
associated `descs.Collection` by calling `ReleaseAll()` when the
transaction hit a retry error upon attempting to commit. Consequently,
descriptors we had attempted to write would persist in the collection's
set of uncommitted descriptors on the next attempt. This manifested in
flakes where import jobs would fail because they expected to be reading
a descriptor from the store, but instead read one with a higher version.
To fix this, we unconditionally `defer` the call to `ReleaseAll()` in
the transaction closure.

Fixes #51197.
Fixes #54630.
Fixes #54549.
Fixes #54385.

Release note: None (bug has not been released)