### PR TITLE
cli: report on the undesirability of `--insecure` differently

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/kr/text"
 )
 
@@ -626,18 +627,33 @@ the socket name programmatically. To use, for example:
 		Name:   "insecure",
 		EnvVar: "COCKROACH_INSECURE",
 		Description: `
-Connect to an insecure cluster. This is strongly discouraged for
-production usage.`,
+Connect to a cluster without using TLS nor authentication.
+This makes the client-server connection vulnerable to MITM attacks. Use with care.`,
 	}
 
 	ServerInsecure = FlagInfo{
 		Name: "insecure",
 		Description: `
-Start an insecure node, using unencrypted (non-TLS) connections,
-listening on all IP addresses (unless --listen-addr is provided) and
-disabling password authentication for all database users. This is
-strongly discouraged for production usage and should never be used on
-a public network without combining it with --listen-addr.`,
+Start a node with all security controls disabled.
+There is no encryption, no authentication and internal security
+checks are also disabled. This makes any client able to take
+over the entire cluster.
+<PRE>
+
+</PRE>
+This flag is only intended for non-production testing.
+<PRE>
+
+</PRE>
+Beware that using this flag on a public network without --listen-addr
+is likely to cause the entire host server to become compromised.
+<PRE>
+
+</PRE>
+To simply accept non-TLS connections for SQL clients while keeping
+the cluster secure, consider using --accept-sql-without-tls instead.
+Also see: ` + unimplemented.MakeURL(53404) + `
+`,
 	}
 
 	ExternalIODisableHTTP = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -394,9 +394,9 @@ func init() {
 
 		// Use a separate variable to store the value of ServerInsecure.
 		// We share the default with the ClientInsecure flag.
+		//
+		// NB: Insecure is deprecated. See #53404.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
-		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
-			"For details, see: "+unimplemented.MakeURL(53404))
 
 		// Enable/disable various external storage endpoints.
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
@@ -561,9 +561,8 @@ func init() {
 		stringFlag(f, &cliCtx.clientConnPort, cliflags.ClientPort)
 		_ = f.MarkHidden(cliflags.ClientPort.Name)
 
+		// NB: Insecure is deprecated. See #53404.
 		boolFlag(f, &baseCfg.Insecure, cliflags.ClientInsecure)
-		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
-			"For details, see: "+unimplemented.MakeURL(53404))
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir)
@@ -744,8 +743,11 @@ func init() {
 		varFlag(f, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 		varFlag(f, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
 		boolFlag(f, &demoCtx.insecure, cliflags.ClientInsecure)
-		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
-			"For details, see: "+unimplemented.MakeURL(53404))
+		// NB: Insecure for `cockroach demo` is deprecated. See #53404.
+		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name,
+			"to start a test server without any security, run start-single-node --insecure\n"+
+				"For details, see: "+unimplemented.MakeURL(53404))
+
 		boolFlag(f, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense)
 		// Mark the --global flag as hidden until we investigate it more.
 		boolFlag(f, &demoCtx.simulateLatency, cliflags.Global)
@@ -809,9 +811,8 @@ func init() {
 		// NB: serverInsecure populates baseCfg.{Insecure,SSLCertsDir} in this the following method
 		// (which is a PreRun for this command):
 		_ = extraServerFlagInit // guru assignment
+		// NB: Insecure is deprecated. See #53404.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
-		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+
-			"For details, see: "+unimplemented.MakeURL(53404))
 
 		stringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir)
 		// NB: this also gets PreRun treatment via extraServerFlagInit to populate BaseCfg.SQLAddr.

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -15,7 +15,7 @@ eexpect $prompt
 
 start_test "Check that --insecure reports that the server is really insecure"
 send "$argv start-single-node --host=localhost --insecure\r"
-eexpect "WARNING: RUNNING IN INSECURE MODE"
+eexpect "WARNING: ALL SECURITY CONTROLS HAVE BEEN DISABLED"
 eexpect "node starting"
 interrupt
 eexpect $prompt

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1126,16 +1126,26 @@ func setupAndInitializeLoggingAndProfiling(
 		// particularly to new users (made worse by it always printing as [n?]).
 		addr := startCtx.serverListenAddr
 		if addr == "" {
-			addr = "<all your IP addresses>"
+			addr = "any of your IP addresses"
 		}
 		log.Shoutf(context.Background(), log.Severity_WARNING,
-			"RUNNING IN INSECURE MODE!\n\n"+
-				"- Your cluster is open for any client that can access %s.\n"+
-				"- Any user, even root, can log in without providing a password.\n"+
-				"- Any user, connecting as root, can read or write any data in your cluster.\n"+
-				"- There is no network encryption nor authentication, and thus no confidentiality.\n\n"+
-				"Check out how to secure your cluster: %s",
-			addr, log.Safe(base.DocsURL("secure-a-cluster.html")))
+			"ALL SECURITY CONTROLS HAVE BEEN DISABLED!\n\n"+
+				"This mode is intended for non-production testing only.\n"+
+				"\n"+
+				"In this mode:\n"+
+				"- Your cluster is open to any client that can access %s.\n"+
+				"- Intruders with access to your machine or network can observe client-server traffic.\n"+
+				"- Intruders can log in without password and read or write any data in the cluster.\n"+
+				"- Intruders can consume all your server's resources and cause unavailability.",
+			addr)
+		log.Shoutf(context.Background(), log.Severity_INFO,
+			"To start a secure server without mandating TLS for clients,\n"+
+				"consider --accept-sql-without-tls instead. For other options, see:\n\n"+
+				"- %s\n"+
+				"- %s",
+			unimplemented.MakeURL(53404),
+			log.Safe(base.DocsURL("secure-a-cluster.html")),
+		)
 	}
 
 	maybeWarnMemorySizes(ctx)


### PR DESCRIPTION
Two changes here:

- do not report a penalty in client commands using a warning;
  the choice to use insecure mode is done by the server's
  administrator and clients cannot influence it.

- make the command-line flag visible in the `--help` text again,
  but with a clearer explanation of its effects.

Example server warning, in v20.1 ("before"):
```
* WARNING: RUNNING IN INSECURE MODE!
*
* - Your cluster is open for any client that can access <all your IP addresses>.
* - Any user, even root, can log in without providing a password.
* - Any user, connecting as root, can read or write any data in your cluster.
* - There is no network encryption nor authentication, and thus no confidentiality.
*
* Check out how to secure your cluster: https://www.cockroachlabs.com/docs/v20.1/secure-a-cluster.html
```

Example server warning, in v20.2 ("after"):
```
* WARNING: ALL SECURITY CONTROLS HAVE BEEN DISABLED!
*
* This mode is intended for non-production testing only.
*
* In this mode:
* - Your cluster is open to any client that can access any of your IP addresses.
* - Intruders with access to your machine or network can observe client-server traffic.
* - Intruders can log in without password and read or write any data in the cluster.
* - Intruders can consume all your server's resources and cause unavailability.
*
*
* INFO: To start a secure server without mandating TLS for clients,
* consider --accept-sql-without-tls instead. For other options, see:
*
* - https://go.crdb.dev/issue-v/53404/v20.2
* - https://www.cockroachlabs.com/docs/v20.2/secure-a-cluster.html
```

Example `--help` text for *client* commands, before:
```
Connect to an insecure cluster. This is strongly discouraged for
production usage.
```

After:
```
Connect to a cluster without using TLS nor authentication. This makes
the client-server connection vulnerable to MITM attacks. Use with care.
```

Example `--help` text for *server* commands, before:
```
Start an insecure node, using unencrypted (non-TLS) connections,
listening on all IP addresses (unless --listen-addr is provided) and
disabling password authentication for all database users. This is
strongly discouraged for production usage and should never be used on a
public network without combining it with --listen-addr.
```

After:
```
Start a node with all security controls disabled. There is no
encryption, no authentication and internal security checks are also
disabled. This makes any client able to take over the entire cluster.

This flag is only intended for non-production testing.

Beware that using this flag on a public network without --listen-addr
is likely to cause the entire host server to become compromised.

To simply accept non-TLS connections for SQL clients while keeping the
cluster secure, consider using --accept-sql-without-tls instead. Also
see: https://go.crdb.dev/issue-v/53404/v20.2
```

Release note (cli change): The `--help` texts and informational
messages upon server start-up have been modified to better inform
the user about the nature and risks of the `--insecure` flag.