### PR TITLE
workload: add back injection of stats for TPC-C tables at start of workload

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -448,6 +448,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange}
 			},
 		)),
+		Stats: w.tpccWarehouseStats(),
 	}
 	district := workload.Table{
 		Name: `district`,
@@ -466,6 +467,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange, 0}
 			},
 		)),
+		Stats: w.tpccDistrictStats(),
 	}
 	customer := workload.Table{
 		Name: `customer`,
@@ -497,6 +499,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange}
 			},
 		)),
+		Stats: w.tpccHistoryStats(),
 	}
 	order := workload.Table{
 		Name: `order`,
@@ -509,6 +512,7 @@ func (w *tpcc) Tables() []workload.Table {
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccOrderInitialRowBatch,
 		},
+		Stats: w.tpccOrderStats(),
 	}
 	newOrder := workload.Table{
 		Name:   `new_order`,


### PR DESCRIPTION
This commit adds back the injection of statistics for some tables at the
start of the TPC-C workload that had been removed by mistake in #35349.
The removal caused a regression in TPC-C since it caused some plans to change
due to the lack of statistics at the beginning of the benchmark. Adding the
stats back should fix the regression.

Fixes #54702

Release note: None