### PR TITLE
cli: support executing "initial SQL" from a directory

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -622,6 +622,25 @@ the socket name programmatically. To use, for example:
 </PRE>`,
 	}
 
+	InitialSQLDir = FlagInfo{
+		Name:   "initial-sql-dir",
+		EnvVar: "COCKROACH_INITIAL_SQL_DIR",
+		Description: `
+When set, CockroachDB will run any .sql files
+contained inside the directory exactly once, prior
+to accepting client connections. If the directory
+does not exist, the parameter is ignored.
+
+The only-once semantics are enforced cluster-wide: if multiple
+nodes have a directory configured, only one of the
+nodes will execute the .sql files within.
+
+This option can be used with containers and orchestration,
+for example by pointing it to a volume mount containing
+SQL scripts to customize a new cluster.
+`,
+	}
+
 	ClientInsecure = FlagInfo{
 		Name:   "insecure",
 		EnvVar: "COCKROACH_INSECURE",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -380,6 +380,10 @@ var startCtx struct {
 	// logging settings specific to file logging.
 	logDir log.DirName
 
+	// initialSQLDir is the directory containing SQL initialization
+	// scripts.
+	initialSQLDir string
+
 	// geoLibsDir is used to specify locations of the GEOS library.
 	geoLibsDir string
 }
@@ -399,6 +403,7 @@ func setStartContextDefaults() {
 	startCtx.pidFile = ""
 	startCtx.inBackground = false
 	startCtx.geoLibsDir = "/usr/local/lib/cockroach"
+	startCtx.initialSQLDir = ""
 }
 
 // quitCtx captures the command-line parameters of the `quit` and

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -392,6 +392,8 @@ func init() {
 		stringFlag(f, &startCtx.pidFile, cliflags.PIDFile)
 		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
 
+		stringFlag(f, &startCtx.initialSQLDir, cliflags.InitialSQLDir)
+
 		// Use a separate variable to store the value of ServerInsecure.
 		// We share the default with the ClientInsecure flag.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)

--- a/pkg/cli/interactive_tests/test_initial_sql.tcl
+++ b/pkg/cli/interactive_tests/test_initial_sql.tcl
@@ -1,0 +1,21 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+system "echo \"CREATE TABLE defaultdb.t(hello) AS SELECT 'world';\" >logs/init.sql"
+
+set ::env(COCKROACH_INITIAL_SQL_DIR) "logs"
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+# Check that the initial script has been run.
+send "TABLE t;\r"
+eexpect "hello"
+eexpect "world"
+eexpect root@
+interrupt
+eexpect eof
+
+stop_server $argv

--- a/pkg/cli/loopback_conn.go
+++ b/pkg/cli/loopback_conn.go
@@ -1,0 +1,74 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/lib/pq"
+)
+
+// newLoopbackSQLConn establishes an in-memory connection to the SQL
+// server. Its authentication method is always "trust" so the
+// password or other credentials do not matter.
+func newLoopbackSQLConn(s *server.Server, username string) *sqlConn {
+	// The URL is using the DSN format because we want to pass a host value
+	// starting with a "/". This short-cuts all the IP-related checks in
+	// lib/pq.
+	//
+	// The particular value of host/port doesn't matter: it is passed as
+	// address into our loopbackDialer's Dial() method below, which
+	// ignores it.
+	//
+	// We do care about the username value though.
+	url := "user=" + username + " password=unused host=/nonexistent port=1234"
+	conn := makeSQLConn(url)
+	conn.dialer = &loopbackDialer{s}
+	return conn
+}
+
+// loopbackDialer makes it possible for lib/pq to use
+// (*server.Server).ConnectLocalSQL().
+type loopbackDialer struct {
+	s *server.Server
+}
+
+var _ pq.Dialer = (*loopbackDialer)(nil)
+var _ pq.DialerContext = (*loopbackDialer)(nil)
+
+// Dial is part of the pq.Dialer interface.
+func (d *loopbackDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+// DialContext is part of the pq.DialerContext interface.
+func (d *loopbackDialer) DialContext(
+	ctx context.Context, network, address string,
+) (net.Conn, error) {
+	return d.s.ConnectLocalSQL(ctx)
+}
+
+// DialTimeout is part of the pq.Dialer interface.
+func (d *loopbackDialer) DialTimeout(
+	network, address string, timeout time.Duration,
+) (conn net.Conn, err error) {
+	err = contextutil.RunWithTimeout(
+		context.Background(), "pq-loopback-dial", timeout,
+		func(ctx context.Context) (fnErr error) {
+			conn, fnErr = d.DialContext(ctx, network, address)
+			return
+		})
+	return
+}

--- a/pkg/cli/loopback_conn_test.go
+++ b/pkg/cli/loopback_conn_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestLoopbackConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer ts.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec("CREATE USER operator WITH PASSWORD 'unused'"); err != nil {
+		t.Fatal(err)
+	}
+
+	s := ts.(*server.TestServer)
+
+	sqlConn := newLoopbackSQLConn(s.Server, "operator")
+
+	if err := sqlConn.ensureConn(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sqlConn.Exec("BEGIN", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := sqlConn.QueryRow("SELECT 123, current_user", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i, ok := data[0].(int64); !ok || i != 123 {
+		t.Fatalf("expected int 123, got %v (%T)", data[0], data[0])
+	}
+	if i, ok := data[1].(string); !ok || i != "operator" {
+		t.Fatalf("expected string operator, got %v (%T)", data[1], data[1])
+	}
+
+	if err := sqlConn.Exec("COMMIT", nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -89,7 +89,7 @@ select '''
 			fmt.Fprintln(stderr, err)
 			return
 		}
-		err := runInteractive(conn, f)
+		err := runShell(conn, f, false /* allowExternalCommands */)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 		}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -564,7 +564,7 @@ If problems persist, please see %s.`
 			}
 
 			// Attempt to start the server.
-			if err := s.Start(ctx); err != nil {
+			if err := s.PreStart(ctx); err != nil {
 				if le := (*server.ListenError)(nil); errors.As(err, &le) {
 					const errorPrefix = "consider changing the port via --%s"
 					if le.Addr == serverCfg.Addr {
@@ -593,6 +593,11 @@ If problems persist, please see %s.`
 			// TODO(knz): If/when we want auto-creation of an initial admin user,
 			// this can be achieved here.
 			if _, err := runInitialSQL(ctx, s, startSingleNode, "" /* adminUser */); err != nil {
+				return err
+			}
+
+			// Now let SQL clients in.
+			if err := s.AcceptClients(ctx); err != nil {
 				return err
 			}
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -593,6 +593,7 @@ If problems persist, please see %s.`
 			// TODO(knz): If/when we want auto-creation of an initial admin user,
 			// this can be achieved here.
 			if _, err := runInitialSQL(ctx, s, startSingleNode, "" /* adminUser */); err != nil {
+				log.Infof(ctx, "initial SQL failed: %v", err)
 				return err
 			}
 

--- a/pkg/server/loopback.go
+++ b/pkg/server/loopback.go
@@ -88,9 +88,15 @@ func (l *loopbackListener) Connect(ctx context.Context) (net.Conn, error) {
 		return nil, errLocalListenerClosed
 	case <-l.active:
 		return nil, errLocalListenerClosed
+	case <-ctx.Done():
+		return nil, errLocalListenerClosed
 	case l.requests <- struct{}{}:
 	}
 	// Get conn from acceptor.
+	//
+	// Note: we do not check ctx.Done() here, because if the request was
+	// sent into the queue above the connection is ready for us to pick
+	// it up; we don't want to let it clog l.conns.
 	select {
 	case <-l.stopper.ShouldQuiesce():
 		return nil, errLocalListenerClosed

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2204,6 +2204,16 @@ func (s *Server) PGServer() *pgwire.Server {
 	return s.sqlServer.pgServer
 }
 
+// ConnectLocalSQL establishes an in-memory client connection to the
+// SQL server but without actually touching the OS and
+// filesystem. This makes it possible for SQL client code to run from
+// within the server process using a regular client driver and benefit
+// from all the SQL executor machinery, but without a dependency on
+// network addresses and a working unix socket.
+func (s *Server) ConnectLocalSQL(ctx context.Context) (net.Conn, error) {
+	return s.sqlServer.loopbackLn.Connect(ctx)
+}
+
 // TODO(benesch): Use https://github.com/NYTimes/gziphandler instead.
 // gzipResponseWriter reinvents the wheel and is not as robust.
 type gzipResponseWriter struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -972,15 +972,32 @@ func getServerEndpointCounter(method string) telemetry.Counter {
 	return telemetry.GetCounter(fmt.Sprintf("%s.%s", counterPrefix, method))
 }
 
-// Start starts the server on the specified port, starts gossip and initializes
-// the node using the engines from the server's context. This is complex since
-// it sets up the listeners and the associated port muxing, but especially since
-// it has to solve the "bootstrapping problem": nodes need to connect to Gossip
-// fairly early, but what drives Gossip connectivity are the first range
-// replicas in the kv store. This in turn suggests opening the Gossip server
-// early. However, naively doing so also serves most other services prematurely,
-// which exposes a large surface of potentially underinitialized services. This
-// is avoided with some additional complexity that can be summarized as follows:
+// Start calls PreStart() and AcceptClient() in sequence.
+// This is suitable for use e.g. in tests.
+func (s *Server) Start(ctx context.Context) error {
+	if err := s.PreStart(ctx); err != nil {
+		return err
+	}
+	return s.AcceptClients(ctx)
+}
+
+// PreStart starts the server on the specified port, starts gossip and
+// initializes the node using the engines from the server's context.
+//
+// It does not activate the SQL client connections over the network,
+// which is done by the AcceptClients() method. The separation
+// between the two exists so that SQL initialization can take place
+// before the first client is accepted.
+//
+// This is complex since it sets up the listeners and the associated
+// port muxing, but especially since it has to solve the
+// "bootstrapping problem": nodes need to connect to Gossip fairly
+// early, but what drives Gossip connectivity are the first range
+// replicas in the kv store. This in turn suggests opening the Gossip
+// server early. However, naively doing so also serves most other
+// services prematurely, which exposes a large surface of potentially
+// underinitialized services. This is avoided with some additional
+// complexity that can be summarized as follows:
 //
 // - before blocking trying to connect to the Gossip network, we already open
 //   the admin UI (so that its diagnostics are available)
@@ -990,7 +1007,7 @@ func getServerEndpointCounter(method string) telemetry.Counter {
 //
 // The passed context can be used to trace the server startup. The context
 // should represent the general startup operation.
-func (s *Server) Start(ctx context.Context) error {
+func (s *Server) PreStart(ctx context.Context) error {
 	ctx = s.AnnotateCtx(ctx)
 
 	// Start the time sanity checker.
@@ -1691,7 +1708,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// executes a SQL query, this must be done after the SQL layer is ready.
 	s.node.recordJoinEvent()
 
-	if err := s.sqlServer.start(
+	if err := s.sqlServer.preStart(
 		workersCtx,
 		s.stopper,
 		s.cfg.TestingKnobs,
@@ -1711,6 +1728,24 @@ func (s *Server) Start(ctx context.Context) error {
 	// started. At this point we know that all sqlmigrations have successfully
 	// been run so it is safe to upgrade to the binary's current version.
 	s.startAttemptUpgrade(ctx)
+
+	log.Event(ctx, "server initialized")
+	return nil
+}
+
+// AcceptClients starts listening for incoming SQL clients over the network.
+func (s *Server) AcceptClients(ctx context.Context) error {
+	workersCtx := s.AnnotateCtx(context.Background())
+
+	if err := s.sqlServer.startServeSQL(
+		workersCtx,
+		s.stopper,
+		s.sqlServer.connManager,
+		s.sqlServer.pgL,
+		s.cfg.SocketFile,
+	); err != nil {
+		return err
+	}
 
 	log.Event(ctx, "server ready")
 	return nil

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -93,6 +93,12 @@ type sqlServer struct {
 	stmtDiagnosticsRegistry *stmtdiagnostics.Registry
 	sqlLivenessProvider     sqlliveness.Provider
 	metricsRegistry         *metric.Registry
+
+	// pgL is the shared RPC/SQL listener, opened when RPC was initialized.
+	pgL net.Listener
+	// connManager is the connection manager to use to set up additional
+	// SQL listeners in AcceptClients().
+	connManager netutil.Server
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are
@@ -652,7 +658,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	}, nil
 }
 
-func (s *sqlServer) start(
+func (s *sqlServer) preStart(
 	ctx context.Context,
 	stopper *stop.Stopper,
 	knobs base.TestingKnobs,
@@ -668,6 +674,8 @@ func (s *sqlServer) start(
 			return err
 		}
 	}
+	s.connManager = connManager
+	s.pgL = pgL
 	s.sqlLivenessProvider.Start(ctx)
 	s.execCfg.GCJobNotifier.Start(ctx)
 	s.temporaryObjectCleaner.Start(ctx, stopper)
@@ -754,11 +762,6 @@ func (s *sqlServer) start(
 	}
 
 	log.Infof(ctx, "done ensuring all necessary migrations have run")
-
-	// Start serving SQL clients.
-	if err := s.startServeSQL(ctx, stopper, connManager, pgL, socketFile); err != nil {
-		return err
-	}
 
 	// Start the async migration to upgrade namespace entries from the old
 	// namespace table (id 2) to the new one (id 30).

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -711,7 +711,7 @@ func StartTenant(
 		return "", "", err
 	}
 
-	if err := s.start(ctx,
+	if err := s.preStart(ctx,
 		args.stopper,
 		args.TestingKnobs,
 		connManager,
@@ -719,6 +719,13 @@ func StartTenant(
 		socketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
+		return "", "", err
+	}
+	if err := s.startServeSQL(ctx,
+		args.stopper,
+		s.connManager,
+		s.pgL,
+		socketFile); err != nil {
 		return "", "", err
 	}
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -25,6 +25,10 @@ type EventLogType string
 // NOTE: When you add a new event type here. Please manually add it to
 // pkg/ui/src/util/eventTypes.ts so that it will be recognized in the UI.
 const (
+	// EventLogInitialSQLExecuted is recorded when the SQL initialization code
+	// has been run by the first node upon cluter initialization.
+	EventLogInitialSQLExecuted EventLogType = "initial_sql_executed"
+
 	// EventLogCreateDatabase is recorded when a database is created.
 	EventLogCreateDatabase EventLogType = "create_database"
 	// EventLogDropDatabase is recorded when a database is dropped.

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -258,6 +258,13 @@ var insecureEntry = hba.Entry{
 	Method:   hba.String{Value: "--insecure"},
 }
 
+var loopbackEntry = hba.Entry{
+	ConnType: hba.ConnLocal,
+	User:     []hba.String{{Value: "all", Quoted: false}},
+	Address:  hba.AnyAddr{},
+	Method:   hba.String{Value: "<loopback>"},
+}
+
 var rootEntry = hba.Entry{
 	ConnType: hba.ConnHostAny,
 	User:     []hba.String{{Value: security.RootUser, Quoted: false}},


### PR DESCRIPTION
**tldr** with this patch, CockroachDB runs `.sql` files from the directory specified via `--initial-sql-dir` exactly once (only on 1 node) upon cluster initialization.

Example use cases for this mechanism:

- create some initial users/roles.
- define some initial passwords.
- create some initial databases/tables.
- load an initial dataset using IMPORT or RESTORE.
- set up cluster settings.

Fixes  #48647. 

- first commit from #54758 - can be ignored.
- 2nd commit (loopback conns) for review by @tbg  
- 3rd commit (exactly-once init) for review by @irfansharif and @tbg, optionally @bdarnell  
- 4th commit (init scripts) for review by @bobvawter, @rafiss, @bdarnell  and @apantel 

Please peruse the commit messages and especially the release notes in the individual commits for details and motivation about the change.