### PR TITLE
cli: support `-f` to read SQL from a file

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -64,7 +64,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		checkInteractive()
+		checkInteractive(os.Stdin)
 		if cliCtx.isInteractive {
 			fmt.Fprintf(stderr, `#
 # Example uses:

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -127,10 +127,6 @@ func (e *cliError) FormatError(p errors.Printer) error {
 // to be captured.
 var stderr = log.OrigStderr
 
-// stdin aliases os.Stdin; we use an alias here so that tests in this
-// package can redirect the input of the CLI shell.
-var stdin = os.Stdin
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "output version information",

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2060,3 +2060,32 @@ func Example_dump_no_visible_columns() {
 	// CREATE TABLE public.t (FAMILY "primary" (rowid)
 	// );
 }
+
+// Example_read_from_file tests the -f parameter.
+// The input file contains a mix of client-side and
+// server-side commands to ensure that both are supported with -f.
+func Example_read_from_file() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	c.RunWithArgs([]string{"sql", "-e", "select 1", "-f", "testdata/inputfile.sql"})
+	c.RunWithArgs([]string{"sql", "-f", "testdata/inputfile.sql"})
+
+	// Output:
+	// sql -e select 1 -f testdata/inputfile.sql
+	// ERROR: unsupported combination: --execute and --file
+	// sql -f testdata/inputfile.sql
+	// SET
+	// CREATE TABLE
+	// > INSERT INTO test(s) VALUES ('hello'), ('world');
+	// INSERT 2
+	// > SELECT * FROM test;
+	// s
+	// hello
+	// world
+	// > SELECT undefined;
+	// ERROR: column "undefined" does not exist
+	// SQLSTATE: 42703
+	// ERROR: column "undefined" does not exist
+	// SQLSTATE: 42703
+}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -256,7 +256,20 @@ Execute the SQL statement(s) on the command line, then exit. This flag may be
 specified multiple times and each value may contain multiple semicolon
 separated statements. If an error occurs in any statement, the command exits
 with a non-zero status code and further statements are not executed. The
-results of each SQL statement are printed on the standard output.`,
+results of each SQL statement are printed on the standard output.
+
+This flag is incompatible with --file / -f.`,
+	}
+
+	File = FlagInfo{
+		Name:      "file",
+		Shorthand: "f",
+		Description: `
+Read and execute the SQL statement(s) from the specified file.
+The file is processed as if it has been redirected on the standard
+input of the shell.
+
+This flag is incompatible with --execute / -e.`,
 	}
 
 	Watch = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -204,7 +204,13 @@ var sqlCtx = struct {
 	setStmts statementsValue
 
 	// execStmts is a list of statements to execute.
+	// Only valid if inputFile is empty.
 	execStmts statementsValue
+
+	// inputFile is the file to read from.
+	// If empty, os.Stdin is used.
+	// Only valid if execStmts is empty.
+	inputFile string
 
 	// repeatDelay indicates that the execStmts should be "watched"
 	// at the specified time interval. Zero disables
@@ -240,6 +246,7 @@ var sqlCtx = struct {
 func setSQLContextDefaults() {
 	sqlCtx.setStmts = nil
 	sqlCtx.execStmts = nil
+	sqlCtx.inputFile = ""
 	sqlCtx.repeatDelay = 0
 	sqlCtx.safeUpdates = false
 	sqlCtx.showTimes = false

--- a/pkg/cli/decode.go
+++ b/pkg/cli/decode.go
@@ -26,13 +26,13 @@ import (
 )
 
 func runDebugDecodeProto(_ *cobra.Command, _ []string) error {
-	if isatty.IsTerminal(stdin.Fd()) {
+	if isatty.IsTerminal(os.Stdin.Fd()) {
 		fmt.Fprintln(stderr,
 			`# Reading proto-encoded pieces of data from stdin.
 # Press Ctrl+C or Ctrl+D to terminate.`,
 		)
 	}
-	return streamMap(os.Stdout, stdin,
+	return streamMap(os.Stdout, os.Stdin,
 		func(s string) (bool, string, error) { return tryDecodeValue(s, debugDecodeProtoName) })
 }
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -253,6 +252,12 @@ func checkDemoConfiguration(
 }
 
 func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
+	cmdIn, closeFn, err := getInputFile()
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
 	if gen, err = checkDemoConfiguration(cmd, gen); err != nil {
 		return err
 	}
@@ -283,7 +288,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 	}
 	demoCtx.transientCluster = &c
 
-	checkInteractive(os.Stdin)
+	checkInteractive(cmdIn)
 
 	if cliCtx.isInteractive {
 		fmt.Printf(`#
@@ -359,7 +364,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 	conn := makeSQLConn(c.connURL)
 	defer conn.Close()
 
-	return runClient(cmd, conn)
+	return runClient(cmd, conn, cmdIn)
 }
 
 func waitForLicense(licenseDone <-chan error) error {

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -282,7 +283,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 	}
 	demoCtx.transientCluster = &c
 
-	checkInteractive()
+	checkInteractive(os.Stdin)
 
 	if cliCtx.isInteractive {
 		fmt.Printf(`#

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -656,6 +656,7 @@ func init() {
 		f := cmd.Flags()
 		varFlag(f, &sqlCtx.setStmts, cliflags.Set)
 		varFlag(f, &sqlCtx.execStmts, cliflags.Execute)
+		stringFlag(f, &sqlCtx.inputFile, cliflags.File)
 		durationFlag(f, &sqlCtx.repeatDelay, cliflags.Watch)
 		boolFlag(f, &sqlCtx.safeUpdates, cliflags.SafeUpdates)
 		boolFlag(f, &sqlCtx.debugMode, cliflags.CliDebugMode)

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1271,7 +1271,7 @@ func (c *cliState) doDecidePath() cliStateEnum {
 
 // runInteractive runs the SQL client interactively, presenting
 // a prompt to the user for each statement.
-func runInteractive(conn *sqlConn) (exitErr error) {
+func runInteractive(conn *sqlConn, cmdIn *os.File) (exitErr error) {
 	c := cliState{conn: conn}
 
 	state := cliStart
@@ -1281,7 +1281,7 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 		}
 		switch state {
 		case cliStart:
-			cleanupFn, err := c.configurePreShellDefaults()
+			cleanupFn, err := c.configurePreShellDefaults(cmdIn)
 			defer cleanupFn()
 			if err != nil {
 				return err
@@ -1340,7 +1340,7 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 //
 // The returned cleanupFn must be called even when the err return is
 // not nil.
-func (c *cliState) configurePreShellDefaults() (cleanupFn func(), err error) {
+func (c *cliState) configurePreShellDefaults(cmdIn *os.File) (cleanupFn func(), err error) {
 	if cliCtx.terminalOutput {
 		// If results are shown on a terminal also enable printing of
 		// times by default.
@@ -1373,11 +1373,11 @@ func (c *cliState) configurePreShellDefaults() (cleanupFn func(), err error) {
 		// the doStart() method because of the defer.
 		c.ins, c.exitErr = readline.InitFiles("cockroach",
 			true, /* wideChars */
-			stdin, os.Stdout, stderr)
+			cmdIn, os.Stdout, stderr)
 		if errors.Is(c.exitErr, readline.ErrWidecharNotSupported) {
 			log.Warning(context.TODO(), "wide character support disabled")
 			c.ins, c.exitErr = readline.InitFiles("cockroach",
-				false, stdin, os.Stdout, stderr)
+				false, cmdIn, os.Stdout, stderr)
 		}
 		if c.exitErr != nil {
 			return cleanupFn, c.exitErr
@@ -1391,7 +1391,7 @@ func (c *cliState) configurePreShellDefaults() (cleanupFn func(), err error) {
 		cleanupFn = func() { c.ins.Close() }
 	} else {
 		c.ins = noLineEditor
-		c.buf = bufio.NewReader(stdin)
+		c.buf = bufio.NewReader(cmdIn)
 		cleanupFn = func() {}
 	}
 
@@ -1476,18 +1476,18 @@ func (c *cliState) runStatements(stmts []string) error {
 
 // checkInteractive sets the isInteractive parameter depending on the
 // execution environment and the presence of -e flags.
-func checkInteractive() {
+func checkInteractive(stdin *os.File) {
 	// We don't consider sessions interactives unless we have a
 	// serious hunch they are. For now, only `cockroach sql` *without*
 	// `-e` has the ability to input from a (presumably) human user,
 	// and we'll also assume that there is no human if the standard
 	// input is not terminal-like -- likely redirected from a file,
 	// etc.
-	cliCtx.isInteractive = len(sqlCtx.execStmts) == 0 && isatty.IsTerminal(os.Stdin.Fd())
+	cliCtx.isInteractive = len(sqlCtx.execStmts) == 0 && isatty.IsTerminal(stdin.Fd())
 }
 
 func runTerm(cmd *cobra.Command, args []string) error {
-	checkInteractive()
+	checkInteractive(os.Stdin)
 
 	if cliCtx.isInteractive {
 		// The user only gets to see the welcome message on interactive sessions.
@@ -1513,7 +1513,7 @@ func runClient(cmd *cobra.Command, conn *sqlConn) error {
 	// Enable safe updates, unless disabled.
 	setupSafeUpdates(cmd, conn)
 
-	return runInteractive(conn)
+	return runInteractive(conn, os.Stdin)
 }
 
 // setupSafeUpdates attempts to enable "safe mode" if the session is

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -71,7 +71,6 @@ select '''
 			f.Close()
 		}
 		_ = os.Remove(fname)
-		stdin = os.Stdin
 	}()
 
 	for _, test := range tests {
@@ -90,10 +89,7 @@ select '''
 			fmt.Fprintln(stderr, err)
 			return
 		}
-		// Override the standard input for runInteractive().
-		stdin = f
-
-		err := runInteractive(conn)
+		err := runInteractive(conn, f)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 		}

--- a/pkg/cli/testdata/inputfile.sql
+++ b/pkg/cli/testdata/inputfile.sql
@@ -1,0 +1,18 @@
+--- input file for Example_read_from_file.
+
+--- don't report timestamps: it makes the output non-deterministic.
+\unset show_times
+
+USE defaultdb;
+CREATE TABLE test(s STRING);
+
+-- make the reminder echo its SQL.
+\set echo
+INSERT INTO test(s) VALUES ('hello'), ('world');
+SELECT * FROM test;
+
+-- produce an error, to test that processing stops.
+SELECT undefined;
+
+-- this is not executed
+SELECT 'unseen';


### PR DESCRIPTION
Fixes #42955

Release note (cli change): `cockroach sql` and `cockroach demo` now
support the command-line parameter `--input-file` (shorthand `-f`) to
read commands from a named file. The behavior is the same as if the
file was redirected on the standard input; in particular, the
processing stops at the first error encountered (which is different
from interactive usage with a prompt).

Note that it is not (yet) possible to combine `-f` with `-e`.