### PR TITLE
Fixed typo in text returned by ALTER DATABASE OWNER statement

### DIFF
--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -174,7 +174,7 @@ var _ CCLOnlyStatement = &ScheduledBackup{}
 func (*AlterDatabaseOwner) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*AlterDatabaseOwner) StatementTag() string { return "ALTER DATABSE OWNER" }
+func (*AlterDatabaseOwner) StatementTag() string { return "ALTER DATABASE OWNER" }
 
 func (*AlterDatabaseOwner) hiddenFromShowQueries() {}
 


### PR DESCRIPTION
Release justification: Non-production code changes

Release note: None