### PR TITLE
cli: automatically detect SQL commands in tests

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -667,7 +667,14 @@ func init() {
 	boolFlag(dumpCmd.Flags(), &dumpCtx.dumpAll, cliflags.DumpAll)
 
 	// Commands that establish a SQL connection.
-	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd, doctorClusterCmd}
+	sqlCmds := []*cobra.Command{
+		sqlShellCmd,
+		dumpCmd,
+		demoCmd,
+		doctorClusterCmd,
+		lsNodesCmd,
+		statusNodeCmd,
+	}
 	sqlCmds = append(sqlCmds, authCmds...)
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	sqlCmds = append(sqlCmds, stmtDiagCmds...)
@@ -675,6 +682,9 @@ func init() {
 	sqlCmds = append(sqlCmds, userFileCmds...)
 	for _, cmd := range sqlCmds {
 		f := cmd.Flags()
+		// The --echo-sql flag is special: it is a marker for CLI tests to
+		// recognize SQL-only commands. If/when adding this flag to non-SQL
+		// commands, ensure the isSQLCommand() predicate is updated accordingly.
 		boolFlag(f, &sqlCtx.echo, cliflags.EchoSQL)
 
 		if cmd != demoCmd {


### PR DESCRIPTION
Motivated by seeing @spaskob and @adityamaru run into this twice in a month.

Prior to this change, every new SQL-only client command needed to be
recognized by the `isSQLCommand` function in `cli_test.go`. This was a
snag because nothing in the "main" code was suggesting this was
necessary, and failure to do so would cause extremely obscure EOF
connection errors during tests.

This patch improves the situation by automatically recognizing
the SQL commands in tests.

Release note: None