### PR TITLE
release-20.2: protectedts: adds hint pointing to the cluster settings that control protectedts

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -91,14 +91,18 @@ func (p *storage) Protect(ctx context.Context, txn *kv.Txn, r *ptpb.Record) erro
 	if failed := *row[0].(*tree.DBool); failed {
 		curNumSpans := int64(*row[1].(*tree.DInt))
 		if curNumSpans+int64(len(r.Spans)) > s.maxSpans {
-			return errors.Errorf("protectedts: limit exceeded: %d+%d > %d spans",
-				curNumSpans, len(r.Spans), s.maxSpans)
+			return errors.WithHint(
+				errors.Errorf("protectedts: limit exceeded: %d+%d > %d spans", curNumSpans,
+					len(r.Spans), s.maxSpans),
+				"SET CLUSTER SETTING kv.protectedts.max_spans to a higher value")
 		}
 		curBytes := int64(*row[2].(*tree.DInt))
 		recordBytes := int64(len(encodedSpans) + len(r.Meta) + len(r.MetaType))
 		if curBytes+recordBytes > s.maxBytes {
-			return errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes",
-				curBytes, recordBytes, s.maxBytes)
+			return errors.WithHint(
+				errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes", curBytes, recordBytes,
+					s.maxBytes),
+				"SET CLUSTER SETTING kv.protectedts.max_bytes to a higher value")
 		}
 		return protectedts.ErrExists
 	}


### PR DESCRIPTION
Backport 1/1 commits from #54694.

/cc @cockroachdb/release

---

We have seen a couple of instances where the limits imposed
on the number of spans and byte size of spans whose ts can be protected
have proved to be low, especially during BACKUPs.

While the error states the current limit and what the system is attempting
to protect, it does not indicate how the limit can be tweaked. This change
adds a hint, pointing the user to the cluster setting.

Fixes: #54674

Release note: None
