### PR TITLE
release-20.2: sql: log on retriable error in schema change

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2029,6 +2029,7 @@ func (r schemaChangeResumer) Resume(
 			case !isPermanentSchemaChangeError(scErr):
 				// Check if the error is on a allowlist of errors we should retry on,
 				// including the schema change not having the first mutation in line.
+				log.Warningf(ctx, "error while running schema change, retrying: %v", scErr)
 			default:
 				// All other errors lead to a failed job.
 				return scErr


### PR DESCRIPTION
Backport 1/1 commits from #54783.

/cc @cockroachdb/release

---

We had zero visibility into retries in schema changes.

Release note: None
