### PR TITLE
roachprod: Support multiple stores on AWS

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -42,8 +42,11 @@ sudo apt-get install -qy --no-install-recommends mdadm
 mount_opts="discard,defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
+use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
+
 disks=()
-mountpoint="/mnt/data1"
+mount_prefix="/mnt/data"
+
 # On different machine types, the drives are either called nvme... or xvdd.
 for d in $(ls /dev/nvme?n1 /dev/xvdd); do
   if ! mount | grep ${d}; then
@@ -53,19 +56,28 @@ for d in $(ls /dev/nvme?n1 /dev/xvdd); do
     echo "Disk ${d} already mounted, skipping..."
   fi
 done
+
+
 if [ "${#disks[@]}" -eq "0" ]; then
+  mountpoint="${mount_prefix}1"
   echo "No disks mounted, creating ${mountpoint}"
   mkdir -p ${mountpoint}
   chmod 777 ${mountpoint}
-elif [ "${#disks[@]}" -eq "1" ]; then
-  echo "One disk mounted, creating ${mountpoint}"
-  mkdir -p ${mountpoint}
-  disk=${disks[0]}
-  mkfs.ext4 -E nodiscard ${disk}
-  mount -o ${mount_opts} ${disk} ${mountpoint}
-  chmod 777 ${mountpoint}
-  echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+elif [ "${#disks[@]}" -eq "1" ] || [ -n "use_multiple_disks" ]; then
+  disknum=1
+  for disk in "${disks[@]}"
+  do
+    mountpoint="${mount_prefix}${disknum}"
+    disknum=$((disknum + 1 ))
+    echo "Creating ${mountpoint}"
+    mkdir -p ${mountpoint}
+    mkfs.ext4 -E nodiscard ${disk}
+    mount -o ${mount_opts} ${disk} ${mountpoint}
+    chmod 777 ${mountpoint}
+    echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+  done
 else
+  mountpoint="${mount_prefix}1"
   echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
   mkdir -p ${mountpoint}
   raiddisk="/dev/md0"
@@ -125,12 +137,13 @@ sudo touch /mnt/data1/.roachprod-initialized
 //
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
-func writeStartupScript(extraMountOpts string) (string, error) {
+func writeStartupScript(extraMountOpts string, useMultiple bool) (string, error) {
 	type tmplParams struct {
-		ExtraMountOpts string
+		ExtraMountOpts   string
+		UseMultipleDisks bool
 	}
 
-	args := tmplParams{ExtraMountOpts: extraMountOpts}
+	args := tmplParams{ExtraMountOpts: extraMountOpts, UseMultipleDisks: useMultiple}
 
 	tmpfile, err := ioutil.TempFile("", "aws-startup-script")
 	if err != nil {


### PR DESCRIPTION
Add an aws specific command line option to make it possible
to create AWS instances with multiple /mnt/dataN directories in
order to support multiple stores.

Release Notes: None
Release Justification: N/A; roachprod script changes.