### PR TITLE
opt: introduce CanBeCompositeSensitive

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -13,6 +13,7 @@ package memo
 import (
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -1584,6 +1585,7 @@ func BuildSharedProps(e opt.Expr, shared *props.Shared) {
 // hasOuterCols returns true if the given expression has outer columns (i.e.
 // columns that are referenced by the expression but not bound by it).
 func hasOuterCols(e opt.Expr) bool {
+	// This is a slightly faster implementation of !getOuterCols(e).Empty().
 	switch t := e.(type) {
 	case *VariableExpr:
 		return true
@@ -1600,6 +1602,25 @@ func hasOuterCols(e opt.Expr) bool {
 	}
 
 	return false
+}
+
+// getOuterCols returns the outer columns of an expression (i.e.  columns that are
+// referenced by the expression but not bound by it).
+func getOuterCols(e opt.Expr) opt.ColSet {
+	switch t := e.(type) {
+	case *VariableExpr:
+		return opt.MakeColSet(t.Col)
+	case RelExpr:
+		return t.Relational().OuterCols
+	case ScalarPropsExpr:
+		return t.ScalarProps().Shared.OuterCols
+	}
+
+	var res opt.ColSet
+	for i, n := 0, e.ChildCount(); i < n; i++ {
+		res.UnionWith(getOuterCols(e.Child(i)))
+	}
+	return res
 }
 
 // MakeTableFuncDep returns the set of functional dependencies derived from the
@@ -2308,4 +2329,69 @@ func deriveWithUses(r opt.Expr) props.WithUsesMap {
 		}
 	}
 	return result
+}
+
+// CanBeCompositeSensitive returns true if a scalar expression could return
+// logically different results because of non-logical differences in outer
+// columns with composite type.
+//
+// Composite values are values that contain more information than the logical
+// value (i.e. the key encoding). Examples are decimals (1.0 = 1.00) and
+// collated strings ('foo' COLLATE en_u_ks_level1 = 'FOO' COLLATE
+// en_u_ks_level1).
+//
+// An example of a composite-sensitive expression is `d::string`, where d is a
+// DECIMAL.
+//
+// This property is used to determine when a scalar expression can be copied,
+// with outer column variable references changed to refer to other columns that
+// are known to be equal to the original columns.
+func CanBeCompositeSensitive(md *opt.Metadata, e opt.Expr) bool {
+	outerCols := getOuterCols(e)
+	var compositeOuterCols opt.ColSet
+	outerCols.ForEach(func(col opt.ColumnID) {
+		if colinfo.HasCompositeKeyEncoding(md.ColumnMeta(col).Type) {
+			compositeOuterCols.Add(col)
+		}
+	})
+	if compositeOuterCols.Empty() {
+		// Fast path: none of the outer columns are composite.
+		return false
+	}
+
+	var canBeSensitive func(e opt.Expr) bool
+	canBeSensitive = func(e opt.Expr) bool {
+		if _, ok := e.(RelExpr); ok {
+			// Not a purely scalar expression.
+			return true
+		}
+		if !getOuterCols(e).Intersects(compositeOuterCols) {
+			// None of the outer columns of this sub-expression are composite.
+			return false
+		}
+		// Check the inputs to the operator. Together, the following conditions are
+		// sufficient to prove that this expression is not sensitive:
+		//  1. None of the inputs are sensitive to composite outer columns.
+		//     Otherwise, the operator can receive different inputs for logically
+		//     equal outer values and thus produce different outputs.
+		//  2. The operator is marked as being always insensitive, or none of the
+		//     input data types are composite.
+		checkTypes := !opt.IsCompositeInsensitiveOp(e)
+		for i, n := 0, e.ChildCount(); i < n; i++ {
+			if canBeSensitive(e.Child(i)) {
+				// Condition 1 not satisfied.
+				return true
+			}
+			if checkTypes {
+				// Note that the canBeSensitive() call above always returns true for
+				// relational expressions, so we are sure that the child is scalar.
+				if child := e.Child(i).(opt.ScalarExpr); colinfo.HasCompositeKeyEncoding(child.DataType()) {
+					// Condition 2 not satisfied.
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return canBeSensitive(e)
 }

--- a/pkg/sql/opt/memo/testdata/composite_sensitive
+++ b/pkg/sql/opt/memo/testdata/composite_sensitive
@@ -1,0 +1,76 @@
+# Non-composite variable.
+composite-sensitive vars=(int)
+@1::string
+----
+false
+
+composite-sensitive vars=(decimal)
+@1::string
+----
+true
+
+composite-sensitive vars=(decimal)
+@1::string = '1.0'
+----
+true
+
+# Composite insensitive operator.
+composite-sensitive vars=(decimal)
+@1 >= 2
+----
+false
+
+composite-sensitive vars=(decimal, decimal)
+@1 <= @2
+----
+false
+
+composite-sensitive vars=(decimal, decimal)
+(@1 + @2)::string
+----
+true
+
+composite-sensitive vars=(decimal, decimal, decimal)
+(@1 + @2 <= @3)::string
+----
+false
+
+composite-sensitive vars=(decimal, decimal)
+@1 + @2 < 10
+----
+false
+
+composite-sensitive vars=(decimal, decimal)
+@1 = 10 AND @2 > 10 
+----
+false
+
+composite-sensitive vars=(int, decimal)
+concat(@1::string, @2::string)
+----
+true
+
+composite-sensitive vars=(int, int)
+concat(@1::string, @2::string)
+----
+false
+
+# Even though the expression contains a potentially problematic cast from
+# decimal to string, it is not sensitive because the input to the cast only
+# depends on non-composite columns.
+composite-sensitive vars=(int, decimal, decimal)
+@1::decimal::string || (@2 > @3)::string
+----
+false
+
+# This is actually not sensitive; we could whitelist certain functions.
+composite-sensitive vars=(decimal, decimal)
+log(@1, @2)
+----
+true
+
+# This is actually not sensitive; we could whitelist certain casts.
+composite-sensitive vars=(decimal)
+@1::float
+----
+true

--- a/pkg/sql/opt/ops/README.md
+++ b/pkg/sql/opt/ops/README.md
@@ -51,6 +51,8 @@ Tags for scalar operators:
  - `ConstValue`: used for operators that represent a constant value.
  - `Aggregate`: used for operators that represent an aggregation function.
  - `Window`: used for operators that represent a window function.
+ - `CompositeInsensitive`: used for operators that only depend on the logical
+   value of composite value inputs (see memo.CanBeCompositeSensitive).
 
 Tags for relational operators:
  - `Join`: used for logical variations of join, including apply joins (but not

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -89,7 +89,7 @@ define Exists {
 
 # Variable is the typed scalar value of a column in the query. The Col field is
 # a metadata ColumnID value that references the column by index.
-[Scalar]
+[Scalar, CompositeInsensitive]
 define Variable {
     Col ColumnID
 }
@@ -316,49 +316,49 @@ define IsTupleNotNull {
     Input ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Eq {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Lt {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Gt {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Le {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Ge {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Ne {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define In {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define NotIn {
     Left ScalarExpr
     Right ScalarExpr
@@ -426,7 +426,7 @@ define NotRegIMatch {
 
 # Is maps to the IS NOT DISTINCT FROM operator which is equivalent to IS for
 # non-tuples. See IsTupleNull for the tuple-specific IS NULL operator.
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Is {
     Left ScalarExpr
     Right ScalarExpr
@@ -435,13 +435,13 @@ define Is {
 # IsNot is the inverse of Is. It maps to the IS DISTINCT FROM operator which is
 # equivalent to IS NOT for non-tuples. See IsTupleNotNull for the
 # tuple-specific IS NOT NULL operator.
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define IsNot {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Bool, Comparison]
+[Scalar, Bool, Comparison, CompositeInsensitive]
 define Contains {
     Left ScalarExpr
     Right ScalarExpr
@@ -514,43 +514,43 @@ define Bitxor {
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Plus {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Minus {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Mult {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Div {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define FloorDiv {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Mod {
     Left ScalarExpr
     Right ScalarExpr
 }
 
-[Scalar, Binary]
+[Scalar, Binary, CompositeInsensitive]
 define Pow {
     Left ScalarExpr
     Right ScalarExpr
@@ -598,7 +598,7 @@ define FetchTextPath {
     Path ScalarExpr
 }
 
-[Scalar, Unary]
+[Scalar, Unary, CompositeInsensitive]
 define UnaryMinus {
     Input ScalarExpr
 }
@@ -608,12 +608,12 @@ define UnaryComplement {
     Input ScalarExpr
 }
 
-[Scalar, Unary]
+[Scalar, Unary, CompositeInsensitive]
 define UnarySqrt {
     Input ScalarExpr
 }
 
-[Scalar, Unary]
+[Scalar, Unary, CompositeInsensitive]
 define UnaryCbrt {
     Input ScalarExpr
 }


### PR DESCRIPTION
This commit adds a method that can tell us if it is safe to remap
outer columns of a scalar expression. For example it is not safe for
`d::STRING` when `d` is a DECIMAL, because two equal values like 1.0
and 1.00 can yield unequal results.

This will be used as a finer-grain check in various places which
currently use the big hammer of checking if any variables are of
composite type.

Release note: None