### PR TITLE
release-20.2: vendor: Bump pebble to 0602c847ff9df5c90a9611a73c5b4b0cef6fff39

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1
+	github.com/cockroachdb/pebble v0.0.0-20200924231120-0602c847ff9d
 	github.com/cockroachdb/redact v1.0.7
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1 h1:F2ixCinj/ffpGnxHTg3uLWrDiAfInAB0+Fi1cuxLPY8=
-github.com/cockroachdb/pebble v0.0.0-20200910150114-e9a2c44e0bf1/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20200924231120-0602c847ff9d h1:yb+I1Emx/vgC7jsIB4YaG9yCX2Sti6dwVDg+tqvo7dw=
+github.com/cockroachdb/pebble v0.0.0-20200924231120-0602c847ff9d/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=


### PR DESCRIPTION
Changes pulled in:

```
0602c847ff9df5c90a9611a73c5b4b0cef6fff39 *: Add compaction-debt based signal for compaction concurrency
1dff9efd2d4b5ab9bc26956e68cbed2f15dfb5d3 *: Have intra-L0 compactions follow flush sizes / splits
893acae538bedc41ec495d0541cde9985601c075 *: Add new WALBytesPerSync option, defaulting to 0
572468c7745c4894a75ba3da183217221dc0e35d db: prevent conflicting, concurrent L0->LBase compactions
```

Subsumes #54754 .

Release note (performance improvement): Optimize compactions in Pebble
to improve read/write performance in some write-heavy workloads.

Release note (bug fix): Fix bug that could cause the storage-level corruption
under rare circumstances while using the Pebble storage engine.