### PR TITLE
changefeedccl: scope backfills to only the tables affected by a schema change

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -254,6 +254,7 @@ func makeKVFeedCfg(
 		Sink:               buf,
 		Settings:           cfg.Settings,
 		DB:                 cfg.DB,
+		Codec:              cfg.Codec,
 		Clock:              cfg.DB.Clock(),
 		Gossip:             cfg.Gossip,
 		Spans:              spans,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -115,6 +115,7 @@ func TestKVFeed(t *testing.T) {
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
 			tc.needsInitialScan, tc.withDiff,
 			tc.initialHighWater,
+			keys.SystemSQLCodec,
 			&tf, sf, rangefeedFactory(ref.run), bufferFactory)
 		ctx, cancel := context.WithCancel(context.Background())
 		g := ctxgroup.WithContext(ctx)


### PR DESCRIPTION
changefeedccl: scope backfills to only the tables affected by a schema change

Release note (bug fix):

Previously, if a changefeed was defined on multiple targets, backfills (if configured) would be run for every target after a schema change on just some.
This is unnecessary work.
This patch has the kv_feed identify affected spans after a schema change, and only kick off backfills on those spans. <s>It also starts tracking the distinction in the changeFrontier in order to enable future enhancements (I don't need those changes yet so I can drop them if they're problematic).</s>