### PR TITLE
release-20.2: cli: fix default value in help text of max-disk-temp-storage flag

### DIFF
--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -398,7 +398,6 @@ func (f *tableDisplayFormat) Set(s string) error {
 // known once other flags are parsed (e.g. --max-disk-temp-storage=10% depends
 // on --store).
 type bytesOrPercentageValue struct {
-	val  *int64
 	bval *humanizeutil.BytesValue
 
 	origVal string
@@ -447,11 +446,7 @@ func diskPercentResolverFactory(dir string) (percentResolverFunc, error) {
 func newBytesOrPercentageValue(
 	v *int64, percentResolver func(percent int) (int64, error),
 ) *bytesOrPercentageValue {
-	if v == nil {
-		v = new(int64)
-	}
 	return &bytesOrPercentageValue{
-		val:             v,
 		bval:            humanizeutil.NewBytesValue(v),
 		percentResolver: percentResolver,
 	}
@@ -502,7 +497,6 @@ func (b *bytesOrPercentageValue) Resolve(v *int64, percentResolver percentResolv
 		return nil
 	}
 	b.percentResolver = percentResolver
-	b.val = v
 	b.bval = humanizeutil.NewBytesValue(v)
 	return b.Set(b.origVal)
 }


### PR DESCRIPTION
Backport 1/1 commits from #54853.

/cc @cockroachdb/release

---

Previously, in the output of `cockroach start --help`, the
`--max-disk-temp-storage` flag section reported that the default value
for the flag was "0 B".

```
$ cockroach start --help
...
      --max-disk-temp-storage bytes
...
          (default 0 B)
```

This is inaccurate, as the actual default value is dependent on whether
the store is a disk store or an in-memory store.

To fix this, this patch changes the BytesValue.String() method when the
underlying value is nil. Previously, it would return "0 B", which caused
our flags library to think the value was a non-zero value. By changing
the method to return `"<nil>"`, our flags library recognizes the value as
a zero value, and does not print an incorrect default value for the flag
in our help text.

Release note (cli change): The --help text for --max-disk-temp-storage
now properly reports the default value.
