### PR TITLE
storage: fix overstimation of timeseries range stats on merge

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -265,12 +265,12 @@ func updateStatsForInline(
 }
 
 // updateStatsOnMerge updates metadata stats while merging inlined
-// values. Unfortunately, we're unable to keep accurate stats on merge
-// as the actual details of the merge play out asynchronously during
-// compaction. Instead, we undercount by adding only the size of the
-// value.Bytes byte slice (an estimated 12 bytes for timestamp,
-// included in valSize by caller). These errors are corrected during
-// splits and merges.
+// values. Unfortunately, we're unable to keep accurate stats on merges as the
+// actual details of the merge play out asynchronously during compaction. We
+// actually undercount by only adding the size of the value.RawBytes byte slice
+// (and eliding MVCCVersionTimestampSize, corresponding to the metadata overhead,
+// even for the very "first" write). These errors are corrected during splits and
+// merges.
 func updateStatsOnMerge(key roachpb.Key, valSize, nowNanos int64) enginepb.MVCCStats {
 	var ms enginepb.MVCCStats
 	sys := isSysLocal(key)
@@ -2172,7 +2172,7 @@ func MVCCMerge(
 	if err == nil {
 		if err = rw.Merge(metaKey, data); err == nil && ms != nil {
 			ms.Add(updateStatsOnMerge(
-				key, int64(len(rawBytes))+MVCCVersionTimestampSize, timestamp.WallTime))
+				key, int64(len(rawBytes)), timestamp.WallTime))
 		}
 	}
 	buf.release()

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5248,6 +5248,46 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 	}
 }
 
+// TestTimeSeriesMVCCStats ensures that merge operations
+// result in an expected increase in timeseries data.
+func TestTimeSeriesMVCCStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+			var ms = enginepb.MVCCStats{}
+
+			// Perform a sequence of merges on the same key
+			// and record the MVCC stats for it.
+			if err := MVCCMerge(ctx, engine, &ms, testKey1, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
+				t.Fatal(err)
+			}
+			firstMS := ms
+
+			if err := MVCCMerge(ctx, engine, &ms, testKey1, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
+				t.Fatal(err)
+			}
+			secondMS := ms
+
+			// Ensure timeseries metrics increase as expected.
+			expectedMS := firstMS
+			expectedMS.LiveBytes += int64(len(tsvalue1.RawBytes))
+			expectedMS.ValBytes += int64(len(tsvalue1.RawBytes))
+
+			if secondMS.LiveBytes != expectedMS.LiveBytes {
+				t.Fatalf("second merged LiveBytes value %v differed from expected LiveBytes value %v", secondMS.LiveBytes, expectedMS.LiveBytes)
+			}
+			if secondMS.ValBytes != expectedMS.ValBytes {
+				t.Fatalf("second merged ValBytes value %v differed from expected ValBytes value %v", secondMS.LiveBytes, expectedMS.LiveBytes)
+			}
+		})
+	}
+}
+
 // TestMVCCTimeSeriesPartialMerge ensures that "partial merges" of merged time
 // series data does not result in a different final result than a "full merge".
 func TestMVCCTimeSeriesPartialMerge(t *testing.T) {


### PR DESCRIPTION
Previously, we overestimated MVCC stats on each merge operation because we were adding mvccVersionTimestampSize each time. Each merge is into the same key, so we are not actually incurring the metadata over each time. To address this, adding of mvccVersionTimestampSize each time was removed and a test case was added to verify correct timeseries data.

Release note: None.