### PR TITLE
roachprod: expose aws instance creation rate limit as a CLI flag

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -86,6 +86,10 @@ type providerOpts struct {
 	// on the geo flag being set. If no zones specified, defaultCreateZones are
 	// used. See defaultCreateZones.
 	CreateZones []string
+	// CreateRateLimit specifies the rate limit used for aws instance creation.
+	// The request limit from aws' side can vary across regions, as well as the
+	// size of cluster being created.
+	CreateRateLimit float64
 }
 
 const (
@@ -150,6 +154,10 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"", "Override image AMI to use.  See https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-images.html")
 	flags.BoolVar(&o.UseMultipleDisks, ProviderName+"-enable-multiple-stores",
 		false, "Enable the use of multiple stores by creating one store directory per disk.  Default is to raid0 stripe all disks.")
+	flags.Float64Var(&o.CreateRateLimit, ProviderName+"-create-rate-limit", 2, "aws"+
+		" rate limit (per second) for instance creation. This is used to avoid hitting the request"+
+		" limits from aws, which can vary based on the region, and the size of the cluster being"+
+		" created. Try lowering this limit when hitting 'Request limit exceeded' errors.")
 }
 
 func (o *providerOpts) ConfigureClusterFlags(flags *pflag.FlagSet, _ vm.MultipleProjectsOption) {
@@ -260,8 +268,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		}
 	}
 	var g errgroup.Group
-	const rateLimit = 2 // per second
-	limiter := rate.NewLimiter(rateLimit, 2 /* buckets */)
+	limiter := rate.NewLimiter(rate.Limit(p.opts.CreateRateLimit), 2 /* buckets */)
 	for i := range names {
 		capName := names[i]
 		placement := zones[i]


### PR DESCRIPTION
See #34870 for why the rate limit exists.

Release note: None