### PR TITLE
release-20.2: changefeeds: Add additional telemetry for changefeeds.

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -152,6 +152,12 @@ var (
 	errJobCanceled = errors.New("job canceled by user")
 )
 
+// HasErrJobCanceled returns true if the error contains the error set as the
+// job's FinalResumError when it has been canceled.
+func HasErrJobCanceled(err error) bool {
+	return errors.Is(err, errJobCanceled)
+}
+
 // deprecatedIsOldSchemaChangeJob returns whether the provided payload is for a
 // job that is a 19.2-style schema change, and therefore cannot be run or
 // updated in 20.1 (without first having undergone a migration).


### PR DESCRIPTION
Backport 1/1 commits from #54583.

/cc @cockroachdb/release

---

Informs  #53429 

Add additional telemetry counters when creating changefeeds.

Release Notes: None
Release Justification: No impact; telemetry counters.
