### PR TITLE
logictest: bump high verbosity timeout to 24h temporarily

### DIFF
--- a/build/teamcity-testlogic-verbose.sh
+++ b/build/teamcity-testlogic-verbose.sh
@@ -16,5 +16,5 @@ tc_end_block "Compile C dependencies"
 tc_start_block "Run TestLogic tests under verbose"
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS='--vmodule=*=10 -show-sql -test.v' TESTTIMEOUT='1h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$'
+  make test GOTESTFLAGS=-json TESTFLAGS='--vmodule=*=10 -show-sql -test.v' TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$'
 tc_end_block "Run TestLogic tests under verbose"


### PR DESCRIPTION
The current timeout of 1h is insufficient for logic tests to complete with
high verbosity. This commit bumps that timeout to 24h which should be enough,
to see how long this really takes. A following commit will reduce the timeout
to what is necessary.

Release note: None

Addresses #54645 