### PR TITLE
roachtest: switch zones used by interleavedpartitioned

### DIFF
--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -120,13 +120,13 @@ func registerInterleaved(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "interleavedpartitioned",
 		Owner:   OwnerPartitioning,
-		Cluster: makeClusterSpec(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
+		Cluster: makeClusterSpec(12, geo(), zones("us-east1-b,us-west1-b,europe-west2-b")),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runInterleaved(ctx, t, c,
 				config{
-					eastName:        `us-east4-b`,
+					eastName:        `europe-west2-b`,
 					westName:        `us-west1-b`,
-					centralName:     `us-central1-a`,
+					centralName:     `us-east1-b`, // us-east is central between us-west and eu-west
 					initSessions:    1000,
 					insertPercent:   80,
 					retrievePercent: 10,


### PR DESCRIPTION
This commit switches the zones used by the `interleavedpartitioned`
roachtest from `us-west1-b,us-east4-b,us-central1-a` to
`us-east1-b,us-west1-b,europe-west2-b`. This acomplishes two goals:
1. it avoids the use of `us-east4-b`, which has been causing issues
   in nightly tests over the past two weeks.
2. it allows the same cluster to be shared between this roachtest and
   `tpccbench/nodes=9/cpu=4/multi-region`.