### PR TITLE
release-20.2: importccl: improve IMPORT telemetry

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -228,6 +228,18 @@ func ensureRequiredPrivileges(
 	return nil
 }
 
+// addToFileFormatTelemetry records the different stages of IMPORT on a per file
+// format basis.
+//
+// The current states being counted are:
+// attempted: Counted at the very beginning of the IMPORT.
+// started: Counted just before the IMPORT job is started.
+// failed: Counted when the IMPORT job is failed or canceled.
+// succeeded: Counted when the IMPORT job completes successfully.
+func addToFileFormatTelemetry(fileFormat, state string) {
+	telemetry.Count(fmt.Sprintf("%s.%s.%s", "import", strings.ToLower(fileFormat), state))
+}
+
 // importPlanHook implements sql.PlanHookFn.
 func importPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
@@ -236,7 +248,8 @@ func importPlanHook(
 	if !ok {
 		return nil, nil, nil, false, nil
 	}
-	telemetry.Count("import.total.attempted")
+
+	addToFileFormatTelemetry(importStmt.FileFormat, "attempted")
 
 	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.VersionPartitionedBackup) {
 		return nil, nil, nil, false, errors.Errorf("IMPORT requires a cluster fully upgraded to version >= 19.2")
@@ -391,7 +404,6 @@ func importPlanHook(
 			if err = validateFormatOptions(importStmt.FileFormat, opts, csvAllowedOptions); err != nil {
 				return err
 			}
-			telemetry.Count("import.format.csv")
 			format.Format = roachpb.IOFileFormat_CSV
 			// Set the default CSV separator for the cases when it is not overwritten.
 			format.Csv.Comma = ','
@@ -435,7 +447,6 @@ func importPlanHook(
 			if err = validateFormatOptions(importStmt.FileFormat, opts, mysqlOutAllowedOptions); err != nil {
 				return err
 			}
-			telemetry.Count("import.format.mysqlout")
 			format.Format = roachpb.IOFileFormat_MysqlOutfile
 			format.MysqlOut = roachpb.MySQLOutfileOptions{
 				RowSeparator:   '\n',
@@ -495,13 +506,11 @@ func importPlanHook(
 			if err = validateFormatOptions(importStmt.FileFormat, opts, mysqlDumpAllowedOptions); err != nil {
 				return err
 			}
-			telemetry.Count("import.format.mysqldump")
 			format.Format = roachpb.IOFileFormat_Mysqldump
 		case "PGCOPY":
 			if err = validateFormatOptions(importStmt.FileFormat, opts, pgCopyAllowedOptions); err != nil {
 				return err
 			}
-			telemetry.Count("import.format.pgcopy")
 			format.Format = roachpb.IOFileFormat_PgCopy
 			format.PgCopy = roachpb.PgCopyOptions{
 				Delimiter: '\t',
@@ -533,7 +542,6 @@ func importPlanHook(
 			if err = validateFormatOptions(importStmt.FileFormat, opts, pgDumpAllowedOptions); err != nil {
 				return err
 			}
-			telemetry.Count("import.format.pgdump")
 			format.Format = roachpb.IOFileFormat_PgDump
 			maxRowSize := int32(defaultScanBuffer)
 			if override, ok := opts[optMaxRowSize]; ok {
@@ -849,7 +857,14 @@ func importPlanHook(
 			}
 			return err
 		}
-		return sj.Run(ctx)
+
+		err = sj.Run(ctx)
+		if err != nil {
+			return err
+		}
+		addToFileFormatTelemetry(format.Format.String(), "started")
+
+		return nil
 	}
 	return fn, utilccl.BulkJobExecutionResultHeader, nil, false, nil
 }
@@ -857,9 +872,7 @@ func importPlanHook(
 func parseAvroOptions(
 	ctx context.Context, opts map[string]string, p sql.PlanHookState, format *roachpb.IOFileFormat,
 ) error {
-	telemetry.Count("import.format.avro")
 	format.Format = roachpb.IOFileFormat_Avro
-
 	// Default input format is OCF.
 	format.Avro.Format = roachpb.AvroOptions_OCF
 	_, format.Avro.StrictMode = opts[avroStrict]
@@ -1162,8 +1175,6 @@ func (r *importResumer) prepareTableDescsForIngestion(
 func (r *importResumer) Resume(
 	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
-	telemetry.Count("import.total.started")
-
 	details := r.job.Details().(jobspb.ImportDetails)
 	p := phs.(sql.PlanHookState)
 	ptsID := details.ProtectedTimestampRecord
@@ -1277,7 +1288,7 @@ func (r *importResumer) Resume(
 		}
 	}
 
-	telemetry.Count("import.total.succeeded")
+	addToFileFormatTelemetry(details.Format.Format.String(), "succeeded")
 	telemetry.CountBucketed("import.rows", r.res.Rows)
 	const mb = 1 << 20
 	sizeMb := r.res.DataSize / mb
@@ -1390,8 +1401,8 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 // by adding the table descriptors in DROP state, which causes the schema change
 // stuff to delete the keys in the background.
 func (r *importResumer) OnFailOrCancel(ctx context.Context, phs interface{}) error {
-	telemetry.Count("import.total.failed")
-
+	details := r.job.Details().(jobspb.ImportDetails)
+	addToFileFormatTelemetry(details.Format.Format.String(), "failed")
 	cfg := phs.(sql.PlanHookState).ExecCfg()
 	lm, ie, db := cfg.LeaseManager, cfg.InternalExecutor, cfg.DB
 	return descs.Txn(ctx, cfg.Settings, lm, ie, db, func(


### PR DESCRIPTION
Backport 1/1 commits from #54792.

/cc @cockroachdb/release

---

This change reworks how we count import telemetry to a
per file format basis. It counts 4 states at different stages
of the import:

The current states being counted are:
- attempted: Counted at the very beginning of the IMPORT.
- started: Counted just before the IMPORT job is started.
- failed: Counted when the IMPORT job is failed or cancelled.
- succeeded: Counted when the IMPORT job completes successfully.

Previously we were counting "started" imports in the Resume job
method which would lead to incorrect numbers because of job
restarts, this change fixes that too.

Fixes: #52734

Release note: None
