### PR TITLE
workload/tpch: Disable FMA to fix ccl/workload/allccl test on s390x

### DIFF
--- a/pkg/workload/tpch/generate.go
+++ b/pkg/workload/tpch/generate.go
@@ -403,7 +403,9 @@ func (w *tpch) tpchOrdersInitialRowBatch(
 		totalPrice := float32(0)
 		for j := 0; j < l.orderData.nOrders; j++ {
 			ep := l.orderData.quantities[j] * makeRetailPriceFromPartKey(l.orderData.partKeys[j])
-			totalPrice += ep * (1 + l.orderData.tax[j]) * (1 - l.orderData.discount[j])
+			// Use an extra float32 conversion to disable "fused multiply and add" (FMA) to force
+			// identical behavior on all platforms. See https://golang.org/ref/spec#Floating_point_operators
+			totalPrice += float32(ep * (1 + l.orderData.tax[j]) * (1 - l.orderData.discount[j])) // nolint:unconvert
 		}
 		// O_TOTALPRICE computed as:
 		// sum (L_EXTENDEDPRICE * (1+L_TAX) * (1-L_DISCOUNT)) for all LINEITEM of


### PR DESCRIPTION
Previously, TestDeterministicInitialData/tpch under ccl/workloadccl/allccl
fail on s390x due to mismatched checksum of tpch initial data. After
comparing the data between two different platforms (intel and s390x),
it was found that the mismatch is due to a difference in the calculated
value of totalPrice under tpchOrders.

The number difference is due to FMA (fused multiply and add) instruction,
and adding a float32() will disable the usage of FMA to fix this difference.
Through testing, this change does not affect the functionality of the
same test on intel. In addition, this patch could be helpful for other
non amd64 platforms that have FMA instruction available.

For FMA related information, it can be found at
https://golang.org/ref/spec#Floating_point_operators