### PR TITLE
Added CONVERT TO SCHEMA to ALTER DATABASE help text

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1410,6 +1410,7 @@ alter_sequence_options_stmt:
 // %Text:
 // ALTER DATABASE <name> RENAME TO <newname>
 // ALTER DATABASE <name> OWNER TO <newowner>
+// ALTER DATABASE <name> CONVERT TO SCHEMA WITH PARENT <name>
 // %SeeAlso: WEBDOCS/alter-database.html
 alter_database_stmt:
   alter_rename_database_stmt


### PR DESCRIPTION
Release justification: Non-production code changes

Release note: None

I noticed that there is no help text for `CONVERT TO SCHEMA` (#52997):

```
demo@127.0.0.1:55642/defaultdb> \h convert
no help available for "convert".
Try \h with no argument to see available help.
```

```
demo@127.0.0.1:55642/defaultdb> \h alter database
Command:     ALTER DATABASE
Description: change the definition of a database
Category:    schema manipulation
Syntax:
ALTER DATABASE <name> RENAME TO <newname>
ALTER DATABASE <name> OWNER TO <newowner>

See also:
  https://www.cockroachlabs.com/docs/v20.2/alter-database.html
```

This change simply adds an additional line:

`ALTER DATABASE <name> CONVERT TO SCHEMA WITH PARENT <name>`
