### PR TITLE
backport-20.2: kvserver: improve redaction for failed consistency checks

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -20,6 +20,8 @@ pkg/sql/catalog/descpb/structured.go | `ColumnID`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
 pkg/sql/sem/tree/table_ref.go | `ID`
 pkg/sql/sem/tree/table_ref.go | `ColumnID`
+pkg/storage/enginepb/mvcc3.go | `MVCCStatsDelta`
+pkg/storage/enginepb/mvcc3.go | `*MVCCStats`
 pkg/util/hlc/timestamp.go | `Timestamp`
 pkg/util/log/redact.go | `reflect.TypeOf(true)`
 pkg/util/log/redact.go | `reflect.TypeOf(123)`

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -227,6 +227,10 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// This test prints a consistency checker diff, so it's
+	// good to make sure we're overly redacting said diff.
+	defer log.TestingSetRedactable(true)()
+
 	if testing.Short() {
 		// Takes 30s as of 2020/07. The test uses on-disk stores because nodes get
 		// killed, and for some reason using the on-disk stores seems to cause

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -11,7 +11,6 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha512"
 	"encoding/binary"
@@ -41,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // fatalOnStatsMismatch, if true, turns stats mismatches into fatal errors. A
@@ -129,19 +129,19 @@ func (r *Replica) CheckConsistency(
 	// There is an inconsistency if and only if there is a minority SHA.
 
 	if minoritySHA != "" {
-		var buf bytes.Buffer
-		_, _ = fmt.Fprintf(&buf, "\n") // New line to align checksums below.
+		var buf redact.StringBuilder
+		buf.Printf("\n") // New line to align checksums below.
 		for sha, idxs := range shaToIdxs {
-			minority := ""
+			minority := redact.Safe("")
 			if sha == minoritySHA {
-				minority = " [minority]"
+				minority = redact.Safe(" [minority]")
 			}
 			for _, idx := range idxs {
-				_, _ = fmt.Fprintf(&buf, "%s: checksum %x%s\n"+
+				buf.Printf("%s: checksum %x%s\n"+
 					"- stats: %+v\n"+
 					"- stats.Sub(recomputation): %+v\n",
 					&results[idx].Replica,
-					sha,
+					redact.Safe(sha),
 					minority,
 					&results[idx].Response.Persisted,
 					&results[idx].Response.Delta,
@@ -154,13 +154,12 @@ func (r *Replica) CheckConsistency(
 				if report := r.store.cfg.TestingKnobs.ConsistencyTestingKnobs.BadChecksumReportDiff; report != nil {
 					report(*r.store.Ident, diff)
 				}
-				_, _ = fmt.Fprintf(&buf, "====== diff(%x, [minority]) ======\n", sha)
-				_, _ = diff.WriteTo(&buf)
+				buf.Printf("====== diff(%x, [minority]) ======\n%v", redact.Safe(sha), diff)
 			}
 		}
 
 		if isQueue {
-			log.Errorf(ctx, "%v", buf.String())
+			log.Errorf(ctx, "%v", buf.RedactableString())
 		}
 		res.Detail += buf.String()
 	} else {
@@ -284,7 +283,16 @@ func (r *Replica) CheckConsistency(
 	for _, idxs := range shaToIdxs[minoritySHA] {
 		args.Terminate = append(args.Terminate, results[idxs].Replica)
 	}
-	log.Errorf(ctx, "consistency check failed; fetching details and shutting down minority %v", args.Terminate)
+	// args.Terminate is a slice of properly redactable values, but
+	// with %v `redact` will not realize that and will redact the
+	// whole thing. Wrap it as a ReplicaDescriptors which is a SafeFormatter
+	// and will get the job done.
+	//
+	// TODO(knz): clean up after https://github.com/cockroachdb/redact/issues/5.
+	{
+		var tmp redact.SafeFormatter = roachpb.MakeReplicaDescriptors(args.Terminate)
+		log.Errorf(ctx, "consistency check failed; fetching details and shutting down minority %v", tmp)
+	}
 
 	// We've noticed in practice that if the snapshot diff is large, the log
 	// file in it is promptly rotated away, so up the limits while the diff

--- a/pkg/kv/kvserver/replica_consistency_diff.go
+++ b/pkg/kv/kvserver/replica_consistency_diff.go
@@ -12,12 +12,11 @@ package kvserver
 
 import (
 	"bytes"
-	"fmt"
-	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/redact"
 )
 
 // ReplicaSnapshotDiff is a part of a []ReplicaSnapshotDiff which represents a diff between
@@ -35,48 +34,31 @@ type ReplicaSnapshotDiff struct {
 // exposes a formatting helper.
 type ReplicaSnapshotDiffSlice []ReplicaSnapshotDiff
 
-// WriteTo writes a string representation of itself to the given writer.
-func (rsds ReplicaSnapshotDiffSlice) WriteTo(w io.Writer) (int64, error) {
-	n, err := w.Write([]byte("--- leaseholder\n+++ follower\n"))
-	if err != nil {
-		return 0, err
-	}
+// SafeFormat implements redact.SafeFormatter.
+func (rsds ReplicaSnapshotDiffSlice) SafeFormat(buf redact.SafePrinter, _ rune) {
+	buf.Printf("--- leaseholder\n+++ follower\n")
 	for _, d := range rsds {
-		prefix := "+"
+		prefix := redact.SafeString("+")
 		if d.LeaseHolder {
 			// Lease holder (RHS) has something follower (LHS) does not have.
-			prefix = "-"
+			prefix = redact.SafeString("-")
 		}
-		ts := d.Timestamp
-		const format = `%s%d.%09d,%d %s
+		const format = `%s%s %s
 %s    ts:%s
 %s    value:%s
 %s    raw mvcc_key/value: %x %x
 `
-		var prettyTime string
-		if d.Timestamp == (hlc.Timestamp{}) {
-			prettyTime = "<zero>"
-		} else {
-			prettyTime = d.Timestamp.GoTime().UTC().String()
-		}
-		mvccKey := storage.MVCCKey{Key: d.Key, Timestamp: ts}
-		num, err := fmt.Fprintf(w, format,
-			prefix, ts.WallTime/1e9, ts.WallTime%1e9, ts.Logical, d.Key,
-			prefix, prettyTime,
+		mvccKey := storage.MVCCKey{Key: d.Key, Timestamp: d.Timestamp}
+		buf.Printf(format,
+			prefix, d.Timestamp, d.Key,
+			prefix, d.Timestamp.GoTime(),
 			prefix, SprintKeyValue(storage.MVCCKeyValue{Key: mvccKey, Value: d.Value}, false /* printKey */),
 			prefix, storage.EncodeKey(mvccKey), d.Value)
-		if err != nil {
-			return 0, err
-		}
-		n += num
 	}
-	return int64(n), nil
 }
 
 func (rsds ReplicaSnapshotDiffSlice) String() string {
-	var buf bytes.Buffer
-	_, _ = rsds.WriteTo(&buf)
-	return buf.String()
+	return redact.StringWithoutMarkers(rsds)
 }
 
 // diffs the two kv dumps between the lease holder and the replica.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7586,15 +7586,13 @@ func TestDiffRange(t *testing.T) {
 +    ts:1970-01-01 00:00:00.000001729 +0000 UTC
 +    value:"foo"
 +    raw mvcc_key/value: 6162636465660000000000000006c1000000010d 666f6f
-+0.000000000,0 "foo"
-+    ts:<zero>
++0,0 "foo"
++    ts:1970-01-01 00:00:00 +0000 UTC
 +    value:"foo"
 +    raw mvcc_key/value: 666f6f00 666f6f
 `
 
-	if diff := stringDiff.String(); diff != expDiff {
-		t.Fatalf("expected:\n%s\ngot:\n%s", expDiff, diff)
-	}
+	require.Equal(t, expDiff, stringDiff.String())
 }
 
 func TestSyncSnapshot(t *testing.T) {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/redact"
 )
 
 // Server implements PerReplicaServer.
@@ -63,7 +64,7 @@ func (is Server) CollectChecksum(
 				// snapshot (if present) intact.
 				if len(req.Checksum) > 0 {
 					log.Errorf(ctx, "consistency check failed on range r%d: expected checksum %x, got %x",
-						req.RangeID, req.Checksum, ccr.Checksum)
+						req.RangeID, redact.Safe(req.Checksum), redact.Safe(ccr.Checksum))
 					// Leave resp.Snapshot alone so that the caller will receive what's
 					// in it (if anything).
 				}

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -12,8 +12,8 @@ package roachpb
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/raftpb"
 )
 
@@ -75,15 +75,18 @@ func MakeReplicaDescriptors(replicas []ReplicaDescriptor) ReplicaDescriptors {
 	return ReplicaDescriptors{wrapped: replicas}
 }
 
-func (d ReplicaDescriptors) String() string {
-	var buf strings.Builder
+// SafeFormat implements redact.SafeFormatter.
+func (d ReplicaDescriptors) SafeFormat(w redact.SafePrinter, _ rune) {
 	for i, desc := range d.wrapped {
 		if i > 0 {
-			buf.WriteByte(',')
+			w.SafeRune(',')
 		}
-		fmt.Fprint(&buf, desc)
+		w.Print(desc)
 	}
-	return buf.String()
+}
+
+func (d ReplicaDescriptors) String() string {
+	return redact.StringWithoutMarkers(d)
 }
 
 // All returns every replica in the set, including both voter replicas and

--- a/pkg/storage/enginepb/mvcc.pb.go
+++ b/pkg/storage/enginepb/mvcc.pb.go
@@ -66,7 +66,7 @@ type MVCCMetadata struct {
 func (m *MVCCMetadata) Reset()      { *m = MVCCMetadata{} }
 func (*MVCCMetadata) ProtoMessage() {}
 func (*MVCCMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_c6139249dd196b26, []int{0}
+	return fileDescriptor_mvcc_a52f79ae78284316, []int{0}
 }
 func (m *MVCCMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -106,7 +106,7 @@ type MVCCMetadata_SequencedIntent struct {
 func (m *MVCCMetadata_SequencedIntent) Reset()      { *m = MVCCMetadata_SequencedIntent{} }
 func (*MVCCMetadata_SequencedIntent) ProtoMessage() {}
 func (*MVCCMetadata_SequencedIntent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_c6139249dd196b26, []int{0, 0}
+	return fileDescriptor_mvcc_a52f79ae78284316, []int{0, 0}
 }
 func (m *MVCCMetadata_SequencedIntent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -150,7 +150,7 @@ func (m *MVCCMetadataSubsetForMergeSerialization) Reset() {
 }
 func (*MVCCMetadataSubsetForMergeSerialization) ProtoMessage() {}
 func (*MVCCMetadataSubsetForMergeSerialization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_c6139249dd196b26, []int{1}
+	return fileDescriptor_mvcc_a52f79ae78284316, []int{1}
 }
 func (m *MVCCMetadataSubsetForMergeSerialization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -268,7 +268,7 @@ func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
 func (m *MVCCStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCStats) ProtoMessage()    {}
 func (*MVCCStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_c6139249dd196b26, []int{2}
+	return fileDescriptor_mvcc_a52f79ae78284316, []int{2}
 }
 func (m *MVCCStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,7 +322,7 @@ func (m *MVCCStatsLegacyRepresentation) Reset()         { *m = MVCCStatsLegacyRe
 func (m *MVCCStatsLegacyRepresentation) String() string { return proto.CompactTextString(m) }
 func (*MVCCStatsLegacyRepresentation) ProtoMessage()    {}
 func (*MVCCStatsLegacyRepresentation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_c6139249dd196b26, []int{3}
+	return fileDescriptor_mvcc_a52f79ae78284316, []int{3}
 }
 func (m *MVCCStatsLegacyRepresentation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2277,9 +2277,9 @@ var (
 	ErrIntOverflowMvcc   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_c6139249dd196b26) }
+func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_a52f79ae78284316) }
 
-var fileDescriptor_mvcc_c6139249dd196b26 = []byte{
+var fileDescriptor_mvcc_a52f79ae78284316 = []byte{
 	// 743 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x95, 0xbf, 0x4e, 0x1b, 0x4b,
 	0x14, 0xc6, 0xbd, 0xd7, 0x06, 0xd6, 0x63, 0x63, 0xc3, 0x8a, 0xc2, 0x32, 0xf7, 0xae, 0x7d, 0xa1,

--- a/pkg/storage/enginepb/mvcc.proto
+++ b/pkg/storage/enginepb/mvcc.proto
@@ -184,6 +184,9 @@ message MVCCStats {
   // abort_span_bytes is the number of bytes stored in a range's
   // abort span. These bytes are a subset of sys_bytes.
   optional sfixed64 abort_span_bytes = 15 [(gogoproto.nullable) = false];
+
+  // WARNING: Do not add any PII-holding fields here, as this
+  // whole message is marked as safe for log redaction.
 }
 
 // MVCCStatsLegacyRepresentation is almost identical to MVCCStats, except

--- a/pkg/storage/enginepb/mvcc3.go
+++ b/pkg/storage/enginepb/mvcc3.go
@@ -12,6 +12,9 @@ package enginepb
 
 import "github.com/cockroachdb/errors"
 
+// SafeValue implements the redact.SafeValue interface.
+func (MVCCStatsDelta) SafeValue() {}
+
 // ToStats converts the receiver to an MVCCStats.
 func (ms *MVCCStatsDelta) ToStats() MVCCStats {
 	return MVCCStats(*ms)
@@ -26,6 +29,9 @@ func (ms *MVCCStats) ToStatsDelta() MVCCStatsDelta {
 func (ms *MVCCPersistentStats) ToStats() MVCCStats {
 	return MVCCStats(*ms)
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (ms *MVCCStats) SafeValue() {}
 
 // ToPersistentStats converts the receiver to an MVCCPersistentStats.
 func (ms *MVCCStats) ToPersistentStats() MVCCPersistentStats {

--- a/pkg/storage/enginepb/mvcc3.pb.go
+++ b/pkg/storage/enginepb/mvcc3.pb.go
@@ -127,7 +127,7 @@ type TxnMeta struct {
 func (m *TxnMeta) Reset()      { *m = TxnMeta{} }
 func (*TxnMeta) ProtoMessage() {}
 func (*TxnMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{0}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{0}
 }
 func (m *TxnMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -163,7 +163,7 @@ func (m *IgnoredSeqNumRange) Reset()         { *m = IgnoredSeqNumRange{} }
 func (m *IgnoredSeqNumRange) String() string { return proto.CompactTextString(m) }
 func (*IgnoredSeqNumRange) ProtoMessage()    {}
 func (*IgnoredSeqNumRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{1}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{1}
 }
 func (m *IgnoredSeqNumRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -213,7 +213,7 @@ func (m *MVCCStatsDelta) Reset()         { *m = MVCCStatsDelta{} }
 func (m *MVCCStatsDelta) String() string { return proto.CompactTextString(m) }
 func (*MVCCStatsDelta) ProtoMessage()    {}
 func (*MVCCStatsDelta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{2}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{2}
 }
 func (m *MVCCStatsDelta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -264,7 +264,7 @@ func (m *MVCCPersistentStats) Reset()         { *m = MVCCPersistentStats{} }
 func (m *MVCCPersistentStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCPersistentStats) ProtoMessage()    {}
 func (*MVCCPersistentStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{3}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{3}
 }
 func (m *MVCCPersistentStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -309,7 +309,7 @@ func (m *RangeAppliedState) Reset()         { *m = RangeAppliedState{} }
 func (m *RangeAppliedState) String() string { return proto.CompactTextString(m) }
 func (*RangeAppliedState) ProtoMessage()    {}
 func (*RangeAppliedState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{4}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{4}
 }
 func (m *RangeAppliedState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -347,7 +347,7 @@ func (m *MVCCWriteValueOp) Reset()         { *m = MVCCWriteValueOp{} }
 func (m *MVCCWriteValueOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCWriteValueOp) ProtoMessage()    {}
 func (*MVCCWriteValueOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{5}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{5}
 }
 func (m *MVCCWriteValueOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -385,7 +385,7 @@ func (m *MVCCWriteIntentOp) Reset()         { *m = MVCCWriteIntentOp{} }
 func (m *MVCCWriteIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCWriteIntentOp) ProtoMessage()    {}
 func (*MVCCWriteIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{6}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{6}
 }
 func (m *MVCCWriteIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -421,7 +421,7 @@ func (m *MVCCUpdateIntentOp) Reset()         { *m = MVCCUpdateIntentOp{} }
 func (m *MVCCUpdateIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCUpdateIntentOp) ProtoMessage()    {}
 func (*MVCCUpdateIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{7}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{7}
 }
 func (m *MVCCUpdateIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -460,7 +460,7 @@ func (m *MVCCCommitIntentOp) Reset()         { *m = MVCCCommitIntentOp{} }
 func (m *MVCCCommitIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCCommitIntentOp) ProtoMessage()    {}
 func (*MVCCCommitIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{8}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{8}
 }
 func (m *MVCCCommitIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -500,7 +500,7 @@ func (m *MVCCAbortIntentOp) Reset()         { *m = MVCCAbortIntentOp{} }
 func (m *MVCCAbortIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCAbortIntentOp) ProtoMessage()    {}
 func (*MVCCAbortIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{9}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{9}
 }
 func (m *MVCCAbortIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -536,7 +536,7 @@ func (m *MVCCAbortTxnOp) Reset()         { *m = MVCCAbortTxnOp{} }
 func (m *MVCCAbortTxnOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCAbortTxnOp) ProtoMessage()    {}
 func (*MVCCAbortTxnOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{10}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{10}
 }
 func (m *MVCCAbortTxnOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -575,7 +575,7 @@ func (m *MVCCLogicalOp) Reset()         { *m = MVCCLogicalOp{} }
 func (m *MVCCLogicalOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCLogicalOp) ProtoMessage()    {}
 func (*MVCCLogicalOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_ffb4a3e3dc0d81a7, []int{11}
+	return fileDescriptor_mvcc3_4c1a1e86b5330d4d, []int{11}
 }
 func (m *MVCCLogicalOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4275,9 +4275,9 @@ var (
 	ErrIntOverflowMvcc3   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_ffb4a3e3dc0d81a7) }
+func init() { proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_4c1a1e86b5330d4d) }
 
-var fileDescriptor_mvcc3_ffb4a3e3dc0d81a7 = []byte{
+var fileDescriptor_mvcc3_4c1a1e86b5330d4d = []byte{
 	// 1190 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x57, 0x41, 0x6f, 0x1a, 0xc7,
 	0x17, 0x67, 0xd9, 0xc5, 0x86, 0x07, 0xb6, 0x61, 0x12, 0xe9, 0x8f, 0xf2, 0x4f, 0x80, 0x72, 0xa8,

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -150,6 +150,9 @@ message MVCCStatsDelta {
   sint64 sys_bytes = 12;
   sint64 sys_count = 13;
   sint64 abort_span_bytes = 15;
+
+  // WARNING: Do not add any PII-holding fields here, as this
+  // whole message is marked as safe for log redaction.
 }
 
 // MVCCPersistentStats is convertible to MVCCStats, but uses signed variable


### PR DESCRIPTION
Backport 1/1 commits from #54108.

/cc @cockroachdb/release

---

Release justification: low-risk change to logging
Release note: None

