### PR TITLE
sql: fix error message refering to session variable as cluster setting

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -273,7 +273,7 @@ var invalidClusterForShardedIndexError = pgerror.Newf(pgcode.FeatureNotSupported
 	"hash sharded indexes can only be created on a cluster that has fully migrated to version 20.1")
 
 var hashShardedIndexesDisabledError = pgerror.Newf(pgcode.FeatureNotSupported,
-	"hash sharded indexes require the experimental_enable_hash_sharded_indexes cluster setting")
+	"hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable")
 
 func setupShardedIndex(
 	ctx context.Context,

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -374,16 +374,16 @@ DROP TABLE sharded_primary
 statement ok
 SET experimental_enable_hash_sharded_indexes = false
 
-statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes cluster setting
+statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
 CREATE TABLE disabled (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 10)
 
 statement ok
 CREATE TABLE disabled_secondary (k INT, v BYTES)
 
-statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes cluster setting
+statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
 CREATE INDEX failure on disabled_secondary (k) USING HASH WITH BUCKET_COUNT = 12
 
-statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes cluster setting
+statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
 CREATE TABLE disabled (k INT, INDEX (k) USING HASH WITH BUCKET_COUNT = 10)
 
 # Ensure everything works with weird column names


### PR DESCRIPTION
This commit updates the error message text which referred to
`experimental_enable_hash_sharded_indexes` as a cluster setting when it
is in fact a session variable.

Release note (bug fix): Error message previously refered to
experimental_enable_hash_sharded_indexes as a cluster setting when it is
in fact a session variable.