### PR TITLE
cli/flags: remove `doctor` from the list of timeout-supporting commands

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -582,7 +582,6 @@ func init() {
 		statusNodeCmd,
 		lsNodesCmd,
 		debugZipCmd,
-		doctorClusterCmd,
 		// If you add something here, make sure the actual implementation
 		// of the command uses `cmdTimeoutContext(.)` or it will ignore
 		// the timeout.


### PR DESCRIPTION
Fixes #54931.

This was unintentionally added - doctor is not meant to support
configurable timeouts (just yet).

Release note: None