### PR TITLE
importccl: added error when nullas option unspecified and null exported

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -178,7 +178,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 
 		writer := newCSVExporter(sp.spec)
 
-		nullsAs := ""
+		var nullsAs string
 		if sp.spec.Options.NullEncoding != nil {
 			nullsAs = *sp.spec.Options.NullEncoding
 		}
@@ -208,8 +208,13 @@ func (sp *csvWriter) Run(ctx context.Context) {
 
 				for i, ed := range row {
 					if ed.IsNull() {
-						csvRow[i] = nullsAs
-						continue
+						if sp.spec.Options.NullEncoding != nil {
+							csvRow[i] = nullsAs
+							continue
+						} else {
+							return errors.New("NULL value encountered during EXPORT, " +
+								"use `WITH nullas` to specify the string representation of NULL")
+						}
 					}
 					if err := ed.EnsureDecoded(typs[i], alloc); err != nil {
 						return err

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -83,11 +83,9 @@ func TestExportImportBank(t *testing.T) {
 
 	chunkSize := 13
 	for _, null := range []string{"", "NULL"} {
-		nullAs, nullIf := "", ", nullif = ''"
-		if null != "" {
-			nullAs = fmt.Sprintf(", nullas = '%s'", null)
-			nullIf = fmt.Sprintf(", nullif = '%s'", null)
-		}
+		nullAs := fmt.Sprintf(", nullas = '%s'", null)
+		nullIf := fmt.Sprintf(", nullif = '%s'", null)
+
 		t.Run("null="+null, func(t *testing.T) {
 			var files []string
 
@@ -120,6 +118,48 @@ func TestExportImportBank(t *testing.T) {
 			db.Exec(t, "DROP TABLE bank2")
 		})
 	}
+}
+
+// Tests if user does not specify nullas option and imports null data, an error is raised.
+func TestExportNullWithEmptyNullAs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+
+	tc := testcluster.StartTestCluster(
+		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir}})
+	defer tc.Stopper().Stop(ctx)
+
+	conn := tc.Conns[0]
+	db := sqlutils.MakeSQLRunner(conn)
+
+	// Set up dummy accounts table with NULL value
+	db.Exec(t, `
+		CREATE TABLE accounts (id INT PRIMARY KEY, balance INT);
+		INSERT INTO accounts VALUES (1, NULL), (2, 8);
+	`)
+
+	// Case when `nullas` option is unspecified: expect error
+	const stmtWithoutNullas = "EXPORT INTO CSV 'nodelocal://0/t' FROM SELECT * FROM accounts"
+	db.ExpectErr(t, "NULL value encountered during EXPORT, "+
+		"use `WITH nullas` to specify the string representation of NULL", stmtWithoutNullas)
+
+	// Case when `nullas` option is specified: operation is successful and NULLs are encoded to "None"
+	const stmtWithNullas = `EXPORT INTO CSV 'nodelocal://0/t' WITH nullas="None" FROM SELECT * FROM accounts`
+	db.Exec(t, stmtWithNullas)
+	contents := readFileByGlob(t, filepath.Join(dir, "t", "export*-n1.0.csv"))
+	require.Equal(t, "1,None\n2,8\n", string(contents))
+
+	// Verify successful IMPORT statement `WITH nullif="None"` to complete round trip
+	const importStmt = `IMPORT TABLE accounts2(id INT PRIMARY KEY, balance INT) CSV DATA ('nodelocal://0/t/export*-n1.0.csv') WITH nullif="None"`
+	db.Exec(t, importStmt)
+	db.CheckQueryResults(t,
+		"SELECT * FROM accounts2", db.QueryStr(t, "SELECT * FROM accounts"),
+	)
+
 }
 
 func TestMultiNodeExportStmt(t *testing.T) {


### PR DESCRIPTION
Previously, the default null encoding for exportcsv was the empty string if the nullas option was unspecified.
This was problematic because if the column type was not a string, an incompatible type error would be raised. Also, the empty string is not round-trippable if the user were to import the exported table.
To address this, an error was added that would be raised if the user omitted the nullas option value and a null was encountered during exportcsv. The error informs the users to specify a nullas option value.

Release note: None
Fixes #44425