### PR TITLE
release-20.2: ui: add SQL Memory graph to SQL metrics

### DIFF
--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -16,14 +16,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 )
 
+// BaseMemoryMetrics contains a max histogram and a current count of the
+// bytes allocated by a sql endpoint.
+type BaseMemoryMetrics struct {
+	MaxBytesHist  *metric.Histogram
+	CurBytesCount *metric.Gauge
+}
+
 // MemoryMetrics contains pointers to the metrics object
 // for one of the SQL endpoints:
 // - "client" for connections received via pgwire.
 // - "admin" for connections received via the admin RPC.
 // - "internal" for activities related to leases, schema changes, etc.
 type MemoryMetrics struct {
-	MaxBytesHist         *metric.Histogram
-	CurBytesCount        *metric.Gauge
+	BaseMemoryMetrics
 	TxnMaxBytesHist      *metric.Histogram
 	TxnCurBytesCount     *metric.Gauge
 	SessionMaxBytesHist  *metric.Histogram
@@ -51,51 +57,41 @@ var _ metric.Struct = MemoryMetrics{}
 // log10int64times1000 = log10(math.MaxInt64) * 1000, rounded up somewhat
 const log10int64times1000 = 19 * 1000
 
+func makeMemMetricMetadata(name, help string) metric.Metadata {
+	return metric.Metadata{
+		Name:        name,
+		Help:        help,
+		Measurement: "Memory",
+		Unit:        metric.Unit_BYTES,
+	}
+}
+
+// MakeBaseMemMetrics instantiates the metric objects for an SQL endpoint, but
+// only includes the root metrics: .max and .current, without txn and session.
+func MakeBaseMemMetrics(endpoint string, histogramWindow time.Duration) BaseMemoryMetrics {
+	prefix := "sql.mem." + endpoint
+	MetaMemMaxBytes := makeMemMetricMetadata(prefix+".max", "Memory usage per sql statement for "+endpoint)
+	MetaMemCurBytes := makeMemMetricMetadata(prefix+".current", "Current sql statement memory usage for "+endpoint)
+	return BaseMemoryMetrics{
+		MaxBytesHist:  metric.NewHistogram(MetaMemMaxBytes, histogramWindow, log10int64times1000, 3),
+		CurBytesCount: metric.NewGauge(MetaMemCurBytes),
+	}
+}
+
 // MakeMemMetrics instantiates the metric objects for an SQL endpoint.
 func MakeMemMetrics(endpoint string, histogramWindow time.Duration) MemoryMetrics {
+	base := MakeBaseMemMetrics(endpoint, histogramWindow)
 	prefix := "sql.mem." + endpoint
-	MetaMemMaxBytes := metric.Metadata{
-		Name:        prefix + ".max",
-		Help:        "Memory usage per sql statement for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
-	MetaMemCurBytes := metric.Metadata{
-		Name:        prefix + ".current",
-		Help:        "Current sql statement memory usage for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
-	MetaMemMaxTxnBytes := metric.Metadata{
-		Name:        prefix + ".txn.max",
-		Help:        "Memory usage per sql transaction for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
-	MetaMemTxnCurBytes := metric.Metadata{
-		Name:        prefix + ".txn.current",
-		Help:        "Current sql transaction memory usage for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
-	MetaMemMaxSessionBytes := metric.Metadata{
-		Name:        prefix + ".session.max",
-		Help:        "Memory usage per sql session for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
-	MetaMemSessionCurBytes := metric.Metadata{
-		Name:        prefix + ".session.current",
-		Help:        "Current sql session memory usage for " + endpoint,
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
+	MetaMemMaxTxnBytes := makeMemMetricMetadata(prefix+".txn.max", "Memory usage per sql transaction for "+endpoint)
+	MetaMemTxnCurBytes := makeMemMetricMetadata(prefix+".txn.current", "Current sql transaction memory usage for "+endpoint)
+	MetaMemMaxSessionBytes := makeMemMetricMetadata(prefix+".session.max", "Memory usage per sql session for "+endpoint)
+	MetaMemSessionCurBytes := makeMemMetricMetadata(prefix+".session.current", "Current sql session memory usage for "+endpoint)
 	return MemoryMetrics{
-		MaxBytesHist:         metric.NewHistogram(MetaMemMaxBytes, histogramWindow, log10int64times1000, 3),
-		CurBytesCount:        metric.NewGauge(MetaMemCurBytes),
+		BaseMemoryMetrics:    base,
 		TxnMaxBytesHist:      metric.NewHistogram(MetaMemMaxTxnBytes, histogramWindow, log10int64times1000, 3),
 		TxnCurBytesCount:     metric.NewGauge(MetaMemTxnCurBytes),
 		SessionMaxBytesHist:  metric.NewHistogram(MetaMemMaxSessionBytes, histogramWindow, log10int64times1000, 3),
 		SessionCurBytesCount: metric.NewGauge(MetaMemSessionCurBytes),
 	}
+
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1754,6 +1754,19 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "SQL Memory"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Current",
+				Metrics: []string{"sql.mem.root.current"},
+			},
+			{
+				Title:   "Max",
+				Metrics: []string{"sql.mem.root.max"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "SQL Memory", "SQL"}},
 		Charts: []chartDescription{
 			{

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -262,6 +262,28 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="SQL Memory"
+      tooltip={
+        `The current amount of allocated SQL memory. This amount is what is
+         compared against the node's --max-sql-memory flag.`
+      }
+    >
+      <Axis units={AxisUnits.Bytes} label="allocated bytes">
+        {
+          _.map(nodeIDs, (node) => (
+            <Metric
+              key={node}
+              name="cr.node.sql.mem.root.current"
+              title={nodeDisplayName(nodesSummary, node)}
+              sources={[node]}
+              downsampleMax
+            />
+          ))
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Schema Changes"
       sources={nodeSources}
       tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}


### PR DESCRIPTION
Backport 2/2 commits from #54846.

/cc @cockroachdb/release

---

The first commit cleans up the memory monitor time series data, removing some
bogus ones that were never written to, and adding a new "root" memory
monitor time series (under `sql.mem.root`) that is attached to the root
memory monitor. This time series will now be usable to inspect the
accounted memory across the entire cluster, which was not previously
possible

The second commit adds a new SQL Memory graph to the SQL metrics dashboard
that tracks the currently allocated bytes that are tracked by the root
SQL memory monitor.

![image](https://user-images.githubusercontent.com/43821/94382858-4263bc80-010c-11eb-99e8-9ba76d09e65d.png)


Release note (admin ui change): add a SQL Memory graph to the SQL
metrics dashboard that tracks the current number of bytes in all SQL
memory accounts. This number is a current snapshot of the number whose
maximum is set by --max-sql-memory.
