### PR TITLE
release-19.2: build: bump timeout for SQL Race Logic tests to 4 hours

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,7 +8,7 @@ maybe_ccache
 
 mkdir -p artifacts
 
-TESTTIMEOUT=2h
+TESTTIMEOUT=4h
 
 build/builder.sh \
 	stdbuf -oL -eL \

--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,10 +8,13 @@ maybe_ccache
 
 mkdir -p artifacts
 
+TESTTIMEOUT=2h
+
 build/builder.sh \
 	stdbuf -oL -eL \
 	make testrace \
 	PKG=./pkg/sql/logictest \
+	TESTTIMEOUT="${TESTTIMEOUT}" \
 	TESTFLAGS='-v' \
 	ENABLE_ROCKSDB_ASSERTIONS=1 \
 	2>&1 \
@@ -26,6 +29,7 @@ build/builder.sh \
 	make testrace \
 	PKG=./pkg/sql/logictest \
 	TESTS='^TestLogic/local$$' \
+	TESTTIMEOUT="${TESTTIMEOUT}" \
 	TESTFLAGS='-optimizer-cost-perturbation=0.9 -v' \
 	ENABLE_ROCKSDB_ASSERTIONS=1 \
 	2>&1 \
@@ -49,6 +53,7 @@ for file in $LOGICTESTS; do
 	        make testrace \
 	        PKG=./pkg/sql/logictest \
 	        TESTS='^TestLogic/local/'${file}'$$' \
+	        TESTTIMEOUT="${TESTTIMEOUT}" \
 	        TESTFLAGS='-disable-opt-rule-probability=0.5 -v' \
 	        ENABLE_ROCKSDB_ASSERTIONS=1 \
 	        2>&1 \


### PR DESCRIPTION
Backport:
  * 1/1 commits from "build: increase default TESTTIMEOUT for SQL Race Logic Tests" (#54615)
  * 1/1 commits from "build: bump timeout for SQL Race Logic tests to 4 hours" (#54691)

Please see individual PRs for details.

/cc @cockroachdb/release
