### PR TITLE
storage/cloud: gate aws sdk's logging on log.V

### DIFF
--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -138,7 +139,9 @@ func MakeS3Storage(
 	if conf.Endpoint != "" {
 		sess.Config.S3ForcePathStyle = aws.Bool(true)
 	}
-	sess.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	if log.V(2) {
+		sess.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	}
 	maxRetries := 10
 	sess.Config.MaxRetries = &maxRetries
 


### PR DESCRIPTION
The AWS SDK's internal logging spews whole requests directly to stderr so
it is not ideal to have it on by default. Gating it on a log.V allows
enabling it when needed instead.

Release note: none.