### PR TITLE
storage: skip extra encoding in pebbleMVCCScanner

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -152,6 +152,11 @@ func (i *Iterator) UnsafeKey() storage.MVCCKey {
 	return i.i.UnsafeKey()
 }
 
+// UnsafeRawKey is part of the engine.Iterator interface.
+func (i *Iterator) UnsafeRawKey() []byte {
+	return i.i.UnsafeRawKey()
+}
+
 // UnsafeValue is part of the engine.Iterator interface.
 func (i *Iterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -92,6 +92,8 @@ type Iterator interface {
 	Prev()
 	// Key returns the current key.
 	Key() MVCCKey
+	// UnsafeRawKey returns the current raw key (i.e. the encoded MVCC key).
+	UnsafeRawKey() []byte
 	// Value returns the current value as a byte slice.
 	Value() []byte
 	// ValueProto unmarshals the value the iterator is currently

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -270,7 +270,6 @@ func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) erro
 		panic("distinct batch open")
 	}
 
-	type unsafeRawKeyGetter interface{ unsafeRawKey() []byte }
 	// Note that this method has the side effect of modifying iter's bounds.
 	// Since all calls to `ClearIterRange` are on new throwaway iterators with no
 	// lower bounds, calling SetUpperBound should be sufficient and safe.
@@ -287,7 +286,7 @@ func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) erro
 			break
 		}
 
-		err = p.batch.Delete(iter.(unsafeRawKeyGetter).unsafeRawKey(), nil)
+		err = p.batch.Delete(iter.UnsafeRawKey(), nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -237,8 +237,8 @@ func (p *pebbleIterator) UnsafeKey() MVCCKey {
 	return mvccKey
 }
 
-// unsafeRawKey returns the raw key from the underlying pebble.Iterator.
-func (p *pebbleIterator) unsafeRawKey() []byte {
+// UnsafeRawKey returns the raw key from the underlying pebble.Iterator.
+func (p *pebbleIterator) UnsafeRawKey() []byte {
 	return p.iter.Key()
 }
 

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -1299,6 +1299,10 @@ func (r *batchIterator) UnsafeKey() MVCCKey {
 	return r.iter.UnsafeKey()
 }
 
+func (r *batchIterator) UnsafeRawKey() []byte {
+	return r.iter.UnsafeRawKey()
+}
+
 func (r *batchIterator) UnsafeValue() []byte {
 	return r.iter.UnsafeValue()
 }
@@ -2025,6 +2029,10 @@ func (r *rocksDBIterator) ValueProto(msg protoutil.Message) error {
 
 func (r *rocksDBIterator) UnsafeKey() MVCCKey {
 	return cToUnsafeGoKey(r.key)
+}
+
+func (r *rocksDBIterator) UnsafeRawKey() []byte {
+	panic("unimplemented; only meant to be used with Pebble")
 }
 
 func (r *rocksDBIterator) UnsafeValue() []byte {

--- a/pkg/storage/tee.go
+++ b/pkg/storage/tee.go
@@ -1166,11 +1166,9 @@ func (t *TeeEngineIter) Key() MVCCKey {
 	return t.iter1.Key()
 }
 
-func (t *TeeEngineIter) unsafeRawKey() []byte {
-	type unsafeRawKeyGetter interface {
-		unsafeRawKey() []byte
-	}
-	return t.iter1.(unsafeRawKeyGetter).unsafeRawKey()
+// UnsafeRawKey implements the Iterator interface.
+func (t *TeeEngineIter) UnsafeRawKey() []byte {
+	return t.iter1.UnsafeRawKey()
 }
 
 // Value implements the Iterator interface.


### PR DESCRIPTION
Previously, we were re-encoding decoded keys in `pebbleMVCCScanner`.

This unnecessary encoding showed up on CPU profiles.

This change avoids the extra encoding by using `rawKey` instead of
`MVCCKey`.

Fixes #49145

Release note: None