### PR TITLE
cmd/roachtest: update clearrange to print range count each iteration

### DIFF
--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -166,6 +166,7 @@ func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bo
 				return err
 			}
 
+			t.WorkerStatus("waiting for ~", curBankRanges, " merges to complete (and for at least ", timeutil.Now().Sub(deadline), " to pass)")
 			select {
 			case <-after:
 			case <-ctx.Done():


### PR DESCRIPTION
Update the clearrange roachtest to print the remaining bank table range
count with each iteration.

Release note: none