### PR TITLE
backupccl: rework protected timestamp span selection for BACKUP

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -110,6 +110,7 @@ type TableDescriptor interface {
 	ForeachIndex(opts IndexOpts, f func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error) error
 	AllNonDropIndexes() []*descpb.IndexDescriptor
 	ForeachNonDropIndex(f func(idxDesc *descpb.IndexDescriptor) error) error
+	TableSpan(codec keys.SQLCodec) roachpb.Span
 	IndexSpan(codec keys.SQLCodec, id descpb.IndexID) roachpb.Span
 	FindIndexByID(id descpb.IndexID) (*descpb.IndexDescriptor, error)
 	FindIndexByName(name string) (_ *descpb.IndexDescriptor, dropped bool, _ error)


### PR DESCRIPTION
Previously, to account for interleaved tables, backup would generate
spans for every table index, which would then be used by the protected
ts record. Recently we saw a couple of instances where this was
resulting in a very large number of spans being generated during backup.
A direct consequence of this is that the record can exceed the default
size of the limits of the protected timestamp subsystem.

With this change we breakdown the span generation into two cases.
- If the table is non-interleaved, then we can simply protect a full
  table span rather than a span for each index.

 - If the table is interleaved, the behavior remains the same as before.

This optimization is one of a few that should help us reduce the number
of spans we try to protect.

Informs: #54747

Release note: None