### PR TITLE
opt: apply SimplifyJoinFilters to non-contradictions only

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -21,7 +21,8 @@
             $item:(FiltersItem
                     (And | True | False | Null | Or)
                 ) &
-                ^(IsUnsimplifiableOr $item)
+                ^(IsUnsimplifiableOr $item) &
+                ^(IsContradiction $item)
             ...
         ] &
         ^(IsFilterFalse $on)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -98,6 +98,38 @@ left-join (cross)
  │    └── fd: ()-->(7,8)
  └── filters (true)
 
+# Regression test for #54717. SimplifyJoinFilters should not simplify
+# contradictions. Doing so can split the filter expressions into two
+# FiltersItems such that they are no longer considered a contradiction, and
+# DetectJoinContradiction does not fire.
+norm expect=DetectJoinContradiction
+SELECT * FROM a LEFT JOIN b ON k<1 AND k>2
+----
+left-join (cross)
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:7 y:8
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,7,8)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── values
+ │    ├── columns: x:7!null y:8!null
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    └── fd: ()-->(7,8)
+ └── filters (true)
+
+norm expect=DetectJoinContradiction
+SELECT * FROM a INNER JOIN xy ON NULL
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null x:7!null y:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5,7,8)
+
 norm expect=DetectJoinContradiction
 SELECT * FROM a FULL JOIN b ON i=5 AND ((k<1 AND k>2) OR (k<4 AND k>5)) AND s='foo'
 ----

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1908,7 +1908,7 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+norm expect=(SimplifySameVarInequalities,DetectJoinContradiction)
 SELECT a.k FROM a FULL OUTER JOIN xy ON a.k != a.k
 ----
 full-join (cross)
@@ -1920,7 +1920,7 @@ full-join (cross)
  └── filters
       └── false [constraints=(contradiction; tight)]
 
-norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+norm expect=(SimplifySameVarInequalities,DetectJoinContradiction)
 SELECT a.k FROM a FULL OUTER JOIN xy ON a.k > a.k
 ----
 full-join (cross)
@@ -1932,7 +1932,7 @@ full-join (cross)
  └── filters
       └── false [constraints=(contradiction; tight)]
 
-norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+norm expect=(SimplifySameVarInequalities,DetectJoinContradiction)
 SELECT a.k FROM a FULL OUTER JOIN xy ON a.k < a.k
 ----
 full-join (cross)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -38,15 +38,6 @@ values
  └── fd: ()-->(1-5)
 
 norm expect=SimplifyJoinFilters
-SELECT * FROM a INNER JOIN xy ON NULL
-----
-values
- ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null x:7!null y:8!null
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5,7,8)
-
-norm expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON x=1 OR NULL
 ----
 inner-join (cross)


### PR DESCRIPTION
Previously, SimplifyJoinFilters was applied to all FiltersItems in the
ON filters. This could split up FiltersItems that were contradictions
into multiple FiltersItems that are not contradictions on their own.
Ultimately, this prevented DetectJoinContradiction from firing.

This commit updates SimplifyJoinFilters so that it only applies to
FiltersItems that are not contradictions, allowing
DetectJoinContradiction to fire in more cases.

Fixes #54717 

Release note (performance improvement): The optimizer simplifies join
expressions to only scan a single table when the join filter is a
contradiction. A limitation, now removed, was preventing this
simplification from occurring in some cases, leading to more efficient
query plans in some cases.