### PR TITLE
sql: fix unescaped casts to regclass and regtype

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -29,3 +29,28 @@ SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
 query T
 SELECT t1.c0 FROM t1 WHERE t1.c0 BETWEEN t1.c0 AND INTERVAL '-1'::DECIMAL
 ----
+
+# This does not work as the `"` character cannot be used for table names.
+statement error relation ".*"regression_53686.*"" does not exist
+SELECT '\"regression_53686\"'::regclass
+
+statement ok
+CREATE TABLE "regression_53686""" (a int)
+
+query T
+SELECT 'regression_53686"'::regclass
+----
+"regression_53686"""
+
+query T
+SELECT 'public.regression_53686"'::regclass
+----
+"regression_53686"""
+
+statement ok
+CREATE TYPE "regression_53686_enum""" AS ENUM()
+
+query T
+SELECT 'public.regression_53686_enum"'::regtype
+----
+regression_53686_enum"

--- a/pkg/sql/sem/tree/casts_test.go
+++ b/pkg/sql/sem/tree/casts_test.go
@@ -203,3 +203,22 @@ func TestTupleCastVolatility(t *testing.T) {
 		}
 	}
 }
+
+func TestRawStringToEscapedUnresolvedObjectName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		in       string
+		expected string
+	}{
+		{"a", "a"},
+		{`a"`, `"a"""`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			out := rawStringToEscapedUnresolvedObjectName(tc.in)
+			require.Equal(t, tc.expected, out)
+		})
+	}
+}


### PR DESCRIPTION

Release note (bug fix): Fix a bug where casts to regtype/regclass were
not escaped (i.e. when the type or table name had " characters).