### PR TITLE
release-20.2: build: script to make custom builds

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
 
@@ -10,6 +10,7 @@ export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh make .buildinfo/tag
 build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+")"
+is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET-cockroach-builds}"
@@ -24,6 +25,16 @@ fi
 
 # Used for docker login for gcloud
 gcr_hostname="us.gcr.io"
+
+cat << EOF
+
+  build_name:      $build_name
+  release_branch:  $release_branch
+  is_custom_build: $is_custom_build
+  bucket:          $bucket
+  gcr_repository:  $gcr_repository
+
+EOF
 tc_end_block "Variable Setup"
 
 
@@ -82,7 +93,14 @@ tc_end_block "Tag docker image as latest-build"
 cat << EOF
 
 
-Git Tag: ${build_name}
+Build ID: ${build_name}
 
 
 EOF
+
+
+if [[ -n "${is_custom_build}" ]] ; then
+  tc_start_block "Delete custombuild tag"
+  push_to_git ssh://git@github.com/cockroachdb/cockroach.git --delete "${TC_BUILD_BRANCH}"
+  tc_end_block "Delete custombuild tag"
+fi

--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -59,5 +59,6 @@ configure_git_ssh_key() {
 }
 
 push_to_git() {
-  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push $1 $2
+  # $@ passes all arguments to this function to the command
+  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push "$@"
 }

--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This script makes it easy to make custom builds.
+#
+# It creates a tag for a SHA that triggers a build in the Make and Publish
+# Build TeamCity build config. Once the build is complete, binaries and a
+# docker image are available. For details on how to validate everything is
+# correct and how to use the binaries/docker image, see:
+# https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/846299518/One-Off+Builds+A+How+To
+#
+# How to use this script:
+#
+# 1) To tag the checked out SHA (the script is not available for releases
+#    v20.1.5, v19.2.10 and older; use option 2 for those releases) run it
+#    with no arguments from the root of the repo.
+#
+# 2) To tag a non-checked out SHA including any SHAs on releases (or branches)
+#    older than v20.1.5 and v19.2.10, run it from the root of the repo with
+#    the SHA that you want to tag as the single argument.
+#
+#      ./scripts/tag-custom-build.sh "$SHA"
+#
+# Note the Tag Name and Build ID (printed at the end of the script output).
+#
+# Verify the SHA on the GitHub page for the tag (it should open automatically
+# in your browser) is the one you tagged. (If the page didn't open in your
+# browser, the tag should be somewhere in this list, not necessarily at the top:
+# https://github.com/cockroachdb/cockroach/tags .)
+#
+# Use the tag name to find the build in the Make and Publish Build build config
+# in TeamCity.
+#
+# Use the Build ID when referencing the binaries and docker image with others.
+
+set -euo pipefail
+
+SHA="${1-}"
+
+if [ -z "$SHA" ] ; then
+    SHA="$(git rev-parse HEAD)"
+fi
+
+# Ensure all the latest tags are downloaded locally
+git fetch -t
+
+ID="$(git describe --tags --match=v[0-9]* "$SHA")"
+TAG="custombuild-$ID"
+
+git tag "$TAG" "$SHA"
+git push git@github.com:cockroachdb/cockroach.git "$TAG"
+
+TAG_URL="https://github.com/cockroachdb/cockroach/releases/tag/${TAG}"
+TEAMCITY_URL="https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_MakeAndPublishBuild?branch=${TAG}&mode=builds"
+if [ "$(command -v open)" ] ; then
+    open "$TEAMCITY_URL"
+    open "$TAG_URL"
+elif [ "$(command -v xdg-open)" ] ; then
+    xdg-open "$TEAMCITY_URL"
+    xdg-open "$TAG_URL"
+fi
+
+cat << EOF
+
+See the one-off builds wiki page for steps for the rest of the process:
+
+  https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/846299518/One-Off+Builds+A+How+To
+
+Here is the tag in GitHub:
+
+  $TAG_URL
+
+Here is where the build run should show up in TeamCity for the tag:
+
+  $TEAMCITY_URL
+
+Tag name: $TAG
+Build ID: $ID
+EOF


### PR DESCRIPTION
Backport 1/1 commits from #54661.

/cc @cockroachdb/release

---

Before: We had the old build process and a not-so-great way to make
custom builds.

Why: We have a new build process that includes a facility for making
custom builds and we want it to be very easy to use.

Now:

This script automates much of the process of making a custom build
and makes it very easy to create one on short notice. Comments in the
script describe how to use it and where to go for getting the binaries
and docker image.

This commit also changes the teamcity-make-and-publish-build.sh script
to delete the temporary custombuild- tag and to be consistent in naming
the Build ID.

Part of https://github.com/cockroachdb/cockroach/issues/45487

Release note: None
