### PR TITLE
roachtest: log teardown to different file

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -755,9 +755,21 @@ func (r *testRunner) runTest(
 		t.spec.Run(runCtx, t, c)
 	}()
 
+	teardownL, err := c.l.ChildLogger("teardown", quietStderr, quietStdout)
+	if err != nil {
+		return false, err
+	}
 	select {
 	case <-done:
+		s := "success"
+		if t.Failed() {
+			s = "failure"
+		}
+		c.l.Printf("tearing down after %s; see teardown.log", s)
+		l, c.l, t.l = teardownL, teardownL, teardownL
 	case <-time.After(timeout):
+		c.l.Printf("tearing down after timeout; see teardown.log")
+		l, c.l, t.l = teardownL, teardownL, teardownL
 		// Timeouts are often opaque. Improve our changes by dumping the stack
 		// so that at least we can piece together what the test is trying to
 		// do at this very moment.


### PR DESCRIPTION
We perform various operations on teardown which typically produce a few
pages of log output (dead nodes, consistency, getting logs, ...).
These tend to make the real test failure harder to find, so this
commit switches out the loggers before we perform teardown; teardown
will log to `teardown.log` instead. The main log (`test.log`) now
ends as follows:

```
[...]
09:41:06 allocator.go:315: 0 mis-replicated ranges
09:41:07 test.go:337: test failure: 	allocator.go:321,test_runner.go:755: boom!
09:41:07 test_runner.go:769: tearing down after failure; see teardown.log
```

Release note: None
