### PR TITLE
[WIP, DNM] cli,server: add a bulk-ops-memory flag to monitor the memory usage by bulk ops

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -99,6 +99,7 @@ type TestServerArgs struct {
 	TimeSeriesQueryWorkerMax    int
 	TimeSeriesQueryMemoryBudget int64
 	SQLMemoryPoolSize           int64
+	BulkOpsMemorySize           int64
 	CacheSize                   int64
 
 	// By default, test servers have AutoInitializeCluster=true set in

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -145,6 +145,17 @@ percentage of physical memory (e.g. .25). If left unspecified, defaults to 25% o
 physical memory.`,
 	}
 
+	BulkOpsMem = FlagInfo{
+		Name: "bulk-ops-memory",
+		Description: `
+Maximum memory capacity available to use during bulk operations such as import,
+index backfills. Primarily used to buffer data prior to being ingested by the
+storage engine.
+Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
+percentage of physical memory (e.g. .25). If left unspecified, defaults to 25%
+of physical memory.`,
+	}
+
 	SQLAuditLogDirName = FlagInfo{
 		Name: "sql-audit-dir",
 		Description: `
@@ -1055,6 +1066,16 @@ execution. Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and
 1GiB) or a percentage of physical memory (e.g. .25). If left unspecified,
 defaults to 128MiB.
 `,
+	}
+	DemoNodeBulkOpsMemSize = FlagInfo{
+		Name: "bulk-ops-memory",
+		Description: `
+Maximum memory capacity available to use during bulk operations such as import,
+index backfills. Primarily used to buffer data prior to being ingested by the
+storage engine.
+Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
+percentage of physical memory (e.g. .25). If left unspecified, defaults to 25%
+of physical memory.`,
 	}
 	DemoNodeCacheSize = FlagInfo{
 		Name: "cache",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -106,6 +106,12 @@ func setServerContextDefaults() {
 	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
 		serverCfg.SQLConfig.MemoryPoolSize = bytes
 	}
+
+	// TODO(adityamaru): Figure out the correct default value.
+	// Attempt to default serverCfg.BulkOpsMemoryPoolSize to 25% if possible.
+	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
+		serverCfg.SQLConfig.BulkOpsMemoryPoolSize = bytes
+	}
 }
 
 // baseCfg points to the base.Config inside serverCfg.
@@ -508,6 +514,7 @@ func setSqlfmtContextDefaults() {
 var demoCtx struct {
 	nodes                     int
 	sqlPoolMemorySize         int64
+	bulkOpsMemorySize         int64
 	cacheSize                 int64
 	disableTelemetry          bool
 	disableLicenseAcquisition bool
@@ -526,6 +533,7 @@ var demoCtx struct {
 func setDemoContextDefaults() {
 	demoCtx.nodes = 1
 	demoCtx.sqlPoolMemorySize = 128 << 20 // 128MB, chosen to fit 9 nodes on 2GB machine.
+	demoCtx.bulkOpsMemorySize = 128 << 20 // TODO(adityamaru) confirm
 	demoCtx.cacheSize = 64 << 20          // 64MB, chosen to fit 9 nodes on 2GB machine.
 	demoCtx.useEmptyDatabase = false
 	demoCtx.simulateLatency = false

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -85,6 +85,10 @@ var demoNodeSQLMemSizeValue = newBytesOrPercentageValue(
 	&demoCtx.sqlPoolMemorySize,
 	memoryPercentResolver,
 )
+var demoNodeBulkOpsMemSizeValue = newBytesOrPercentageValue(
+	&demoCtx.bulkOpsMemorySize,
+	memoryPercentResolver,
+)
 
 type regionPair struct {
 	regionA string

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -314,6 +314,7 @@ func testServerArgsForTransientCluster(
 		DisableTLSForHTTP:       true,
 		StoreSpecs:              []base.StoreSpec{storeSpec},
 		SQLMemoryPoolSize:       demoCtx.sqlPoolMemorySize,
+		BulkOpsMemorySize:       demoCtx.bulkOpsMemorySize,
 		CacheSize:               demoCtx.cacheSize,
 		NoAutoInitializeCluster: true,
 		// This disables the tenant server. We could enable it but would have to
@@ -495,6 +496,7 @@ func (c *transientCluster) RestartNode(nodeID roachpb.NodeID) error {
 
 func maybeWarnMemSize(ctx context.Context) {
 	if maxMemory, err := status.GetTotalMemory(ctx); err == nil {
+		// TODO(adityamaru): Consider including bulkops memory usage here too.
 		requestedMem := (demoCtx.cacheSize + demoCtx.sqlPoolMemorySize) * int64(demoCtx.nodes)
 		maxRecommendedMem := int64(.75 * float64(maxMemory))
 		if requestedMem > maxRecommendedMem {

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -29,6 +29,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		nodeID            roachpb.NodeID
 		joinAddr          string
 		sqlPoolMemorySize int64
+		bulkOpsMemorySize int64
 		cacheSize         int64
 
 		expected base.TestServerArgs
@@ -37,12 +38,14 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			nodeID:            roachpb.NodeID(1),
 			joinAddr:          "127.0.0.1",
 			sqlPoolMemorySize: 2 << 10,
+			bulkOpsMemorySize: 3 << 10,
 			cacheSize:         1 << 10,
 			expected: base.TestServerArgs{
 				PartOfCluster:           true,
 				JoinAddr:                "127.0.0.1",
 				DisableTLSForHTTP:       true,
 				SQLMemoryPoolSize:       2 << 10,
+				BulkOpsMemorySize:       3 << 10,
 				CacheSize:               1 << 10,
 				NoAutoInitializeCluster: true,
 				TenantAddr:              new(string),
@@ -52,12 +55,14 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			nodeID:            roachpb.NodeID(3),
 			joinAddr:          "127.0.0.1",
 			sqlPoolMemorySize: 4 << 10,
+			bulkOpsMemorySize: 4 << 10,
 			cacheSize:         4 << 10,
 			expected: base.TestServerArgs{
 				PartOfCluster:           true,
 				JoinAddr:                "127.0.0.1",
 				DisableTLSForHTTP:       true,
 				SQLMemoryPoolSize:       4 << 10,
+				BulkOpsMemorySize:       4 << 10,
 				CacheSize:               4 << 10,
 				NoAutoInitializeCluster: true,
 				TenantAddr:              new(string),

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -435,6 +435,7 @@ func init() {
 		// Engine flags.
 		varFlag(f, cacheSizeValue, cliflags.Cache)
 		varFlag(f, sqlSizeValue, cliflags.SQLMem)
+		varFlag(f, bulkOpsSizeValue, cliflags.BulkOpsMem)
 		// N.B. diskTempStorageSizeValue.ResolvePercentage() will be called after
 		// the stores flag has been parsed and the storage device that a percentage
 		// refers to becomes known.
@@ -742,6 +743,7 @@ func init() {
 		varFlag(f, &demoCtx.localities, cliflags.DemoNodeLocality)
 		boolFlag(f, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas)
 		varFlag(f, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
+		varFlag(f, demoNodeBulkOpsMemSizeValue, cliflags.DemoNodeBulkOpsMemSize)
 		varFlag(f, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
 		boolFlag(f, &demoCtx.insecure, cliflags.ClientInsecure)
 		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name, "it will be removed in a subsequent release.\n"+

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -130,6 +130,8 @@ func initMutexProfile() {
 
 var cacheSizeValue = newBytesOrPercentageValue(&serverCfg.CacheSize, memoryPercentResolver)
 var sqlSizeValue = newBytesOrPercentageValue(&serverCfg.MemoryPoolSize, memoryPercentResolver)
+var bulkOpsSizeValue = newBytesOrPercentageValue(&serverCfg.BulkOpsMemoryPoolSize,
+	memoryPercentResolver)
 var diskTempStorageSizeValue = newBytesOrPercentageValue(nil /* v */, nil /* percentResolver */)
 
 func initExternalIODir(ctx context.Context, firstStore base.StoreSpec) (string, error) {
@@ -974,6 +976,9 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		}
 		log.Warningf(ctx, "%s", buf.String())
 	}
+
+	// TODO(adityamaru): Add recommendations and account for bulkOpsMemory in the below warning after
+	// ascertaining appropriate values.
 
 	// Check that the total suggested "max" memory is well below the available memory.
 	if maxMemory, err := status.GetTotalMemory(ctx); err == nil {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -50,9 +50,11 @@ const (
 	// settings and we'll warn in the logs about doing so.
 	DefaultCacheSize         = 128 << 20 // 128 MB
 	defaultSQLMemoryPoolSize = 128 << 20 // 128 MB
-	defaultScanInterval      = 10 * time.Minute
-	defaultScanMinIdleTime   = 10 * time.Millisecond
-	defaultScanMaxIdleTime   = 1 * time.Second
+	// TODO(adityamaru): Consider what the correct default value is.
+	defaultBulkOpsMemoryPoolSize = 128 << 20 // 128 MB
+	defaultScanInterval          = 10 * time.Minute
+	defaultScanMinIdleTime       = 10 * time.Millisecond
+	defaultScanMaxIdleTime       = 1 * time.Second
 
 	DefaultStorePath = "cockroach-data"
 	// TempDirPrefix is the filename prefix of any temporary subdirectory
@@ -319,6 +321,10 @@ type SQLConfig struct {
 	// used by SQL clients to store row data in server RAM.
 	MemoryPoolSize int64
 
+	// BulkOpsMemoryPoolSize is the amount of memory in bytes that can be used by
+	// Bulk operations to store row data in server RAM.
+	BulkOpsMemoryPoolSize int64
+
 	// AuditLogDirName is the target directory name for SQL audit logs.
 	AuditLogDirName *log.DirName
 
@@ -344,12 +350,13 @@ type SQLConfig struct {
 // MakeSQLConfig returns a SQLConfig with default values.
 func MakeSQLConfig(tenID roachpb.TenantID, tempStorageCfg base.TempStorageConfig) SQLConfig {
 	sqlCfg := SQLConfig{
-		TenantID:           tenID,
-		MemoryPoolSize:     defaultSQLMemoryPoolSize,
-		TableStatCacheSize: defaultSQLTableStatCacheSize,
-		QueryCacheSize:     defaultSQLQueryCacheSize,
-		TempStorageConfig:  tempStorageCfg,
-		LeaseManagerConfig: base.NewLeaseManagerConfig(),
+		TenantID:              tenID,
+		MemoryPoolSize:        defaultSQLMemoryPoolSize,
+		BulkOpsMemoryPoolSize: defaultBulkOpsMemoryPoolSize,
+		TableStatCacheSize:    defaultSQLTableStatCacheSize,
+		QueryCacheSize:        defaultSQLQueryCacheSize,
+		TempStorageConfig:     tempStorageCfg,
+		LeaseManagerConfig:    base.NewLeaseManagerConfig(),
 	}
 	return sqlCfg
 }
@@ -412,6 +419,7 @@ func (cfg *Config) String() string {
 	fmt.Fprintln(w, "max offset\t", cfg.MaxOffset)
 	fmt.Fprintln(w, "cache size\t", humanizeutil.IBytes(cfg.CacheSize))
 	fmt.Fprintln(w, "SQL memory pool size\t", humanizeutil.IBytes(cfg.MemoryPoolSize))
+	fmt.Fprintln(w, "BulkOps memory pool size\t", humanizeutil.IBytes(cfg.BulkOpsMemoryPoolSize))
 	fmt.Fprintln(w, "scan interval\t", cfg.ScanInterval)
 	fmt.Fprintln(w, "scan min idle time\t", cfg.ScanMinIdleTime)
 	fmt.Fprintln(w, "scan max idle time\t", cfg.ScanMaxIdleTime)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -186,6 +186,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLMemoryPoolSize != 0 {
 		cfg.MemoryPoolSize = params.SQLMemoryPoolSize
 	}
+	if params.BulkOpsMemorySize != 0 {
+		cfg.BulkOpsMemoryPoolSize = params.BulkOpsMemorySize
+	}
 	if params.CacheSize != 0 {
 		cfg.CacheSize = params.CacheSize
 	}


### PR DESCRIPTION
Previously, the `bulkMemoryMonitor` which was used to track the memory
usages of bulk ops such as index backfill, import, was a child monitor
of the rootSQLMemoryMonitor. The rootSQLMemoryMonitor is governed by the
`max-sql-memory` CLI flag.

This change decouples the `bulkMemoryMonitor` by making it its own root
monitor and adds a `bulk-ops-memory` flag to control the resources
allocated to this monitor.  Recent memory accounting added to the index
backfiller has exposed a need to have more fine-grained control over
bulk op related memory monitoring, instead of asking users to change
`max-sql-memory` which has other unrelated implications.

Release note: None