### PR TITLE
release-20.2: roachtest tpcc fixture fixes

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -580,11 +580,12 @@ func RestoreFixture(
 		g.GoCtx(func(ctx context.Context) error {
 			start := timeutil.Now()
 			importStmt := fmt.Sprintf(`RESTORE %s.%s FROM $1 WITH into_db=$2`, genName, table.TableName)
+			log.Infof(ctx, "Restoring from %s", table.BackupURI)
 			var rows, index, tableBytes int64
 			var discard interface{}
 			res, err := sqlDB.Query(importStmt, table.BackupURI, database)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "backup: %s", table.BackupURI)
 			}
 			defer res.Close()
 			if !res.Next() {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -136,6 +136,10 @@ func setupTPCC(
 	c.Put(ctx, cockroach, "./cockroach", workloadNode)
 	c.Put(ctx, workload, "./workload", workloadNode)
 
+	extraArgs := opts.ExtraSetupArgs
+	if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
+		extraArgs += " --deprecated-fk-indexes"
+	}
 	func() {
 		db := c.Conn(ctx, 1)
 		defer db.Close()
@@ -144,14 +148,13 @@ func setupTPCC(
 		switch opts.SetupType {
 		case usingFixture:
 			t.Status("loading fixture")
-			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, opts.Warehouses, opts.ExtraSetupArgs))
+			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, opts.Warehouses, extraArgs))
 		case usingInit:
 			t.Status("initializing tables")
-			cmd := fmt.Sprintf("./workload init tpcc --warehouses=%d %s {pgurl:1}",
-				opts.Warehouses, opts.ExtraSetupArgs)
-			if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
-				cmd += " --deprecated-fk-indexes"
-			}
+			cmd := fmt.Sprintf(
+				"./workload init tpcc --warehouses=%d %s {pgurl:1}",
+				opts.Warehouses, extraArgs,
+			)
 			c.Run(ctx, workloadNode, cmd)
 		default:
 			t.Fatal("unknown tpcc setup type")

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -385,7 +385,7 @@ func registerTPCC(r *testRegistry) {
 		CPUs:  4,
 
 		LoadWarehouses: 1000,
-		EstimatedMax:   gceOrAws(cloud, 400, 600),
+		EstimatedMax:   gceOrAws(cloud, 650, 800),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 3,

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -63,36 +63,10 @@ type tpccOptions struct {
 }
 
 // tpccFixturesCmd generates the command string to load tpcc data for the
-// specified warehouse count into a cluster using either `fixtures import`
-// or `fixtures load` depending on the cloud.
-func tpccFixturesCmd(t *test, cloud string, warehouses int, extraArgs string) string {
-	var command string
-	switch cloud {
-	case gce:
-		// TODO(nvanbenschoten): We could switch to import for both clouds.
-		// At the moment, import is still a little unstable and load is still
-		// marginally faster.
-		command = "./workload fixtures load"
-		fixtureWarehouses := -1
-		for _, w := range []int{1, 10, 100, 1000, 2000, 5000, 10000} {
-			if w >= warehouses {
-				fixtureWarehouses = w
-				break
-			}
-		}
-		if fixtureWarehouses == -1 {
-			t.Fatalf("could not find fixture big enough for %d warehouses", warehouses)
-		}
-		warehouses = fixtureWarehouses
-	case aws, azure:
-		// For fixtures import, use the version built into the cockroach binary
-		// so the tpcc workload-versions match on release branches.
-		command = "./cockroach workload fixtures import"
-	default:
-		t.Fatalf("unknown cloud: %q", cloud)
-	}
-	return fmt.Sprintf("%s tpcc --warehouses=%d %s {pgurl:1}",
-		command, warehouses, extraArgs)
+// specified warehouse count into a cluster.
+func tpccFixturesCmd(t *test, warehouses int, extraArgs string) string {
+	return fmt.Sprintf("./workload fixtures import tpcc --warehouses=%d %s {pgurl:1}",
+		warehouses, extraArgs)
 }
 
 func setupTPCC(
@@ -148,7 +122,7 @@ func setupTPCC(
 		switch opts.SetupType {
 		case usingFixture:
 			t.Status("loading fixture")
-			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, opts.Warehouses, extraArgs))
+			c.Run(ctx, workloadNode, tpccFixturesCmd(t, opts.Warehouses, extraArgs))
 		case usingInit:
 			t.Status("initializing tables")
 			cmd := fmt.Sprintf(
@@ -686,7 +660,7 @@ func loadTPCCBench(
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
 	waitForFullReplication(t, db)
-	cmd := tpccFixturesCmd(t, cloud, b.LoadWarehouses, loadArgs)
+	cmd := tpccFixturesCmd(t, b.LoadWarehouses, loadArgs)
 	if err := c.RunE(ctx, loadNode, cmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: fix for tpcc tests against older versions" (#54884)
  * 2/2 commits from "roachtest: use fixtures import for tpcc, regardless of cloud" (#54880)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: testing-only code change.