### PR TITLE
build: correct ELF info for libgeos

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200818-182851
+version=20201001-110640
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libncurses-dev \
     make \
     patch \
+    patchelf \
     texinfo \
     xz-utils \
  && apt-get clean

--- a/c-deps/geos-rebuild
+++ b/c-deps/geos-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing geos configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+5


### PR DESCRIPTION
Looks like cross compiling with rpath does not work, so install patchelf
and use them on the given .so files such that dlopen works using the
regular pattern.

Refs #54841

Release note (general change, bug fix): Fixed the rpath and so names of
libgeos.so and libgeos_c.so such that a dlopen to libgeos.so is not
needed.

