### PR TITLE
roachprod: Allow io2 EBS volumes

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -702,7 +702,7 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 		case "gp2":
 			ebsParams = fmt.Sprintf("{VolumeSize=%d,VolumeType=%s,DeleteOnTermination=true}",
 				p.opts.EBSVolumeSize, t)
-		case "io1":
+		case "io1", "io2":
 			ebsParams = fmt.Sprintf("{VolumeSize=%d,VolumeType=%s,Iops=%d,DeleteOnTermination=true}",
 				p.opts.EBSVolumeSize, t, p.opts.EBSProvisionedIOPs)
 		default:


### PR DESCRIPTION
AWS recently launched a new type of EBS volumes, io2, that allows more
IOPS than io1. This change lets us create io2 volumes using roachprod.

Release note: None.