### PR TITLE
sql: ensure backfills use the same timestamp in their evalContext

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1956,13 +1956,7 @@ func createSchemaChangeEvalCtx(
 		},
 	}
 	// The backfill is going to use the current timestamp for the various
-	// functions, like now(), that need it.  It's possible that the backfill has
-	// been partially performed already by another SchemaChangeManager with
-	// another timestamp.
-	//
-	// TODO(andrei): Figure out if this is what we want, and whether the
-	// timestamp from the session that enqueued the schema change
-	// is/should be used for impure functions like now().
+	// functions, like now(), that need it.
 	evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, ts.WallTime))
 	evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, ts.WallTime))
 


### PR DESCRIPTION
This fixes a bug whereby column backfills which are restarted and rely on
`now()` or functions like it actually return the same value throughout
the backfill.

Release note (bug fix): Fixed a bug in column additions which utilized time
functions that could lead to multiple different values being used throughout
a backfill if an internal restart occurred.