### PR TITLE
delegate: fix SHOW ENUMS column names

### DIFF
--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -15,7 +15,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 func (d *delegator) delegateShowEnums() (tree.Statement, error) {
 	query := `
 SELECT
-	schema, name, string_agg(label, '|'), owner AS value
+	schema, name, string_agg(label, '|') AS values, owner
 FROM
 	(
 		SELECT

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -17,7 +17,7 @@ func (d *delegator) delegateShowTypes() (tree.Statement, error) {
 	//  they should be added here.
 	return parse(`
 SELECT
-  schema, name, value AS description
+  schema, name, owner
 FROM
   [SHOW ENUMS]
 ORDER BY

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1121,9 +1121,10 @@ local
 statement ok
 ROLLBACK
 
-query TTTT
+query TTTT colnames
 SHOW ENUMS
 ----
+schema  name       values                            owner
 public  as_bytes   bytes                             root
 public  dbs        postgres|mysql|spanner|cockroach  root
 public  farewell   bye|seeya                         root
@@ -1132,9 +1133,10 @@ public  greeting2  hello                             root
 public  int        Z|S of int                        root
 public  notbad     dup|DUP                           root
 
-query TTT
+query TTT colnames
 SHOW TYPES
 ----
+schema  name       owner
 public  as_bytes   root
 public  dbs        root
 public  farewell   root
@@ -1147,9 +1149,10 @@ statement ok
 CREATE SCHEMA uds;
 CREATE TYPE uds.typ AS ENUM ('schema')
 
-query TTTT
+query TTTT colnames
 SHOW ENUMS
 ----
+schema  name       values                            owner
 public  as_bytes   bytes                             root
 public  dbs        postgres|mysql|spanner|cockroach  root
 public  farewell   bye|seeya                         root


### PR DESCRIPTION
Fixes a bug in #54708. 

Release note (bug fix): Fix SHOW ENUMS column names to have `values`
instead of `string_agg` for column names, and `owner` for the owner
itself.