### PR TITLE
sql: skip TestSchemaChangeEvalContext

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3742,6 +3742,7 @@ CREATE TABLE d.t (
 // the backfilled columns.
 func TestSchemaChangeEvalContext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 54775, "flaky test")
 	defer log.Scope(t).Close(t)
 	const numNodes = 3
 	const chunkSize = 200


### PR DESCRIPTION
Refs: #54775

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None