### PR TITLE
cmd/roachprod-stress: copy over geo-lib

### DIFF
--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -138,6 +138,16 @@ func run() error {
 		return err
 	}
 
+	const localLibDir = "lib.docker_amd64/"
+	if fi, err := os.Stat(localLibDir); err == nil && fi.IsDir() {
+		cmd = exec.Command("roachprod", "put", cluster, localLibDir, "lib")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+
 	cmd = exec.Command("roachprod", "run", cluster, "mkdir -p "+pkg)
 	if err := cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
Not all packages need GEOS but when they do, not having it is catasrophic.
Copy it over if it exists. This enables roachprod-stress of logictests for
example.

Release note: None