### PR TITLE
release-20.2: row: properly size memory accounting for scans

### DIFF
--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -231,3 +231,5 @@ func DecodeRowInfo(
 	}
 	return index, names, values, nil
 }
+
+func (f *singleKVFetcher) close(context.Context) {}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -52,6 +52,8 @@ type kvBatchFetcher interface {
 	// version - both must be handled by calling code.
 	nextBatch(ctx context.Context) (ok bool, kvs []roachpb.KeyValue,
 		batchResponse []byte, origSpan roachpb.Span, err error)
+
+	close(ctx context.Context)
 }
 
 type tableInfo struct {
@@ -654,7 +656,7 @@ func (rf *Fetcher) StartScanFrom(ctx context.Context, f kvBatchFetcher) error {
 	if rf.kvFetcher != nil {
 		rf.kvFetcher.Close(ctx)
 	}
-	rf.kvFetcher = newKVFetcher(f, rf.mon)
+	rf.kvFetcher = newKVFetcher(f)
 	// Retrieve the first key.
 	_, err := rf.NextKey(ctx)
 	return err

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -32,7 +32,6 @@ type KVFetcher struct {
 	bytesRead     int64
 	Span          roachpb.Span
 	newSpan       bool
-	acc           mon.BoundAccount
 }
 
 // NewKVFetcher creates a new KVFetcher.
@@ -50,15 +49,12 @@ func NewKVFetcher(
 	kvBatchFetcher, err := makeKVBatchFetcher(
 		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy, mon,
 	)
-	return newKVFetcher(&kvBatchFetcher, mon), err
+	return newKVFetcher(&kvBatchFetcher), err
 }
 
-func newKVFetcher(batchFetcher kvBatchFetcher, mon *mon.BytesMonitor) *KVFetcher {
+func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
 	ret := &KVFetcher{
 		kvBatchFetcher: batchFetcher,
-	}
-	if mon != nil {
-		ret.acc = mon.MakeBoundAccount()
 	}
 	return ret
 }
@@ -116,49 +112,15 @@ func (f *KVFetcher) NextKV(
 			}, newSpan, nil
 		}
 
-		monitoring := f.acc.Monitor() != nil
-
-		const tokenFetchAllocation = 1 << 10
-		if monitoring && f.acc.Used() < tokenFetchAllocation {
-			// Pre-reserve a token fraction of the maximum amount of memory this scan
-			// could return. Most of the time, scans won't use this amount of memory,
-			// so it's unnecessary to reserve it all. We reserve something rather than
-			// nothing at all to preserve some accounting.
-			if err := f.acc.ResizeTo(ctx, tokenFetchAllocation); err != nil {
-				return ok, kv, false, err
-			}
-		}
 		ok, f.kvs, f.batchResponse, f.Span, err = f.nextBatch(ctx)
 		if err != nil {
 			return ok, kv, false, err
-		}
-		returnedBytes := int64(len(f.batchResponse))
-		if monitoring && returnedBytes > f.acc.Used() {
-			// Resize up to the actual amount of bytes we got back from the fetch,
-			// but don't ratchet down. We would much prefer to over-account, and the
-			// worst we can over-account by is around 10 MB, the maximum fetch size.
-			//
-			// The reason we don't want to precisely account here is to hopefully
-			// protect ourselves from "slop" in our memory handling. In general, we
-			// expect that all SQL operators that buffer data for longer than a single
-			// call to Next do their own accounting, so theoretically, by the time
-			// this fetch method is called again, all memory will either be released
-			// from the system or accounted for elsewhere. In reality, though, Go's
-			// garbage collector has some lag between when the memory is no longer
-			// referenced and when it is freed. Also, we're not perfect with
-			// accounting by any means. When we start doing large fetches, it's more
-			// likely that we'll expose ourselves to OOM conditions, so that's the
-			// reasoning for why we never ratchet this account down - only up, toward
-			// the maximum fetch size (maxScanResponseBytes).
-			if err := f.acc.ResizeTo(ctx, returnedBytes); err != nil {
-				return ok, kv, false, err
-			}
 		}
 		if !ok {
 			return false, kv, false, nil
 		}
 		f.newSpan = true
-		f.bytesRead += returnedBytes
+		f.bytesRead += int64(len(f.batchResponse))
 	}
 }
 
@@ -166,7 +128,7 @@ func (f *KVFetcher) NextKV(
 // at the end of execution if the fetcher was provisioned with a memory
 // monitor.
 func (f *KVFetcher) Close(ctx context.Context) {
-	f.acc.Close(ctx)
+	f.kvBatchFetcher.close(ctx)
 }
 
 // SpanKVFetcher is a kvBatchFetcher that returns a set slice of kvs.
@@ -185,3 +147,5 @@ func (f *SpanKVFetcher) nextBatch(
 	f.KVs = nil
 	return true, res, nil, roachpb.Span{}, nil
 }
+
+func (f *SpanKVFetcher) close(context.Context) {}


### PR DESCRIPTION
Backport 1/1 commits from #54847.

/cc @cockroachdb/release

---

Previously, memory accounting for scans that had multiple returned
batches would undercount. The maximum we'd account for was the maximum
size of any individual batch. In reality, since we fetch several batches
at once, the maximum we account for must be the sum of the size of all
of the batches that are fetched in one go.

This commit fixes the issue by moving the logic that does the memory
accounting one layer lower, into the kv batch fetcher, from where it
used to live in the kv fetcher.

Release note (bug fix): fix a bug in 20.2 pre-releases that
under-accounted for scan memory. Note that the bug wasn't a regression
from 20.1, which never had any scan memory accounting at all.
