### PR TITLE
release-20.2: sqlmigrations: fail all pre-20.1 non-terminal schema change jobs

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -365,6 +366,12 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		// Introduced in v20.2.
 		name:   "add CREATELOGIN privilege to roles with CREATEROLE",
 		workFn: extendCreateRoleWithCreateLogin,
+	},
+	{
+		// Introduced in v20.2.
+		name:                "mark non-terminal schema change jobs with a pre-20.1 format version as failed",
+		workFn:              markDeprecatedSchemaChangeJobsFailed,
+		includedInBootstrap: clusterversion.VersionByKey(clusterversion.VersionLeasedDatabaseDescriptors),
 	},
 }
 
@@ -1066,6 +1073,76 @@ func extendCreateRoleWithCreateLogin(ctx context.Context, r runner) error {
 	return r.execAsRootWithRetry(ctx,
 		"add CREATELOGIN where a role already has CREATEROLE",
 		upsertCreateRoleStmt)
+}
+
+func markDeprecatedSchemaChangeJobsFailed(ctx context.Context, r runner) error {
+	ctx = logtags.AddTag(ctx, "mark-deprecated-schema-changes-failed", nil)
+	const batchSize = 100
+	workLeft := true
+	prevBatchSize := 0
+	for workLeft {
+		if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// Get jobs in a non-terminal state.
+			rows, err := r.sqlExecutor.QueryEx(
+				ctx, "get-deprecated-schema-change-jobs", txn,
+				sessiondata.InternalExecutorOverride{User: security.RootUser},
+				`SELECT id, status, payload FROM system.jobs WHERE status NOT IN ($1, $2, $3) LIMIT $4`,
+				jobs.StatusSucceeded, jobs.StatusCanceled, jobs.StatusFailed, batchSize,
+			)
+			if err != nil {
+				return err
+			}
+			prevBatchSize = len(rows)
+			if len(rows) < batchSize {
+				workLeft = false
+			}
+			for _, row := range rows {
+				id := tree.MustBeDInt(row[0])
+				status := tree.MustBeDString(row[1])
+				payload, err := jobs.UnmarshalPayload(row[2])
+				if err != nil {
+					log.Errorf(ctx, "error unmarshaling job payload for id %d, skipping", id)
+					continue
+				}
+				schemaChangeDetails := payload.GetSchemaChange()
+				if schemaChangeDetails == nil {
+					log.VEventf(ctx, 3, "job %d is not a schema change job, skipping", id)
+					continue
+				}
+				if v := schemaChangeDetails.FormatVersion; v > jobspb.BaseFormatVersion {
+					log.VEventf(ctx, 2, "job %d is a schema change job with format version %d, skipping", id, v)
+					continue
+				}
+
+				// Update the job status and error.
+				payload.Error = "schema change jobs started prior to v20.1 that have " +
+					"not yet undergone the automatic internal migration in v20.1 cannot" +
+					"be run in v20.2, and are automatically marked as failed"
+				newPayloadBytes, err := protoutil.Marshal(payload)
+				if err != nil {
+					log.Errorf(ctx, "error marshaling job payload for id %d, skipping", id)
+					continue
+				}
+				if _, err := r.sqlExecutor.ExecEx(
+					ctx, "update-deprecated-schema-change-job", txn,
+					sessiondata.InternalExecutorOverride{User: security.RootUser},
+					`UPDATE system.jobs SET status = $1, payload = $2 WHERE id = $3`,
+					jobs.StatusFailed, newPayloadBytes, id,
+				); err != nil {
+					return err
+				}
+				log.Warningf(ctx,
+					"job %d (previously %s) is a schema change job started prior to v20.1 "+
+						"that will be marked as failed as part of the v20.2 upgrade: %+v",
+					id, status, payload)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		log.Infof(ctx, "checked %d jobs for existence of deprecated schema change jobs", prevBatchSize)
+	}
+	return nil
 }
 
 func createReportsMetaTable(ctx context.Context, r runner) error {


### PR DESCRIPTION
Backport 1/1 commits from #54383.

/cc @cockroachdb/release

---

This PR adds a sqlmigration to mark all non-terminal, non-migrated
schema change jobs started prior to 20.1 (as indicated by their format
version) as failed.

Closes #51181.

Release note (general change): This change affects schema change jobs
originally initiated on clusters running v19.2 or earlier which have not
reached a terminal state (i.e., `succeeded`, `failed`, or `canceled`),
and which have not finished undergoing an automatic internal migration
to allow them to run in 20.1 clusters. These jobs will now be marked as
`failed` upon upgrading to 20.2. Users who have ongoing schema changes
initiated in 19.2 are advised to wait for them to finish running on 20.1
before upgrading to 20.2. (At the very least, they must wait until at
least the 20.1 internal migration for the job has completed, which is
indicated in the logs).

This may also affect users who have schema change jobs from prior to
20.1 which are stuck in a non-terminal state due to bugs despite making
no progress. In this case, marking the job as failed has no real effect.
