### PR TITLE
roachtest: use crdb's workload for fixtures import tpcc

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 )
 
@@ -36,11 +35,7 @@ func registerImportTPCC(r *testRegistry) {
 		hc := NewHealthChecker(c, c.All())
 		m.Go(hc.Runner)
 
-		workloadStr := `./workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`
-		if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
-			workloadStr += " --deprecated-fk-indexes"
-		}
-
+		workloadStr := `./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
 			defer hc.Done()

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -45,7 +45,7 @@ type tpccOLAPSpec struct {
 func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
 	crdbNodes, workloadNode := setupTPCC(
 		ctx, t, c, tpccOptions{
-			Warehouses: s.Warehouses, SetupType: usingFixture,
+			Warehouses: s.Warehouses, SetupType: usingImport,
 		})
 	const queryFileName = "queries.sql"
 	// querybench expects the entire query to be on a single line.

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -312,7 +312,7 @@ func makeIndexAddTpccTest(spec clusterSpec, warehouses int, length time.Duration
 					})
 				},
 				Duration:  length,
-				SetupType: usingFixture,
+				SetupType: usingImport,
 			})
 		},
 		MinVersion: "v19.1.0",
@@ -457,7 +457,7 @@ func makeSchemaChangeDuringTPCC(spec clusterSpec, warehouses int, length time.Du
 					})
 				},
 				Duration:  length,
-				SetupType: usingFixture,
+				SetupType: usingImport,
 			})
 		},
 		MinVersion: "v19.1.0",

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -82,7 +82,7 @@ func makeScrubTPCCTest(
 					return nil
 				},
 				Duration:  length,
-				SetupType: usingFixture,
+				SetupType: usingImport,
 			})
 		},
 		MinVersion: "v19.1.0",


### PR DESCRIPTION
Fixes #55042.
Fixes #55041.
Fixes #55039.
Fixes #55038.
Fixes #55037.
Fixes #55036.
Fixes #55035.
Fixes #55033.
Fixes #55029.
Fixes #55024.
Fixes #55022.
Fixes #55020.
Fixes #55019.
Fixes #55018.
Fixes #55017.
Fixes #55016.
Fixes #55013.
Fixes #55010.
Fixes #55009.
Fixes #55008.
Fixes #55003.
Fixes #55002.
Fixes #54998.
Fixes #54995.
Fixes #54822.
Fixes #52693.
Fixes #54802.

We were already doing this in some places, but needed it in others.