### PR TITLE
sql: close subquery plans when they encounter an error

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -249,7 +249,7 @@ func runPlanInsidePlan(
 		params.extendedEvalCtx.copy,
 		plan.subqueryPlans,
 		recv,
-		true,
+		false, /* maybeDistribute */
 	) {
 		if err := rowResultWriter.Err(); err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -351,3 +351,31 @@ UPDATE cpk SET extra = (
     WHERE k='k1'
 )
 WHERE ((cpk.key, cpk.value) IN (SELECT new_values.k, new_values.v FROM new_values))
+
+# Regression test for not closing the subqueries in the apply join if they hit
+# an error (#54166).
+query error pgcode XX000 invalid index .*
+SELECT
+  (
+    SELECT
+      tab_4.col_4
+    FROM
+      (VALUES (1)) AS tab_1 (col_1)
+      JOIN (
+          VALUES
+            (
+              (
+                SELECT
+                  1
+                FROM
+                  (SELECT 1)
+                WHERE
+                  EXISTS(SELECT 1)
+              )
+            )
+        )
+          AS tab_6 (col_6) ON (tab_1.col_1) = (tab_6.col_6)
+  )
+FROM
+  (VALUES (NULL)) AS tab_4 (col_4),
+  (VALUES (NULL), (NULL)) AS tab_5 (col_5)


### PR DESCRIPTION
Previously, when executing an apply join with subqueries, if we
encounter an error, we would not close the subqueries' plans because we
delegate that responsibility to the closure of the whole plan which
under normal circumstances occurs as a part of cleanup of `PlanAndRun`.
However, if a subquery gets an error, we will never get there. This
commit updates the subqueries' runner to always close them if an error
is encountered.

Note that I tried closing the whole right side plan in case of the apply
join unconditionally but ran into some issues. My thinking was that
we're creating a brand new plan for each left row, so it should be ok to
close the plan, but we probably have the references to the same planNodes,
so we can't just close the plans like that.

Additionally, we update `maybeDistribute` hint for subqueries in the apply
join to be `false` because we do so for the main query and - I believe -
we cannot distribute in case of the apply join anyway.

Closes: #54166.

Release note: None