### PR TITLE
sql: add metrics to schema changer

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -544,6 +544,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	} else {
 		execCfg.TypeSchemaChangerTestingKnobs = new(sql.TypeSchemaChangerTestingKnobs)
 	}
+	execCfg.SchemaChangerMetrics = sql.NewSchemaChangerMetrics()
+	cfg.registry.AddMetricStruct(execCfg.SchemaChangerMetrics)
+
 	if gcJobTestingKnobs := cfg.TestingKnobs.GCJob; gcJobTestingKnobs != nil {
 		execCfg.GCJobTestingKnobs = gcJobTestingKnobs.(*sql.GCJobTestingKnobs)
 	} else {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -695,6 +695,8 @@ type ExecutorConfig struct {
 	InternalExecutor        *InternalExecutor
 	QueryCache              *querycache.C
 
+	SchemaChangerMetrics *SchemaChangerMetrics
+
 	TestingKnobs                  ExecutorTestingKnobs
 	PGWireTestingKnobs            *PGWireTestingKnobs
 	SchemaChangerTestingKnobs     *SchemaChangerTestingKnobs

--- a/pkg/sql/schema_changer_metrics.go
+++ b/pkg/sql/schema_changer_metrics.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// TODO(ajwerner): Add many more metrics.
+
+var (
+	metaRunning = metric.Metadata{
+		Name:        "sql.schema_changer.running",
+		Help:        "Gauge of currently running schema changes",
+		Measurement: "Schema changes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaSuccesses = metric.Metadata{
+		Name:        "sql.schema_changer.successes",
+		Help:        "Counter of the number of schema changer resumes which succeed",
+		Measurement: "Schema changes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRetryErrors = metric.Metadata{
+		Name:        "sql.schema_changer.retry_errors",
+		Help:        "Counter of the number of retriable errors experienced by the schema changer",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaPermanentErrors = metric.Metadata{
+		Name:        "sql.schema_changer.permanent_errors",
+		Help:        "Counter of the number of permanent errors experienced by the schema changer",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// SchemaChangerMetrics are metrics corresponding to the schema changer.
+type SchemaChangerMetrics struct {
+	RunningSchemaChanges *metric.Gauge
+	Successes            *metric.Counter
+	RetryErrors          *metric.Counter
+	PermanentErrors      *metric.Counter
+}
+
+// MetricStruct makes SchemaChangerMetrics a metric.Struct.
+func (s *SchemaChangerMetrics) MetricStruct() {}
+
+var _ metric.Struct = (*SchemaChangerMetrics)(nil)
+
+// NewSchemaChangerMetrics constructs a new SchemaChangerMetrics.
+func NewSchemaChangerMetrics() *SchemaChangerMetrics {
+	return &SchemaChangerMetrics{
+		RunningSchemaChanges: metric.NewGauge(metaRunning),
+		Successes:            metric.NewCounter(metaSuccesses),
+		RetryErrors:          metric.NewCounter(metaRetryErrors),
+		PermanentErrors:      metric.NewCounter(metaPermanentErrors),
+	}
+}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6054,6 +6054,13 @@ CREATE UNIQUE INDEX i ON t.test(v);
 		testutils.SucceedsSoon(t, func() error {
 			return checkTableKeyCountExact(ctx, kvDB, 2)
 		})
+		var permanentErrors int
+		require.NoError(t, sqlDB.QueryRow(`
+SELECT value
+  FROM crdb_internal.node_metrics
+ WHERE name = 'sql.schema_changer.permanent_errors';
+`).Scan(&permanentErrors))
+		require.Equal(t, 1, permanentErrors)
 	}
 
 	t.Run("error-before-backfill", func(t *testing.T) {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1484,6 +1484,26 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "Schema Changer"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Running",
+				Metrics: []string{"sql.schema_changer.running"},
+			},
+			{
+				Title:       "Run Outcomes",
+				Downsampler: DescribeAggregator_MAX,
+				Aggregator:  DescribeAggregator_SUM,
+				Metrics: []string{
+					"sql.schema_changer.permanent_errors",
+					"sql.schema_changer.retry_errors",
+					"sql.schema_changer.successes",
+				},
+				AxisLabel: "Schema Change Executions",
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "DistSQL", "Flows"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
It's far from exhaustive and hardly tested but something is better than
nothing.

Touches #52078

Release note (general change): Added some metrics surrounding schema changes.