### PR TITLE
rowexec: introduce a helper for hashing EncDatumRows

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -80,7 +80,7 @@ func (d *Datum) Cast(dVec interface{}, toType *types.T) (tree.Datum, error) {
 // Hash returns the hash of the datum as a byte slice.
 func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	ed := rowenc.EncDatum{Datum: maybeUnwrapDatum(d)}
-	b, err := ed.Fingerprint(d.ResolvedType(), da, nil /* appendTo */)
+	b, err := ed.Fingerprint(d.ResolvedType(), da, descpb.DatumEncoding_ASCENDING_KEY, nil /* appendTo */)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -24,6 +24,9 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+// TODO(yuzefovich): methods in this file do *not* perform memory accounting
+// of the newly allocated tree.Datums. This should be fixed.
+
 // VecToDatumConverter is a helper struct that converts vectors from batches to
 // their datum representations.
 // TODO(yuzefovich): the result of converting the vectors to datums is usually

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -27,6 +27,9 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+// TODO(yuzefovich): methods in this file do *not* perform memory accounting
+// of the newly allocated tree.Datums. This should be fixed.
+
 // VecToDatumConverter is a helper struct that converts vectors from batches to
 // their datum representations.
 // TODO(yuzefovich): the result of converting the vectors to datums is usually

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
@@ -355,7 +356,7 @@ func (b *distinctAggregatorHelperBase) selectDistinctTuples(
 		for _, colIdx := range inputIdxs {
 			b.scratch.ed.Datum = b.aggColsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
 			b.scratch.encoded, err = b.scratch.ed.Fingerprint(
-				b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded,
+				b.inputTypes[colIdx], b.datumAlloc, descpb.DatumEncoding_ASCENDING_KEY, b.scratch.encoded,
 			)
 			if err != nil {
 				colexecerror.InternalError(err)

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -204,7 +205,8 @@ func (d *distinct) encode(appendTo []byte, row rowenc.EncDatumRow) ([]byte, erro
 			continue
 		}
 
-		appendTo, err = datum.Fingerprint(d.types[i], &d.datumAlloc, appendTo)
+		// TODO(yuzefovich): reuse the helper here.
+		appendTo, err = datum.Fingerprint(d.types[i], &d.datumAlloc, descpb.DatumEncoding_ASCENDING_KEY, appendTo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -524,7 +525,10 @@ func (s *sketchInfo) addRow(
 		isNull := true
 		*buf = (*buf)[:0]
 		for _, col := range s.spec.Columns {
-			*buf, err = row[col].Fingerprint(typs[col], da, *buf)
+			// TODO(yuzefovich): we might decode the encoded datum (meaning we
+			// might incur an allocation) that is not accounted for. That
+			// should be fixed.
+			*buf, err = row[col].Fingerprint(typs[col], da, descpb.DatumEncoding_ASCENDING_KEY, *buf)
 			isNull = isNull && row[col].IsNull()
 			if err != nil {
 				return err


### PR DESCRIPTION
This commit introduces a helper that can fingerprint rows on a subset of
columns while taking advantage of already present encoding. For example,
previously if the incoming EncDatums had value encoding, we would always
decode them and encode tree.Datums using key ASC encoding; however, the
helper will track whether there was an encoded representation already
available on the first row and will be using that type of encoding
later. In the example, it would realize that value encoding is present
on the first row, and all consequent EncDatums will be fingerprinted
using value encoding. This should be more efficient given the assumption
that we expect for a stream of EncDatums have the same type of encoding.

The helper is now utilized by the hash aggregator, windower, and hash
router. Additionally, we will now be performing the memory accounting
for those decoded datums during fingerprinting in the hash aggregator
and windower. That might lead to partial over-accounting which is
acceptable given we usually tend to under-account.

TODO: update description.

Addresses: #54360.

Release note: None