### PR TITLE
release-20.2: backupccl: add scheduled backup telemetry

### DIFF
--- a/pkg/sql/sqltelemetry/scheduled_backups.go
+++ b/pkg/sql/sqltelemetry/scheduled_backups.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// ScheduledBackupControlCounter is to be incremented every time a scheduled job
+// control action is taken.
+func ScheduledBackupControlCounter(desiredStatus string) telemetry.Counter {
+	return telemetry.GetCounter("sql.backup.scheduled.job.control." + desiredStatus)
+}


### PR DESCRIPTION
Backport 1/1 commits from #54546.

/cc @cockroachdb/release

---

This commit adds more telemetry and scheduled backups.  Telemetry was
added for scheduled backup creation.  Additionally, telemetry was added
for scheduled job control (PAUSE, CANCEL, and DROP).

Fixes #53427.


Release note: None
