### PR TITLE
release-20.1: workload: add back injection of stats for TPC-C tables at start of workload

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -433,6 +433,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange}
 			},
 		)),
+		Stats: w.tpccWarehouseStats(),
 	}
 	district := workload.Table{
 		Name: `district`,
@@ -451,6 +452,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange, 0}
 			},
 		)),
+		Stats: w.tpccDistrictStats(),
 	}
 	customer := workload.Table{
 		Name: `customer`,
@@ -482,6 +484,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return []interface{}{(i + 1) * numWarehousesPerRange}
 			},
 		)),
+		Stats: w.tpccHistoryStats(),
 	}
 	order := workload.Table{
 		Name: `order`,
@@ -494,6 +497,7 @@ func (w *tpcc) Tables() []workload.Table {
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccOrderInitialRowBatch,
 		},
+		Stats: w.tpccOrderStats(),
 	}
 	newOrder := workload.Table{
 		Name:   `new_order`,


### PR DESCRIPTION
Backport 1/1 commits from #54713.

/cc @cockroachdb/release

---

This commit adds back the injection of statistics for some tables at the
start of the TPC-C workload that had been removed by mistake in #35349.
The removal caused a regression in TPC-C since it caused some plans to change
due to the lack of statistics at the beginning of the benchmark. Adding the
stats back should fix the regression.

Fixes #54702

Release note: None
