### PR TITLE
delegate: add schema to SHOW SEQUENCES

### DIFF
--- a/pkg/sql/delegate/show_sequences.go
+++ b/pkg/sql/delegate/show_sequences.go
@@ -27,10 +27,9 @@ func (d *delegator) delegateShowSequences(n *tree.ShowSequences) (tree.Statement
 	}
 
 	getSequencesQuery := fmt.Sprintf(`
-	  SELECT sequence_name
+	  SELECT sequence_schema, sequence_name
 	    FROM %[1]s.information_schema.sequences
 	   WHERE sequence_catalog = %[2]s
-	     AND sequence_schema = 'public'
 	ORDER BY sequence_name`,
 		name.String(), // note: (tree.Name).String() != string(name)
 		lex.EscapeSQLString(string(name)),

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -146,25 +146,33 @@ TRUNCATE foo
 statement error pgcode 42809 "foo" is not a table
 DROP TABLE foo
 
+# Create a sequence on another schema
+statement ok
+CREATE SCHEMA other_schema
+
+statement ok
+CREATE SEQUENCE other_schema.seq
+
 # List sequences with SHOW
 
-query T
+query TT rowsort
 SHOW SEQUENCES
 ----
-foo
-high_minvalue_test
-ignored_options_test
-lastval_test
-lastval_test_2
-show_create_test
+public        foo
+public        high_minvalue_test
+public        ignored_options_test
+public        lastval_test
+public        lastval_test_2
+other_schema  seq
+public        show_create_test
 
 statement ok
 CREATE DATABASE seqdb; USE seqdb; CREATE SEQUENCE otherseq; USE test
 
-query T
+query TT rowsort
 SHOW SEQUENCES FROM seqdb
 ----
-otherseq
+public  otherseq
 
 # You can select from a sequence to get its value.
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -179,10 +179,10 @@ pg_catalog
 pg_extension
 public
 
-query T colnames
+query TT colnames
 SELECT * FROM [SHOW SEQUENCES FROM system]
 ----
-sequence_name
+sequence_schema  sequence_name
 
 query TTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]


### PR DESCRIPTION
Resolves #54962 .

Release note (sql change): SHOW SEQUENCES now show sequences in user
defined schemas. The schema is displayed in a newly added
`sequence_schema` column.