### PR TITLE
release-20.2: cli/flags: remove `doctor` from the list of timeout-supporting commands

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -581,7 +581,6 @@ func init() {
 		statusNodeCmd,
 		lsNodesCmd,
 		debugZipCmd,
-		doctorClusterCmd,
 		// If you add something here, make sure the actual implementation
 		// of the command uses `cmdTimeoutContext(.)` or it will ignore
 		// the timeout.


### PR DESCRIPTION
Backport 1/1 commits from #55034.

/cc @cockroachdb/release

---

Ensures we don't present a non-effective flag to users in the output of `--help`.