### PR TITLE
rowexec: optimize partially ordered distinct

### DIFF
--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -40,8 +39,12 @@ type distinct struct {
 	lastGroupKey     rowenc.EncDatumRow
 	arena            stringarena.Arena
 	seen             map[string]struct{}
-	orderedCols      []uint32
-	distinctCols     util.FastIntSet
+	distinctCols     struct {
+		// ordered and nonOrdered are such that their union determines the set
+		// of distinct columns and their intersection is empty.
+		ordered    []uint32
+		nonOrdered []uint32
+	}
 	memAcc           mon.BoundAccount
 	datumAlloc       rowenc.DatumAlloc
 	scratch          []byte
@@ -53,7 +56,7 @@ type distinct struct {
 // sortedDistinct is a specialized distinct that can be used when all of the
 // distinct columns are also ordered.
 type sortedDistinct struct {
-	distinct
+	*distinct
 }
 
 var _ execinfra.Processor = &distinct{}
@@ -81,52 +84,36 @@ func newDistinct(
 		return nil, errors.AssertionFailedf("0 distinct columns specified for distinct processor")
 	}
 
-	var distinctCols, orderedCols util.FastIntSet
-	allSorted := true
-
-	for _, col := range spec.OrderedColumns {
-		orderedCols.Add(int(col))
-	}
+	nonOrderedCols := make([]uint32, 0, len(spec.DistinctColumns)-len(spec.OrderedColumns))
 	for _, col := range spec.DistinctColumns {
-		if !orderedCols.Contains(int(col)) {
-			allSorted = false
+		ordered := false
+		for _, ordCol := range spec.OrderedColumns {
+			if col == ordCol {
+				ordered = true
+				break
+			}
 		}
-		distinctCols.Add(int(col))
-	}
-	if !orderedCols.SubsetOf(distinctCols) {
-		return nil, errors.AssertionFailedf("ordered cols must be a subset of distinct cols")
+		if !ordered {
+			nonOrderedCols = append(nonOrderedCols, col)
+		}
 	}
 
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem")
 	d := &distinct{
 		input:            input,
-		orderedCols:      spec.OrderedColumns,
-		distinctCols:     distinctCols,
 		memAcc:           memMonitor.MakeBoundAccount(),
 		types:            input.OutputTypes(),
 		nullsAreDistinct: spec.NullsAreDistinct,
 		errorOnDup:       spec.ErrorOnDup,
 	}
+	d.distinctCols.ordered = spec.OrderedColumns
+	d.distinctCols.nonOrdered = nonOrderedCols
 
 	var returnProcessor execinfra.RowSourcedProcessor = d
-	if allSorted {
+	if len(nonOrderedCols) == 0 {
 		// We can use the faster sortedDistinct processor.
-		// TODO(asubiotto): We should have a distinctBase, rather than making a copy
-		// of a distinct processor.
-		sd := &sortedDistinct{
-			distinct: distinct{
-				input:            input,
-				orderedCols:      spec.OrderedColumns,
-				distinctCols:     distinctCols,
-				memAcc:           memMonitor.MakeBoundAccount(),
-				types:            input.OutputTypes(),
-				nullsAreDistinct: spec.NullsAreDistinct,
-				errorOnDup:       spec.ErrorOnDup,
-			},
-		}
-		// Set d to the new distinct copy for further initialization.
-		d = &sd.distinct
+		sd := &sortedDistinct{distinct: d}
 		returnProcessor = sd
 	}
 
@@ -172,7 +159,7 @@ func (d *distinct) matchLastGroupKey(row rowenc.EncDatumRow) (bool, error) {
 	if !d.haveLastGroupKey {
 		return false, nil
 	}
-	for _, colIdx := range d.orderedCols {
+	for _, colIdx := range d.distinctCols.ordered {
 		res, err := d.lastGroupKey[colIdx].Compare(
 			d.types[colIdx], &d.datumAlloc, d.EvalCtx, &row[colIdx],
 		)
@@ -195,16 +182,9 @@ func (d *distinct) matchLastGroupKey(row rowenc.EncDatumRow) (bool, error) {
 func (d *distinct) encode(appendTo []byte, row rowenc.EncDatumRow) ([]byte, error) {
 	var err error
 	foundNull := false
-	for i, datum := range row {
-		// Ignore columns that are not in the distinctCols, as if we are
-		// post-processing to strip out column Y, we cannot include it as
-		// (X1, Y1) and (X1, Y2) will appear as distinct rows, but if we are
-		// stripping out Y, we do not want (X1) and (X1) to be in the results.
-		if !d.distinctCols.Contains(i) {
-			continue
-		}
-
-		appendTo, err = datum.Fingerprint(d.types[i], &d.datumAlloc, appendTo)
+	for _, colIdx := range d.distinctCols.nonOrdered {
+		datum := row[colIdx]
+		appendTo, err = datum.Fingerprint(d.types[colIdx], &d.datumAlloc, appendTo)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This commit optimizes the partially ordered distinct by fixing a bug in
the implementation of the optimization's intention. When we have
partially ordered input stream, it is sufficient to only hash
non-ordered columns in order to distinguish between the rows. That has
also been the intention, but we actually hashed all distinct columns.
This is now fixed which gives a minor speedup.

Release note: None