### PR TITLE
release-20.2: workload: bump the tpcc fixture version; create statistics when making fixtures

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -47,6 +47,7 @@ func config() workloadccl.FixtureConfig {
 		config.BillingProject = *gcsBillingProjectOverride
 	}
 	config.CSVServerURL = *fixturesMakeImportCSVServerURL
+	config.TableStats = *fixturesMakeTableStats
 	return config
 }
 
@@ -90,6 +91,10 @@ var fixturesMakeOnlyTable = fixturesMakeCmd.PersistentFlags().String(
 var fixturesMakeFilesPerNode = fixturesMakeCmd.PersistentFlags().Int(
 	`files-per-node`, 1,
 	`number of file URLs to generate per node when using csv-server`)
+
+var fixturesMakeTableStats = fixturesMakeCmd.PersistentFlags().Bool(
+	`table-stats`, true,
+	`generate full table statistics for all tables`)
 
 var fixturesImportFilesPerNode = fixturesImportCmd.PersistentFlags().Int(
 	`files-per-node`, 1,

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -60,6 +60,10 @@ type FixtureConfig struct {
 	// storage requests. This is required to be set if using a "requestor pays"
 	// bucket.
 	BillingProject string
+
+	// If TableStats is true, CREATE STATISTICS is called on all tables before
+	// creating the fixture.
+	TableStats bool
 }
 
 func (s FixtureConfig) objectPathToURI(folder string) string {
@@ -277,6 +281,28 @@ func MakeFixture(
 	// yak will remain unshaved.
 	if _, err := l.InitialDataLoad(ctx, sqlDB, gen); err != nil {
 		return Fixture{}, err
+	}
+
+	if config.TableStats {
+		// Clean up any existing statistics.
+		_, err := sqlDB.Exec("DELETE FROM system.table_statistics WHERE true")
+		if err != nil {
+			return Fixture{}, errors.Wrapf(err, "while deleting table statistics")
+		}
+		g := ctxgroup.WithContext(ctx)
+		for _, t := range gen.Tables() {
+			t := t
+			g.Go(func() error {
+				log.Infof(ctx, "Creating table stats for %s", t.Name)
+				_, err := sqlDB.Exec(fmt.Sprintf(
+					`CREATE STATISTICS pre_backup FROM "%s"."%s"`, dbName, t.Name,
+				))
+				return err
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return Fixture{}, err
+		}
 	}
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -141,7 +141,7 @@ var tpccMeta = workload.Meta{
 	Name: `tpcc`,
 	Description: `TPC-C simulates a transaction processing workload` +
 		` using a rich schema of multiple tables`,
-	Version:      `2.1.0`,
+	Version:      `2.2.0`,
 	PublicFacing: true,
 	New: func() workload.Generator {
 		g := &tpcc{}
@@ -162,9 +162,6 @@ var tpccMeta = workload.Meta{
 			`workers`:            {RuntimeOnly: true},
 			`conns`:              {RuntimeOnly: true},
 			`expensive-checks`:   {RuntimeOnly: true, CheckConsistencyOnly: true},
-			// We set runtime only to true for deprecated-fk-indexes so that it
-			// doesn't appear in the fixture name output.
-			`deprecated-fk-indexes`: {RuntimeOnly: true},
 		}
 
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Random number generator seed`)


### PR DESCRIPTION
Backport 2/2 commits from #54772.

/cc @cockroachdb/release

---

#### workload: bump the tpcc fixture version

The TPCC fixtures need refreshing: they contain FK indexes that we no
longer need, and they are missing stats for some of the tables.

This commit bumps the fixture version and incorporates the
`deprecated-fk-indexes` flag into the fixture name.

Release note: None

#### workload: create statistics when making fixtures

`workload make` imports a workload and then creates the backup (that
can be later used by `workload load`).

This change adds functionality to call CREATE STATISTICS on all tables
before creating the backup. This can be turned off using a flag.

Release note: None


I am in the process of regenerating the fixtures with the new version.

Informs #54702.
Informs #50911.
