### PR TITLE
pkg/storage: expose read amp and num sstable metrics

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -736,47 +736,6 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var debugSSTablesCmd = &cobra.Command{
-	Use:   "sstables <directory>",
-	Short: "list the sstables in a store",
-	Long: `
-
-List the sstables in a store. The output format is 1 or more lines of:
-
-  level [ total size #files ]: file sizes
-
-Only non-empty levels are shown. For levels greater than 0, the files span
-non-overlapping ranges of the key space. Level-0 is special in that sstables
-are created there by flushing the mem-table, thus every level-0 sstable must be
-consulted to see if it contains a particular key. Within a level, the file
-sizes are displayed in decreasing order and bucketed by the number of files of
-that size. The following example shows 3-level output. In Level-3, there are 19
-total files and 14 files that are 129 MiB in size.
-
-  1 [   8M  3 ]: 7M 1M 63K
-  2 [ 110M  7 ]: 31M 30M 13M[2] 10M 8M 5M
-  3 [   2G 19 ]: 129M[14] 122M 93M 24M 18M 9M
-
-The suffixes K, M, G and T are used for terseness to represent KiB, MiB, GiB
-and TiB.
-`,
-	Args: cobra.ExactArgs(1),
-	RunE: MaybeDecorateGRPCError(runDebugSSTables),
-}
-
-func runDebugSSTables(cmd *cobra.Command, args []string) error {
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	db, err := OpenExistingStore(args[0], stopper, true /* readOnly */)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s", db.GetSSTables())
-	return nil
-}
-
 var debugGossipValuesCmd = &cobra.Command{
 	Use:   "gossip-values",
 	Short: "dump all the values in a node's gossip instance",
@@ -1235,7 +1194,6 @@ var DebugCmdsForRocksDB = []*cobra.Command{
 	debugRaftLogCmd,
 	debugRangeDataCmd,
 	debugRangeDescriptorsCmd,
-	debugSSTablesCmd,
 }
 
 // All other debug commands go here.

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1628,26 +1628,26 @@ func (sm *TenantsStorageMetrics) subtractMVCCStats(
 	sm.incMVCCGauges(ctx, tenantID, neg)
 }
 
-func (sm *StoreMetrics) updateRocksDBStats(stats storage.Stats) {
-	// We do not grab a lock here, because it's not possible to get a point-in-
-	// time snapshot of RocksDB stats. Retrieving RocksDB stats doesn't grab any
-	// locks, and there's no way to retrieve multiple stats in a single operation.
-	sm.RdbBlockCacheHits.Update(stats.BlockCacheHits)
-	sm.RdbBlockCacheMisses.Update(stats.BlockCacheMisses)
-	sm.RdbBlockCacheUsage.Update(stats.BlockCacheUsage)
-	sm.RdbBlockCachePinnedUsage.Update(stats.BlockCachePinnedUsage)
-	sm.RdbBloomFilterPrefixUseful.Update(stats.BloomFilterPrefixUseful)
-	sm.RdbBloomFilterPrefixChecked.Update(stats.BloomFilterPrefixChecked)
-	sm.RdbMemtableTotalSize.Update(stats.MemtableTotalSize)
-	sm.RdbFlushes.Update(stats.Flushes)
-	sm.RdbFlushedBytes.Update(stats.FlushedBytes)
-	sm.RdbCompactions.Update(stats.Compactions)
-	sm.RdbIngestedBytes.Update(stats.IngestedBytes)
-	sm.RdbCompactedBytesRead.Update(stats.CompactedBytesRead)
-	sm.RdbCompactedBytesWritten.Update(stats.CompactedBytesWritten)
-	sm.RdbTableReadersMemEstimate.Update(stats.TableReadersMemEstimate)
-	sm.DiskSlow.Update(stats.DiskSlowCount)
-	sm.DiskStalled.Update(stats.DiskStallCount)
+func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
+	sm.RdbBlockCacheHits.Update(m.BlockCacheHits)
+	sm.RdbBlockCacheMisses.Update(m.BlockCacheMisses)
+	sm.RdbBlockCacheUsage.Update(m.BlockCacheUsage)
+	sm.RdbBlockCachePinnedUsage.Update(m.BlockCachePinnedUsage)
+	sm.RdbBloomFilterPrefixUseful.Update(m.BloomFilterPrefixUseful)
+	sm.RdbBloomFilterPrefixChecked.Update(m.BloomFilterPrefixChecked)
+	sm.RdbMemtableTotalSize.Update(m.MemtableTotalSize)
+	sm.RdbFlushes.Update(m.Flushes)
+	sm.RdbFlushedBytes.Update(m.FlushedBytes)
+	sm.RdbCompactions.Update(m.Compactions)
+	sm.RdbIngestedBytes.Update(m.IngestedBytes)
+	sm.RdbCompactedBytesRead.Update(m.CompactedBytesRead)
+	sm.RdbCompactedBytesWritten.Update(m.CompactedBytesWritten)
+	sm.RdbTableReadersMemEstimate.Update(m.TableReadersMemEstimate)
+	sm.RdbReadAmplification.Update(m.ReadAmplification)
+	sm.RdbPendingCompaction.Update(m.PendingCompactionBytesEstimate)
+	sm.RdbNumSSTables.Update(m.NumSSTables)
+	sm.DiskSlow.Update(m.DiskSlowCount)
+	sm.DiskStalled.Update(m.DiskStallCount)
 }
 
 func (sm *StoreMetrics) updateEnvStats(stats storage.EnvStats) {

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -719,7 +719,7 @@ func TestEngineTimeBound(t *testing.T) {
 	}
 }
 
-func TestFlushWithSSTables(t *testing.T) {
+func TestFlushNumSSTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -749,8 +749,11 @@ func TestFlushWithSSTables(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ssts := engine.GetSSTables()
-			if len(ssts) == 0 {
+			m, err := engine.GetMetrics()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if m.NumSSTables == 0 {
 				t.Fatal("expected non-zero sstables, got 0")
 			}
 		})
@@ -1148,19 +1151,19 @@ func TestIngestDelayLimit(t *testing.T) {
 	max, ramp := time.Second*5, time.Second*5/10
 
 	for _, tc := range []struct {
-		exp   time.Duration
-		stats Stats
+		exp     time.Duration
+		metrics Metrics
 	}{
-		{0, Stats{}},
-		{0, Stats{L0FileCount: 19, L0SublevelCount: -1}},
-		{0, Stats{L0FileCount: 20, L0SublevelCount: -1}},
-		{ramp, Stats{L0FileCount: 21, L0SublevelCount: -1}},
-		{ramp * 2, Stats{L0FileCount: 22, L0SublevelCount: -1}},
-		{ramp * 2, Stats{L0FileCount: 22, L0SublevelCount: 22}},
-		{ramp * 2, Stats{L0FileCount: 55, L0SublevelCount: 22}},
-		{max, Stats{L0FileCount: 55, L0SublevelCount: -1}},
+		{0, Metrics{}},
+		{0, Metrics{L0FileCount: 19, L0SublevelCount: -1}},
+		{0, Metrics{L0FileCount: 20, L0SublevelCount: -1}},
+		{ramp, Metrics{L0FileCount: 21, L0SublevelCount: -1}},
+		{ramp * 2, Metrics{L0FileCount: 22, L0SublevelCount: -1}},
+		{ramp * 2, Metrics{L0FileCount: 22, L0SublevelCount: 22}},
+		{ramp * 2, Metrics{L0FileCount: 55, L0SublevelCount: 22}},
+		{max, Metrics{L0FileCount: 55, L0SublevelCount: -1}},
 	} {
-		require.Equal(t, tc.exp, calculatePreIngestDelay(s, &tc.stats))
+		require.Equal(t, tc.exp, calculatePreIngestDelay(s, &tc.metrics))
 	}
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -787,19 +787,20 @@ func (p *Pebble) Flush() error {
 	return p.db.Flush()
 }
 
-// GetStats implements the Engine interface.
-func (p *Pebble) GetStats() (*Stats, error) {
+// GetMetrics implements the Engine interface.
+func (p *Pebble) GetMetrics() (*Metrics, error) {
 	m := p.db.Metrics()
 
 	// Aggregate compaction stats across levels.
-	var ingestedBytes, compactedBytesRead, compactedBytesWritten int64
+	var ingestedBytes, compactedBytesRead, compactedBytesWritten, numSSTables int64
 	for _, lm := range m.Levels {
 		ingestedBytes += int64(lm.BytesIngested)
 		compactedBytesRead += int64(lm.BytesRead)
 		compactedBytesWritten += int64(lm.BytesCompacted)
+		numSSTables += lm.NumFiles
 	}
 
-	return &Stats{
+	return &Metrics{
 		BlockCacheHits:                 m.BlockCache.Hits,
 		BlockCacheMisses:               m.BlockCache.Misses,
 		BlockCacheUsage:                m.BlockCache.Size,
@@ -819,6 +820,8 @@ func (p *Pebble) GetStats() (*Stats, error) {
 		PendingCompactionBytesEstimate: int64(m.Compact.EstimatedDebt),
 		L0FileCount:                    m.Levels[0].NumFiles,
 		L0SublevelCount:                int64(m.Levels[0].Sublevels),
+		ReadAmplification:              int64(m.ReadAmp()),
+		NumSSTables:                    numSSTables,
 	}, nil
 }
 
@@ -1071,24 +1074,11 @@ func (p *Pebble) CreateCheckpoint(dir string) error {
 	return p.db.Checkpoint(dir)
 }
 
-// GetSSTables implements the WithSSTables interface.
-func (p *Pebble) GetSSTables() (sstables SSTableInfos) {
-	for level, tables := range p.db.SSTables() {
-		for _, table := range tables {
-			startKey, _ := DecodeMVCCKey(table.Smallest.UserKey)
-			endKey, _ := DecodeMVCCKey(table.Largest.UserKey)
-			info := SSTableInfo{
-				Level: level,
-				Size:  int64(table.Size),
-				Start: startKey,
-				End:   endKey,
-			}
-			sstables = append(sstables, info)
-		}
-	}
-
-	sort.Sort(sstables)
-	return sstables
+// GetSSTables implements the Engine interface.
+func (p *Pebble) GetSSTables() SSTableInfos {
+	// TODO(jackson): Remove GetSSTables from the Engine interface altogether
+	// once RocksDB and the compactor queue is removed.
+	panic("unimplemented")
 }
 
 type pebbleReadOnly struct {

--- a/pkg/storage/sst_info_test.go
+++ b/pkg/storage/sst_info_test.go
@@ -20,58 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-func TestSSTableInfosString(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	info := func(level int, size int64) SSTableInfo {
-		return SSTableInfo{
-			Level: level,
-			Size:  size,
-		}
-	}
-	tables := SSTableInfos{
-		info(1, 7<<20),
-		info(1, 1<<20),
-		info(1, 63<<10),
-		info(2, 10<<20),
-		info(2, 8<<20),
-		info(2, 13<<20),
-		info(2, 31<<20),
-		info(2, 13<<20),
-		info(2, 30<<20),
-		info(2, 5<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 9<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 93<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 122<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 129<<20),
-		info(3, 24<<20),
-		info(3, 18<<20),
-	}
-	expected := `1 [   8M  3 ]: 7M 1M 63K
-2 [ 110M  7 ]: 31M 30M 13M[2] 10M 8M 5M
-3 [   2G 19 ]: 129M[14] 122M 93M 24M 18M 9M
-`
-	sort.Sort(tables)
-	s := tables.String()
-	if expected != s {
-		t.Fatalf("expected\n%s\ngot\n%s", expected, s)
-	}
-}
-
 func TestReadAmplification(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -89,7 +37,7 @@ func TestReadAmplification(t *testing.T) {
 		info(0, 0),
 		info(1, 0),
 	}
-	if a, e := tables1.ReadAmplification(-1), 4; a != e {
+	if a, e := tables1.readAmplification(-1), int64(4); a != e {
 		t.Errorf("got %d, expected %d", a, e)
 	}
 
@@ -99,7 +47,7 @@ func TestReadAmplification(t *testing.T) {
 		info(2, 0),
 		info(3, 0),
 	}
-	if a, e := tables2.ReadAmplification(-1), 4; a != e {
+	if a, e := tables2.readAmplification(-1), int64(4); a != e {
 		t.Errorf("got %d, expected %d", a, e)
 	}
 
@@ -114,13 +62,13 @@ func TestReadAmplification(t *testing.T) {
 		info(3, 0),
 		info(6, 0),
 	}
-	if a, e := tables3.ReadAmplification(-1), 7; a != e {
+	if a, e := tables3.readAmplification(-1), int64(7); a != e {
 		t.Errorf("got %d, expected %d", a, e)
 	}
-	if a, e := tables3.ReadAmplification(2), 6; a != e {
+	if a, e := tables3.readAmplification(2), int64(6); a != e {
 		t.Errorf("got %d, expected %d", a, e)
 	}
-	if a, e := tables3.ReadAmplification(1), 5; a != e {
+	if a, e := tables3.readAmplification(1), int64(5); a != e {
 		t.Errorf("got %d, expected %d", a, e)
 	}
 }

--- a/pkg/storage/tee.go
+++ b/pkg/storage/tee.go
@@ -257,9 +257,9 @@ func (t *TeeEngine) GetCompactionStats() string {
 	return t.eng1.GetCompactionStats()
 }
 
-// GetStats implements the Engine interface.
-func (t *TeeEngine) GetStats() (*Stats, error) {
-	return t.eng1.GetStats()
+// GetMetrics implements the Engine interface.
+func (t *TeeEngine) GetMetrics() (*Metrics, error) {
+	return t.eng1.GetMetrics()
 }
 
 // GetEncryptionRegistries implements the Engine interface.


### PR DESCRIPTION
This commit cleans up the recording storage-engine metrics to avoid
O(# sstables) operations and takes the opportunity to clean up some
adjacent code.

It renames the `Stats` type to `Metrics` to align with Pebble's
`Metrics` method and type, as well as kvserver's own terminology during
its usage. It also removes the histogram of sstable sizes printed every
10m.

Fix #52981.

Release note: none