### PR TITLE
roachprod gc cron: GC the andrei-jepsen project

### DIFF
--- a/pkg/cmd/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/cmd/roachprod/k8s/roachprod-gc.yaml
@@ -34,6 +34,7 @@ spec:
               image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
               args:
                 - gc
+                -- --gce-project=cockroach-ephemeral,andrei-jepsen
                 - --slack-token
                 - $(SLACK_TOKEN)
               env:


### PR DESCRIPTION
andrei-jepsen is a badly named project with tons of quota that we use occasionally. 
This patch makes it so that we GC it like we do for cockroach-ephemeral.
I'm pretty sure we used to GC it but it probably got lost in the move to k8s.