### PR TITLE
sql: correct schema name for crdb_internal.tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -79,11 +79,25 @@ SELECT * FROM crdb_internal.schema_changes
 table_id parent_id name type target_id target_name state direction
 
 # We don't select the modification time as it does not remain contant.
-query IITTITTTTTTT colnames
-SELECT table_id, parent_id, name, database_name, version, format_version, state, sc_lease_node_id, sc_lease_expiration_time, drop_time, audit_mode, schema_name FROM crdb_internal.tables WHERE NAME = 'descriptor'
+query IITTITTTTTTTI colnames
+SELECT
+  table_id,
+  parent_id,
+  name,
+  database_name,
+  version,
+  format_version,
+  state,
+  sc_lease_node_id,
+  sc_lease_expiration_time,
+  drop_time,
+  audit_mode,
+  schema_name,
+  parent_schema_id
+FROM crdb_internal.tables WHERE NAME = 'descriptor'
 ----
-table_id  parent_id  name       database_name  version  format_version            state   sc_lease_node_id  sc_lease_expiration_time  drop_time  audit_mode  schema_name
-3        1          descriptor  system         1        InterleavedFormatVersion  PUBLIC  NULL              NULL                      NULL       DISABLED    public
+table_id  parent_id  name        database_name  version  format_version            state   sc_lease_node_id  sc_lease_expiration_time  drop_time  audit_mode  schema_name  parent_schema_id
+3         1          descriptor  system         1        InterleavedFormatVersion  PUBLIC  NULL              NULL                      NULL       DISABLED    public       29
 
 # Verify that table names are not double escaped.
 

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1219,4 +1219,4 @@ DROP DATABASE to_drop CASCADE;
 # descriptors, including dropped ones, and hydrate them, causing a panic as
 # the referenced type no longer exists.
 statement ok
-SELECT * FROM crdb_internal.tables;
+SELECT * FROM crdb_internal.tables

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -534,6 +534,35 @@ SELECT * FROM testuser.test_table
 ----
 a
 
+query TITITI rowsort
+SELECT
+  database_name, parent_id, schema_name, parent_schema_id, name, table_id
+FROM crdb_internal.tables
+WHERE database_name IN ('test', 'new_db')
+----
+test    52   myschema2    54   tb                55
+test    52   myschema2    54   v                 58
+test    52   myschema2    54   s                 59
+test    52   myschema2    54   tb2               60
+test    52   [62]         62   myschema_t1       64
+test    52   [62]         62   myschema_t2       65
+test    52   [62]         62   myschema_seq1     66
+test    52   [62]         62   myschema_t3       67
+test    52   otherschema  70   otherschema_v1    71
+test    52   otherschema  70   otherschema_t1    72
+test    52   otherschema  70   otherschema_seq1  73
+test    52   [75]         75   scdrop1_t1        78
+test    52   [75]         75   scdrop1_t2        79
+test    52   [76]         76   scdrop2_t1        80
+test    52   [76]         76   scdrop2_v1        81
+test    52   [77]         77   scdrop3_v1        82
+test    52   privs        90   tbl               93
+test    52   privs        90   usage_tbl         96
+new_db  103  [104]        104  bar               105
+new_db  103  public       29   public_table      107
+new_db  103  testuser     106  test_table        108
+new_db  103  public       29   test_table        109
+
 # Ensure that when we create a schema, it inherits privileges from its parent
 # database, but only those which are valid for schemas.
 subtest create_schema_inherits_db_privileges

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_automatic_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_automatic_stats
@@ -197,3 +197,31 @@ __auto__         {d}           550        0
 __auto__         {d}           0          0
 __auto__         {rowid}       550        0
 __auto__         {rowid}       0          0
+
+
+# Test user-defined schemas.
+
+# Disable automatic stats
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
+statement ok
+CREATE SCHEMA my_schema;
+CREATE TABLE my_schema.my_table (k INT PRIMARY KEY, v STRING);
+
+# Enable automatic stats
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
+
+# Insert 10 rows.
+statement ok
+INSERT INTO my_schema.my_table SELECT k, NULL FROM
+   generate_series(1, 10) AS k(k)
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE my_schema.my_table] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {k}           10         10              0
+__auto__         {v}           10         1               10

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -326,7 +326,7 @@ func (r *Refresher) ensureAllTables(
 	getAllTablesQuery := fmt.Sprintf(
 		`
 SELECT table_id FROM crdb_internal.tables AS OF SYSTEM TIME '-%s'
-WHERE schema_name = 'public'
+WHERE database_name IS NOT NULL
 AND drop_time IS NULL
 `,
 		initialTableCollectionDelay)


### PR DESCRIPTION
Resolves #54976 
Based on top of #54981 

Release note (bug fix): Previously, all tables in any schema showed up
as "public" in the schema_name crdb_internal column. They now display
the correct schema.

Release note (sql change): Add the parent_schema_id field to
crdb_internal.tables.

