### PR TITLE
builtins: default follower_read_timestamp() to -4.8s instead of error

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -442,7 +442,9 @@ historical reads against a time which is recent but sufficiently old for reads
 to be performed against the closest replica as opposed to the currently
 leaseholder for a given range.</p>
 <p>Note that this function requires an enterprise license on a CCL distribution to
-return without an error.</p>
+return a result that is less likely the closest replica. It is otherwise
+hardcoded as -4.8s from the statement time, which may not result in reading from the
+nearest replica.</p>
 </span></td></tr>
 <tr><td><a name="localtimestamp"></a><code>localtimestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -35,11 +35,23 @@ SELECT * FROM t AS OF SYSTEM TIME (SELECT '-1h'::INTERVAL)
 statement error pq: relation "t" does not exist
 SELECT * FROM t AS OF SYSTEM TIME '-1h'
 
-statement error pq: follower_read_timestamp\(\): follower_read_timestamp is only available in ccl distribution
-SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
+query T noticetrace
+SELECT pg_sleep(5) -- we need to sleep so that the 4.8s elapses and the SELECT * FROM t returns something.
+----
 
-statement error pq: experimental_follower_read_timestamp\(\): follower_read_timestamp is only available in ccl distribution
+# Notices print twice -- once during planning and once during execution.
+# There's no nice way of reducing this to once without some hacks -- so left as is.
+query T noticetrace
+SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
+----
+NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
+NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
+
+query T noticetrace
 SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()
+----
+NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
+NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
 
 statement error pq: unknown signature: follower_read_timestamp\(string\) \(desired <timestamptz>\)
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -52,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -79,6 +81,8 @@ var (
 	// builtin functions.
 	SequenceNameArg = "sequence_name"
 )
+
+const defaultFollowerReadDuration = -4800 * time.Millisecond
 
 const maxAllocatedStringSize = 128 * 1024 * 1024
 
@@ -2131,7 +2135,7 @@ var builtins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn:         followerReadTimestamp,
-			Info: `Returns a timestamp which is very likely to be safe to perform
+			Info: fmt.Sprintf(`Returns a timestamp which is very likely to be safe to perform
 against a follower replica.
 
 This function is intended to be used with an AS OF SYSTEM TIME clause to perform
@@ -2140,7 +2144,9 @@ to be performed against the closest replica as opposed to the currently
 leaseholder for a given range.
 
 Note that this function requires an enterprise license on a CCL distribution to
-return without an error.`,
+return a result that is less likely the closest replica. It is otherwise
+hardcoded as %s from the statement time, which may not result in reading from the
+nearest replica.`, defaultFollowerReadDuration),
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
@@ -6302,12 +6308,32 @@ var EvalFollowerReadOffset func(clusterID uuid.UUID, _ *cluster.Settings) (time.
 
 func recentTimestamp(ctx *tree.EvalContext) (time.Time, error) {
 	if EvalFollowerReadOffset == nil {
-		return time.Time{}, pgerror.New(pgcode.FeatureNotSupported,
-			tree.FollowerReadTimestampFunctionName+
-				" is only available in ccl distribution")
+		telemetry.Inc(sqltelemetry.FollowerReadDisabledCCLCounter)
+		ctx.ClientNoticeSender.BufferClientNotice(
+			ctx.Context,
+			pgnotice.Newf(
+				tree.FollowerReadTimestampFunctionName+
+					" does not returns a value that is less likely to read from the closest replica "+
+					"in a non-CCL distribution, using %s from statement time instead",
+				defaultFollowerReadDuration,
+			),
+		)
+		return ctx.StmtTimestamp.Add(defaultFollowerReadDuration), nil
 	}
 	offset, err := EvalFollowerReadOffset(ctx.ClusterID, ctx.Settings)
 	if err != nil {
+		if code := pgerror.GetPGCode(err); code == pgcode.CCLValidLicenseRequired {
+			telemetry.Inc(sqltelemetry.FollowerReadDisabledNoEnterpriseLicense)
+			ctx.ClientNoticeSender.BufferClientNotice(
+				ctx.Context,
+				pgnotice.Newf(
+					"%s: using %s from current statement time instead",
+					defaultFollowerReadDuration,
+					err.Error(),
+				),
+			)
+			return ctx.StmtTimestamp.Add(defaultFollowerReadDuration), nil
+		}
 		return time.Time{}, err
 	}
 	return ctx.StmtTimestamp.Add(offset), nil

--- a/pkg/sql/sqltelemetry/follower_reads.go
+++ b/pkg/sql/sqltelemetry/follower_reads.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// FollowerReadDisabledCCLCounter is to be increment every time follower reads
+// are requested but unavailable due to not having the CCL build.
+var FollowerReadDisabledCCLCounter = telemetry.GetCounterOnce("follower_reads.disabled.ccl")
+
+// FollowerReadDisabledNoEnterpriseLicense is to be incremented every time follower reads
+// are requested but unavailable due to not having enterprise enabled.
+var FollowerReadDisabledNoEnterpriseLicense = telemetry.GetCounterOnce("follower_reads.disabled.no_enterprise_license")


### PR DESCRIPTION
Resolves #50890.

A little unsure of wording, bit annoyed at double notice printing but
I'm sure there's a way around it....

----

Release note (sql change): follower_read_timestamp() will now return
(statement_time - 4.8s) instead of erroring if enterprise features are
not enabled.