### PR TITLE
sql: fix a bug tracking spans in a backfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -956,6 +956,7 @@ func (sc *SchemaChanger) distBackfill(
 		// variable and assign to todoSpans after committing.
 		var updatedTodoSpans []roachpb.Span
 		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			updatedTodoSpans = todoSpans
 			// Report schema change progress. We define progress at this point
 			// as the the fraction of fully-backfilled ranges of the primary index of
 			// the table being scanned. Since we may have already modified the
@@ -988,7 +989,7 @@ func (sc *SchemaChanger) distBackfill(
 			}
 			metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
 				if meta.BulkProcessorProgress != nil {
-					updatedTodoSpans = roachpb.SubtractSpans(todoSpans,
+					updatedTodoSpans = roachpb.SubtractSpans(updatedTodoSpans,
 						meta.BulkProcessorProgress.CompletedSpans)
 				}
 				return nil

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3742,7 +3742,6 @@ CREATE TABLE d.t (
 // the backfilled columns.
 func TestSchemaChangeEvalContext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 54775, "flaky test")
 	defer log.Scope(t).Close(t)
 	const numNodes = 3
 	const chunkSize = 200


### PR DESCRIPTION
Fixes a bug introduced in #54755 whereby we'd always subtract from the original
set of spans rather than from the updated set of spans meaning that we could
backfill the same span multiple times.

Fixes #54775.

Release note: None