### PR TITLE
logictest: randomly backup/restore in logic tests

### DIFF
--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql/logictest",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -22,6 +23,18 @@ const logictestPkg = "../../sql/logictest/"
 func TestCCLLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, testdataGlob)
+}
+
+// TestBackupRestoreLogic runs all non-CCL logic test files under the
+// 3node-backup configuration, which randomly runs a backup and restore between
+// logic test statements to ensure that we can always take a backup and restore
+// the data correctly. Test files that blocklist the 3node-backup configuration
+// (i.e. "# LogicTest: !3node-backup") are not run.
+func TestBackupRestoreLogic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderStress(t, "times out under stress")
+	logictest.RunLogicTestWithDefaultConfig(t, logictest.TestServerArgs{}, "3node-backup",
+		true /* runCCLConfigs */, logictestPkg+testdataGlob)
 }
 
 // TestTenantLogic runs all non-CCL logic test files under the 3node-tenant

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1058,8 +1058,13 @@ type logicTest struct {
 	subtestT *testing.T
 	rng      *rand.Rand
 	cfg      testClusterConfig
-	// the number of nodes in the cluster.
+	// cluster is the test cluster against which we are testing. This cluster
+	// may be reset during the lifetime of the test.
 	cluster serverutils.TestClusterInterface
+	// sharedIODir is the ExternalIO directory that is shared between all clusters
+	// created in the same logicTest. It is populated during setup() of the logic
+	// test.
+	sharedIODir string
 	// the index of the node (within the cluster) against which we run the test
 	// statements.
 	nodeIdx int
@@ -1072,9 +1077,18 @@ type logicTest struct {
 	// client currently in use. This can change during processing
 	// of a test input file when encountering the "user" directive.
 	// see setUser() for details.
-	user         string
-	db           *gosql.DB
-	cleanupFuncs []func()
+	user string
+	db   *gosql.DB
+	// clusterCleanupFuncs contains the cleanup methods that are specific to a
+	// cluster. These will be called during cluster tear-down. Note that 1 logic
+	// test may reset its cluster throughout a test. Cleanup methods that should
+	// be stored here include PGUrl connections for the users for a cluster.
+	clusterCleanupFuncs []func()
+	// testCleanupFuncs are cleanup methods that are only called when closing a
+	// test (rather than a specific cluster). One test may reset a cluster with a
+	// new one, but keep some shared resources across the entire test. An example
+	// would be an IO directory used throughout the test.
+	testCleanupFuncs []func()
 	// progress holds the number of tests executed so far.
 	progress int
 	// failures holds the number of tests failed so far, when
@@ -1177,22 +1191,12 @@ func (t *logicTest) emit(line string) {
 func (t *logicTest) close() {
 	t.traceStop()
 
-	for _, cleanup := range t.cleanupFuncs {
+	t.shutdownCluster()
+
+	for _, cleanup := range t.testCleanupFuncs {
 		cleanup()
 	}
-	t.cleanupFuncs = nil
-
-	if t.cluster != nil {
-		t.cluster.Stopper().Stop(context.TODO())
-		t.cluster = nil
-	}
-	if t.clients != nil {
-		for _, c := range t.clients {
-			c.Close()
-		}
-		t.clients = nil
-	}
-	t.db = nil
+	t.testCleanupFuncs = nil
 }
 
 // out emits a message both on stdout and the log files if
@@ -1257,10 +1261,11 @@ func (t *logicTest) setUser(user string) func() {
 	return cleanupFunc
 }
 
-func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
-	t.cfg = cfg
-	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
-	// MySQL or Postgres instance.
+// newCluster creates a new cluster. It should be called after the logic tests's
+// server args are configured. That is, either during setup() when creating the
+// initial cluster to be used in a test, or when creating additional test
+// clusters, after logicTest.setup() has been called.
+func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 	// TODO(andrei): if createTestServerParams() is used here, the command filter
 	// it installs detects a transaction that doesn't have
 	// modifiedSystemConfigSpan set even though it should, for
@@ -1271,6 +1276,7 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 	} else {
 		tempStorageConfig = base.DefaultTestTempStorageConfigWithSize(cluster.MakeTestingClusterSettings(), serverArgs.tempStorageDiskLimit)
 	}
+
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			// Specify a fixed memory limit (some test cases verify OOM conditions; we
@@ -1293,8 +1299,8 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 					DeterministicExplainAnalyze: true,
 				},
 			},
-			ClusterName: "testclustername",
-			UseDatabase: "test",
+			ClusterName:   "testclustername",
+			ExternalIODir: t.sharedIODir,
 		},
 		// For distributed SQL tests, we use the fake span resolver; it doesn't
 		// matter where the data really is.
@@ -1304,6 +1310,7 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 	distSQLKnobs := &execinfra.TestingKnobs{
 		MetadataTestLevel: execinfra.Off, DeterministicStats: true, CheckVectorizedFlowIsClosedCorrectly: true,
 	}
+	cfg := t.cfg
 	if cfg.sqlExecUseDisk {
 		distSQLKnobs.ForceDiskSpill = true
 	}
@@ -1536,10 +1543,48 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 
 	// db may change over the lifetime of this function, with intermediate
 	// values cached in t.clients and finally closed in t.close().
-	t.cleanupFuncs = append(t.cleanupFuncs, t.setUser(security.RootUser))
+	t.clusterCleanupFuncs = append(t.clusterCleanupFuncs, t.setUser(security.RootUser))
+}
 
+// shutdownCluster performs the necessary cleanup to shutdown the current test
+// cluster.
+func (t *logicTest) shutdownCluster() {
+	for _, cleanup := range t.clusterCleanupFuncs {
+		cleanup()
+	}
+	t.clusterCleanupFuncs = nil
+
+	if t.cluster != nil {
+		t.cluster.Stopper().Stop(context.TODO())
+		t.cluster = nil
+	}
+	if t.clients != nil {
+		for _, c := range t.clients {
+			c.Close()
+		}
+		t.clients = nil
+	}
+	t.db = nil
+}
+
+// setup creates the initial cluster for the logic test and populates the
+// relevant fields on logicTest. It is expected to be called only once, and
+// before processing any test files - unless a mock logicTest is created (see
+// parallelTest.processTestFile).
+func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
+	t.cfg = cfg
+	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
+	// MySQL or Postgres instance.
+	tempExternalIODir, tempExternalIODirCleanup := testutils.TempDir(t.rootT)
+	t.sharedIODir = tempExternalIODir
+	t.testCleanupFuncs = append(t.testCleanupFuncs, tempExternalIODirCleanup)
+
+	t.newCluster(serverArgs)
+
+	// Only create the test database on the initial cluster, since cluster restore
+	// expects an empty cluster.
 	if _, err := t.db.Exec(`
-CREATE DATABASE test;
+CREATE DATABASE test; USE test;
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # A basic sanity check to demonstrate column type changes.
 subtest SanityCheck
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,3 +1,8 @@
+# LogicTest: !3node-backup
+
+# This test works fine with backup restore except for the SHOW JOBS statement
+# that is finding 2 jobs.
+
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,3 +1,4 @@
+# LogicTest: !3node-backup
 
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Some tests for RENAME TYPE.
 statement ok
 CREATE TYPE greeting AS ENUM ('hi', 'hello');

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, str STRING);
 CREATE TABLE u (l INT PRIMARY KEY, str2 STRING);

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file because the config runs with
 # a CCL binary, so the expected failures from using follower reads don't occur.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
 statement ok
 CREATE TABLE t (i INT)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854) !fakedist-spec-planning
+# LogicTest: !3node-tenant(49854) !fakedist-spec-planning !3node-backup
 # TODO(asubiotto): Possibly split out the test that attempts to set a zone
 # config in order to run the other ones.
 

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 query T
 SHOW bytea_output
 ----

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -1,7 +1,7 @@
-# 3node-tenant is blocked from running this file because the config runs with
-# a CCL binary, so the expected failures from using follower reads don't occur
-# (we get unauthenticated errors instead).
-# LogicTest: !3node-tenant
+# 3node-tenant and 3node-backup is blocked from running this file because the
+# config runs with a CCL binary, so the expected failures from using follower
+# reads don't occur (we get unauthenticated errors instead).
+# LogicTest: !3node-tenant !3node-backup
 
 # CCL-only statements error out trying to handle the parsed statements.
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file due to heavy reliance on
 # unavailable node IDs in this test.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t (
   a TIMESTAMP PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET SEARCH_PATH = foo
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50047)
+# LogicTest: !3node-tenant(50047) !3node-backup
 
 ###################
 # CREATE STATISTICS

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET sql_safe_updates = false;
 SET enable_experimental_alter_column_type_general = true;

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
 
 statement ok
 CREATE TYPE t AS ENUM ()

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50047)
+# LogicTest: !3node-tenant(50047) !3node-backup
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,4 +1,4 @@
-# LogicTest: fakedist-vec-off
+# LogicTest: fakedist-vec-off !3node-backup
 #
 # TODO(radu): enable other configs when the vectorized stat collector issue
 # #56928 is fixed.

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
 
 statement ok
 SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE

--- a/pkg/sql/logictest/testdata/logic_test/grant_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/grant_in_txn
@@ -1,7 +1,7 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
-# skip this test in the multi-tenant setting because the timeout seems to get
-# triggered.
+# skip this test in the multi-tenant and backup-restore setting because the
+# timeout seems to get triggered.
 
 # This tests ensures that transactions to perform grants on entities created
 # inside of a transaction do not get blocked and take a very long time.

--- a/pkg/sql/logictest/testdata/logic_test/hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/hash_join
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE  t1 (k INT PRIMARY KEY, v INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file because of the absence of
 # the tenant table for tenants.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 subtest defaults
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
 # Grandparent table
 statement ok
 CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # 3node-tenant fails due to AUTO STATS being returned in SHOW JOBS. Changing
 # the cluster setting to disable auto stats doesn't work:
 # https://github.com/cockroachdb/cockroach/issues/47918

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 query I
 SELECT generate_series FROM generate_series(1, 100) ORDER BY generate_series LIMIT 5;
 ----

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 subtest automatic_retry
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
 
 statement ok
 GRANT CREATE ON DATABASE test TO testuser

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
@@ -1,3 +1,4 @@
+# LogicTest: !3node-backup
 # Parallel statement execution was removed in 19.2. See #34789.
 # The RETURNING NOTHING syntax was retained to ensure backward compatibility,
 # even though the runtime semantics of parallel statements were removed. This

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1,7 +1,7 @@
-# 3node-tenant is blocked from running this file because the config runs with
-# a CCL binary, so the expected failures from using follower reads don't occur
-# (we get unauthenticated errors instead).
-# LogicTest: !3node-tenant
+# 3node-tenant and 3node-backup are blocked from running this file because the
+# config runs with a CCL binary, so the expected failures from using follower
+# reads don't occur (we get unauthenticated errors instead).
+# LogicTest: !3node-tenant !3node-backup
 
 statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (

--- a/pkg/sql/logictest/testdata/logic_test/poison_after_push
+++ b/pkg/sql/logictest/testdata/logic_test/poison_after_push
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # This example session documents that a SERIALIZABLE transaction is
 # not immediately poisoned when it revisits a Range on which one of
 # its intents has had its timestamp pushed. This allows it to continue

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -1,4 +1,4 @@
-# LogicTest: default-configs local-mixed-20.1-20.2
+# LogicTest: default-configs local-mixed-20.1-20.2 3node-backup
 # The mixed configuration is enabled to test backward compatibility for database
 # schema changes.
 

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t()
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: local 3node-tenant
+# LogicTest: local 3node-tenant !3node-backup
 
 statement error a role/user named admin already exists
 CREATE ROLE admin

--- a/pkg/sql/logictest/testdata/logic_test/save_table
+++ b/pkg/sql/logictest/testdata/logic_test/save_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # savetables is the name of the database where tables created by the
 # saveTableNode are stored.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET experimental_enable_temp_tables = true;
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Test all feature flags when set to off in SQL package.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE;

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,4 +1,4 @@
- # LogicTest: !3node-tenant(49854)
+ # LogicTest: !3node-tenant(49854) !3node-backup
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,3 +1,4 @@
+# LogicTest: !3node-backup
 # This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
 
 # Schema changes that experienced retriable errors in RELEASE

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Cockroach currently supports all of the row locking modes as no-ops, so just
 # test that they parse and run.
 query I

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
 # USING THE `lastval` FUNCTION

--- a/pkg/sql/logictest/testdata/logic_test/sequences_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_distsql
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Test that sequence functions work in DistSQL queries.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -1,3 +1,4 @@
+# LogicTest: !3node-backup
 subtest serial_rowid
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
+++ b/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Demonstrates late restarting of a serializable transaction when its
 # commit timestamp has moved forward.
 # TODO(tschottdorf): implement eager restart for CLI.

--- a/pkg/sql/logictest/testdata/logic_test/set_schema
+++ b/pkg/sql/logictest/testdata/logic_test/set_schema
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE SCHEMA s1
 

--- a/pkg/sql/logictest/testdata/logic_test/split_at
+++ b/pkg/sql/logictest/testdata/logic_test/split_at
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
 # Test formatting of keys in output of SPLIT AT
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1,4 +1,5 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
+
 query TTTTT
 SHOW DATABASES
 ----

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, INDEX i (z));
 INSERT INTO t VALUES (1, 2, 3)

--- a/pkg/sql/logictest/testdata/logic_test/system_namespace
+++ b/pkg/sql/logictest/testdata/logic_test/system_namespace
@@ -1,6 +1,6 @@
 # system_namespace fails when run as a tenant because of the absence of the
 # tenants table. This is expected.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 
 # When run with a tenant, system.namespace has an extra entry for
 # descriptor_id_seq.

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET DATABASE = ""
 

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !3node-backup
 query IBT colnames
 SELECT * FROM system.tenants ORDER BY id
 ----

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 query T
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP
 ----

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE tb(unused INT); INSERT INTO tb VALUES (1)
 

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Transaction involving schema changes.
 statement ok
 BEGIN TRANSACTION

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE t (i INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Check that we auto-retry pushed transactions which can't be refreshed - if
 # they're pushed while we can still auto-retry them.
 subtest autoretry-on-push-first-batch

--- a/pkg/sql/logictest/testdata/logic_test/txn_stats
+++ b/pkg/sql/logictest/testdata/logic_test/txn_stats
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 # Some sanity checks for node_txn_stats virtual table.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 subtest strict
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
 

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -1,3 +1,5 @@
+# LogicTest: !3node-backup
+
 statement ok
 CREATE TABLE x(a) AS SELECT generate_series(1, 3)
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(49854)
+# LogicTest: !3node-tenant(49854) !3node-backup
 # Check that we can alter the default zone config.
 
 statement ok


### PR DESCRIPTION
This commit introduces a new configuration to logic tests that will
randomly backup the cluster, re-create the cluster and restore that
backup to the new cluster.

This is primarily beneficial since it runs backup/restore under a much
more comprehensive set of SQL states.

Closes #54060.

Release note: None