### PR TITLE
delegate: modify SHOW ENUMS and SHOW TYPES to display empty ENUMS

### DIFF
--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -15,7 +15,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 func (d *delegator) delegateShowEnums() (tree.Statement, error) {
 	query := `
 SELECT
-	schema, name, string_agg(label, '|'), owner AS value
+	schema, name, string_agg(label, '|') AS values, owner
 FROM
 	(
 		SELECT

--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -13,28 +13,31 @@ package delegate
 import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
 func (d *delegator) delegateShowEnums() (tree.Statement, error) {
+	// We can't query pg_enum directly as there are no rows in
+	// pg_enum if we create an empty enum (e.g. CREATE TYPE x AS ENUM()).
+	// Instead, use a CTE to aggregate enums, and use pg_type with an
+	// enum filter to LEFT JOIN against the aggregated enums to ensure
+	// we include these rows.
 	query := `
+WITH enums(enumtypid, values) AS (
+	SELECT
+		enums.enumtypid AS enumtypid,
+		string_agg(enums.enumlabel, '|') WITHIN GROUP (ORDER BY (enumsortorder)) AS values
+	FROM pg_catalog.pg_enum AS enums
+	GROUP BY enumtypid
+)
 SELECT
-	schema, name, string_agg(label, '|') AS values, owner
+	nsp.nspname AS schema,
+	types.typname AS name,
+	values,
+	rl.rolname AS owner
 FROM
-	(
-		SELECT
-			nsp.nspname AS schema,
-			type.typname AS name,
-			enum.enumlabel AS label,
-      rl.rolname AS owner
-		FROM
-			pg_catalog.pg_enum AS enum
-			JOIN pg_catalog.pg_type AS type ON (type.oid = enum.enumtypid)
-      LEFT JOIN pg_catalog.pg_roles AS rl on (type.typowner = rl.oid)
-			JOIN pg_catalog.pg_namespace AS nsp ON (type.typnamespace = nsp.oid)
-		ORDER BY
-			(enumtypid, enumsortorder)
-	)
-GROUP BY
-	(schema, name, owner)
-ORDER BY
-	(schema, name, owner);
+	pg_catalog.pg_type AS types
+	LEFT JOIN enums ON (types.oid = enums.enumtypid)
+	LEFT JOIN pg_catalog.pg_roles AS rl on (types.typowner = rl.oid)
+	JOIN pg_catalog.pg_namespace AS nsp ON (types.typnamespace = nsp.oid)
+WHERE types.typtype = 'e'
+ORDER BY (nsp.nspname, types.typname)
 `
 	return parse(query)
 }

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -17,7 +17,7 @@ func (d *delegator) delegateShowTypes() (tree.Statement, error) {
 	//  they should be added here.
 	return parse(`
 SELECT
-  schema, name, value AS description
+  schema, name, owner
 FROM
   [SHOW ENUMS]
 ORDER BY

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1121,9 +1121,10 @@ local
 statement ok
 ROLLBACK
 
-query TTTT
+query TTTT colnames
 SHOW ENUMS
 ----
+schema  name       values                            owner
 public  as_bytes   bytes                             root
 public  dbs        postgres|mysql|spanner|cockroach  root
 public  farewell   bye|seeya                         root
@@ -1132,9 +1133,10 @@ public  greeting2  hello                             root
 public  int        Z|S of int                        root
 public  notbad     dup|DUP                           root
 
-query TTT
+query TTT colnames
 SHOW TYPES
 ----
+schema  name       owner
 public  as_bytes   root
 public  dbs        root
 public  farewell   root
@@ -1147,9 +1149,10 @@ statement ok
 CREATE SCHEMA uds;
 CREATE TYPE uds.typ AS ENUM ('schema')
 
-query TTTT
+query TTTT colnames
 SHOW ENUMS
 ----
+schema  name       values                            owner
 public  as_bytes   bytes                             root
 public  dbs        postgres|mysql|spanner|cockroach  root
 public  farewell   bye|seeya                         root

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1124,26 +1124,34 @@ ROLLBACK
 query TTTT colnames
 SHOW ENUMS
 ----
-schema  name       values                            owner
-public  as_bytes   bytes                             root
-public  dbs        postgres|mysql|spanner|cockroach  root
-public  farewell   bye|seeya                         root
-public  greeting   hello|howdy|hi                    root
-public  greeting2  hello                             root
-public  int        Z|S of int                        root
-public  notbad     dup|DUP                           root
+schema  name        values                            owner
+public  _collision  NULL                              root
+public  as_bytes    bytes                             root
+public  collision   NULL                              root
+public  dbs         postgres|mysql|spanner|cockroach  root
+public  empty       NULL                              root
+public  farewell    bye|seeya                         root
+public  greeting    hello|howdy|hi                    root
+public  greeting2   hello                             root
+public  int         Z|S of int                        root
+public  notbad      dup|DUP                           root
+public  t           NULL                              root
 
 query TTT colnames
 SHOW TYPES
 ----
-schema  name       owner
-public  as_bytes   root
-public  dbs        root
-public  farewell   root
-public  greeting   root
-public  greeting2  root
-public  int        root
-public  notbad     root
+schema  name        owner
+public  _collision  root
+public  as_bytes    root
+public  collision   root
+public  dbs         root
+public  empty       root
+public  farewell    root
+public  greeting    root
+public  greeting2   root
+public  int         root
+public  notbad      root
+public  t           root
 
 statement ok
 CREATE SCHEMA uds;
@@ -1152,15 +1160,19 @@ CREATE TYPE uds.typ AS ENUM ('schema')
 query TTTT colnames
 SHOW ENUMS
 ----
-schema  name       values                            owner
-public  as_bytes   bytes                             root
-public  dbs        postgres|mysql|spanner|cockroach  root
-public  farewell   bye|seeya                         root
-public  greeting   hello|howdy|hi                    root
-public  greeting2  hello                             root
-public  int        Z|S of int                        root
-public  notbad     dup|DUP                           root
-uds     typ        schema                            root
+schema  name        values                            owner
+public  _collision  NULL                              root
+public  as_bytes    bytes                             root
+public  collision   NULL                              root
+public  dbs         postgres|mysql|spanner|cockroach  root
+public  empty       NULL                              root
+public  farewell    bye|seeya                         root
+public  greeting    hello|howdy|hi                    root
+public  greeting2   hello                             root
+public  int         Z|S of int                        root
+public  notbad      dup|DUP                           root
+public  t           NULL                              root
+uds     typ         schema                            root
 
 statement error pq: cannot create "fakedb.typ" because the target database or schema does not exist
 CREATE TYPE fakedb.typ AS ENUM ('schema')


### PR DESCRIPTION
Fixes #55137 
Based on #55139 

Release note (bug fix): Fix a bug where empty enums did not show up for
SHOW ENUMS or SHOW TYPES.

