### PR TITLE
build: reduce high-verbosity nightly logic test timeout to 2h

### DIFF
--- a/build/teamcity-testlogic-verbose.sh
+++ b/build/teamcity-testlogic-verbose.sh
@@ -16,5 +16,5 @@ tc_end_block "Compile C dependencies"
 tc_start_block "Run TestLogic tests under verbose"
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS='--vmodule=*=10 -show-sql -test.v' TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$'
+  make test GOTESTFLAGS=-json TESTFLAGS='--vmodule=*=10 -show-sql -test.v' TESTTIMEOUT='2h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$'
 tc_end_block "Run TestLogic tests under verbose"


### PR DESCRIPTION
After bumping this timeout to 24h, the tests completed in 1h10mins so this
commit reduces the timeout to 2h.

Release note: None

Closes #54645