### PR TITLE
sql: schemas only inherit valid privileges from db

### DIFF
--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -95,8 +95,12 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 		return err
 	}
 
-	// Inherit the parent privileges.
+	// Inherit the parent privileges and filter out those which are not valid for
+	// schemas.
 	privs := protoutil.Clone(db.GetPrivileges()).(*descpb.PrivilegeDescriptor)
+	for i := range privs.Users {
+		privs.Users[i].Privileges &= privilege.SchemaPrivileges.ToBitField()
+	}
 
 	if n.AuthRole != "" {
 		exists, err := p.RoleExists(params.ctx, n.AuthRole)

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -533,3 +533,29 @@ query I colnames
 SELECT * FROM testuser.test_table
 ----
 a
+
+# Ensure that when we create a schema, it inherits privileges from its parent
+# database, but only those which are valid for schemas.
+subtest create_schema_inherits_db_privileges
+
+user root
+
+statement ok
+CREATE DATABASE d54662;
+GRANT CREATE, SELECT ON DATABASE d54662 TO testuser;
+USE d54662;
+CREATE SCHEMA s
+
+query T
+SELECT privilege_type FROM [SHOW GRANTS ON schema s FOR testuser]
+----
+CREATE
+
+statement ok
+GRANT USAGE ON SCHEMA s TO testuser
+
+query T rowsort
+SELECT privilege_type FROM [SHOW GRANTS ON schema s FOR testuser]
+----
+CREATE
+USAGE


### PR DESCRIPTION
When a new user-defined schema is created, it inherits privileges from
its parent database. However, we were not restricting this to privileges
which are valid for schemas. This meant that the schema could inherit
inappropriate privileges like SELECT, which caused validation errors
down the line. Now we filter out such privileges.

Fixes #54662

Release note: None