### PR TITLE
release-20.2: userfile: add userfile telemetry

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -788,6 +789,22 @@ func importPlanHook(
 		}
 
 		telemetry.CountBucketed("import.files", int64(len(files)))
+
+		// Record telemetry for userfile being used as the import target.
+		for _, file := range files {
+			uri, err := url.Parse(file)
+			// This should never be true as we have parsed these file names in an
+			// earlier step of import.
+			if err != nil {
+				log.Warningf(ctx, "failed to collect file specific import telemetry for %s", uri)
+				continue
+			}
+
+			if uri.Scheme == "userfile" {
+				telemetry.Count("import.storage.userfile")
+				break
+			}
+		}
 
 		// Here we create the job and protected timestamp records in a side
 		// transaction and then kick off the job. This is awful. Rather we should be

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
@@ -79,7 +80,13 @@ func runUserFileDelete(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	glob := args[0]
-	return deleteUserFile(context.Background(), conn, glob)
+
+	if err := deleteUserFile(context.Background(), conn, glob); err != nil {
+		return err
+	}
+
+	telemetry.Count("userfile.command.delete")
+	return nil
 }
 
 func runUserFileList(cmd *cobra.Command, args []string) error {
@@ -94,7 +101,12 @@ func runUserFileList(cmd *cobra.Command, args []string) error {
 		glob = args[0]
 	}
 
-	return listUserFile(context.Background(), conn, glob)
+	if err := listUserFile(context.Background(), conn, glob); err != nil {
+		return err
+	}
+
+	telemetry.Count("userfile.command.list")
+	return nil
 }
 
 func runUserFileUpload(cmd *cobra.Command, args []string) error {
@@ -117,7 +129,12 @@ func runUserFileUpload(cmd *cobra.Command, args []string) error {
 	}
 	defer reader.Close()
 
-	return uploadUserFile(context.Background(), conn, reader, source, destination)
+	if err := uploadUserFile(context.Background(), conn, reader, source, destination); err != nil {
+		return err
+	}
+
+	telemetry.Count("userfile.command.upload")
+	return nil
 }
 
 func openUserFile(source string) (io.ReadCloser, error) {


### PR DESCRIPTION
Backport 1/1 commits from #54450.

/cc @cockroachdb/release

---

Adds telemetry to userfile upload, delete, list, and counts how many
times userfile is used as the import source.

Informs: #53431

Release note: None
