### PR TITLE
release-20.2: sql: fix bug whereby backfiller would drop spans on txn restart

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -949,7 +949,12 @@ func (sc *SchemaChanger) distBackfill(
 
 	for len(todoSpans) > 0 {
 		log.VEventf(ctx, 2, "backfill: process %+v spans", todoSpans)
+		// Make sure not to update todoSpans inside the transaction closure as it
+		// may not commit. Instead write the updated value for todoSpans to this
+		// variable and assign to todoSpans after committing.
+		var updatedTodoSpans []roachpb.Span
 		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			updatedTodoSpans = todoSpans
 			// Report schema change progress. We define progress at this point
 			// as the the fraction of fully-backfilled ranges of the primary index of
 			// the table being scanned. Since we may have already modified the
@@ -982,7 +987,7 @@ func (sc *SchemaChanger) distBackfill(
 			}
 			metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
 				if meta.BulkProcessorProgress != nil {
-					todoSpans = roachpb.SubtractSpans(todoSpans,
+					updatedTodoSpans = roachpb.SubtractSpans(updatedTodoSpans,
 						meta.BulkProcessorProgress.CompletedSpans)
 				}
 				return nil
@@ -1019,6 +1024,8 @@ func (sc *SchemaChanger) distBackfill(
 		}); err != nil {
 			return err
 		}
+		todoSpans = updatedTodoSpans
+
 		if !inMemoryStatusEnabled {
 			var resumeSpans []roachpb.Span
 			// There is a worker node of older version that will communicate
@@ -1035,7 +1042,6 @@ func (sc *SchemaChanger) distBackfill(
 			}
 			// A \intersect B = A - (A - B)
 			todoSpans = roachpb.SubtractSpans(todoSpans, roachpb.SubtractSpans(todoSpans, resumeSpans))
-
 		}
 		// Record what is left to do for the job.
 		// TODO(spaskob): Execute this at a regular cadence.


### PR DESCRIPTION
Backport 1/1 commits from #54755.

/cc @cockroachdb/release

---

This bug was caught by testing with #54695. Before that change, it would fail
almost immediately, now it does not fail under stress. I'm open to suggestions
on how to more generally test this.

Release note (bug fix): Fixed a rare bug which can lead to index backfills
failing in the face of transaction restarts.
