### PR TITLE
release-20.2: backfill: clear bound account after index KV has been written

### DIFF
--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -186,6 +186,13 @@ func (ib *indexBackfiller) runChunk(
 			return nil, ib.wrapDupError(ctx, err)
 		}
 	}
+
+	// After the index KVs have been copied to the underlying BulkAdder, we can
+	// free the memory which was accounted when building the index entries of the
+	// current chunk.
+	entries = nil
+	ib.Clear(ctx)
+
 	if knobs.RunAfterBackfillChunk != nil {
 		if err := ib.adder.Flush(ctx); err != nil {
 			return nil, ib.wrapDupError(ctx, err)


### PR DESCRIPTION
Backport 1/1 commits from #55051.

/cc @cockroachdb/release

---

Previously, we were not clearing the bound account associated
with the index backfiller once the index KVs (which it was
monitoring memory for) had been written and didn't need to
be referenced in the future.

This change clears the bound account after each "chunk" is
processed by the index backfiller. Since the bound account is
only used to track the memory of the index KVs generated when
processing a "chunk", we can simply Clear() it instead of doing
any fine grained shrinking.

Important to callout that clearing this bound account does not
affect the underlying row fetcher which has its own child monitor
and bound account to work with.

Release note: None
