### PR TITLE
jobs: check liveness session when updating jobs

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -166,6 +166,7 @@ FROM system.jobs WHERE id = $1 AND claim_session_id = $2`,
 	job := &Job{id: &jobID, registry: r}
 	job.mu.payload = *payload
 	job.mu.progress = *progress
+	job.sessionID = s.ID()
 
 	resumer, err := r.createResumer(job, r.settings)
 	if err != nil {

--- a/pkg/jobs/deprecated.go
+++ b/pkg/jobs/deprecated.go
@@ -12,6 +12,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go"
 )
 
 // Functions deprecated in release 20.2 that should be removed in release 21.1.
@@ -256,7 +258,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 			continue
 		}
 		// Adopt job and resume/revert it.
-		if err := job.adopt(ctx, payload.Lease); err != nil {
+		if err := job.deprecatedAdopt(ctx, payload.Lease); err != nil {
 			r.unregister(*id)
 			return errors.Wrap(err, "unable to acquire lease")
 		}
@@ -268,7 +270,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 			return err
 		}
 		log.Infof(ctx, "job %d: resuming execution", *id)
-		errCh, err := r.resume(resumeCtx, resumer, resultsCh, job, nil)
+		errCh, err := r.deprecatedResume(resumeCtx, resumer, resultsCh, job, nil)
 		if err != nil {
 			r.unregister(*id)
 			return err
@@ -331,4 +333,124 @@ func (r *Registry) deprecatedCancelAll(ctx context.Context) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.deprecatedCancelAllLocked(ctx)
+}
+
+// deprecatedResume starts or resumes a job. If no error is returned then the
+// job was asynchronously executed. The job is executed with the ctx, so ctx
+// must only by canceled if the job should also be canceled. resultsCh is passed
+// to the resumable func and should be closed by the caller after errCh sends
+// a value. The onDone function is called when the async task completes or if
+// an error is returned.
+func (r *Registry) deprecatedResume(
+	ctx context.Context, resumer Resumer, resultsCh chan<- tree.Datums, job *Job, onDone func(),
+) (<-chan error, error) {
+	errCh := make(chan error, 1)
+	if err := r.stopper.RunAsyncTask(ctx, job.taskName(), func(ctx context.Context) {
+		if onDone != nil {
+			defer onDone()
+		}
+		// Bookkeeping.
+		payload := job.Payload()
+		phs, cleanup := r.planFn("resume-"+job.taskName(), payload.Username)
+		defer cleanup()
+		spanName := fmt.Sprintf(`%s-%d`, payload.Type(), *job.ID())
+		var span opentracing.Span
+		ctx, span = r.ac.AnnotateCtxWithSpan(ctx, spanName)
+		defer span.Finish()
+
+		// Run the actual job.
+		status, err := job.CurrentStatus(ctx)
+		if err == nil {
+			var finalResumeError error
+			if job.Payload().FinalResumeError != nil {
+				finalResumeError = errors.DecodeError(ctx, *job.Payload().FinalResumeError)
+			}
+			err = r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, status, finalResumeError)
+			if err != nil {
+				// TODO (lucy): This needs to distinguish between assertion errors in
+				// the job registry and assertion errors in job execution returned from
+				// Resume() or OnFailOrCancel(), and only fail on the former. We have
+				// tests that purposely introduce bad state in order to produce
+				// assertion errors, which shouldn't cause the test to panic. For now,
+				// comment this out.
+				// if errors.HasAssertionFailure(err) {
+				// 	log.ReportOrPanic(ctx, nil, err.Error())
+				// }
+				log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
+			}
+			status, err := job.CurrentStatus(ctx)
+			if err != nil {
+				log.Errorf(ctx, "job %d: failed querying status: %v", *job.ID(), err)
+			} else {
+				log.Infof(ctx, "job %d: status %s after adoption finished", *job.ID(), status)
+			}
+		}
+		r.unregister(*job.ID())
+		errCh <- err
+	}); err != nil {
+		if onDone != nil {
+			onDone()
+		}
+		return nil, err
+	}
+	return errCh, nil
+}
+
+func (j *Job) deprecatedInsert(ctx context.Context, id int64, lease *jobspb.Lease) error {
+	if j.id != nil {
+		// Already created - do nothing.
+		return nil
+	}
+
+	j.mu.payload.Lease = lease
+
+	if err := j.runInTxn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		// Note: although the following uses ReadTimestamp and
+		// ReadTimestamp can diverge from the value of now() throughout a
+		// transaction, this may be OK -- we merely required ModifiedMicro
+		// to be equal *or greater* than previously inserted timestamps
+		// computed by now(). For now ReadTimestamp can only move forward
+		// and the assertion ReadTimestamp >= now() holds at all times.
+		j.mu.progress.ModifiedMicros = timeutil.ToUnixMicros(txn.ReadTimestamp().GoTime())
+		payloadBytes, err := protoutil.Marshal(&j.mu.payload)
+		if err != nil {
+			return err
+		}
+		progressBytes, err := protoutil.Marshal(&j.mu.progress)
+		if err != nil {
+			return err
+		}
+
+		if j.createdBy == nil {
+			const stmt = "INSERT INTO system.jobs (id, status, payload, progress) VALUES ($1, $2, $3, $4)"
+			_, err = j.registry.ex.Exec(ctx, "job-insert", txn, stmt, id, StatusRunning, payloadBytes, progressBytes)
+			return err
+		}
+		const stmt = `
+INSERT INTO system.jobs (id, status, payload, progress, created_by_type, created_by_id) 
+VALUES ($1, $2, $3, $4, $5, $6)`
+		_, err = j.registry.ex.Exec(ctx, "job-insert", txn, stmt,
+			id, StatusRunning, payloadBytes, progressBytes, j.createdBy.Name, j.createdBy.ID)
+		return err
+
+	}); err != nil {
+		return err
+	}
+	j.id = &id
+	return nil
+}
+
+func (j *Job) deprecatedAdopt(ctx context.Context, oldLease *jobspb.Lease) error {
+	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
+		if !md.Payload.Lease.Equal(oldLease) {
+			return errors.Errorf("current lease %v did not match expected lease %v",
+				md.Payload.Lease, oldLease)
+		}
+		md.Payload.Lease = j.registry.deprecatedNewLease()
+		if md.Payload.StartedMicros == 0 {
+			md.Payload.StartedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
+		}
+		ju.UpdatePayload(md.Payload)
+		return nil
+	})
 }

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 // FakeResumer calls optional callbacks during the job lifecycle.
@@ -69,10 +70,12 @@ func (j *Job) Started(ctx context.Context) error {
 	return j.started(ctx)
 }
 
-// Created is a wrapper around the internal function that creates the initial
-// job state.
+// Created is a test only function that inserts a new jobs table row.
 func (j *Job) Created(ctx context.Context) error {
-	return j.created(ctx)
+	if j.ID() != nil {
+		return errors.Errorf("job already created with ID %v", *j.ID())
+	}
+	return j.deprecatedInsert(ctx, j.registry.makeJobID(), nil /* lease */)
 }
 
 // Paused is a wrapper around the internal function that moves a job to the

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -626,6 +626,9 @@ func (j *Job) succeeded(ctx context.Context, fn func(context.Context, *kv.Txn) e
 // SetDetails sets the details field of the currently running tracked job.
 func (j *Job) SetDetails(ctx context.Context, details interface{}) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
+		if err := md.CheckRunningOrReverting(); err != nil {
+			return err
+		}
 		md.Payload.Details = jobspb.WrapPayloadDetails(details)
 		ju.UpdatePayload(md.Payload)
 		return nil
@@ -635,6 +638,9 @@ func (j *Job) SetDetails(ctx context.Context, details interface{}) error {
 // SetProgress sets the details field of the currently running tracked job.
 func (j *Job) SetProgress(ctx context.Context, details interface{}) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
+		if err := md.CheckRunningOrReverting(); err != nil {
+			return err
+		}
 		md.Progress.Details = jobspb.WrapProgressDetails(details)
 		ju.UpdateProgress(md.Progress)
 		return nil

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -207,15 +207,6 @@ func (j *Job) ID() *int64 {
 	return j.id
 }
 
-// SessionIDString returns the session of the job that this Job is currently
-// tracking. This will be "<empty>" if the job is created before version 20.1.
-func (j *Job) SessionIDString() string {
-	if j.sessionID == "" {
-		return "<empty>"
-	}
-	return string(j.sessionID)
-}
-
 // CreatedBy returns name/id of this job creator.  This will be nil if this information
 // was not set.
 func (j *Job) CreatedBy() *CreatedByInfo {

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1331,7 +1331,8 @@ func TestJobLifecycle(t *testing.T) {
 		}
 	})
 
-	updateStmt := `UPDATE system.jobs SET claim_session_id = $1 WHERE id = $2`
+	updateClaimStmt := `UPDATE system.jobs SET claim_session_id = $1 WHERE id = $2`
+	updateStatusStmt := `UPDATE system.jobs SET status = $1 WHERE id = $2`
 
 	t.Run("set details works", func(t *testing.T) {
 		job, exp := startLeasedJob(t, defaultRecord)
@@ -1343,14 +1344,19 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, job.SetDetails(ctx, newDetails))
 
 		// Now change job's session id and check that updates are rejected.
-		_, err := exp.DB.Exec(updateStmt, "!@#!@$!$@#", *job.ID())
+		_, err := exp.DB.Exec(updateClaimStmt, "!@#!@$!$@#", *job.ID())
 		require.NoError(t, err)
-		require.Error(
-			t,
-			job.SetDetails(ctx, newDetails),
-			fmt.Sprintf("no such job %d found with session !@#!@$!$@#", *job.ID()),
-		)
+		require.Error(t, job.SetDetails(ctx, newDetails))
 		require.NoError(t, exp.verify(job.ID(), jobs.StatusRunning))
+	})
+
+	t.Run("set details fails", func(t *testing.T) {
+		job, exp := startLeasedJob(t, defaultRecord)
+		require.NoError(t, exp.verify(job.ID(), jobs.StatusRunning))
+		_, err := exp.DB.Exec(updateStatusStmt, jobs.StatusCancelRequested, *job.ID())
+		require.NoError(t, err)
+		require.Error(t, job.SetDetails(ctx, jobspb.ImportDetails{URIs: []string{"new"}}))
+		require.NoError(t, exp.verify(job.ID(), jobs.StatusCancelRequested))
 	})
 
 	t.Run("set progress works", func(t *testing.T) {
@@ -1362,14 +1368,19 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, exp.verify(job.ID(), jobs.StatusRunning))
 
 		// Now change job's session id and check that updates are rejected.
-		_, err := exp.DB.Exec(updateStmt, "!@#!@$!$@#", *job.ID())
+		_, err := exp.DB.Exec(updateClaimStmt, "!@#!@$!$@#", *job.ID())
 		require.NoError(t, err)
-		require.Error(
-			t,
-			job.SetDetails(ctx, newProgress),
-			fmt.Sprintf("no such job %d found with session !@#!@$!$@#", *job.ID()),
-		)
+		require.Error(t, job.SetDetails(ctx, newProgress))
 		require.NoError(t, exp.verify(job.ID(), jobs.StatusRunning))
+	})
+
+	t.Run("set progress fails", func(t *testing.T) {
+		job, exp := startLeasedJob(t, defaultRecord)
+		require.NoError(t, exp.verify(job.ID(), jobs.StatusRunning))
+		_, err := exp.DB.Exec(updateStatusStmt, jobs.StatusPauseRequested, *job.ID())
+		require.NoError(t, err)
+		require.Error(t, job.SetProgress(ctx, jobspb.ImportProgress{ResumePos: []int64{42}}))
+		require.NoError(t, exp.verify(job.ID(), jobs.StatusPauseRequested))
 	})
 
 	t.Run("job with created by fields", func(t *testing.T) {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -409,7 +409,7 @@ func (r *Registry) CreateJobWithTxn(ctx context.Context, record Record, txn *kv.
 	if !r.startUsingSQLLivenessAdoption(ctx) {
 		// TODO(spaskob): remove in 20.2 as this code path is only needed while
 		// migrating to 20.2 cluster.
-		if err := j.WithTxn(txn).insert(ctx, r.makeJobID(), r.deprecatedNewLease()); err != nil {
+		if err := j.WithTxn(txn).deprecatedInsert(ctx, r.makeJobID(), r.deprecatedNewLease()); err != nil {
 			return nil, err
 		}
 		return j, nil
@@ -457,7 +457,7 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 	// in the cluster) to adopt this job at a later time.
 	lease := &jobspb.Lease{NodeID: invalidNodeID}
 
-	if err := j.WithTxn(txn).insert(ctx, r.makeJobID(), lease); err != nil {
+	if err := j.WithTxn(txn).deprecatedInsert(ctx, r.makeJobID(), lease); err != nil {
 		return nil, err
 	}
 	return j, nil
@@ -1176,67 +1176,6 @@ func (r *Registry) stepThroughStateMachine(
 		return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 			"job %d: has unsupported status %s", *job.ID(), status)
 	}
-}
-
-// resume starts or resumes a job. If no error is returned then the job was
-// asynchronously executed. The job is executed with the ctx, so ctx must
-// only by canceled if the job should also be canceled. resultsCh is passed
-// to the resumable func and should be closed by the caller after errCh sends
-// a value. The onDone function is called when the async task completes or if
-// an error is returned.
-func (r *Registry) resume(
-	ctx context.Context, resumer Resumer, resultsCh chan<- tree.Datums, job *Job, onDone func(),
-) (<-chan error, error) {
-	errCh := make(chan error, 1)
-	if err := r.stopper.RunAsyncTask(ctx, job.taskName(), func(ctx context.Context) {
-		if onDone != nil {
-			defer onDone()
-		}
-		// Bookkeeping.
-		payload := job.Payload()
-		phs, cleanup := r.planFn("resume-"+job.taskName(), payload.Username)
-		defer cleanup()
-		spanName := fmt.Sprintf(`%s-%d`, payload.Type(), *job.ID())
-		var span opentracing.Span
-		ctx, span = r.ac.AnnotateCtxWithSpan(ctx, spanName)
-		defer span.Finish()
-
-		// Run the actual job.
-		status, err := job.CurrentStatus(ctx)
-		if err == nil {
-			var finalResumeError error
-			if job.Payload().FinalResumeError != nil {
-				finalResumeError = errors.DecodeError(ctx, *job.Payload().FinalResumeError)
-			}
-			err = r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, status, finalResumeError)
-			if err != nil {
-				// TODO (lucy): This needs to distinguish between assertion errors in
-				// the job registry and assertion errors in job execution returned from
-				// Resume() or OnFailOrCancel(), and only fail on the former. We have
-				// tests that purposely introduce bad state in order to produce
-				// assertion errors, which shouldn't cause the test to panic. For now,
-				// comment this out.
-				// if errors.HasAssertionFailure(err) {
-				// 	log.ReportOrPanic(ctx, nil, err.Error())
-				// }
-				log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
-			}
-			status, err := job.CurrentStatus(ctx)
-			if err != nil {
-				log.Errorf(ctx, "job %d: failed querying status: %v", *job.ID(), err)
-			} else {
-				log.Infof(ctx, "job %d: status %s after adoption finished", *job.ID(), status)
-			}
-		}
-		r.unregister(*job.ID())
-		errCh <- err
-	}); err != nil {
-		if onDone != nil {
-			onDone()
-		}
-		return nil, err
-	}
-	return errCh, nil
 }
 
 func (r *Registry) adoptionDisabled(ctx context.Context) bool {

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -11,6 +11,7 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -105,32 +106,37 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 	var payload *jobspb.Payload
 	var progress *jobspb.Progress
 	if err := j.runInTxn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		selectStmt := "SELECT status, payload, progress FROM system.jobs WHERE id = $1"
+		stmt := "SELECT status, payload, progress FROM system.jobs WHERE id = $1"
 		if j.sessionID != "" {
-			selectStmt = fmt.Sprintf("%s AND claim_session_id=$2", selectStmt)
+			stmt = "SELECT status, payload, progress, claim_session_id FROM system.jobs WHERE id = $1"
 		}
 		var err error
 		var row tree.Datums
-		if j.sessionID == "" {
-			row, err = j.registry.ex.QueryRowEx(
-				ctx, "log-job", txn, sessiondata.InternalExecutorOverride{User: security.RootUser},
-				selectStmt, *j.id)
-		} else {
-			row, err = j.registry.ex.QueryRowEx(
-				ctx, "log-job", txn, sessiondata.InternalExecutorOverride{User: security.RootUser},
-				selectStmt, *j.id, j.sessionID.UnsafeBytes())
-		}
+		row, err = j.registry.ex.QueryRowEx(
+			ctx, "log-job", txn, sessiondata.InternalExecutorOverride{User: security.RootUser},
+			stmt, *j.id,
+		)
 		if err != nil {
 			return err
 		}
 		if row == nil {
-			return errors.Errorf("no such job %d found with session %s", *j.ID(), j.SessionIDString())
+			return errors.Errorf("job %d: not found in system.jobs table", *j.ID())
 		}
 
 		statusString, ok := row[0].(*tree.DString)
 		if !ok {
 			return errors.AssertionFailedf("job %d: expected string status, but got %T", *j.id, statusString)
 		}
+
+		if j.sessionID != "" {
+			storedSession := []byte(*row[3].(*tree.DBytes))
+			if !bytes.Equal(storedSession, j.sessionID.UnsafeBytes()) {
+				return errors.Errorf(
+					"job %d: with status '%s': expected session '%s' but found '%s'",
+					*j.ID(), statusString, j.sessionID, storedSession)
+			}
+		}
+
 		status := Status(*statusString)
 		if payload, err = UnmarshalPayload(row[1]); err != nil {
 			return err

--- a/pkg/sql/rowexec/backfiller_test.go
+++ b/pkg/sql/rowexec/backfiller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteResumeSpan(t *testing.T) {
@@ -100,10 +101,15 @@ func TestWriteResumeSpan(t *testing.T) {
 		{ResumeSpans: resumeSpans}}}
 
 	job, err := registry.LoadJob(ctx, jobID)
-
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "can't find job %d", jobID))
 	}
+
+	require.NoError(t, job.Update(ctx,
+		func(_ *kv.Txn, _ jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			ju.UpdateStatus(jobs.StatusRunning)
+			return nil
+		}))
 
 	err = job.SetDetails(ctx, details)
 	if err != nil {


### PR DESCRIPTION
Currently when we resume a job, the jobs starts running on the local node
and periodically may update its progress. It may happen that the node gets
partitioned and that the job is adopted on another node. If the partitioned
node gets reconnected the first job may try to update its progress and
overwrite the second job's progress.

With the implementation of liveness leases we can avoid that by passing the
liveness session at the time of adoption to the job and the job `Update`
method can verify if the job liveness session has changed.

Release note: none.