### PR TITLE
ui: Redesign custom date range component

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1233,8 +1233,9 @@ func TestLint(t *testing.T) {
 
 		ignoredRules := []string{
 			"licence",
-			"mitre",   // PostGIS commands spell these as mitre.
-			"analyse", // required by SQL grammar
+			"mitre",     // PostGIS commands spell these as mitre.
+			"analyse",   // required by SQL grammar
+			"seperator", // pkg/ui depends on 3rd party package (rc-calendar) with spelling
 		}
 
 		if err := stream.ForEach(stream.Sequence(

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -29,6 +29,7 @@
     "nvd3": "^1.8.5",
     "popper.js": "^1.14.4",
     "raw-loader": "^0.5.1",
+    "rc-calendar": "^9.15.11",
     "rc-form": "^2.4.11",
     "rc-progress": "^2.2.1",
     "react": "^16.12.0",

--- a/pkg/ui/src/components/index.ts
+++ b/pkg/ui/src/components/index.ts
@@ -23,3 +23,4 @@ export * from "./tooltip";
 export * from "./select";
 export * from "./downloadFile";
 export * from "./modal";
+export * from "./rangeCalendar";

--- a/pkg/ui/src/components/rangeCalendar/dateRangeLabel.tsx
+++ b/pkg/ui/src/components/rangeCalendar/dateRangeLabel.tsx
@@ -1,0 +1,45 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Moment } from "moment";
+import { Text, TextTypes } from "src/components";
+
+export interface DateRangeLabelProps {
+  from: Moment;
+  to: Moment;
+}
+
+export const DateRangeLabel: React.FC<DateRangeLabelProps> = ({
+  from,
+  to,
+}) => {
+  const dateFormat = "MMM D";
+  const timeFormat = "LT";
+  const fromDateStr = from.format(dateFormat);
+  const toDateStr = to.format(dateFormat);
+  const fromTimeStr = from.format(timeFormat);
+  const toTimeStr = to.format(timeFormat);
+  const isUTC = to.isUTC() && from.isUTC();
+  return (
+    <div style={{ textAlign: "left" }}>
+      <Text textType={TextTypes.Body}>{fromDateStr}{", "}</Text>
+      <Text textType={TextTypes.BodyStrong}>{fromTimeStr}</Text>
+      <Text textType={TextTypes.Body}>{" — "}</Text>
+      <Text textType={TextTypes.Body}>{toDateStr}{", "}</Text>
+      <Text textType={TextTypes.BodyStrong}>{toTimeStr}</Text>
+      {
+        isUTC &&
+          <Text textType={TextTypes.Body}>{" UTC"}</Text>
+      }
+
+    </div>
+  );
+};

--- a/pkg/ui/src/components/rangeCalendar/index.ts
+++ b/pkg/ui/src/components/rangeCalendar/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./rangeCalendar";

--- a/pkg/ui/src/components/rangeCalendar/rangeCalendar.module.styl
+++ b/pkg/ui/src/components/rangeCalendar/rangeCalendar.module.styl
@@ -1,0 +1,163 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~src/components/core/index.styl'
+
+.crl-calendar
+  @extends $text--body
+
+  // Calendar header
+  // Fix calendar positioning for year/month/decade panels
+  // when `showDateInput` set to false.
+  :global(.rc-calendar-year-panel),
+  :global(.rc-calendar-month-panel),
+  :global(.rc-calendar-decade-panel)
+    top 0
+
+  // Hide Prev/Next year navigation buttons in 'date' mode
+  // Allow only month navigation
+  :global(.rc-calendar-prev-year-btn),
+  :global(.rc-calendar-next-year-btn)
+    display none
+
+  :global(.rc-calendar-prev-month-btn),
+  :global(.rc-calendar-next-month-btn)
+    &:after
+      content ''
+      height 16px
+      width 12px
+      background-repeat no-repeat
+      position absolute
+      top 6px
+
+  :global(.rc-calendar-prev-month-btn)
+    &:after
+      background-image url("../../../assets/caret-left.svg")
+
+  :global(.rc-calendar-next-month-btn)
+    &:after
+      background-image url("../../../assets/caret-right.svg")
+
+  :global(.rc-calendar-body)
+    border-bottom none
+
+  :global(.rc-calendar-header)
+    border-bottom none
+    margin-top 16px
+
+  :global(.rc-calendar-my-select),
+  :global(.rc-calendar-my-select > .rc-calendar-month-select),
+  :global(.rc-calendar-my-select > .rc-calendar-year-select)
+    @extends $text--heading-5
+
+  :global(.rc-calendar-my-select > .rc-calendar-year-select)
+    padding-left 0
+  // Calendar header. End
+
+  // Calendar panel
+  :global(.rc-calendar-column-header > .rc-calendar-column-header-inner)
+    @extends $text--heading-5
+
+  :global(.rc-calendar-cell)
+    &:global(.rc-calendar-today > .rc-calendar-date)
+      border none
+      color $colors--primary-blue-3
+      font-weight $font-weight--bold
+
+    &:global(.rc-calendar-today.rc-calendar-in-range-cell > .rc-calendar-date)
+    &:global(.rc-calendar-today.rc-calendar-selected-start-date > .rc-calendar-date)
+    &:global(.rc-calendar-today.rc-calendar-selected-end-date > .rc-calendar-date)
+      color $colors--white
+
+    :global(.rc-calendar-date)
+      border-radius 50%
+      &:hover
+        background $colors--neutral-2
+
+  :global(.rc-calendar-selected-date.rc-calendar-today > .rc-calendar-date),
+  :global(.rc-calendar-selected-day > .rc-calendar-date)
+    background $colors--primary-blue-3
+    color $colors--white
+    &:hover
+      background $colors--primary-blue-4
+
+  :global(.rc-calendar-selected-start-date)
+    border-top-left-radius 16px
+    border-bottom-left-radius 16px
+    background $colors--primary-blue-3
+
+  :global(.rc-calendar-selected-end-date)
+    border-top-right-radius 16px
+    border-bottom-right-radius 16px
+    background $colors--primary-blue-3
+
+  :global(.rc-calendar-in-range-cell)
+    background $colors--primary-blue-3
+    :global(.rc-calendar-date)
+      color $colors--white
+      &:hover
+        background $colors--primary-blue-4
+
+  :global(.rc-calendar-last-month-cell > .rc-calendar-date)
+    color $colors--neutral-4
+
+  // Calendar panel. End
+
+  // Calendar footer
+  :global(.rc-calendar-footer-btn)
+    padding-left $spacing-smaller
+    padding-bottom $spacing-small
+    text-align: center
+    &:after
+      content ''
+
+  .crl-footer
+    display flex
+    flex-direction column
+    > div
+      display flex
+      flex-direction row
+      > div
+        margin 0 10px
+
+
+  .crl-time-picker-container
+    margin-bottom $spacing-medium
+    > div
+      width 50%
+
+
+  &.crl-calendar__no-borders
+    border none
+    box-shadow none
+
+// Timepicker
+.crl-time-picker
+  // antd timepicker doesn't allow to redefine its width without !important directive
+  width 100%!important
+  :global(.ant-time-picker-input)
+    height 40px
+
+.crl-time-picker-popup
+  :global(.ant-time-picker-panel-input-wrap)
+    display none
+
+.crl-date-preview
+  justify-content flex-start
+  align-self center
+  flex-grow 1
+
+.crl-action-buttons
+  text-align right
+  > button
+    margin-left $spacing-base
+
+
+

--- a/pkg/ui/src/components/rangeCalendar/rangeCalendar.module.styl
+++ b/pkg/ui/src/components/rangeCalendar/rangeCalendar.module.styl
@@ -142,8 +142,10 @@
 .crl-time-picker
   // antd timepicker doesn't allow to redefine its width without !important directive
   width 100%!important
+  cursor pointer!important
   :global(.ant-time-picker-input)
     height 40px
+    cursor pointer
 
 .crl-time-picker-popup
   :global(.ant-time-picker-panel-input-wrap)

--- a/pkg/ui/src/components/rangeCalendar/rangeCalendar.stories.tsx
+++ b/pkg/ui/src/components/rangeCalendar/rangeCalendar.stories.tsx
@@ -1,0 +1,21 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { RangeCalendar } from "./index";
+import { styledWrapper } from "src/util/decorators";
+
+storiesOf("Range Calendar", module)
+  .addDecorator(styledWrapper({padding: "24px"}))
+  .add("default", () => (
+    <RangeCalendar />
+  ));

--- a/pkg/ui/src/components/rangeCalendar/rangeCalendar.tsx
+++ b/pkg/ui/src/components/rangeCalendar/rangeCalendar.tsx
@@ -1,0 +1,192 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useCallback, useMemo, useState } from "react";
+import moment, { DurationInputArg1, DurationInputArg2, Moment } from "moment";
+import { noop } from "lodash";
+import { TimePicker } from "antd";
+import { TimePickerProps } from "antd/es/time-picker";
+import RcRangeCalendar from "rc-calendar/es/RangeCalendar";
+import locale from "rc-calendar/es/locale/en_US";
+import "rc-calendar/assets/index.css";
+import classNames from "classnames/bind";
+import { CaretDown } from "@cockroachlabs/icons";
+
+import { Button } from "src/components";
+import styles from "./rangeCalendar.module.styl";
+import { DateRangeLabel } from "./dateRangeLabel";
+
+const cx = classNames.bind(styles);
+
+locale.monthFormat = "MMMM";
+
+interface OwnProps {
+  timeFormat?: string;
+  minTimeRange?: [DurationInputArg1, DurationInputArg2];
+  onSubmit?: (range: [Moment, Moment]) => void;
+  onCancel?: () => void;
+  onInvalidRangeSelect?: (allowedRange: [DurationInputArg1, DurationInputArg2]) => void;
+  showBorders?: boolean;
+}
+
+interface RcTimePickerProps {
+  align: {
+    offset: [number, number];
+  };
+}
+
+export type RangeCalendarProps = OwnProps;
+
+export const RangeCalendar: React.FC<RangeCalendarProps> = ({
+  timeFormat = "h:mm A",
+  minTimeRange = [10, "minute"],
+  onCancel = noop,
+  onSubmit = noop,
+  onInvalidRangeSelect = noop,
+  showBorders = true,
+}) => {
+  const currentDate = useMemo<Moment>(() => moment.utc().startOf("day"), []);
+  const [startDate, setStartDate] = useState<Moment>(currentDate);
+  const [endDate, setEndDate] = useState<Moment>(moment.utc(currentDate).endOf("day"));
+
+  const isBelowMinDateRange = (from: Moment, to: Moment) => {
+    const minutesInRange = Math.abs(from.diff(to, minTimeRange[1], true));
+    return minutesInRange < minTimeRange[0];
+  };
+
+  const onDateRangeSelected = useCallback(
+    ([selectedStartDate, selectedEndDate]: [Moment | null, Moment | null]) => {
+      // Set only Date part and keep Time part unchanged
+      setStartDate(prevDate => moment.utc(prevDate).set({
+        year: selectedStartDate.year(),
+        month: selectedStartDate.month(),
+        date: selectedStartDate.date(),
+      }));
+
+      setEndDate(prevDate => moment.utc(prevDate).set({
+        year: selectedEndDate.year(),
+        month: selectedEndDate.month(),
+        date: selectedEndDate.date(),
+      }));
+
+      // If date range is lower than allowed, update end date to be
+      // equal startDate + min allowed date range
+      if (isBelowMinDateRange(selectedStartDate, selectedEndDate)) {
+        setEndDate(moment.utc(selectedStartDate).add(...minTimeRange));
+        onInvalidRangeSelect(minTimeRange);
+      }
+    },
+    [startDate, endDate, isBelowMinDateRange, setStartDate, setEndDate],
+  );
+
+  const onTimeChange = useCallback(
+    (rangePart: "from" | "to") => (nextTime: Moment) => {
+      const setDate = rangePart === "from" ? setStartDate : setEndDate;
+      const setOtherDate = rangePart !== "from" ? setStartDate : setEndDate;
+      const otherDate = rangePart === "from" ? endDate : startDate;
+
+      setDate(prevDate => moment.utc(prevDate)
+        .set({
+          hour: nextTime.get("hour"),
+          minute: nextTime.get("minute"),
+          second: nextTime.get("second"),
+        }));
+
+      // Handle edge case when `startDate` and `endDate` is the same day, In this case,
+      // if `startTime` > `endTime` then endTime = startTime + 10min
+      // if `endTime` < `startTime` then startTime = endTime - 10min
+      // Keep new value for changed time part and update opposite part
+      // automatically to keep at least 10min range.
+      if (isBelowMinDateRange(nextTime, otherDate)) {
+        const date = rangePart === "from" ?
+          nextTime.add(...minTimeRange) :
+          nextTime.subtract(...minTimeRange);
+
+        setOtherDate(date);
+        onInvalidRangeSelect(minTimeRange);
+      }
+    },
+    [startDate, endDate, isBelowMinDateRange, setStartDate, setEndDate],
+  );
+
+  const onSubmitClick = useCallback(
+    () => onSubmit([startDate, endDate]),
+    [startDate, endDate],
+  );
+
+  const timePickerDefaultProps: TimePickerProps & RcTimePickerProps = {
+    allowClear: false,
+    use12Hours: true,
+    inputReadOnly: true,
+    format: timeFormat,
+    className: cx("crl-time-picker"),
+    popupClassName: cx("crl-time-picker-popup"),
+    defaultValue: currentDate,
+    suffixIcon: <CaretDown fontSize={14} />,
+    placeholder: "",
+    // Reposition popup to avoid overlapping it on top
+    // of timepicker input.
+    align: {
+      offset: [4, 41],
+    },
+  };
+
+  const renderFooter = () => {
+    return (
+      <div className={cx("crl-footer")}>
+        <div className={cx("crl-time-picker-container")}>
+          <div>
+            <TimePicker
+              {...timePickerDefaultProps}
+              onChange={onTimeChange("from")}
+              value={startDate}
+            />
+          </div>
+          <div>
+            <TimePicker
+              {...timePickerDefaultProps}
+              onChange={onTimeChange("to")}
+              value={endDate}
+            />
+          </div>
+        </div>
+        <div className={cx("")}>
+          <div className={cx("crl-date-preview")}>
+            <DateRangeLabel from={startDate} to={endDate} />
+          </div>
+          <div className={cx("crl-action-buttons")}>
+            <Button onClick={onCancel} type="secondary">Cancel</Button>
+            <Button onClick={onSubmitClick}>Apply</Button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <RcRangeCalendar
+      mode={["date", "date"]}
+      defaultSelectedValue={[startDate, endDate]}
+      selectedValue={[startDate, endDate]}
+      locale={locale}
+      showToday={false}
+      showDateInput={false}
+      seperator=""
+      renderFooter={renderFooter}
+      className={cx(
+        "crl-calendar",
+        {
+          "crl-calendar__no-borders": !showBorders,
+        },
+      )}
+      onSelect={onDateRangeSelected}
+    />
+  );
+};

--- a/pkg/ui/src/interfaces/vendors.d.ts
+++ b/pkg/ui/src/interfaces/vendors.d.ts
@@ -1,0 +1,16 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/*
+* rc-calendar package doesn't provide typings to `RangeCalendar` component
+* and locales.
+* */
+declare module "rc-calendar/es/RangeCalendar";
+declare module "rc-calendar/es/locale/en_US";

--- a/pkg/ui/src/views/cluster/components/range/range.styl
+++ b/pkg/ui/src/views/cluster/components/range/range.styl
@@ -48,10 +48,6 @@
   align-items flex-start
   cursor default
   z-index 99
-  &.__custom
-    width 555px
-    padding 22px 17px 40px
-    justify-content space-between
   &.__options
     width 423px
     padding 12px 9px

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -10040,6 +10040,19 @@ rc-animate@^3.0.0-rc.1:
     rc-util "^4.5.0"
     react-lifecycles-compat "^3.0.4"
 
+rc-calendar@^9.15.11:
+  version "9.15.11"
+  resolved "https://registry.yarnpkg.com/rc-calendar/-/rc-calendar-9.15.11.tgz#ce1e5ea8e4d77435be66a8c77db12f1f0f9a345f"
+  integrity sha512-qv0VXfAAnysMWJigxaP6se4bJHvr17D9qsLbi8BOpdgEocsS0RkgY1IUiFaOVYKJDy/EyLC447O02sV/y5YYBg==
+  dependencies:
+    babel-runtime "6.x"
+    classnames "2.x"
+    moment "2.x"
+    prop-types "^15.5.8"
+    rc-trigger "^2.2.0"
+    rc-util "^4.1.1"
+    react-lifecycles-compat "^3.0.4"
+
 rc-calendar@~9.15.5:
   version "9.15.8"
   resolved "https://registry.yarnpkg.com/rc-calendar/-/rc-calendar-9.15.8.tgz#6a3dbc2716c5297b46c8442dc2c748a17346111d"


### PR DESCRIPTION
Resolves #53165
Depends on https://github.com/cockroachdb/yarn-vendored/pull/39

`RangeCalendar` is used in a single place as a child
component (for Range component) and it makes its
integration straightforward.

Previously, changes for single `from` or `to` dates
dispatched separate actions and caused re-rendering for components.
Now, changes dispatched after `from` and `to` dates
selected.

The logic for validation date ranges are removed from Range
component because it is now embedded into RangeCalendar
component.

Note. `RangeCalendar` component from `rc-calendar` has misspelled prop
so it is added in the ignore list for lint spelling check.

Release note (admin ui change): Updated design for
Custom date range selector on Cluster > Maps view and
Metrics pages

Screens:
![Screen Shot 2020-09-28 at 12 17 50 PM](https://user-images.githubusercontent.com/3106437/94414224-c35e9a80-0184-11eb-967e-4e932ee229e7.png)
![Screen Shot 2020-09-28 at 12 18 32 PM](https://user-images.githubusercontent.com/3106437/94414229-c5285e00-0184-11eb-869d-2e9466dd2a13.png)
![Screen Shot 2020-09-28 at 12 18 04 PM](https://user-images.githubusercontent.com/3106437/94414235-c6f22180-0184-11eb-8f31-cc3d57b4fdd2.png)
