### PR TITLE
rowexec: add a clarifying comment about distinct aggregation

### DIFF
--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -931,6 +931,10 @@ func (a *aggregateFuncHolder) isDistinct(
 	}
 	if otherArgs != nil {
 		for _, arg := range otherArgs {
+			// Note that we don't need to explicitly unset ed because encoded
+			// field is never set during fingerprinting - we'll compute the
+			// encoding and return it without updating the EncDatum; therefore,
+			// simply setting Datum field to the argument is sufficient.
 			ed.Datum = arg
 			encoded, err = ed.Fingerprint(arg.ResolvedType(), alloc, encoded)
 			if err != nil {


### PR DESCRIPTION
I thought that we were handling the DISTINCT aggregation when the
aggregate function has multiple arguments incorrectly, but I was wrong.
In order to prevent confuses like this let's add a clarifying comment.

Informs: #54721.

Release note: None