### PR TITLE
pgwire: add server.max_connections public cluster setting

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -231,6 +231,10 @@ type Config struct {
 	// The flag exists mostly for the benefit of tests, and for
 	// `cockroach start-single-node`.
 	AutoInitializeCluster bool
+
+	// MaxSQLConns specifies the maximum allowed number of open SQL connections to
+	// the server.
+	MaxSQLConns int
 }
 
 // HistogramWindowInterval is used to determine the approximate length of time
@@ -270,6 +274,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.DisableClusterNameVerification = false
 	cfg.ClockDevicePath = ""
 	cfg.AcceptSQLWithoutTLS = false
+	cfg.MaxSQLConns = 0
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -100,6 +100,7 @@ type TestServerArgs struct {
 	TimeSeriesQueryMemoryBudget int64
 	SQLMemoryPoolSize           int64
 	CacheSize                   int64
+	MaxSQLConns                 int
 
 	// By default, test servers have AutoInitializeCluster=true set in
 	// their config. If NoAutoInitializeCluster is set, that behavior is disabled

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -531,6 +531,16 @@ The port number should be the same as in --sql-addr unless port
 forwarding is set up on an intermediate firewall/router.`,
 	}
 
+	ListenMaxSQLConns = FlagInfo{
+		Name: "max-sql-conns",
+		Description: `
+Maximum number of client SQL conns that can be open at a time on this node. If
+left unspecified, there is no limit. This setting can be used to protect a
+cluster against misconfiguration of client apps. For good security, a rate
+limiter should be used in combination with this setting. Note that SQL admins
+are not affected by (although they do contribute to) this limit.`,
+	}
+
 	ListenHTTPAddr = FlagInfo{
 		Name: "http-addr",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -377,6 +377,8 @@ func init() {
 
 		// More server flags.
 
+		intFlag(f, &baseCfg.MaxSQLConns, cliflags.ListenMaxSQLConns)
+
 		varFlag(f, &localityAdvertiseHosts, cliflags.LocalityAdvertiseAddr)
 
 		stringFlag(f, &serverCfg.Attrs, cliflags.Attrs)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2452,28 +2452,7 @@ func (c *adminPrivilegeChecker) getUserAndRole(
 }
 
 func (c *adminPrivilegeChecker) hasAdminRole(ctx context.Context, user string) (bool, error) {
-	if user == security.RootUser {
-		// Shortcut.
-		return true, nil
-	}
-	rows, _, err := c.ie.QueryWithCols(
-		ctx, "check-is-admin", nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: user},
-		"SELECT crdb_internal.is_admin()")
-	if err != nil {
-		return false, err
-	}
-	if len(rows) != 1 {
-		return false, errors.AssertionFailedf("hasAdminRole: expected 1 row, got %d", len(rows))
-	}
-	if len(rows[0]) != 1 {
-		return false, errors.AssertionFailedf("hasAdminRole: expected 1 column, got %d", len(rows[0]))
-	}
-	dbDatum, ok := tree.AsDBool(rows[0][0])
-	if !ok {
-		return false, errors.AssertionFailedf("hasAdminRole: expected bool, got %T", rows[0][0])
-	}
-	return bool(dbDatum), nil
+	return sql.HasAdminRole(ctx, c.ie, user)
 }
 
 func (c *adminPrivilegeChecker) hasRoleOption(

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -149,6 +149,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
 	cfg.Locality = params.Locality
+	cfg.MaxSQLConns = params.MaxSQLConns
 	if knobs := params.Knobs.Store; knobs != nil {
 		if mo := knobs.(*kvserver.StoreTestingKnobs).MaxOffset; mo != 0 {
 			cfg.MaxOffset = MaxOffsetType(mo)

--- a/pkg/sql/admin.go
+++ b/pkg/sql/admin.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+// HasAdminRole is a helper function to determine if a user is an admin using
+// the given internal executor.
+func HasAdminRole(ctx context.Context, ie *InternalExecutor, user string) (bool, error) {
+	if user == security.RootUser {
+		// Shortcut.
+		return true, nil
+	}
+	rows, _, err := ie.QueryWithCols(
+		ctx, "check-is-admin", nil, /* txn */
+		sessiondata.InternalExecutorOverride{User: user},
+		"SELECT crdb_internal.is_admin()")
+	if err != nil {
+		return false, err
+	}
+	if len(rows) != 1 {
+		return false, errors.AssertionFailedf("hasAdminRole: expected 1 row, got %d", len(rows))
+	}
+	if len(rows[0]) != 1 {
+		return false, errors.AssertionFailedf("hasAdminRole: expected 1 column, got %d", len(rows[0]))
+	}
+	dbDatum, ok := tree.AsDBool(rows[0][0])
+	if !ok {
+		return false, errors.AssertionFailedf("hasAdminRole: expected bool, got %T", rows[0][0])
+	}
+	return bool(dbDatum), nil
+}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1401,4 +1401,3 @@ ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT v_unique TO 
 
 statement error relation idx_v already exists
 ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO idx_v;
-

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -44,6 +45,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgx"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 func wrongArgCountString(want, got int) string {
@@ -233,6 +235,122 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 
 		pgServer.Undrain()
 	})
+}
+
+func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var (
+		ctx    = context.Background()
+		params = base.TestServerArgs{
+			MaxSQLConns: 1,
+		}
+		pgServer = serverutils.NewServer(params)
+	)
+
+	require.NoError(t, pgServer.Start())
+	defer pgServer.Stopper().Stop(ctx)
+
+	// Users.
+	const (
+		staff    = "staff"
+		nonAdmin = server.TestUser
+	)
+
+	// openConnWithUser opens a connection to the pgServer for the given user
+	// and always returns an associated cleanup function, even in case of error,
+	// which should be called. The returned cleanup function is idempotent.
+	openConnWithUser := func(user string) (*gosql.Conn, func(), error) {
+		pgURL, cleanup := sqlutils.PGUrlWithOptionalClientCerts(
+			t,
+			pgServer.ServingSQLAddr(),
+			t.Name(),
+			url.User(user),
+			user != staff, /* withClientCerts */
+		)
+		if user == staff {
+			// TODO(asubiotto): How can I make this work with client certs?
+			pgURL.User = url.UserPassword(staff, staff)
+		}
+		defer cleanup()
+		db, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
+			return nil, func() {}, err
+		}
+		closed := false
+		c, err := db.Conn(ctx)
+		if err != nil {
+			return nil, func() {
+				if closed {
+					return
+				}
+				_ = db.Close()
+				closed = true
+			}, err
+		}
+		return c, func() {
+			if closed {
+				return
+			}
+			_ = c.Close()
+			_ = db.Close()
+			closed = true
+		}, err
+	}
+
+	// tryOpenConnWithUser does the same as openConnWithUser but closes the
+	// connection immediately upon success.
+	tryOpenConnWithUser := func(user string) error {
+		_, cleanup, err := openConnWithUser(user)
+		cleanup()
+		return err
+	}
+
+	assertTooManyConnectionsErr := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		pqErr, ok := err.(*pq.Error)
+		require.True(t, ok, "expected pq error: %v", err)
+		require.True(t, pgcode.TooManyConnections.String() == string(pqErr.Code), "expected pgcode %s (TooManyConnections) but got %s", pgcode.TooManyConnections, pqErr.Code)
+	}
+
+	rootConn, rootConn1Cleanup, err := openConnWithUser(security.RootUser)
+	defer rootConn1Cleanup()
+	require.NoError(t, err)
+
+	// A second connection with the user root should not encounter a limit.
+	require.NoError(t, tryOpenConnWithUser(security.RootUser))
+
+	// Create a non-root admin user and a normal non-admin user.
+	_, err = rootConn.ExecContext(ctx, fmt.Sprintf("CREATE USER %[1]s WITH PASSWORD %[1]s; GRANT admin TO %[1]s; CREATE USER %[2]s", staff, nonAdmin))
+	require.NoError(t, err)
+
+	// A non admin will not be able to create a connection at this point because
+	// of the root connection.
+	assertTooManyConnectionsErr(t, tryOpenConnWithUser(nonAdmin))
+
+	// Close the root connection and try again, this should succeed.
+	rootConn1Cleanup()
+	_, nonAdmin1Cleanup, err := openConnWithUser(nonAdmin)
+	defer nonAdmin1Cleanup()
+	require.NoError(t, err)
+
+	// Another non-admin connection would bring us over the limit.
+	assertTooManyConnectionsErr(t, tryOpenConnWithUser(nonAdmin))
+
+	// An admin user can still open a connection.
+	require.NoError(t, tryOpenConnWithUser(staff))
+
+	// If the non-admin connection currently open is closed, it should be possible
+	// to open a new one.
+	nonAdmin1Cleanup()
+	_, nonAdmin2Cleanup, err := openConnWithUser(nonAdmin)
+	defer nonAdmin2Cleanup()
+	require.NoError(t, err)
+
+	// Try to open another non-admin connection. This should fail.
+	assertTooManyConnectionsErr(t, tryOpenConnWithUser(nonAdmin))
 }
 
 // We want to ensure that despite use of errors.{Wrap,Wrapf}, we are surfacing a


### PR DESCRIPTION
This setting is disabled by default. If non-zero, this setting specifies a
maximum number of connections that a server can have open at any given time.
If a new connection would exceed this limit, the same error message is
returned as postgres: "sorry, too many connections" with the 53300 error code
that corresponds to "too many connections".

Release note (sql change): an off-by-default server.max_connections cluster
setting has been added to limit the maximum number of connections to a server.

Closes #54653 

cc @awoods187 

Example error from the SQL shell:
```
./cockroach sql --insecure
Flag --insecure has been deprecated, it will be removed in a subsequent release.
For details, see: https://go.crdb.dev/issue-v/53404/v20.2
#
# Welcome to the CockroachDB SQL shell.
# All statements must be terminated by a semicolon.
# To exit, type: \q.
#
ERROR: sorry, too many clients already
SQLSTATE: 53300
HINT: the maximum number of allowed connections is 1 and can be modified using the server.max_connections cluster setting
Failed running "sql"
```