### PR TITLE
build: bump timeout for SQL Race Logic tests to 4 hours

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,7 +8,7 @@ maybe_ccache
 
 mkdir -p artifacts
 
-TESTTIMEOUT=2h
+TESTTIMEOUT=4h
 
 run_json_test build/builder.sh \
   stdbuf -oL -eL \


### PR DESCRIPTION
The test is still timing out after 2 hours, so this commit bumps the
timeout to 4 hours.

Release note: None