### PR TITLE
[DNM] kv: add environment variable to inject retries

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1073,6 +1073,7 @@ func (r *Registry) stepThroughStateMachine(
 				return err
 			}
 		}
+		resumeCtx = kv.ContextWithInjectRetry(ctx)
 		err := resumer.Resume(resumeCtx, phs, resultsCh)
 		if err == nil {
 			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusSucceeded, nil)


### PR DESCRIPTION
This patch extends the testserver to inject retry errors in calls to send
batch requests at a rate indicated by an environment variable. This should
help us uncover bugs due to bad handling of transaction retries.

Release note: None