### PR TITLE
release-20.2: rowexec: fix zigzag joiner not updating txn coord sender

### DIFF
--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -512,6 +512,9 @@ func (z *zigzagJoiner) producerMeta(err error) *execinfrapb.ProducerMetadata {
 		} else if trace := execinfra.GetTraceData(z.Ctx); trace != nil {
 			meta = &execinfrapb.ProducerMetadata{TraceData: trace}
 		}
+		if tfs := execinfra.GetLeafTxnFinalState(z.Ctx, z.FlowCtx.Txn); tfs != nil {
+			z.returnedMeta = append(z.returnedMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
+		}
 		// We need to close as soon as we send producer metadata as we're done
 		// sending rows. The consumer is allowed to not call ConsumerDone().
 		z.close()


### PR DESCRIPTION
This commit adds the propagation of the refresh spans read by the zigzag
joiner (which reads directly from the disk itself). I'm not sure exactly
what the impact of not having that propagation is, but I'm guessing it's
pretty bad.

Release note: None