### PR TITLE
release-20.2: storage/cloud: fix implicit auth check for gs storage

### DIFF
--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -88,6 +88,11 @@ func makeGCSStorage(
 	// "specified": the JSON object for authentication is given by the CREDENTIALS param.
 	// "implicit": only use the environment data.
 	// "": if default key is in the settings use it; otherwise use environment data.
+	if ioConf.DisableImplicitCredentials && conf.Auth != AuthParamSpecified {
+		return nil, errors.New(
+			"implicit credentials disallowed for gs due to --external-io-disable-implicit-credentials flag")
+	}
+
 	switch conf.Auth {
 	case "", AuthParamDefault:
 		var key string
@@ -124,10 +129,6 @@ func makeGCSStorage(
 		}
 		opts = append(opts, option.WithTokenSource(source.TokenSource(ctx)))
 	case AuthParamImplicit:
-		if ioConf.DisableImplicitCredentials {
-			return nil, errors.New(
-				"implicit credentials disallowed for gs due to --external-io-implicit-credentials flag")
-		}
 		// Do nothing; use implicit params:
 		// https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials
 	default:


### PR DESCRIPTION
Backport 1/1 commits from #55067.

/cc @cockroachdb/release

---

Previously the disable implicit auth flag was checked when AUTH=implicit was passed, but when no auth param
is passed, gs storage will use a shared cluster-wide setting or, if it is not present, fall back to implicit
auth. Either case -- using a cluster-wide setting or a node-wide machine account -- is what is supposed to be
disabled by this flag.

Instead, a safer check (as is done in the admin role requirement check) is that anything other than auth=specified
should be disabled by the flag.

Fixes #55075 .

Release note (security update): fix a case where connecitons to google cloud storage would ignore the --external-io-disable-implicit-credentials flag.
