### PR TITLE
server: split server pre-start from accepting clients

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -564,7 +564,7 @@ If problems persist, please see %s.`
 			}
 
 			// Attempt to start the server.
-			if err := s.Start(ctx); err != nil {
+			if err := s.PreStart(ctx); err != nil {
 				if le := (*server.ListenError)(nil); errors.As(err, &le) {
 					const errorPrefix = "consider changing the port via --%s"
 					if le.Addr == serverCfg.Addr {
@@ -593,6 +593,11 @@ If problems persist, please see %s.`
 			// TODO(knz): If/when we want auto-creation of an initial admin user,
 			// this can be achieved here.
 			if _, err := runInitialSQL(ctx, s, startSingleNode, "" /* adminUser */); err != nil {
+				return err
+			}
+
+			// Now let SQL clients in.
+			if err := s.AcceptClients(ctx); err != nil {
 				return err
 			}
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -711,7 +711,7 @@ func StartTenant(
 		return "", "", err
 	}
 
-	if err := s.start(ctx,
+	if err := s.preStart(ctx,
 		args.stopper,
 		args.TestingKnobs,
 		connManager,
@@ -719,6 +719,13 @@ func StartTenant(
 		socketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
+		return "", "", err
+	}
+	if err := s.startServeSQL(ctx,
+		args.stopper,
+		s.connManager,
+		s.pgL,
+		socketFile); err != nil {
 		return "", "", err
 	}
 


### PR DESCRIPTION

This will enable the introduction of further cluster initialization
using SQL in `start.go`, before clients become able to connect.

I found this to be a prerequisite to #48647.
