### PR TITLE
sql: populate owner ID (oid) to pg_database's datdba field

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -242,12 +242,12 @@ SELECT oid, datname, datdba, encoding, datcollate, datctype, datistemplate, data
 FROM pg_catalog.pg_database
 ORDER BY oid
 ----
-oid  datname        datdba  encoding  datcollate  datctype    datistemplate  datallowconn
-1    system         NULL    6         en_US.utf8  en_US.utf8  false          true
-50   defaultdb      NULL    6         en_US.utf8  en_US.utf8  false          true
-51   postgres       NULL    6         en_US.utf8  en_US.utf8  false          true
-52   test           NULL    6         en_US.utf8  en_US.utf8  false          true
-54   constraint_db  NULL    6         en_US.utf8  en_US.utf8  false          true
+oid  datname        datdba      encoding  datcollate  datctype    datistemplate  datallowconn
+1    system         3233629770  6         en_US.utf8  en_US.utf8  false          true
+50   defaultdb      1546506610  6         en_US.utf8  en_US.utf8  false          true
+51   postgres       1546506610  6         en_US.utf8  en_US.utf8  false          true
+52   test           1546506610  6         en_US.utf8  en_US.utf8  false          true
+54   constraint_db  1546506610  6         en_US.utf8  en_US.utf8  false          true
 
 query OTIOIIOT colnames
 SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1244,7 +1244,7 @@ CREATE TABLE pg_catalog.pg_database (
 				return addRow(
 					dbOid(db.GetID()),           // oid
 					tree.NewDName(db.GetName()), // datname
-					tree.DNull,                  // datdba
+					getOwnerOID(db),             // datdba
 					// If there is a change in encoding value for the database we must update
 					// the definitions of getdatabaseencoding within pg_builtin.
 					builtins.DatEncodingUTFId,  // encoding


### PR DESCRIPTION
Previously this populated as `DNull`. We want to correctly
populate the field to make our ownership logic tests
more robust.

Release note (sql change): Populate the datdba field of
pg_catalog.pg_database. This was previously DNull.
