### PR TITLE
vendor: Bump pebble to 71cdee7c3cc7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540
+	github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7
 	github.com/cockroachdb/redact v1.0.7
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540 h1:eBX0kuZHgURpBqr23FWSnjrf9HQ1FJGZpJ4NbbbY1DM=
-github.com/cockroachdb/pebble v0.0.0-20200915204653-08b545a1f540/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7 h1:iSWWcgAfvbEVlCWXx3NHvw4oPh3zshjqOwT9DHiuAXE=
+github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=

--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -110,8 +110,6 @@ func createTestPebbleVarOpts(path string, seed int64) (storage.Engine, error) {
 	opts.MaxOpenFiles = int(rngIntRange(rng, 20, 2000))
 	opts.MemTableSize = 1 << rngIntRange(rng, 10, 28)
 	opts.MemTableStopWritesThreshold = int(rngIntRange(rng, 2, 7))
-	opts.MinCompactionRate = int(rngIntRange(rng, 1<<8, 8<<20))
-	opts.MinFlushRate = int(rngIntRange(rng, 1<<8, 4<<20))
 	opts.MaxConcurrentCompactions = int(rngIntRange(rng, 1, 4))
 
 	opts.Cache = pebble.NewCache(1 << rngIntRange(rng, 1, 30))

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -312,7 +312,6 @@ func DefaultPebbleOptions() *pebble.Options {
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,
-		MinFlushRate:                4 << 20, // 4 MB/sec
 		TablePropertyCollectors:     PebbleTablePropertyCollectors,
 	}
 	opts.Experimental.L0SublevelCompactions = true


### PR DESCRIPTION
Changes pulled in:

```
71cdee7c3cc7b7ac8593da782a22611839c335c3 *: Add compaction-debt based signal for compaction concurrency
9863058df5decc1c54dd265f6cfe9c753bdbe03e *: Have intra-L0 compactions follow flush sizes / splits
0d3f2675859c1009f34b3830adf5a25cc4273b10 *: Add new WALBytesPerSync option, defaulting to 0
bd5f01dcf683f2c54de9d1ab2cc09639f5ded423 internal/metamorphic: parse empty string as nil
c63d50ebde6b5b2f92a6313e9eeee31a8820c1a1 *: crlfmt all code
1ea4dba3507e420ee628a6eee83c22d634677539 db: check for in-progress compactions during input expansion
3102d0e6aca672fa6b513c80c57cbe1cc1064304 db: prevent conflicting, concurrent L0->LBase compactions
733a15c74045474735ed63ec71d7127222fdc07a db: use incrementally-computed sizes in initLevelMaxBytes
255915dc5f666a5600ebfa299a4e9e319fa0b069 internal/manifest: remove node recycling
826246a01f2aa70992907182b4053a5cea9f5882 pebble: fix compilation failure and atomic fields on 32bits
06477863d87cea08bdaf63d7d6df1f35076647e5 internal/rawalloc: add benchmarks to show performance gain compare to make
f48c916ce1d1992359a8f4ecba51776082e9577a *: Add Compact.InProgressBytes metric to track in-progress writes
2715d2642b20d0c646df02e338853ff57b843b98 db: add unit test for removing failed compaction outputs
ca943166e9aa7832d7ea448617bb54de620fc9e1 internal/manifest: remove LevelIterator.Empty
7cec24060f46f44537640108c93ebddabf1ba990 db: add Example_PrefixIteration
e92a04d48b727d0001bbb94e6fe3a479e5c20b06 db: unexport Options.Min{Flush,Compaction}Rate
360913e707ed9e9d22126dd0c1045bb70648b662 db: remove "demo" directory after the example finishes
e98b546aca8991b6a1762115f6618a6554e2eca1 db: remove Options.TableFormat
e5f22a86a86bbb65d3a17bb853f0ef104cb3b854 db: add benchmark for creating a new version with many sstables
18cef9de47a91ee16ca65b5539b46c87f46ba232 db: improve godoc documentation
45470877be6eec0048dc49bce2f14df7f59fa2e3 internal/metamorphic: generate a new seed every run
e37465a79285a4961aed3188bd7089653eb48ea7 db: fix a few lazy initializations of Batch data
4e219a90ba5bd2ef9b705a9f252264b02a5b37fd internal/manifest: add helper for comparing iterator positions
4fa33242cd9e27f170ff6565345e9880fe987e8e db: fix Go microbenchmarks to clean up correctly.
1224ac2d866dfc5074ada49165ee5568b630b8b6 internal/manifest: unexport internal btree type methods
60957a6e283ac1b559ddecbddee33805c0b9e15f db: remove unneeded assignments
8aa960238e777eba3d802a09182711325f21af65 comapction: specify type for compactionKind consts
```

Release note (performance improvement): Optimize compactions in Pebble
to improve read/write performance in some write-heavy workloads.