### PR TITLE
backupccl: update default backup telemetry source to ".manual"

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -897,7 +897,7 @@ func backupPlanHook(
 
 		collectTelemetry := func() {
 			// sourceSuffix specifies if this schedule was created by a schedule.
-			sourceSuffix := ""
+			sourceSuffix := ".manual"
 			if backupStmt.CreatedByInfo != nil &&
 				backupStmt.CreatedByInfo.Name == jobs.CreatedByScheduledJobs {
 				sourceSuffix = ".scheduled"


### PR DESCRIPTION
This commit updates the telemetry for backup to always include the
source (either ".manual" or ".scheduled"). This allows for folks to
search by a prefix to get the telemetry for all backups, and the
specific source can be appened to filter the telemetry between manual
and scheduled backups.

Release note: None