### PR TITLE
release-20.1: sql: add memory accounting for fetches

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -103,11 +103,13 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 
 	var rf row.Fetcher
 	if err := rf.Init(
+		context.TODO(),
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&c.a,
+		nil, /* memMonitor */
 		row.FetcherTableArgs{
 			Spans:            tableDesc.AllIndexSpans(),
 			Desc:             tableDesc,

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -121,11 +121,14 @@ func (cb *ColumnBackfiller) Init(
 		ValNeededForCol: valNeededForCol,
 	}
 	return cb.fetcher.Init(
+		evalCtx.Context,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&cb.alloc,
+		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
+		nil, /* memMonitor */
 		tableArgs,
 	)
 }
@@ -364,11 +367,14 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 		ValNeededForCol: valNeededForCol,
 	}
 	return ib.fetcher.Init(
+		context.TODO(),
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&ib.alloc,
+		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
+		nil, /* memMonitor */
 		tableArgs,
 	)
 }

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -487,8 +487,17 @@ func (rf *cFetcher) StartScan(
 		firstBatchLimit++
 	}
 
+	// Note that we pass a nil memMonitor here, because the cfetcher does its own
+	// memory accounting.
 	f, err := row.NewKVFetcher(
-		txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.lockStr, rf.returnRangeInfo,
+		txn,
+		spans,
+		rf.reverse,
+		limitBatches,
+		firstBatchLimit,
+		rf.lockStr,
+		rf.returnRangeInfo,
+		nil, /* memMonitor */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -185,6 +185,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		}
 	}
 	if err := d.fetcher.Init(
+		params.ctx,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will
@@ -193,6 +194,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&params.p.alloc,
+		nil, /* memMonitor */
 		allTables...,
 	); err != nil {
 		return err

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -414,11 +414,13 @@ func (c *cascader) addIndexPKRowFetcher(
 	isSecondary := table.PrimaryIndex.ID != index.ID
 	var rowFetcher Fetcher
 	if err := rowFetcher.Init(
+		c.evalCtx.Context,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		c.alloc,
+		nil, /* memMonitor */
 		FetcherTableArgs{
 			Desc:             table,
 			Index:            index,
@@ -479,6 +481,7 @@ func (c *cascader) addRowDeleter(
 	}
 	var rowFetcher Fetcher
 	if err := rowFetcher.Init(
+		c.evalCtx.Context,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will
@@ -487,6 +490,7 @@ func (c *cascader) addRowDeleter(
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		c.alloc,
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return Deleter{}, Fetcher{}, err
@@ -545,6 +549,7 @@ func (c *cascader) addRowUpdater(
 	}
 	var rowFetcher Fetcher
 	if err := rowFetcher.Init(
+		c.evalCtx.Context,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will
@@ -553,6 +558,7 @@ func (c *cascader) addRowUpdater(
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		c.alloc,
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return Updater{}, Fetcher{}, err

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -109,11 +109,13 @@ func NewUniquenessConstraintViolationError(
 		ValNeededForCol:  valNeededForCol,
 	}
 	if err := rf.Init(
+		ctx,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&sqlbase.DatumAlloc{},
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return err

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -106,11 +106,13 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	}
 	var rf row.Fetcher
 	if err := rf.Init(
+		ctx,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		true,  /* isCheck */
 		&sqlbase.DatumAlloc{},
+		nil, /* memMonitor */
 		args...,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/row/fk_existence_base.go
+++ b/pkg/sql/row/fk_existence_base.go
@@ -11,6 +11,7 @@
 package row
 
 import (
+	"context"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -117,6 +118,7 @@ type fkExistenceCheckBaseHelper struct {
 //   TODO(knz): this should become homogeneous across the 3 packages
 //   sql, sqlbase, row. The proliferation is annoying.
 func makeFkExistenceCheckBaseHelper(
+	ctx context.Context,
 	txn *kv.Txn,
 	otherTables FkTableMetadata,
 	ref *sqlbase.ForeignKeyConstraint,
@@ -147,11 +149,13 @@ func makeFkExistenceCheckBaseHelper(
 	}
 	rf := &Fetcher{}
 	if err := rf.Init(
+		ctx,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		alloc,
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return ret, err

--- a/pkg/sql/row/fk_existence_delete.go
+++ b/pkg/sql/row/fk_existence_delete.go
@@ -83,7 +83,7 @@ func makeFkExistenceCheckHelperForDelete(
 			return fkExistenceCheckForDelete{}, errors.NewAssertionErrorWithWrappedErrf(
 				err, "failed to find a suitable index on table %d for deletion", ref.ReferencedTableID)
 		}
-		fk, err := makeFkExistenceCheckBaseHelper(txn, otherTables, fakeRef, searchIdx, mutatedIdx, colMap, alloc,
+		fk, err := makeFkExistenceCheckBaseHelper(ctx, txn, otherTables, fakeRef, searchIdx, mutatedIdx, colMap, alloc,
 			CheckDeletes)
 		if err == errSkipUnusedFK {
 			continue

--- a/pkg/sql/row/fk_existence_insert.go
+++ b/pkg/sql/row/fk_existence_insert.go
@@ -75,7 +75,8 @@ func makeFkExistenceCheckHelperForInsert(
 			return h, errors.NewAssertionErrorWithWrappedErrf(err,
 				"failed to find suitable search index for fk %q", ref.Name)
 		}
-		fk, err := makeFkExistenceCheckBaseHelper(txn, otherTables, ref, searchIdx, mutatedIdx, colMap, alloc, CheckInserts)
+		fk, err := makeFkExistenceCheckBaseHelper(ctx, txn, otherTables, ref, searchIdx, mutatedIdx, colMap, alloc,
+			CheckInserts)
 		if err == errSkipUnusedFK {
 			continue
 		}

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // KVFetcher wraps kvBatchFetcher, providing a NextKV interface that returns the
@@ -30,9 +31,11 @@ type KVFetcher struct {
 	bytesRead     int64
 	Span          roachpb.Span
 	newSpan       bool
+	acc           mon.BoundAccount
 }
 
 // NewKVFetcher creates a new KVFetcher.
+// If mon is non-nil, this fetcher will track its fetches and must be Closed.
 func NewKVFetcher(
 	txn *kv.Txn,
 	spans roachpb.Spans,
@@ -41,17 +44,22 @@ func NewKVFetcher(
 	firstBatchLimit int64,
 	lockStr sqlbase.ScanLockingStrength,
 	returnRangeInfo bool,
+	mon *mon.BytesMonitor,
 ) (*KVFetcher, error) {
 	kvBatchFetcher, err := makeKVBatchFetcher(
-		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStr, returnRangeInfo,
+		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStr, returnRangeInfo, mon,
 	)
-	return newKVFetcher(&kvBatchFetcher), err
+	return newKVFetcher(&kvBatchFetcher, mon), err
 }
 
-func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
-	return &KVFetcher{
+func newKVFetcher(batchFetcher kvBatchFetcher, mon *mon.BytesMonitor) *KVFetcher {
+	ret := &KVFetcher{
 		kvBatchFetcher: batchFetcher,
 	}
+	if mon != nil {
+		ret.acc = mon.MakeBoundAccount()
+	}
+	return ret
 }
 
 // NextKV returns the next kv from this fetcher. Returns false if there are no
@@ -84,14 +92,55 @@ func (f *KVFetcher) NextKV(
 			}, newSpan, nil
 		}
 
+		monitoring := f.acc.Monitor() != nil
+
+		const tokenFetchAllocation = 1 << 10
+		if monitoring && f.acc.Used() < tokenFetchAllocation {
+			// Pre-reserve a token fraction of the maximum amount of memory this scan
+			// could return. Most of the time, scans won't use this amount of memory,
+			// so it's unnecessary to reserve it all. We reserve something rather than
+			// nothing at all to preserve some accounting.
+			if err := f.acc.ResizeTo(ctx, tokenFetchAllocation); err != nil {
+				return ok, kv, false, err
+			}
+		}
 		ok, f.kvs, f.batchResponse, f.Span, err = f.nextBatch(ctx)
 		if err != nil {
 			return ok, kv, false, err
+		}
+		returnedBytes := int64(len(f.batchResponse))
+		if monitoring && returnedBytes > f.acc.Used() {
+			// Resize up to the actual amount of bytes we got back from the fetch,
+			// but don't ratchet down. We would much prefer to over-account, and the
+			// worst we can over-account by is around 10 MB, the maximum fetch size.
+			//
+			// The reason we don't want to precisely account here is to hopefully
+			// protect ourselves from "slop" in our memory handling. In general, we
+			// expect that all SQL operators that buffer data for longer than a single
+			// call to Next do their own accounting, so theoretically, by the time
+			// this fetch method is called again, all memory will either be released
+			// from the system or accounted for elsewhere. In reality, though, Go's
+			// garbage collector has some lag between when the memory is no longer
+			// referenced and when it is freed. Also, we're not perfect with
+			// accounting by any means. When we start doing large fetches, it's more
+			// likely that we'll expose ourselves to OOM conditions, so that's the
+			// reasoning for why we never ratchet this account down - only up, toward
+			// the maximum fetch size (maxScanResponseBytes).
+			if err := f.acc.ResizeTo(ctx, returnedBytes); err != nil {
+				return ok, kv, false, err
+			}
 		}
 		if !ok {
 			return false, kv, false, nil
 		}
 		f.newSpan = true
-		f.bytesRead += int64(len(f.batchResponse))
+		f.bytesRead += returnedBytes
 	}
+}
+
+// Close releases the resources held by this KVFetcher. It must be called
+// at the end of execution if the fetcher was provisioned with a memory
+// monitor.
+func (f *KVFetcher) Close(ctx context.Context) {
+	f.acc.Close(ctx)
 }

--- a/pkg/sql/rowexec/index_skip_table_reader.go
+++ b/pkg/sql/rowexec/index_skip_table_reader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/pkg/errors"
 )
 
@@ -124,12 +125,18 @@ func newIndexSkipTableReader(
 		ValNeededForCol:  neededColumns,
 	}
 
+	var memMon *mon.BytesMonitor
+	if accountForKVBytes.Get(&flowCtx.EvalCtx.Settings.SV) {
+		memMon = flowCtx.EvalCtx.Mon
+	}
 	if err := t.fetcher.Init(
+		flowCtx.EvalCtx.Context,
 		t.reverse,
 		spec.LockingStrength,
 		true,  /* returnRangeInfo */
 		false, /* isCheck */
 		&t.alloc,
+		memMon, /* memMon */
 		tableArgs,
 	); err != nil {
 		return nil, err
@@ -248,15 +255,21 @@ func (t *indexSkipTableReader) Release() {
 }
 
 func (t *indexSkipTableReader) ConsumerClosed() {
-	t.InternalClose()
+	t.close()
 }
 
 func (t *indexSkipTableReader) generateTrailingMeta(
 	ctx context.Context,
 ) []execinfrapb.ProducerMetadata {
 	trailingMeta := t.generateMeta(ctx)
-	t.InternalClose()
+	t.close()
 	return trailingMeta
+}
+
+func (t *indexSkipTableReader) close() {
+	if t.InternalClose() {
+		t.fetcher.Close(t.Ctx)
+	}
 }
 
 func (t *indexSkipTableReader) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -121,7 +121,7 @@ func newScrubTableReader(
 
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
-		&fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(), spec.Reverse,
+		flowCtx.EvalCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(), spec.Reverse,
 		neededColumns, true /* isCheck */, &tr.alloc,
 		execinfrapb.ScanVisibility_PUBLIC, spec.LockingStrength,
 	); err != nil {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -293,7 +293,14 @@ func newZigzagJoiner(
 		0, /* numMerged */
 		post,
 		output,
-		execinfra.ProcStateOpts{}, // zigzagJoiner doesn't have any inputs to drain.
+		execinfra.ProcStateOpts{
+			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+				// producerMeta appends any extra metadata to the z.returnedMeta
+				// field, so we can just return that afterwards.
+				z.producerMeta(nil /* err */)
+				return z.returnedMeta
+			},
+		}, // zigzagJoiner doesn't have any inputs to drain.
 	)
 	if err != nil {
 		return nil, err
@@ -442,6 +449,7 @@ func (z *zigzagJoiner) setupInfo(
 
 	// Setup the Fetcher.
 	_, _, err := initRowFetcher(
+		z.FlowCtx.EvalCtx,
 		&(info.fetcher),
 		info.table,
 		int(indexOrdinal),
@@ -471,9 +479,10 @@ func (z *zigzagJoiner) setupInfo(
 }
 
 func (z *zigzagJoiner) close() {
-	if z.InternalClose() {
-		log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
+	for i := range z.infos {
+		z.infos[i].fetcher.Close(z.Ctx)
 	}
+	log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
 }
 
 // producerMeta constructs the ProducerMetadata after consumption of rows has
@@ -482,7 +491,7 @@ func (z *zigzagJoiner) close() {
 // nil indicating that we're done producing rows even though no error occurred.
 func (z *zigzagJoiner) producerMeta(err error) *execinfrapb.ProducerMetadata {
 	var meta *execinfrapb.ProducerMetadata
-	if !z.Closed {
+	if z.InternalClose() {
 		if err != nil {
 			meta = &execinfrapb.ProducerMetadata{Err: err}
 		} else if trace := execinfra.GetTraceData(z.Ctx); trace != nil {
@@ -962,7 +971,9 @@ func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 // ConsumerClosed is part of the RowSource interface.
 func (z *zigzagJoiner) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
-	z.close()
+	if z.InternalClose() {
+		z.close()
+	}
 }
 
 // DrainMeta is part of the MetadataSource interface.

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -165,6 +165,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 		ValNeededForCol: valNeededForCol,
 	}
 	if err := rf.Init(
+		ctx,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will
@@ -173,6 +174,8 @@ func (td *tableDeleter) deleteAllRowsScan(
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		td.alloc,
+		// TODO(bulkio): this might need a memory monitor for the slow case of truncate.
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return resume, err
@@ -285,6 +288,7 @@ func (td *tableDeleter) deleteIndexScan(
 		ValNeededForCol: valNeededForCol,
 	}
 	if err := rf.Init(
+		ctx,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will
@@ -293,6 +297,8 @@ func (td *tableDeleter) deleteIndexScan(
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		td.alloc,
+		// TODO(bulkio): this might need a memory monitor.
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return resume, err


### PR DESCRIPTION
Backport 1/1 commits from #52496.

/cc @cockroachdb/release

---

This commit adds a memory monitor to the kv fetcher infrastructure
that's initialized by its users. When kv fetches occur, the new
infrastructure ensure that there's always at least 1 kilobyte allocated
for the fetch before it happens. Once the fetch returns, the accounting
is adjusted to include the entire size of the fetch. Subsequent fetches
that return less memory do *not* ratchet down the allocation size to
preserve safety and reduce some pointless allocation adjustment
churning.

Closes #51551.

Release note (sql change): the memory used by disk scans is accounted
for, reducing the likelihood of out of memory conditions that result in
process crashes as opposed to SQL out of memory error messages.

Release justification: fixes for high-priority bugs in existing functionality

