### PR TITLE
sql: make independent decision to distribute sub- and postqueries

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -249,7 +249,6 @@ func runPlanInsidePlan(
 		params.extendedEvalCtx.copy,
 		plan.subqueryPlans,
 		recv,
-		false, /* maybeDistribute */
 	) {
 		if err := rowResultWriter.Err(); err != nil {
 			return err
@@ -260,8 +259,11 @@ func runPlanInsidePlan(
 	// Make a copy of the EvalContext so it can be safely modified.
 	evalCtx := params.p.ExtendedEvalContextCopy()
 	plannerCopy := *params.p
+	distributePlan := getPlanDistribution(
+		params.ctx, &plannerCopy, plannerCopy.execCfg.NodeID, plannerCopy.SessionData().DistSQLMode, plan.main,
+	)
 	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(
-		params.ctx, evalCtx, &plannerCopy, params.p.txn, false, /* distribute */
+		params.ctx, evalCtx, &plannerCopy, params.p.txn, distributePlan.WillDistribute(),
 	)
 	planCtx.planner.curPlan.planComponents = *plan
 	planCtx.ExtendedEvalCtx.Planner = &plannerCopy

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -991,7 +991,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 
 	if len(planner.curPlan.subqueryPlans) != 0 {
 		if !ex.server.cfg.DistSQLPlanner.PlanAndRunSubqueries(
-			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv, distribute,
+			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv,
 		) {
 			return recv.stats, recv.commErr
 		}
@@ -1010,7 +1010,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	}
 
 	ex.server.cfg.DistSQLPlanner.PlanAndRunCascadesAndChecks(
-		ctx, planner, evalCtxFactory, &planner.curPlan.planComponents, recv, distribute,
+		ctx, planner, evalCtxFactory, &planner.curPlan.planComponents, recv,
 	)
 
 	return recv.stats, recv.commErr

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -139,7 +139,6 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			params.extendedEvalCtx.copy,
 			n.plan.subqueryPlans,
 			recv,
-			willDistribute,
 		) {
 			if err := rw.Err(); err != nil {
 				return err
@@ -263,7 +262,6 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			params.extendedEvalCtx.copy,
 			&n.plan,
 			recv,
-			willDistribute,
 		) {
 			if err := rw.Err(); err != nil {
 				return err


### PR DESCRIPTION
Previously, if the main query is not distributed, we would also not
distribute the sub- and postqueries. However, I believe there is no
inherent reason why we can't do so. This commit changes that
distribution decision to be independent of the main query distribution.
Note that if some part of the sub- or postquery's plan is not
distributed, the physical planner will do the right thing.

Release note: None