### PR TITLE
cloud: fix fluentd time format regex

### DIFF
--- a/cloud/kubernetes/fluentd-configmap.yml
+++ b/cloud/kubernetes/fluentd-configmap.yml
@@ -60,7 +60,7 @@ data:
       format multi_format
       <pattern>
         # CockroachDB log format
-        format /^(?<severity>\w{1})(?<time>\d{6}\s\d{2}:\d{2}:\d{2})\.\d{6}\s*(?<log>.*)/
+        format /^(?<severity>\w{1})(?<time>\d{6}\s\d{2}:\d{2}:\d{2}\.\d{6})\s*(?<log>.*)/
         time_key time
         time_format %y%m%d %H:%M:%S.%N
       </pattern>


### PR DESCRIPTION
Fixes part of the `fluentd` configuration example added in #26685.

Currently, in some cases, fluentd uses a regex to extract log timestamps **excluding** microseconds ([regex101 demo](https://regex101.com/r/wr4agd/2)).
This causes fluentd to later fail parsing the timestamp with the configured format string `%y%m%d %H:%M:%S.%N`, and prevents the log line from being processed correctly.

This PR updates the extraction regex to **include** microseconds ([regex101 demo](https://regex101.com/r/wr4agd/1/)).

I can't see a good place to add a test for this change, but I can confirm that I am running this in our stack at work and it behaves as expected.
