### PR TITLE
sql: fix ownership privilege checks

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -301,17 +301,13 @@ func (p *planner) alterTypeOwner(ctx context.Context, n *alterTypeNode, newOwner
 	typeDesc := n.desc
 	privs := typeDesc.GetPrivileges()
 
-	hasOwnership, err := p.HasOwnership(ctx, typeDesc)
-	if err != nil {
-		return err
-	}
-
-	if err := p.checkCanAlterToNewOwner(ctx, typeDesc, privs, newOwner, hasOwnership); err != nil {
+	if err := p.checkCanAlterToNewOwner(ctx, typeDesc, newOwner); err != nil {
 		return err
 	}
 
 	// Ensure the new owner has CREATE privilege on the type's schema.
-	if err := p.canCreateOnSchema(ctx, typeDesc.GetParentSchemaID(), newOwner); err != nil {
+	if err := p.canCreateOnSchema(
+		ctx, typeDesc.GetParentSchemaID(), typeDesc.ParentID, newOwner, checkPublicSchema); err != nil {
 		return err
 	}
 
@@ -347,15 +343,21 @@ func (n *alterTypeNode) Close(ctx context.Context)           {}
 func (n *alterTypeNode) ReadingOwnWrites()                   {}
 
 func (p *planner) canModifyType(ctx context.Context, desc *typedesc.Mutable) error {
+	hasAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	if hasAdmin {
+		return nil
+	}
+
 	hasOwnership, err := p.HasOwnership(ctx, desc)
 	if err != nil {
 		return err
 	}
-
 	if !hasOwnership {
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
 			"must be owner of type %s", tree.Name(desc.GetName()))
 	}
-
 	return nil
 }

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -500,16 +500,49 @@ const ConnAuditingClusterSettingName = "server.auth_log.sql_connections.enabled"
 // create a circular dependency.
 const AuthAuditingClusterSettingName = "server.auth_log.sql_sessions.enabled"
 
-func (p *planner) canCreateOnSchema(ctx context.Context, schemaID descpb.ID, user string) error {
+// shouldCheckPublicSchema indicates whether canCreateOnSchema should check
+// CREATE privileges for the public schema.
+type shouldCheckPublicSchema bool
+
+const (
+	checkPublicSchema     shouldCheckPublicSchema = true
+	skipCheckPublicSchema shouldCheckPublicSchema = false
+)
+
+// canCreateOnSchema returns whether a user has permission to create new objects
+// on the specified schema. For `public` schemas, it checks if the user has
+// CREATE privileges on the specified dbID. Note that skipCheckPublicSchema may
+// be passed to skip this check, since some callers check this separately.
+//
+// Privileges on temporary schemas are not validated. This is the caller's
+// responsibility.
+func (p *planner) canCreateOnSchema(
+	ctx context.Context,
+	schemaID descpb.ID,
+	dbID descpb.ID,
+	user string,
+	checkPublicSchema shouldCheckPublicSchema,
+) error {
 	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
 	if err != nil {
 		return err
 	}
 
 	switch resolvedSchema.Kind {
-	case catalog.SchemaPublic, catalog.SchemaTemporary:
-		// Anyone can CREATE on a public schema, and callers check whether the
-		// temporary schema is valid to create in.
+	case catalog.SchemaPublic:
+		// The public schema is valid to create in if the parent database is.
+		if !checkPublicSchema {
+			// The caller wishes to skip this check.
+			return nil
+		}
+		dbDesc, err := p.Descriptors().GetDatabaseVersionByID(
+			ctx, p.Txn(), dbID, tree.DatabaseLookupFlags{Required: true})
+		if err != nil {
+			return err
+		}
+		return p.CheckPrivilegeForUser(ctx, dbDesc, privilege.CREATE, user)
+	case catalog.SchemaTemporary:
+		// Callers must check whether temporary schemas are valid to create in.
 		return nil
 	case catalog.SchemaVirtual:
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
@@ -546,15 +579,11 @@ func (p *planner) canResolveDescUnderSchema(
 	}
 }
 
-// checkCanAlterToNewOwner checks if the new owner exists, the current user
-// has privileges to alter the owner of the object and the current user is a
-//  member of the new owner role.
+// checkCanAlterToNewOwner checks that the new owner exists and the current user
+// has privileges to alter the owner of the object. If the current user is not
+// a superuser, it also checks that they are a member of the new owner role.
 func (p *planner) checkCanAlterToNewOwner(
-	ctx context.Context,
-	desc catalog.MutableDescriptor,
-	privs *descpb.PrivilegeDescriptor,
-	newOwner string,
-	hasOwnership bool,
+	ctx context.Context, desc catalog.MutableDescriptor, newOwner string,
 ) error {
 	// Make sure the newOwner exists.
 	roleExists, err := p.RoleExists(ctx, newOwner)
@@ -563,6 +592,15 @@ func (p *planner) checkCanAlterToNewOwner(
 	}
 	if !roleExists {
 		return pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", newOwner)
+	}
+
+	// If the user is a superuser, skip privilege checks.
+	hasAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	if hasAdmin {
+		return nil
 	}
 
 	var objType string
@@ -579,27 +617,28 @@ func (p *planner) checkCanAlterToNewOwner(
 		return errors.AssertionFailedf("unknown object descriptor type %v", desc)
 	}
 
-	// Make sure the user has ownership on the table
-	// and not just create privilege.
+	hasOwnership, err := p.HasOwnership(ctx, desc)
+	if err != nil {
+		return err
+	}
 	if !hasOwnership {
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
 			"must be owner of %s %s", tree.Name(objType), tree.Name(desc.GetName()))
 	}
 
-	// Requirements from PG:
-	// To alter the owner, you must also be a direct or indirect member of the
-	// new owning role, and that role must have CREATE privilege on the
-	// table's schema.
-	memberOf, err := p.MemberOfWithAdminOption(ctx, privs.Owner)
+	// To alter the owner, you must also be a direct or indirect member of the new
+	// owning role.
+	if p.User() == newOwner {
+		return nil
+	}
+	memberOf, err := p.MemberOfWithAdminOption(ctx, p.User())
 	if err != nil {
 		return err
 	}
-	if _, ok := memberOf[newOwner]; !ok {
-		return pgerror.Newf(
-			pgcode.InsufficientPrivilege, "must be member of role %q", newOwner)
+	if _, ok := memberOf[newOwner]; ok {
+		return nil
 	}
-
-	return nil
+	return pgerror.Newf(pgcode.InsufficientPrivilege, "must be member of role %q", newOwner)
 }
 
 // HasOwnershipOnSchema checks if the current user has ownership on the schema.

--- a/pkg/sql/catalog/descpb/privilege.go
+++ b/pkg/sql/catalog/descpb/privilege.go
@@ -366,6 +366,9 @@ func (p PrivilegeDescriptor) CheckPrivilege(user string, priv privilege.Kind) bo
 
 // AnyPrivilege returns true if 'user' has any privilege on this descriptor.
 func (p PrivilegeDescriptor) AnyPrivilege(user string) bool {
+	if p.Owner == user {
+		return true
+	}
 	userPriv, ok := p.findUser(user)
 	if !ok {
 		return false

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -203,7 +203,8 @@ func getTableCreateParams(
 	}
 
 	// Check permissions on the schema.
-	if err := params.p.canCreateOnSchema(params.ctx, schemaID, params.p.User()); err != nil {
+	if err := params.p.canCreateOnSchema(
+		params.ctx, schemaID, dbID, params.p.User(), skipCheckPublicSchema); err != nil {
 		return nil, 0, err
 	}
 

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -93,13 +93,15 @@ func getCreateTypeParams(
 		}
 	}
 	// Get the ID of the schema the type is being created in.
-	schemaID, err = params.p.getSchemaIDForCreate(params.ctx, params.ExecCfg().Codec, db.GetID(), name.Schema())
+	dbID := db.GetID()
+	schemaID, err = params.p.getSchemaIDForCreate(params.ctx, params.ExecCfg().Codec, dbID, name.Schema())
 	if err != nil {
 		return nil, 0, err
 	}
 
 	// Check permissions on the schema.
-	if err := params.p.canCreateOnSchema(params.ctx, schemaID, params.p.User()); err != nil {
+	if err := params.p.canCreateOnSchema(
+		params.ctx, schemaID, dbID, params.p.User(), skipCheckPublicSchema); err != nil {
 		return nil, 0, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_owner
@@ -1,63 +1,76 @@
 statement ok
-CREATE DATABASE d
-
-# Ensure user must exist for set owner.
-statement error pq: role/user "fake_user" does not exist
-ALTER DATABASE d OWNER TO fake_user
-
-# Ensure the current user is a member of the role we're setting to.
-statement error pq: must be member of role "testuser"
-ALTER DATABASE d OWNER TO testuser
-
-user testuser
-
-# Ensure the user has to be an owner alter the owner.
-statement error pq: must be owner of database d
-ALTER DATABASE d OWNER TO testuser
-
-user root
-
-statement ok
-GRANT testuser TO root
-
-# testuser satisfies all the requirements to become an owner.
-statement ok
-ALTER DATABASE d OWNER TO testuser
-
-statement ok
+CREATE DATABASE d;
 CREATE USER testuser2
 
-# setup to allow testuser2 as a member of testuser to alter the owner.
+# Ensure user must exist for set owner.
+statement error role/user "fake_user" does not exist
+ALTER DATABASE d OWNER TO fake_user
+
+# Superusers can alter owner to any user.
 statement ok
-REVOKE testuser FROM root
+ALTER DATABASE d OWNER TO testuser
 
-statement ok
-GRANT testuser TO testuser2
-
-statement ok
-GRANT root TO testuser
-
-user testuser2
-
-# testuser2 should be able to alter the owner since it is a member of testuser.
 statement ok
 ALTER DATABASE d OWNER TO root
 
-# set the owner back to testuser.
+# Other users must be owner to alter the owner.
+user testuser
 
+statement error must be owner of database d
+ALTER DATABASE d OWNER TO testuser
+
+# Non-superusers also must be a member of the new owning role.
 user root
-
-statement ok
-REVOKE root FROM testuser
-
-statement ok
-GRANT testuser TO root
 
 statement ok
 ALTER DATABASE d OWNER TO testuser
 
 user testuser
 
-# Ensure testuser is owner by dropping the database.
+statement error must be member of role "testuser2"
+ALTER DATABASE d OWNER TO testuser2
+
+user root
+
 statement ok
-DROP DATABASE d
+GRANT testuser2 TO testuser
+
+user testuser
+
+statement error user testuser does not have CREATEDB privilege
+ALTER DATABASE d OWNER TO testuser2
+
+user root
+
+statement ok
+ALTER USER testuser CREATEDB
+
+user testuser
+
+statement ok
+ALTER DATABASE d OWNER TO testuser2
+
+query T
+SELECT r.rolname FROM pg_database d JOIN pg_roles r ON d.datdba = r.oid WHERE d.datname = 'd';
+----
+testuser2
+
+# Test that a user can reassign the owner from one role to another if they are
+# a member of both roles, even if those roles are not members of each other.
+user root
+
+statement ok
+CREATE ROLE a;
+CREATE ROLE b;
+GRANT a, b TO testuser;
+ALTER DATABASE d OWNER TO a
+
+user testuser
+
+statement ok
+ALTER DATABASE d OWNER TO b
+
+query T
+SELECT r.rolname FROM pg_database d JOIN pg_roles r ON d.datdba = r.oid WHERE d.datname = 'd';
+----
+b

--- a/pkg/sql/logictest/testdata/logic_test/alter_schema_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_schema_owner
@@ -1,78 +1,52 @@
 statement ok
-CREATE SCHEMA s
+CREATE SCHEMA s;
+CREATE USER testuser2
 
-# Ensure user must exist for set owner.
-statement error pq: role/user "fake_user" does not exist
-ALTER SCHEMA s OWNER TO fake_user
+# Superusers can alter owner to any user.
+statement ok
+ALTER SCHEMA s OWNER TO testuser
 
-# Ensure the current user is a member of the role we're setting to.
-statement error pq: must be member of role "testuser"
+statement ok
+ALTER SCHEMA s OWNER TO root
+
+# Other users must be owner to alter the owner.
+user testuser
+
+statement error must be owner of schema "s"
+ALTER SCHEMA s OWNER TO testuser
+
+# Non-superusers also must be a member of the new owning role.
+user root
+
+statement ok
 ALTER SCHEMA s OWNER TO testuser
 
 user testuser
 
-# Ensure the user has to be an owner to alter the owner.
-statement error pq: must be owner of schema "s"
-ALTER SCHEMA s OWNER TO testuser
-
-user root
-
-statement ok
-GRANT testuser TO root
-
-statement ok
-CREATE USER testuser2
-
-statement ok
-GRANT testuser2 TO root
-
-# Ensure the desired owner has CREATE privilege on the database.
-statement error pq: user testuser2 does not have CREATE privilege on database test
+statement error must be member of role "testuser2"
 ALTER SCHEMA s OWNER TO testuser2
 
-statement ok
-GRANT CREATE ON DATABASE test TO testuser, testuser2
-
-# testuser has the required privileges to become the new owner of schema s.
-statement ok
-ALTER SCHEMA s OWNER TO testuser
-
-# setup to allow testuser2 as a member of testuser to alter the owner.
-statement ok
-REVOKE testuser, testuser2 FROM root
-
-statement ok
-GRANT testuser TO testuser2
-
-statement ok
-GRANT root TO testuser
-
-user testuser2
-
-# testuser2 should be able to alter the owner since it is a member of testuser.
-statement ok
-ALTER SCHEMA s OWNER TO root
-
-# set the owner back to testuser.
-
 user root
-
-statement ok
-REVOKE root FROM testuser
-
-statement ok
-GRANT testuser TO root
-
-statement ok
-ALTER SCHEMA s OWNER TO testuser
-
-# setup to allow testuser2 to become the owner again.
-statement ok
-REVOKE testuser FROM testuser2
 
 statement ok
 GRANT testuser2 TO testuser
 
-# Ensure testuser is owner by dropping the schema.
+user testuser
+
+statement error user testuser does not have CREATE privilege on database test
+ALTER SCHEMA s OWNER TO testuser2
+
+user root
+
 statement ok
-DROP SCHEMA s
+GRANT CREATE ON DATABASE test TO testuser
+
+user testuser
+
+statement ok
+ALTER SCHEMA s OWNER TO testuser2
+
+query T
+SELECT pg_get_userbyid(nspowner) FROM pg_namespace WHERE nspname = 's';
+----
+testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_owner
@@ -1,142 +1,61 @@
 statement ok
-CREATE TABLE t()
+CREATE SCHEMA s;
+CREATE TABLE t ();
+CREATE TABLE s.t ();
+CREATE USER testuser2
 
 # Ensure user must exist for set owner.
 statement error pq: role/user "fake_user" does not exist
 ALTER TABLE t OWNER TO fake_user
 
-# Ensure the current user is a member of the role we're setting to.
-statement error pq: must be member of role "testuser"
+# Superusers can alter owner to any user which has CREATE privileges on the
+# parent schema (or in the case of the public schema on the parent database.)
+statement error pq: user testuser does not have CREATE privilege on database test
 ALTER TABLE t OWNER TO testuser
 
-user testuser
-
-# Ensure the user has to be an owner to alter the owner.
-statement error pq: must be owner of table t
-ALTER TABLE t OWNER TO testuser
-
-user root
-
-statement ok
-GRANT testuser TO root
-
-# Test set owner for a table in the public schema.
-statement ok
-ALTER TABLE t OWNER TO testuser
-
-statement ok
-GRANT CREATE ON DATABASE test TO testuser
-
-user testuser
-
-statement ok
-CREATE SCHEMA s
-
-user root
-
-# testuser2 does not have owner/create privilege on schema s.
-statement ok
-CREATE USER testuser2
-
-statement ok
-CREATE TABLE s.t()
-
-statement ok
-GRANT testuser2 TO root
-
-# Ensure the new owner has create privilege on the schema.
-statement error pq: user testuser2 does not have CREATE privilege on schema s
-ALTER TABLE s.t OWNER TO testuser2
-
-statement ok
-GRANT testuser TO root
-
-# testuser satisfies all the conditions to become the new owner.
-statement ok
+statement error pq: user testuser does not have CREATE privilege on schema s
 ALTER TABLE s.t OWNER TO testuser
 
-# setup to allow testuser2 as a member of testuser to alter the owner.
 statement ok
-REVOKE testuser, testuser2 FROM root
+GRANT CREATE ON DATABASE test TO testuser, testuser2;
+GRANT CREATE ON SCHEMA s TO testuser, testuser2
 
 statement ok
-GRANT testuser TO testuser2
-
-statement ok
-GRANT root TO testuser
-
-user testuser2
-
-# testuser2 should be able to alter the owner since it is a member of testuser.
-statement ok
+ALTER TABLE t OWNER TO testuser;
+ALTER TABLE s.t OWNER TO testuser;
+ALTER TABLE t OWNER TO root;
 ALTER TABLE s.t OWNER TO root
 
-# set the owner back to testuser.
+# Other users must be owner to alter the owner.
+user testuser
+
+statement error must be owner of table t
+ALTER TABLE t OWNER TO testuser2
+
+# Non-superusers also must be a member of the new owning role.
+user root
+
+statement ok
+ALTER TABLE t OWNER TO testuser
+
+user testuser
+
+statement error must be member of role "testuser2"
+ALTER TABLE t OWNER TO testuser2
 
 user root
 
 statement ok
-REVOKE root FROM testuser
-
-statement ok
-GRANT testuser TO root
-
-statement ok
-ALTER TABLE s.t OWNER TO testuser
+GRANT testuser2 TO testuser
 
 user testuser
 
-# Ensure testuser is owner by dropping the table.
 statement ok
-DROP TABLE s.t
-
-# Test ALTER TABLE OWNER in a combined statement.
-
-user testuser2
-
-statement ok
-CREATE TABLE t2()
-
-statement ok
-ALTER TABLE t2 ADD COLUMN x INT, OWNER TO testuser
+ALTER TABLE t OWNER TO testuser2
 
 user root
 
-# Add this testcase back once #52904 is addressed.
-
-#statement ok
-#SET experimental_enable_temp_tables = on
-
-#statement ok
-#CREATE TEMP TABLE temp()
-
-# Should not be able to alter the owner of a temporary table.
-#statement error pq: cannot CREATE on schema pg_temp_
-#ALTER TABLE temp OWNER TO testuser
-
-# Ensure admins who don't have explicit CREATE privilege on a schema can
-# still become the owner.
-
-# Ensure root does not have CREATE privilege on schema by being a member
-# of testuser.
-statement ok
-REVOKE testuser FROM root
-
-user testuser
-
-statement ok
-CREATE SCHEMA s2
-
-statement ok
-CREATE TABLE s2.t()
-
-user root
-
-statement ok
-GRANT root TO testuser
-
-user testuser
-
-# This should succeed despite root not having explicit CREATE privilege on s2.
-statement ok
-ALTER TABLE s2.t OWNER TO root
+query T
+SELECT tableowner FROM pg_tables WHERE schemaname = 'public' AND tablename = 't'
+----
+testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_type_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type_owner
@@ -1,104 +1,67 @@
 statement ok
-CREATE TYPE typ AS ENUM ()
+CREATE SCHEMA s;
+CREATE TYPE s.typ AS ENUM ();
+CREATE USER testuser2
 
 # Ensure user must exist for set owner.
 statement error pq: role/user "fake_user" does not exist
-ALTER TYPE typ OWNER TO fake_user
+ALTER TYPE s.typ OWNER TO fake_user
 
-# Ensure the current user is a member of the role we're setting to.
-statement error pq: must be member of role "testuser"
-ALTER TYPE typ OWNER TO testuser
-
-user testuser
-
-# Ensure the user has to be an owner to alter the owner.
-statement error pq: must be owner of type t
-ALTER TYPE typ OWNER TO testuser
-
-user root
+# Superusers can alter owner to any user which has CREATE privileges on the
+# parent schema.
+statement error pq: user testuser does not have CREATE privilege on schema s
+ALTER TYPE s.typ OWNER TO testuser
 
 statement ok
-GRANT testuser TO root
+GRANT CREATE, USAGE ON SCHEMA s TO testuser, testuser2
 
-# Test set owner for a type in the public schema.
-statement ok
-ALTER TYPE typ OWNER TO testuser
-
-statement ok
-GRANT CREATE ON DATABASE test TO testuser
-
-user testuser
-
-statement ok
-CREATE SCHEMA s
-
-user root
-
-# testuser2 does not have owner/create privilege on schema s.
-statement ok
-CREATE USER testuser2
-
-statement ok
-CREATE TYPE s.typ AS ENUM ()
-
-statement ok
-GRANT testuser2 TO root
-
-# Ensure the new owner has create privilege on the schema.
-statement error pq: user testuser2 does not have CREATE privilege on schema s
-ALTER TYPE s.typ OWNER TO testuser2
-
-statement ok
-GRANT testuser TO root
-
-# testuser satisfies all the conditions to become the new owner.
 statement ok
 ALTER TYPE s.typ OWNER TO testuser
 
-# setup to allow testuser2 as a member of testuser to alter the owner.
-statement ok
-REVOKE testuser, testuser2 FROM root
-
-statement ok
-GRANT testuser TO testuser2
-
-statement ok
-GRANT root TO testuser
-
-user testuser2
-
-# testuser2 should be able to alter the owner since it is a member of testuser.
 statement ok
 ALTER TYPE s.typ OWNER TO root
 
-# set the owner back to testuser.
+# Other users must be owner to alter the owner.
+user testuser
 
+statement error must be owner of type typ
+ALTER TYPE s.typ OWNER TO testuser
+
+# Non-superusers also must be a member of the new owning role.
 user root
-
-statement ok
-REVOKE root FROM testuser
-
-statement ok
-GRANT testuser TO root
 
 statement ok
 ALTER TYPE s.typ OWNER TO testuser
 
 user testuser
 
-# Ensure testuser is owner by dropping the type.
-statement ok
-DROP TYPE s.typ
+statement error must be member of role "testuser2"
+ALTER TYPE s.typ OWNER TO testuser2
 
 user root
 
+statement ok
+GRANT testuser2 TO testuser
+
+user testuser
+
+statement ok
+ALTER TYPE s.typ OWNER TO testuser2
+
+# Ensure testuser2 is owner.
+user root
+
+query T
+SELECT pg_get_userbyid(typowner) FROM pg_type WHERE typname = 'typ';
+----
+testuser2
+
 # Ensure admins who don't have explicit CREATE privilege on a schema can
 # still become the owner.
+user root
 
-# Ensure root does not have CREATE privilege on schema by being a member
-# of testuser.
 statement ok
-REVOKE testuser FROM root
+GRANT CREATE ON DATABASE test TO testuser
 
 user testuser
 


### PR DESCRIPTION
I fixed the following bugs related to ownership privilege checks.
- Admins should be able to change the owner even if they are not a
  member of the old or new roles.
- Admins should be able to rename a schema even if they don't own it.
- Changing a schema's owner requires the current user to have the CREATE
  privilege on the database, not the new owner.
- The user who alters the owner must be a member of the new owning role.
  Previously we were mistakenly checking if the old owner was a member
  of the new owner.
- A user should be able to alter the owner to herself. (This previously
  failed because the role was not considered a member of itself.)
- CheckAnyPrivilege should return true for owners.

Fixes #54144