### PR TITLE
cli/sql: further polish statement statistics

### DIFF
--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -8,10 +8,10 @@ spawn $argv demo movr
 eexpect root@
 
 start_test "Test that server execution time and network latency are printed by default."
-send "SELECT * FROM vehicles LIMIT 1;\r"
+send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "1 row"
-eexpect "/ net"
-eexpect "/ other"
+eexpect "execution"
+eexpect "network"
 
 # Ditto with multiple statements on one line
 send "SELECT * FROM vehicles LIMIT 1; CREATE TABLE t(a int);\r"
@@ -21,10 +21,10 @@ end_test
 
 start_test "Test show_server_execution_times works correctly"
 send "\\set show_server_times=false\r"
-send "SELECT * FROM vehicles LIMIT 1;\r"
+send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "\nTime:"
 send "\\set show_server_times=true\r"
-send "SELECT * FROM vehicles LIMIT 1;\r"
-eexpect "/ net"
-eexpect "/ other"
+send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
+eexpect "execution"
+eexpect "network"
 end_test

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -199,7 +199,7 @@ func (c *sqlConn) ensureConn() error {
 // SHOW LAST QUERY STATISTICS statements. This allows the CLI client to report
 // server side execution timings instead of timing on the client.
 func (c *sqlConn) tryEnableServerExecutionTimings() {
-	_, _, err := c.getLastQueryStatistics()
+	_, _, _, _, err := c.getLastQueryStatistics()
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: cannot show server execution timings: unexpected column found\n")
 		sqlCtx.enableServerExecutionTimings = false
@@ -393,13 +393,12 @@ func (c *sqlConn) getServerValue(what, sql string) (driver.Value, bool) {
 // performs sanity checks, and returns the exec latency and service latency from
 // the sql row parsed as time.Duration.
 func (c *sqlConn) getLastQueryStatistics() (
-	execLatency time.Duration,
-	serviceLatency time.Duration,
+	parseLat, planLat, execLat, serviceLat time.Duration,
 	err error,
 ) {
 	rows, err := c.Query("SHOW LAST QUERY STATISTICS", nil)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, 0, err
 	}
 	defer func() {
 		closeErr := rows.Close()
@@ -407,17 +406,22 @@ func (c *sqlConn) getLastQueryStatistics() (
 	}()
 
 	if len(rows.Columns()) != 4 {
-		return 0, 0,
+		return 0, 0, 0, 0,
 			errors.New("unexpected number of columns in SHOW LAST QUERY STATISTICS")
 	}
 
-	if rows.Columns()[2] != "exec_latency" || rows.Columns()[3] != "service_latency" {
-		return 0, 0,
+	if rows.Columns()[0] != "parse_latency" ||
+		rows.Columns()[1] != "plan_latency" ||
+		rows.Columns()[2] != "exec_latency" ||
+		rows.Columns()[3] != "service_latency" {
+		return 0, 0, 0, 0,
 			errors.New("unexpected columns in SHOW LAST QUERY STATISTICS")
 	}
 
 	iter := newRowIter(rows, true /* showMoreChars */)
 	nRows := 0
+	var parseLatencyRaw string
+	var planLatencyRaw string
 	var execLatencyRaw string
 	var serviceLatencyRaw string
 	for {
@@ -425,9 +429,11 @@ func (c *sqlConn) getLastQueryStatistics() (
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return 0, 0, err
+			return 0, 0, 0, 0, err
 		}
 
+		parseLatencyRaw = formatVal(row[0], false, false)
+		planLatencyRaw = formatVal(row[1], false, false)
 		execLatencyRaw = formatVal(row[2], false, false)
 		serviceLatencyRaw = formatVal(row[3], false, false)
 
@@ -435,14 +441,18 @@ func (c *sqlConn) getLastQueryStatistics() (
 	}
 
 	if nRows != 1 {
-		return 0, 0,
+		return 0, 0, 0, 0,
 			errors.Newf("unexpected number of rows in SHOW LAST QUERY STATISTICS: %d", nRows)
 	}
 
 	parsedExecLatency, _ := tree.ParseDInterval(execLatencyRaw)
 	parsedServiceLatency, _ := tree.ParseDInterval(serviceLatencyRaw)
+	parsedPlanLatency, _ := tree.ParseDInterval(planLatencyRaw)
+	parsedParseLatency, _ := tree.ParseDInterval(parseLatencyRaw)
 
-	return time.Duration(parsedExecLatency.Duration.Nanos()),
+	return time.Duration(parsedParseLatency.Duration.Nanos()),
+		time.Duration(parsedPlanLatency.Duration.Nanos()),
+		time.Duration(parsedExecLatency.Duration.Nanos()),
 		time.Duration(parsedServiceLatency.Duration.Nanos()),
 		nil
 }
@@ -989,23 +999,33 @@ func maybeShowTimes(
 	}
 
 	// If discrete server/network timings are available, also print them.
-	execLatency, serviceLatency, err := conn.getLastQueryStatistics()
+	parseLat, planLat, execLat, serviceLat, err := conn.getLastQueryStatistics()
 	if err != nil {
 		fmt.Fprintf(stderr, "\nwarning: %v", err)
 		return
 	}
 
-	networkLatency := clientSideQueryTime - serviceLatency
+	fmt.Fprint(stderr, " total")
+
+	networkLat := clientSideQueryTime - serviceLat
+	otherLat := serviceLat - parseLat - planLat - execLat
 	if sqlCtx.verboseTimings {
-		fmt.Fprintf(w, " total (exec %s / net %s / other %s)\n",
-			execLatency, networkLatency, serviceLatency-execLatency)
-	} else {
-		// Simplified display: just show percentages.
-		totalSeconds := clientSideQueryTime.Seconds()
-		fmt.Fprintf(w, " total (exec %.1f%% / net %.1f%% / other %.1f%%)\n",
-			execLatency.Seconds()*100/totalSeconds,
-			networkLatency.Seconds()*100/totalSeconds,
-			(serviceLatency-execLatency).Seconds()*100/totalSeconds)
+		fmt.Fprintf(w, " (parse %s / plan %s / exec %s / other %s / network %s)\n",
+			parseLat, planLat, execLat, otherLat, networkLat)
+	} else if clientSideQueryTime.Milliseconds() > 1 {
+		// Simplified display: just show the execution/network breakdown.
+		//
+		// Note: we omit the report of percentages for queries that
+		// last for a millisecond or less. This is because for such
+		// small queries, the detail is just noise to the human observer.
+		sep := " ("
+		reportTiming := func(label string, lat time.Duration) {
+			fmt.Fprintf(w, "%s%s %.3fs", sep, label, lat.Seconds())
+			sep = " / "
+		}
+		reportTiming("execution", serviceLat)
+		reportTiming("network", networkLat)
+		fmt.Fprintln(w, ")")
 	}
 }
 


### PR DESCRIPTION
The following rules are applied:

- the breakdown is only displayed if the total execution time exceeds
  1ms. We assume that (human) users don't care about the breakdown if a
  statement is faster than that.

- if `verbose_timings` is unset (default), the server-side latencies
  are all grouped together (the "service latency") under a single
  `execution` label.

- the user can invoke `\set verbose_timings` to get the full
  breakdown.

Example outputs follow.

The breakdown is omitted because the total time is under 1ms:

```
root@127.0.0.1:44820/defaultdb> select 1;
  ?column?
------------
         1
(1 row)

Time: 0.000s total
```

A query is simple to parse/plan, but takes a while to execute because
it produces a lot of data:

```
root@127.0.0.1:44820/defaultdb> select generate_series(1,10000);
...
(10000 rows)

Time: 0.013s total (execution 0.004s / network 0.009s)
```

A more complex statement:

```
root@127.0.0.1:44820/defaultdb> create table t(x int);
CREATE TABLE

Time: 0.003s total (execution 0.002s / network 0.001s)
```

Release note (cli change): The display of statement timings in the SQL
shell (`cockroach sql` and `cockroach demo`) has been further simplified.