### PR TITLE
roachtest: reduce initial disk space expectation in drop tests

### DIFF
--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -88,7 +88,7 @@ func registerDrop(r *testRegistry) {
 
 				t.l.Printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
 
-				// Return if the size of the directory is less than 100mb
+				// Return if the size of the directory is less than expected.
 				if size < initDiskSpace {
 					t.Fatalf("Node %d space used: %s less than %s", j, humanizeutil.IBytes(int64(size)),
 						humanizeutil.IBytes(int64(initDiskSpace)))
@@ -160,9 +160,7 @@ func registerDrop(r *testRegistry) {
 
 	warehouses := 100
 	numNodes := 9
-
-	// 1GB
-	initDiskSpace := int(1e9)
+	initDiskSpace := 256 << 20 // 256 MB
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
@@ -175,9 +173,7 @@ func registerDrop(r *testRegistry) {
 			if local {
 				numNodes = 4
 				warehouses = 1
-
-				// 100 MB
-				initDiskSpace = 1e8
+				initDiskSpace = 5 << 20 // 5 MB
 				fmt.Printf("running with w=%d,nodes=%d in local mode\n", warehouses, numNodes)
 			}
 			runDrop(ctx, t, c, warehouses, numNodes, initDiskSpace)


### PR DESCRIPTION
Fixes #55011.
Fixes #55000.
Fixes #54836.
Fixes #54834.

The `drop/tpcc/w=100,nodes=9` were placing an expectation on the initial
lsm size of a crdb node immediately after an import. This was getting
tripped up because we recently regenerated tpcc fixtures, which picked
up a change to begin compressing SSTs in backups. The compressed SSTs
are now about 1/4 the size they were before compression was enabled. To
account for this, we drop the initial disk space expectation in this test.

```
➜ gsutil du -sh 'gs://cockroach-fixtures/workload/tpcc/version=2.2.0,deprecated-fk-indexes=false,fks=true,interleaved=false,seed=1,warehouses=100'
1.92 GiB     gs://cockroach-fixtures/workload/tpcc/version=2.2.0,deprecated-fk-indexes=false,fks=true,interleaved=false,seed=1,warehouses=100
➜ gsutil du -sh 'gs://cockroach-fixtures/workload/tpcc/version=2.1.0,fks=true,interleaved=false,seed=1,warehouses=100'
6.95 GiB     gs://cockroach-fixtures/workload/tpcc/version=2.1.0,fks=true,interleaved=false,seed=1,warehouses=100
```