### PR TITLE
roachtest: fix for tpcc tests against older versions

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -580,11 +580,12 @@ func RestoreFixture(
 		g.GoCtx(func(ctx context.Context) error {
 			start := timeutil.Now()
 			importStmt := fmt.Sprintf(`RESTORE %s.%s FROM $1 WITH into_db=$2`, genName, table.TableName)
+			log.Infof(ctx, "Restoring from %s", table.BackupURI)
 			var rows, index, tableBytes int64
 			var discard interface{}
 			res, err := sqlDB.Query(importStmt, table.BackupURI, database)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "backup: %s", table.BackupURI)
 			}
 			defer res.Close()
 			if !res.Next() {


### PR DESCRIPTION
#### workload: show the backup object name

Log the backup object URL and return it as part of any error.

Release note: None

#### roachtest: fix for tpcc tests against older versions

Add the `--deprecated-fk-indexes` flag when using a fixture (and not
just `init`).

Note that although this is the right thing to do, we don't have these
fixtures yet. Unfortunately, 20.1 and older aren't able to load
backups created by 20.2 in the first place.

Release note: None
