### PR TITLE
roachtest: (re-)skip flaky election-after-restart test

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -22,6 +22,7 @@ func registerElectionAfterRestart(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "election-after-restart",
 		Owner:   OwnerKV,
+		Skip:    "https://github.com/cockroachdb/cockroach/issues/54246",
 		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			skip.UnderRace(t, "race builds make this test exceed its timeout")


### PR DESCRIPTION
See #54246. It was unskipped recently, but it's still flakey (with the
same symptoms from over a year ago).

Release note: None