### PR TITLE
release-20.2: backupccl: fix bug in cleanup of restored databases with types or sch…

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1886,18 +1886,18 @@ func TestRestoreFailDatabaseCleanup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	params := base.TestServerArgs{}
-	// Disable external processing of mutations so that the final check of
-	// crdb_internal.tables is guaranteed to not be cleaned up. Although this
-	// was never observed by a stress test, it is here for safety.
-	blockGC := make(chan struct{})
-	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { <-blockGC; return nil }}
-
 	const numAccounts = 1000
 	_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
 		InitNone, base.TestClusterArgs{ServerArgs: params})
 	defer cleanup()
 
 	dir = dir + "/foo"
+
+	// Create a user defined type and check that it is cleaned up after the
+	// failed restore.
+	sqlDB.Exec(t, `CREATE TYPE data.myenum AS ENUM ('hello')`)
+	// Do the same with a user defined schema.
+	sqlDB.Exec(t, `USE data; CREATE SCHEMA myschema`)
 
 	sqlDB.Exec(t, `BACKUP DATABASE data TO $1`, LocalFoo)
 	// Bugger the backup by removing the SST files.
@@ -1921,7 +1921,6 @@ func TestRestoreFailDatabaseCleanup(t *testing.T) {
 		t, `database "data" does not exist`,
 		`DROP DATABASE data`,
 	)
-	close(blockGC)
 }
 
 func TestBackupRestoreUserDefinedSchemas(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #54993.

/cc @cockroachdb/release

---

…emas

While cleaning up a database that we attempted to restore, if the
database has any child tables, types, or schemas, we preserve the
database as-is instead of deleting it. The problem was that while we
correctly disregarded tables we tried to restore in the same operation,
we didn't do the same for types and schemas, so the presence of any
types or schemas in the database would prevent a failed database RESTORE
from being cleaned up. This commit fixes that bug.

Release note (bug fix): Fixes a bug where the presence of types or
schemas in a database to be restored would prevent the database from
being cleaned up on restore failure.
