### PR TITLE
release-20.1: fix 19.2 - 20.1 closedts incompatibility

### DIFF
--- a/pkg/kv/kvserver/closedts/container/container.go
+++ b/pkg/kv/kvserver/closedts/container/container.go
@@ -101,6 +101,8 @@ func (s delayedServer) Get(client ctpb.ClosedTimestamp_GetServer) error {
 func (c *Container) RegisterClosedTimestampServer(s *grpc.Server) {
 	c.delayedServer = &delayedServer{}
 	ctpb.RegisterClosedTimestampServer(s, c.delayedServer)
+	// Also register under the service name expected by 19.2 nodes.
+	ctpb.RegisterClosedTimestampServerUnder192Name(s, c.delayedServer)
 }
 
 // Start starts the Container. The Stopper used to create the Container is in

--- a/pkg/kv/kvserver/closedts/container/container_test.go
+++ b/pkg/kv/kvserver/closedts/container/container_test.go
@@ -38,7 +38,11 @@ type LateBoundDialer struct {
 	Wrapped *transporttestutils.ChanDialer
 }
 
-func (d *LateBoundDialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (ctpb.Client, error) {
+var _ closedts.Dialer = &LateBoundDialer{}
+
+func (d *LateBoundDialer) Dial(
+	ctx context.Context, nodeID roachpb.NodeID,
+) (closedts.BackwardsCompatibleClosedTimestampClient, error) {
 	return d.Wrapped.Dial(ctx, nodeID)
 }
 

--- a/pkg/kv/kvserver/closedts/container/noop.go
+++ b/pkg/kv/kvserver/closedts/container/noop.go
@@ -24,6 +24,8 @@ import (
 
 type noopEverything struct{}
 
+var _ closedts.Dialer = noopEverything{}
+
 // NoopContainer returns a Container for which all parts of the subsystem are
 // mocked out. This is for usage in testing where there just needs to be a
 // structure that stays out of the way.
@@ -78,7 +80,12 @@ func (noopEverything) MaxClosed(
 }
 func (noopEverything) Request(roachpb.NodeID, roachpb.RangeID) {}
 func (noopEverything) EnsureClient(roachpb.NodeID)             {}
-func (noopEverything) Dial(context.Context, roachpb.NodeID) (ctpb.Client, error) {
+
+// Dial implements the closedts.Dialer interface.
+func (noopEverything) Dial(
+	context.Context, roachpb.NodeID,
+) (closedts.BackwardsCompatibleClosedTimestampClient, error) {
 	return nil, errors.New("closed timestamps disabled")
 }
+
 func (noopEverything) Ready(roachpb.NodeID) bool { return false }

--- a/pkg/kv/kvserver/closedts/ctpb/service.go
+++ b/pkg/kv/kvserver/closedts/ctpb/service.go
@@ -36,3 +36,29 @@ func (c *closedTimestampClient) Get192(
 	x := &closedTimestampGetClient{stream}
 	return x, nil
 }
+
+// _ClosedTimestampServiceDesc192 is like _ClosedTimestamp_serviceDesc, except
+// it uses the service name that 19.2 nodes were using. We've changed the
+// service name in 20.1 by mistake.
+var _ClosedTimestampServiceDesc192 = grpc.ServiceDesc{
+	// Instead of "cockroach.kv.kvserver.ctupdate.ClosedTimestamp".
+	ServiceName: "cockroach.storage.ctupdate.ClosedTimestamp",
+	HandlerType: (*ClosedTimestampServer)(nil),
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "Get",
+			Handler:       _ClosedTimestamp_Get_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+	Metadata: "kv/kvserver/closedts/ctpb/service.proto",
+}
+
+// RegisterClosedTimestampServerUnder192Name is like
+// RegisterClosedTimestampServer, except it uses a different service name - the
+// old name that 19.2 nodes are using.
+func RegisterClosedTimestampServerUnder192Name(s *grpc.Server, srv ClosedTimestampServer) {
+	s.RegisterService(&_ClosedTimestampServiceDesc192, srv)
+}

--- a/pkg/kv/kvserver/closedts/ctpb/service.go
+++ b/pkg/kv/kvserver/closedts/ctpb/service.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ctpb
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// ClosedTimestampClient192 is like ClosedTimestampClient, except its Get192()
+// method uses the RPC service that 19.2 had, not the 20.1 one. In 20.1 we've
+// changed the name of the RPC service.
+type ClosedTimestampClient192 interface {
+	// Get192 calls Get() on the RPC service exposed by 19.2 nodes.
+	Get192(ctx context.Context, opts ...grpc.CallOption) (ClosedTimestamp_GetClient, error)
+}
+
+func (c *closedTimestampClient) Get192(
+	ctx context.Context, opts ...grpc.CallOption,
+) (ClosedTimestamp_GetClient, error) {
+	// Instead of "/cockroach.kv.kvserver.ctupdate.ClosedTimestamp/Get".
+	stream, err := c.cc.NewStream(ctx, &_ClosedTimestamp_serviceDesc.Streams[0],
+		"/cockroach.storage.ctupdate.ClosedTimestamp/Get", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &closedTimestampGetClient{stream}
+	return x, nil
+}


### PR DESCRIPTION
In 20.1 we've inadvertently changed the name of an RPC service by
switching a package name. This was causing 20.1 nodes to not be able to
connect to 19.2 nodes in order to receive closedts updates. This patch
introduces a fallback for the old service name.
19.2 nodes also can't connect to 20.1 nodes; that'll be fixed in the
next commit.

Release note: A bug causing 20.1 nodes to not be able to serve follower
reads in mixed-version 19.2/20.1 cluster has been fixed.