### PR TITLE
partialidx: fast path for simplify filters there are no exactMatches

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -711,8 +711,12 @@ func (im *Implicator) warmCache(filters memo.FiltersExpr) {
 func (im *Implicator) simplifyFiltersExpr(
 	e memo.FiltersExpr, exactMatches exprSet,
 ) memo.FiltersExpr {
-	filters := make(memo.FiltersExpr, 0, len(e))
+	// If exactMatches is empty, then e cannot be simplified.
+	if exactMatches.empty() {
+		return e
+	}
 
+	filters := make(memo.FiltersExpr, 0, len(e))
 	for i := range e {
 		// If an entire FiltersItem exists in exactMatches, don't add it to the
 		// output filters.
@@ -828,6 +832,11 @@ func (s exprSet) addIf(e opt.Expr, fn func() bool) {
 	if s != nil && fn() {
 		s[e] = struct{}{}
 	}
+}
+
+// empty returns true if the set is nil or empty.
+func (s exprSet) empty() bool {
+	return len(s) == 0
 }
 
 // contains returns true if the set is non-nil and the given expression exists


### PR DESCRIPTION
Previously, the Implicator would traverse the entire query FiltersExpr
to attempt to simplify it by removing any sub-expressions that were
exact matches to expressions in the predicate. This traversal would
occur even if the set of exact matches was empty. This commit changes
the behavior so that the simplifcation function returns early if the
exact matches are empty, leading to a significant performance
improvement in a handful of the benchmarks.

    name                                               old time/op  new time/op  delta
    Implicator/single-inexact-match-extra-filters-16   3.90µs ± 1%  0.60µs ± 2%  -84.63%  (p=0.008 n=5+5)
    Implicator/range-inexact-match-16                  2.38µs ± 1%  0.68µs ± 1%  -71.59%  (p=0.008 n=5+5)
    Implicator/multi-column-or-exact-match-reverse-16  1.75µs ± 2%  0.54µs ± 2%  -69.35%  (p=0.008 n=5+5)
    Implicator/single-inexact-match-16                  928ns ± 0%   325ns ± 1%  -64.94%  (p=0.016 n=4+5)
    Implicator/multi-column-and-inexact-match-16       2.04µs ± 0%  0.72µs ± 1%  -64.81%  (p=0.008 n=5+5)
    Implicator/multi-column-or-inexact-match-16        2.20µs ± 3%  0.95µs ± 0%  -56.87%  (p=0.016 n=5+4)
    Implicator/many-columns-inexact-match10-16         13.2µs ± 1%   6.8µs ± 2%  -48.57%  (p=0.008 n=5+5)
    Implicator/many-columns-inexact-match100-16         527µs ± 3%   447µs ± 2%  -15.23%  (p=0.008 n=5+5)
    Implicator/multi-column-or-exact-match-16          89.2ns ±11%  78.0ns ± 1%  -12.58%  (p=0.008 n=5+5)
    Implicator/multi-column-and-exact-match-16         85.4ns ± 0%  84.3ns ± 1%   -1.29%  (p=0.040 n=5+5)
    Implicator/single-exact-match-16                   78.3ns ± 1%  78.1ns ± 2%     ~     (p=0.286 n=5+5)
    Implicator/single-exact-match-extra-filters-16      321ns ± 1%   318ns ± 1%     ~     (p=0.119 n=5+5)
    Implicator/in-implies-or-16                         789ns ± 0%   782ns ± 1%     ~     (p=0.151 n=5+5)
    Implicator/and-filters-do-not-imply-pred-16        3.64µs ± 0%  3.64µs ± 2%     ~     (p=0.516 n=5+5)
    Implicator/or-filters-do-not-imply-pred-16          835ns ± 3%   828ns ± 1%     ~     (p=0.460 n=5+5)
    Implicator/many-columns-exact-match10-16            292ns ± 1%   290ns ± 1%     ~     (p=0.143 n=5+5)
    Implicator/many-columns-exact-match100-16          20.2µs ± 1%  20.2µs ± 2%     ~     (p=0.690 n=5+5)

Release note: None