### PR TITLE
release-20.2: docker: Base the docker image on RedHat UBI

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,14 +1,12 @@
-FROM debian:9.12-slim
+FROM registry.access.redhat.com/ubi8/ubi
 
-# For deployment, we need
-# libc6 - dynamically linked by cockroach binary
+# For deployment, we need the following installed (they are installed
+# by default in RedHat UBI standard):
+# glibc - dynamically linked by cockroach binary
 # ca-certificates - to authenticate TLS connections for telemetry and
 #                   bulk-io with S3/GCS/Azure
 # tzdata - for time zone functions
-RUN apt-get update && \
-	apt-get -y upgrade && \
-	apt-get install -y libc6 ca-certificates tzdata && \
-	rm -rf /var/lib/apt/lists/*
+RUN yum update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos -y && rm -rf /var/cache/yum
 
 # Install GEOS libraries.
 RUN mkdir /usr/local/lib/cockroach
@@ -16,13 +14,13 @@ COPY libgeos.so libgeos_c.so /usr/local/lib/cockroach/
 
 RUN mkdir -p /cockroach
 COPY cockroach.sh cockroach /cockroach/
+
 # Set working directory so that relative paths
 # are resolved appropriately when passed as args.
 WORKDIR /cockroach/
 
-# Include the directory into the path
-# to make it easier to invoke commands
-# via Docker
+# Include the directory in the path to make it easier to invoke
+# commands via Docker
 ENV PATH=/cockroach:$PATH
 
 ENV COCKROACH_CHANNEL=official-docker


### PR DESCRIPTION
Backport 1/1 commits from #54812.

/cc @cockroachdb/release

---

Before: The docker image was based on Debian 9.12 slim.

Why: This change will help on-prem customers from a security and
compliance perspective. It also aligns with our publishing images into
the RedHat Marketplace.

Now: Published docker images are based on the RedHat UBI 8 base image.

Fixes: #49643

Release note (backward-incompatible change): CockroachDB Docker images
are now based on the RedHat ubi8/ubi base image instead of Debian 9.12
slim. This will help on-prem customers from a security and compliance
perspective.
