### PR TITLE
workload/schemachange support user defined schemas in workload

### DIFF
--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -1038,6 +1038,15 @@ type Mutator interface {
 	Mutate(rng *rand.Rand, stmts []tree.Statement) (mutated []tree.Statement, changed bool)
 }
 
+// MakeSchemaName creates a CreateSchema definition
+func MakeSchemaName(ifNotExists bool, schema string, authRole string) *tree.CreateSchema {
+	return &tree.CreateSchema{
+		IfNotExists: ifNotExists,
+		Schema:      schema,
+		AuthRole:    authRole,
+	}
+}
+
 // RandCreateTables creates random table definitions.
 func RandCreateTables(
 	rng *rand.Rand, prefix string, num int, mutators ...Mutator,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -16,30 +16,31 @@ func _() {
 	_ = x[createTableAs-5]
 	_ = x[createView-6]
 	_ = x[createEnum-7]
-	_ = x[dropColumn-8]
-	_ = x[dropColumnDefault-9]
-	_ = x[dropColumnNotNull-10]
-	_ = x[dropColumnStored-11]
-	_ = x[dropConstraint-12]
-	_ = x[dropIndex-13]
-	_ = x[dropSequence-14]
-	_ = x[dropTable-15]
-	_ = x[dropView-16]
-	_ = x[renameColumn-17]
-	_ = x[renameIndex-18]
-	_ = x[renameSequence-19]
-	_ = x[renameTable-20]
-	_ = x[renameView-21]
-	_ = x[setColumnDefault-22]
-	_ = x[setColumnNotNull-23]
-	_ = x[setColumnType-24]
-	_ = x[insertRow-25]
-	_ = x[validate-26]
+	_ = x[createSchema-8]
+	_ = x[dropColumn-9]
+	_ = x[dropColumnDefault-10]
+	_ = x[dropColumnNotNull-11]
+	_ = x[dropColumnStored-12]
+	_ = x[dropConstraint-13]
+	_ = x[dropIndex-14]
+	_ = x[dropSequence-15]
+	_ = x[dropTable-16]
+	_ = x[dropView-17]
+	_ = x[renameColumn-18]
+	_ = x[renameIndex-19]
+	_ = x[renameSequence-20]
+	_ = x[renameTable-21]
+	_ = x[renameView-22]
+	_ = x[setColumnDefault-23]
+	_ = x[setColumnNotNull-24]
+	_ = x[setColumnType-25]
+	_ = x[insertRow-26]
+	_ = x[validate-27]
 }
 
-const _opType_name = "addColumnaddConstraintcreateIndexcreateSequencecreateTablecreateTableAscreateViewcreateEnumdropColumndropColumnDefaultdropColumnNotNulldropColumnStoreddropConstraintdropIndexdropSequencedropTabledropViewrenameColumnrenameIndexrenameSequencerenameTablerenameViewsetColumnDefaultsetColumnNotNullsetColumnTypeinsertRowvalidate"
+const _opType_name = "addColumnaddConstraintcreateIndexcreateSequencecreateTablecreateTableAscreateViewcreateEnumcreateSchemadropColumndropColumnDefaultdropColumnNotNulldropColumnStoreddropConstraintdropIndexdropSequencedropTabledropViewrenameColumnrenameIndexrenameSequencerenameTablerenameViewsetColumnDefaultsetColumnNotNullsetColumnTypeinsertRowvalidate"
 
-var _opType_index = [...]uint16{0, 9, 22, 33, 47, 58, 71, 81, 91, 101, 118, 135, 151, 165, 174, 186, 195, 203, 215, 226, 240, 251, 261, 277, 293, 306, 315, 323}
+var _opType_index = [...]uint16{0, 9, 22, 33, 47, 58, 71, 81, 91, 103, 113, 130, 147, 163, 177, 186, 198, 207, 215, 227, 238, 252, 263, 273, 289, 305, 318, 327, 335}
 
 func (i opType) String() string {
 	if i < 0 || i >= opType(len(_opType_index)-1) {

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -26,21 +26,22 @@ func _() {
 	_ = x[dropSequence-15]
 	_ = x[dropTable-16]
 	_ = x[dropView-17]
-	_ = x[renameColumn-18]
-	_ = x[renameIndex-19]
-	_ = x[renameSequence-20]
-	_ = x[renameTable-21]
-	_ = x[renameView-22]
-	_ = x[setColumnDefault-23]
-	_ = x[setColumnNotNull-24]
-	_ = x[setColumnType-25]
-	_ = x[insertRow-26]
-	_ = x[validate-27]
+	_ = x[dropSchema-18]
+	_ = x[renameColumn-19]
+	_ = x[renameIndex-20]
+	_ = x[renameSequence-21]
+	_ = x[renameTable-22]
+	_ = x[renameView-23]
+	_ = x[setColumnDefault-24]
+	_ = x[setColumnNotNull-25]
+	_ = x[setColumnType-26]
+	_ = x[insertRow-27]
+	_ = x[validate-28]
 }
 
-const _opType_name = "addColumnaddConstraintcreateIndexcreateSequencecreateTablecreateTableAscreateViewcreateEnumcreateSchemadropColumndropColumnDefaultdropColumnNotNulldropColumnStoreddropConstraintdropIndexdropSequencedropTabledropViewrenameColumnrenameIndexrenameSequencerenameTablerenameViewsetColumnDefaultsetColumnNotNullsetColumnTypeinsertRowvalidate"
+const _opType_name = "addColumnaddConstraintcreateIndexcreateSequencecreateTablecreateTableAscreateViewcreateEnumcreateSchemadropColumndropColumnDefaultdropColumnNotNulldropColumnStoreddropConstraintdropIndexdropSequencedropTabledropViewdropSchemarenameColumnrenameIndexrenameSequencerenameTablerenameViewsetColumnDefaultsetColumnNotNullsetColumnTypeinsertRowvalidate"
 
-var _opType_index = [...]uint16{0, 9, 22, 33, 47, 58, 71, 81, 91, 103, 113, 130, 147, 163, 177, 186, 198, 207, 215, 227, 238, 252, 263, 273, 289, 305, 318, 327, 335}
+var _opType_index = [...]uint16{0, 9, 22, 33, 47, 58, 71, 81, 91, 103, 113, 130, 147, 163, 177, 186, 198, 207, 215, 225, 237, 248, 262, 273, 283, 299, 315, 328, 337, 345}
 
 func (i opType) String() string {
 	if i < 0 || i >= opType(len(_opType_index)-1) {

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -42,7 +42,7 @@ import (
 // includes table creation but note that the tables contain no data.
 //
 // Example usage:
-// `bin/workload run schemachange --init --concurrency=2 --verbose=false --max-ops=1000`
+// `bin/workload run schemachange --init --concurrency=2 --verbose=0 --max-ops-per-worker=1000`
 // will execute up to 1000 schema change operations per txn in two concurrent txns.
 //
 // TODO(peter): This is still work in progress, we need to

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -116,6 +116,7 @@ const (
 	createTableAs  // CREATE TABLE <table> AS <def>
 	createView     // CREATE VIEW <view> AS <def>
 	createEnum     // CREATE TYPE <type> ENUM AS <def>
+	createSchema   // CREATE SCHEMA <schema>
 
 	dropColumn        // ALTER TABLE <table> DROP COLUMN <column>
 	dropColumnDefault // ALTER TABLE <table> ALTER [COLUMN] <column> DROP DEFAULT
@@ -151,6 +152,7 @@ var opWeights = []int{
 	createTableAs:     1,
 	createView:        1,
 	createEnum:        1,
+	createSchema:      1,
 	dropColumn:        1,
 	dropColumnDefault: 1,
 	dropColumnNotNull: 1,
@@ -405,6 +407,9 @@ func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, string, error) {
 
 		case createEnum:
 			stmt, err = w.createEnum(tx)
+
+		case createSchema:
+			stmt, err = w.createSchema(tx)
 
 		case dropColumn:
 			stmt, err = w.dropColumn(tx)
@@ -1121,6 +1126,37 @@ func (w *schemaChangeWorker) randType(tx *pgx.Tx) (tree.ResolvableTypeReference,
 		return n.ToUnresolvedObjectName(tree.NoAnnotation)
 	}
 	return rowenc.RandSortingType(w.rng), nil
+}
+
+func (w *schemaChangeWorker) createSchema(tx *pgx.Tx) (string, error) {
+	schemaName, err := w.randSchema(tx, 10)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO(jayshrivastava): Support authorization
+	stmt := rowenc.MakeSchemaName(w.rng.Intn(2) == 0, schemaName, "")
+	return tree.Serialize(stmt), nil
+}
+
+func (w *schemaChangeWorker) randSchema(tx *pgx.Tx, pctExisting int) (string, error) {
+	if w.rng.Intn(100) >= pctExisting {
+		return fmt.Sprintf("schema%d", atomic.AddInt64(w.seqNum, 1)), nil
+	}
+	const q = `
+  SELECT schema_name
+    FROM information_schema.schemata
+   WHERE schema_name
+    LIKE 'schema%'
+      OR schema_name = 'public'
+ORDER BY random()
+   LIMIT 1;
+`
+	var name string
+	if err := tx.QueryRow(q).Scan(&name); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 // txTypeResolver is a minimal type resolver to support writing enum values to

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -127,6 +127,7 @@ const (
 	dropSequence      // DROP SEQUENCE <sequence>
 	dropTable         // DROP TABLE <table>
 	dropView          // DROP VIEW <view>
+	dropSchema        // DROP SCHEMA <schema>
 
 	renameColumn   // ALTER TABLE <table> RENAME [COLUMN] <column> TO <column>
 	renameIndex    // ALTER TABLE <table> RENAME CONSTRAINT <constraint> TO <constraint>
@@ -162,6 +163,7 @@ var opWeights = []int{
 	dropSequence:      1,
 	dropTable:         1,
 	dropView:          1,
+	dropSchema:        1,
 	renameColumn:      1,
 	renameIndex:       1,
 	renameSequence:    1,
@@ -437,6 +439,9 @@ func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, string, error) {
 
 		case dropView:
 			stmt, err = w.dropView(tx)
+
+		case dropSchema:
+			stmt, err = w.dropSchema(tx)
 
 		case renameColumn:
 			stmt, err = w.renameColumn(tx)
@@ -1157,6 +1162,14 @@ ORDER BY random()
 		return "", err
 	}
 	return name, nil
+}
+
+func (w *schemaChangeWorker) dropSchema(tx *pgx.Tx) (string, error) {
+	schemaName, err := w.randSchema(tx, 100)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, schemaName), nil
 }
 
 // txTypeResolver is a minimal type resolver to support writing enum values to

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -503,7 +503,7 @@ func (w *schemaChangeWorker) addColumn(tx *pgx.Tx) (string, error) {
 		Type: typ,
 	}
 	def.Nullable.Nullability = tree.Nullability(rand.Intn(1 + int(tree.SilentNull)))
-	return fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN %s`, tableName, tree.Serialize(def)), nil
+	return fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s`, tableName, tree.Serialize(def)), nil
 }
 
 func (w *schemaChangeWorker) addConstraint(tx *pgx.Tx) (string, error) {
@@ -600,7 +600,7 @@ func (w *schemaChangeWorker) createTableAs(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(`CREATE TABLE "%s" AS SELECT %s FROM "%s"`,
+	return fmt.Sprintf(`CREATE TABLE %s AS SELECT %s FROM %s`,
 		destTableName, tree.Serialize(&names), tableName), nil
 }
 
@@ -627,7 +627,7 @@ func (w *schemaChangeWorker) createView(tx *pgx.Tx) (string, error) {
 	}
 
 	// TODO(peter): Create views that are dependent on multiple tables.
-	return fmt.Sprintf(`CREATE VIEW "%s" AS SELECT %s FROM "%s"`,
+	return fmt.Sprintf(`CREATE VIEW %s AS SELECT %s FROM %s`,
 		destViewName, tree.Serialize(&names), tableName), nil
 }
 
@@ -641,7 +641,7 @@ func (w *schemaChangeWorker) dropColumn(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" DROP COLUMN "%s"`, tableName, columnName), nil
+	return fmt.Sprintf(`ALTER TABLE %s DROP COLUMN "%s"`, tableName, columnName), nil
 }
 
 func (w *schemaChangeWorker) dropColumnDefault(tx *pgx.Tx) (string, error) {
@@ -653,7 +653,7 @@ func (w *schemaChangeWorker) dropColumnDefault(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" DROP DEFAULT`, tableName, columnName), nil
+	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" DROP DEFAULT`, tableName, columnName), nil
 }
 
 func (w *schemaChangeWorker) dropColumnNotNull(tx *pgx.Tx) (string, error) {
@@ -665,7 +665,7 @@ func (w *schemaChangeWorker) dropColumnNotNull(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" DROP NOT NULL`, tableName, columnName), nil
+	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" DROP NOT NULL`, tableName, columnName), nil
 }
 
 func (w *schemaChangeWorker) dropColumnStored(tx *pgx.Tx) (string, error) {
@@ -678,7 +678,7 @@ func (w *schemaChangeWorker) dropColumnStored(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" DROP STORED`, tableName, columnName), nil
+	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" DROP STORED`, tableName, columnName), nil
 }
 
 func (w *schemaChangeWorker) dropConstraint(tx *pgx.Tx) (string, error) {
@@ -691,7 +691,7 @@ func (w *schemaChangeWorker) dropConstraint(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" DROP CONSTRAINT "%s"`, tableName, constraintName), nil
+	return fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT "%s"`, tableName, constraintName), nil
 }
 
 func (w *schemaChangeWorker) dropIndex(tx *pgx.Tx) (string, error) {
@@ -704,7 +704,7 @@ func (w *schemaChangeWorker) dropIndex(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`DROP INDEX "%s"@"%s"`, tableName, indexName), nil
+	return fmt.Sprintf(`DROP INDEX %s@"%s"`, tableName, indexName), nil
 }
 
 func (w *schemaChangeWorker) dropSequence(tx *pgx.Tx) (string, error) {
@@ -720,7 +720,7 @@ func (w *schemaChangeWorker) dropTable(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`DROP TABLE "%s"`, tableName), nil
+	return fmt.Sprintf(`DROP TABLE %s`, tableName), nil
 }
 
 func (w *schemaChangeWorker) dropView(tx *pgx.Tx) (string, error) {
@@ -728,7 +728,7 @@ func (w *schemaChangeWorker) dropView(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`DROP VIEW "%s"`, viewName), nil
+	return fmt.Sprintf(`DROP VIEW %s`, viewName), nil
 }
 
 func (w *schemaChangeWorker) renameColumn(tx *pgx.Tx) (string, error) {
@@ -747,7 +747,7 @@ func (w *schemaChangeWorker) renameColumn(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(`ALTER TABLE "%s" RENAME COLUMN "%s" TO "%s"`,
+	return fmt.Sprintf(`ALTER TABLE %s RENAME COLUMN "%s" TO "%s"`,
 		tableName, srcColumnName, destColumnName), nil
 }
 
@@ -767,7 +767,7 @@ func (w *schemaChangeWorker) renameIndex(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(`ALTER TABLE "%s" RENAME CONSTRAINT "%s" TO "%s"`,
+	return fmt.Sprintf(`ALTER TABLE %s RENAME CONSTRAINT "%s" TO "%s"`,
 		tableName, srcIndexName, destIndexName), nil
 }
 
@@ -796,7 +796,7 @@ func (w *schemaChangeWorker) renameTable(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(`ALTER TABLE "%s" RENAME TO "%s"`, srcTableName, destTableName), nil
+	return fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, srcTableName, destTableName), nil
 }
 
 func (w *schemaChangeWorker) renameView(tx *pgx.Tx) (string, error) {
@@ -810,7 +810,7 @@ func (w *schemaChangeWorker) renameView(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(`ALTER VIEW "%s" RENAME TO "%s"`, srcViewName, destViewName), nil
+	return fmt.Sprintf(`ALTER VIEW %s RENAME TO %s`, srcViewName, destViewName), nil
 }
 
 func (w *schemaChangeWorker) setColumnDefault(tx *pgx.Tx) (string, error) {
@@ -828,7 +828,7 @@ func (w *schemaChangeWorker) setColumnNotNull(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" SET NOT NULL`, tableName, columnName), nil
+	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" SET NOT NULL`, tableName, columnName), nil
 }
 
 func (w *schemaChangeWorker) setColumnType(tx *pgx.Tx) (string, error) {
@@ -844,7 +844,7 @@ func (w *schemaChangeWorker) setColumnType(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" SET DATA TYPE %s`,
+	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" SET DATA TYPE %s`,
 		tableName, columnName, typ), nil
 }
 
@@ -872,7 +872,7 @@ func (w *schemaChangeWorker) insertRow(tx *pgx.Tx) (string, error) {
 		rows = append(rows, fmt.Sprintf("(%s)", strings.Join(row, ",")))
 	}
 	return fmt.Sprintf(
-		`INSERT INTO "%s" (%s) VALUES %s`,
+		`INSERT INTO %s (%s) VALUES %s`,
 		tableName,
 		strings.Join(colNames, ","),
 		strings.Join(rows, ","),
@@ -919,7 +919,7 @@ type column struct {
 func (w *schemaChangeWorker) getTableColumns(tx *pgx.Tx, tableName string) ([]column, error) {
 	q := fmt.Sprintf(`
   SELECT column_name, data_type, is_nullable
-    FROM [SHOW COLUMNS FROM "%s"]
+    FROM [SHOW COLUMNS FROM %s]
 `, tableName)
 	rows, err := tx.Query(q)
 	if err != nil {
@@ -971,7 +971,7 @@ func (w *schemaChangeWorker) randColumn(
 	}
 	q := fmt.Sprintf(`
   SELECT column_name
-    FROM [SHOW COLUMNS FROM "%s"]
+    FROM [SHOW COLUMNS FROM %s]
 ORDER BY random()
    LIMIT 1;
 `, tableName)
@@ -985,7 +985,7 @@ ORDER BY random()
 func (w *schemaChangeWorker) randConstraint(tx *pgx.Tx, tableName string) (string, error) {
 	q := fmt.Sprintf(`
   SELECT constraint_name
-    FROM [SHOW CONSTRAINTS FROM "%s"]
+    FROM [SHOW CONSTRAINTS FROM %s]
 ORDER BY random()
    LIMIT 1;
 `, tableName)
@@ -1008,7 +1008,7 @@ func (w *schemaChangeWorker) randIndex(
 	}
 	q := fmt.Sprintf(`
   SELECT index_name
-    FROM [SHOW INDEXES FROM "%s"]
+    FROM [SHOW INDEXES FROM %s]
 ORDER BY random()
    LIMIT 1;
 `, tableName)
@@ -1134,7 +1134,7 @@ ORDER BY random()
 func (w *schemaChangeWorker) tableColumnsShuffled(tx *pgx.Tx, tableName string) ([]string, error) {
 	q := fmt.Sprintf(`
 SELECT column_name
-FROM [SHOW COLUMNS FROM "%s"];
+FROM [SHOW COLUMNS FROM %s];
 `, tableName)
 
 	rows, err := tx.Query(q)


### PR DESCRIPTION
Adds support for user-defined schemas 
- create schema op
- drop schema op
- updates tables, enums, and views to be qualified with schema name prefixes

Resolves: #54408
Release note: None