### PR TITLE
release-20.2: sql: wait for canceled mutations to be at the head of the queue for reverse

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -699,6 +699,21 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 	ctx context.Context, err error, evalCtx *extendedEvalContext,
 ) error {
+
+	// Ensure that this mutation is first in line prior to reverting.
+	{
+		// Pull out the requested descriptor.
+		desc, descErr := sc.getTargetDescriptor(ctx)
+		if descErr != nil {
+			return descErr
+		}
+
+		// Check that we aren't queued behind another schema changer.
+		if err := sc.notFirstInLine(ctx, desc); err != nil {
+			return err
+		}
+	}
+
 	if rollbackErr := sc.rollbackSchemaChange(ctx, err); rollbackErr != nil {
 		// From now on, the returned error will be a secondary error of the returned
 		// error, so we'll record the original error now.
@@ -1434,6 +1449,20 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		if err := descsCol.AddUncommittedDescriptor(scTable); err != nil {
 			return err
 		}
+
+		// If this is a real mutation, it should be the first mutation. Assert that.
+		if sc.mutationID != descpb.InvalidMutationID {
+			if len(scTable.Mutations) == 0 {
+				return errors.AssertionFailedf("expected mutation %d to be the"+
+					" first mutation when reverted, found no mutations in descriptor %d",
+					sc.mutationID, scTable.ID)
+			} else if scTable.Mutations[0].MutationID != sc.mutationID {
+				return errors.AssertionFailedf("expected mutation %d to be the"+
+					" first mutation when reverted, found %d in descriptor %d",
+					sc.mutationID, scTable.Mutations[0].MutationID, scTable.ID)
+			}
+		}
+
 		for _, mutation := range scTable.Mutations {
 			if mutation.MutationID != sc.mutationID {
 				break

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -16,6 +16,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -63,7 +64,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // setTestJobsAdoptInterval sets a short job adoption interval for a test
@@ -6266,4 +6269,88 @@ ALTER DATABASE db RENAME TO db2;
 	sqlRun.ExpectErr(t, `type "typ" does not exist`, `ALTER TYPE typ RENAME TO typ3`)
 	sqlRun.ExpectErr(t, `unknown schema "sc"`, `ALTER SCHEMA sc RENAME TO sc3`)
 	sqlRun.ExpectErr(t, `database "db" does not exist`, `ALTER DATABASE db RENAME TO db3`)
+}
+
+// TestCancelMultipleQueued tests that canceling schema changes when there are
+// multiple queued schema changes works as expected.
+func TestCancelMultipleQueued(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	ctx := context.Background()
+
+	canProceed := make(chan struct{})
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeBackfill: func() error {
+				<-canProceed
+				return nil
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `CREATE TABLE db.t (i INT PRIMARY KEY, j INT)`)
+	var schemaChangeWaitGroup sync.WaitGroup
+	var jobsErrGroup errgroup.Group
+	const numIndexes = 10               // number of indexes to add
+	jobIDs := make([]int64, numIndexes) // job IDs for the index additions
+	shouldCancel := make([]bool, numIndexes)
+	for i := 0; i < numIndexes; i++ {
+		idxName := "t_" + strconv.Itoa(i) + "_idx"
+		schemaChangeWaitGroup.Add(1)
+		i := i
+		shouldCancel[i] = rand.Float64() < .5
+		go func() {
+			defer schemaChangeWaitGroup.Done()
+			_, err := sqlDB.Exec("CREATE INDEX " + idxName + " ON db.t (j)")
+			if shouldCancel[i] {
+				assert.Regexp(t, "job canceled by user", err)
+			} else {
+				assert.NoError(t, err)
+			}
+		}()
+		jobsErrGroup.Go(func() error {
+			return testutils.SucceedsSoonError(func() error {
+				return sqlDB.QueryRow(`
+SELECT job_id FROM crdb_internal.jobs 
+ WHERE description LIKE '%` + idxName + `%'`).Scan(&jobIDs[i])
+			})
+		})
+	}
+	require.NoError(t, jobsErrGroup.Wait())
+	for i, id := range jobIDs {
+		if shouldCancel[i] {
+			tdb.Exec(t, "CANCEL JOB $1", id)
+		}
+	}
+	close(canProceed)
+	schemaChangeWaitGroup.Wait()
+
+	// Verify that after all of the canceled jobs have been canceled and all of
+	// the other indexes which were not canceled have completed, that we can
+	// perform another schema change. This ensures that there are no orphaned
+	// mutations.
+	tdb.Exec(t, "CREATE INDEX foo ON db.t (j)")
+
+	// Verify that all the jobs reached the expected terminal state.
+	// Do this after the above change to ensure that all canceled states have
+	// been reached.
+	for i, id := range jobIDs {
+		var status jobs.Status
+		tdb.QueryRow(t, "SELECT status FROM system.jobs WHERE id = $1", id).
+			Scan(&status)
+		if shouldCancel[i] {
+			require.Equal(t, jobs.StatusCanceled, status)
+		} else {
+			require.Equal(t, jobs.StatusSucceeded, status)
+		}
+
+		if shouldCancel[i] {
+			tdb.Exec(t, "CANCEL JOB $1", id)
+		}
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #54876.

/cc @cockroachdb/release

---

Before this commit, we'd totally skip the process of rolling back a mutation if
it were not the first mutation in line. This behavior was nonsense. Perhaps
there is a more principled change to be made whereby we just remove mutations
which are not at the head of the queue. I'm open to making such a change. This
seemed more pragmatic, though it may have problems I am not aware of.

Fixes #54861

Release note (bug fix): Fixed a bug which can occur when canceling schema
changes when there are multiple queued schema changes that could result in
future schema changes being stuck.
