### PR TITLE
rowexec: account for some allocations due to hashing of datums

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -11,6 +11,8 @@
 package coldataext
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
@@ -80,7 +82,9 @@ func (d *Datum) Cast(dVec interface{}, toType *types.T) (tree.Datum, error) {
 // Hash returns the hash of the datum as a byte slice.
 func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	ed := rowenc.EncDatum{Datum: maybeUnwrapDatum(d)}
-	b, err := ed.Fingerprint(d.ResolvedType(), da, nil /* appendTo */)
+	// We know that we have tree.Datum, so there will definitely be no need to
+	// decode ed for fingerprinting, so we pass in nil memory account.
+	b, err := ed.Fingerprint(context.TODO(), d.ResolvedType(), da, nil /* appendTo */, nil /* acc */)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -354,8 +354,11 @@ func (b *distinctAggregatorHelperBase) selectDistinctTuples(
 		}
 		for _, colIdx := range inputIdxs {
 			b.scratch.ed.Datum = b.aggColsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
+			// We know that we have tree.Datum, so there will definitely be no
+			// need to decode b.scratch.ed for fingerprinting, so we pass in
+			// nil memory account.
 			b.scratch.encoded, err = b.scratch.ed.Fingerprint(
-				b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded,
+				ctx, b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded, nil, /* acc */
 			)
 			if err != nil {
 				colexecerror.InternalError(err)

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -617,7 +617,9 @@ func (hr *hashRouter) computeDestination(row rowenc.EncDatumRow) (int, error) {
 			return -1, err
 		}
 		var err error
-		hr.buffer, err = row[col].Fingerprint(hr.types[col], &hr.alloc, hr.buffer)
+		// We choose to not perform the memory accounting for possibly decoded
+		// tree.Datum because we will lose the references to row very soon.
+		hr.buffer, err = row[col].Fingerprint(context.TODO(), hr.types[col], &hr.alloc, hr.buffer, nil /* acc */)
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
This commit adds memory accounting for the allocations of `tree.Datum`s
that might occur during `Fingerprint`ing (for example, when the encoded
datum uses a value encoding and we want to use the key ASC encoding). In
many cases, the newly allocated datums are only needed temporary, but we
know that GC takes its time with reclaiming the memory, so we choose to
go this route of possibly over-accounting in several places (in case of
the hash aggregator, windower, and sampler). This should improve the
stability of CockroachDB by preventing some crashes.

Note that the sampler is using an unlimited memory account for the
tracking of these allocations because if we limit it with default 64MB,
the stats jobs might never succeed and the throttling should kick in to
prevent the stats collection to reserve all the memory in the cluster.

Addresses: #54360.
Informs: #54670.

Release note: None