### PR TITLE
 backupccl: properly restore defaultdb schemas/types in cluster restore

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -54,10 +54,26 @@ FROM system.jobs
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 	sqlDBRestore.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 
-	// Create some other databases and tables.
-	sqlDB.Exec(t, `CREATE TABLE defaultdb.foo (a int);`)
-	sqlDB.Exec(t, `CREATE DATABASE data2;`)
-	sqlDB.Exec(t, `CREATE TABLE data2.foo (a int);`)
+	// Create some other descriptors as well.
+	sqlDB.Exec(t, `
+USE data;
+CREATE SCHEMA test_data_schema;
+CREATE TABLE data.test_data_schema.test_table (a int);
+INSERT INTO data.test_data_schema.test_table VALUES (1), (2);
+
+USE defaultdb;
+CREATE SCHEMA test_schema;
+CREATE TABLE defaultdb.test_schema.test_table (a int);
+INSERT INTO defaultdb.test_schema.test_table VALUES (1), (2);
+CREATE TABLE defaultdb.foo (a int);
+CREATE TYPE greeting AS ENUM ('hi');
+CREATE TABLE welcomes (a greeting);
+
+CREATE DATABASE data2;
+USE data2;
+CREATE SCHEMA empty_schema;
+CREATE TABLE data2.foo (a int);
+`)
 
 	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
 	// Populate system.users.
@@ -130,6 +146,19 @@ FROM system.jobs
 				{"postgres", security.RootUser},
 				{"system", security.NodeUser},
 			})
+	})
+
+	t.Run("ensure all schemas are restored", func(t *testing.T) {
+		expectedSchemas := map[string][][]string{
+			"defaultdb": {{"crdb_internal"}, {"information_schema"}, {"pg_catalog"}, {"pg_extension"}, {"public"}, {"test_schema"}},
+			"data":      {{"crdb_internal"}, {"information_schema"}, {"pg_catalog"}, {"pg_extension"}, {"public"}, {"test_data_schema"}},
+			"data2":     {{"crdb_internal"}, {"empty_schema"}, {"information_schema"}, {"pg_catalog"}, {"pg_extension"}, {"public"}},
+		}
+		for dbName, expectedSchemas := range expectedSchemas {
+			sqlDBRestore.CheckQueryResults(t,
+				fmt.Sprintf(`USE %s; SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name;`, dbName),
+				expectedSchemas)
+		}
 	})
 
 	t.Run("ensure system table data restored", func(t *testing.T) {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -306,7 +306,24 @@ func allocateDescriptorRewrites(
 		if err != nil {
 			return nil, err
 		}
+		// Remap all of the descriptor belonging to system tables to the temp system
+		// DB.
 		descriptorRewrites[tempSysDBID] = &jobspb.RestoreDetails_DescriptorRewrite{ID: tempSysDBID}
+		for _, table := range tablesByID {
+			if table.GetParentID() == systemschema.SystemDB.ID {
+				descriptorRewrites[table.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
+			}
+		}
+		for _, sc := range typesByID {
+			if sc.GetParentID() == systemschema.SystemDB.ID {
+				descriptorRewrites[sc.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
+			}
+		}
+		for _, typ := range typesByID {
+			if typ.GetParentID() == systemschema.SystemDB.ID {
+				descriptorRewrites[typ.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
+			}
+		}
 	}
 
 	// Fail fast if the necessary databases don't exist or are otherwise
@@ -326,38 +343,14 @@ func allocateDescriptorRewrites(
 		// TODO (rohany, pbardea): These checks really need to be refactored.
 		// Construct rewrites for any user defined schemas.
 		for _, sc := range schemasByID {
-			var targetDB string
-			if renaming {
-				targetDB = overrideDB
-			} else if descriptorCoverage == tree.AllDescriptors && sc.ParentID < catalogkeys.MaxDefaultDescriptorID {
-				// This is a table that is in a database that already existed at
-				// cluster creation time.
-				defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.DefaultDatabaseName)
-				if err != nil {
-					return err
-				}
-				postgresDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.PgDatabaseName)
-				if err != nil {
-					return err
-				}
+			if _, ok := descriptorRewrites[sc.ID]; ok {
+				continue
+			}
 
-				if sc.ParentID == systemschema.SystemDB.GetID() {
-					// For full cluster backups, put the system tables in the temporary
-					// system table.
-					targetDB = restoreTempSystemDB
-					descriptorRewrites[sc.ID] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
-				} else if sc.ParentID == defaultDBID {
-					targetDB = catalogkeys.DefaultDatabaseName
-				} else if sc.ParentID == postgresDBID {
-					targetDB = catalogkeys.PgDatabaseName
-				}
-			} else {
-				database, ok := databasesByID[sc.ParentID]
-				if !ok {
-					return errors.Errorf("no database with ID %d in backup for schema %q",
-						sc.ParentID, sc.Name)
-				}
-				targetDB = database.Name
+			targetDB, err := resolveTargetDB(ctx, txn, p, databasesByID, renaming, overrideDB,
+				descriptorCoverage, sc)
+			if err != nil {
+				return err
 			}
 
 			if _, ok := restoreDBNames[targetDB]; ok {
@@ -407,38 +400,15 @@ func allocateDescriptorRewrites(
 		}
 
 		for _, table := range tablesByID {
-			var targetDB string
-			if renaming {
-				targetDB = overrideDB
-			} else if descriptorCoverage == tree.AllDescriptors && table.ParentID < catalogkeys.MaxDefaultDescriptorID {
-				// This is a table that is in a database that already existed at
-				// cluster creation time.
-				defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.DefaultDatabaseName)
-				if err != nil {
-					return err
-				}
-				postgresDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.PgDatabaseName)
-				if err != nil {
-					return err
-				}
+			// If a descriptor has already been assigned a rewrite, then move on.
+			if _, ok := descriptorRewrites[table.ID]; ok {
+				continue
+			}
 
-				if table.ParentID == systemschema.SystemDB.GetID() {
-					// For full cluster backups, put the system tables in the temporary
-					// system table.
-					targetDB = restoreTempSystemDB
-					descriptorRewrites[table.ID] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
-				} else if table.ParentID == defaultDBID {
-					targetDB = catalogkeys.DefaultDatabaseName
-				} else if table.ParentID == postgresDBID {
-					targetDB = catalogkeys.PgDatabaseName
-				}
-			} else {
-				database, ok := databasesByID[table.ParentID]
-				if !ok {
-					return errors.Errorf("no database with ID %d in backup for table %q",
-						table.ParentID, table.Name)
-				}
-				targetDB = database.GetName()
+			targetDB, err := resolveTargetDB(ctx, txn, p, databasesByID, renaming, overrideDB,
+				descriptorCoverage, table)
+			if err != nil {
+				return err
 			}
 
 			if _, ok := restoreDBNames[targetDB]; ok {
@@ -493,38 +463,10 @@ func allocateDescriptorRewrites(
 				continue
 			}
 
-			var targetDB string
-			if renaming {
-				targetDB = overrideDB
-			} else if descriptorCoverage == tree.AllDescriptors && typ.ParentID < catalogkeys.MaxDefaultDescriptorID {
-				// This is a table that is in a database that already existed at
-				// cluster creation time.
-				defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.DefaultDatabaseName)
-				if err != nil {
-					return err
-				}
-				postgresDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.PgDatabaseName)
-				if err != nil {
-					return err
-				}
-
-				if typ.ParentID == systemschema.SystemDB.GetID() {
-					// For full cluster backups, put the system tables in the temporary
-					// system table.
-					targetDB = restoreTempSystemDB
-					descriptorRewrites[typ.ID] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
-				} else if typ.ParentID == defaultDBID {
-					targetDB = catalogkeys.DefaultDatabaseName
-				} else if typ.ParentID == postgresDBID {
-					targetDB = catalogkeys.PgDatabaseName
-				}
-			} else {
-				database, ok := databasesByID[typ.ParentID]
-				if !ok {
-					return errors.Errorf("no database with ID %d in backup for type %q",
-						typ.ParentID, typ.Name)
-				}
-				targetDB = database.Name
+			targetDB, err := resolveTargetDB(ctx, txn, p, databasesByID, renaming, overrideDB,
+				descriptorCoverage, typ)
+			if err != nil {
+				return err
 			}
 
 			if _, ok := restoreDBNames[targetDB]; ok {
@@ -712,6 +654,53 @@ func allocateDescriptorRewrites(
 	}
 
 	return descriptorRewrites, nil
+}
+
+func resolveTargetDB(
+	ctx context.Context,
+	txn *kv.Txn,
+	p sql.PlanHookState,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	renaming bool,
+	overrideDB string,
+	descriptorCoverage tree.DescriptorCoverage,
+	descriptor catalog.Descriptor,
+) (string, error) {
+	if renaming {
+		return overrideDB, nil
+	}
+
+	if descriptorCoverage == tree.AllDescriptors && descriptor.GetParentID() < catalogkeys.MaxDefaultDescriptorID {
+		// This is a table that is in a database that already existed at
+		// cluster creation time.
+		defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.DefaultDatabaseName)
+		if err != nil {
+			return "", err
+		}
+		postgresDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.PgDatabaseName)
+		if err != nil {
+			return "", err
+		}
+
+		var targetDB string
+		if descriptor.GetParentID() == systemschema.SystemDB.GetID() {
+			// For full cluster backups, put the system tables in the temporary
+			// system table.
+			targetDB = restoreTempSystemDB
+		} else if descriptor.GetParentID() == defaultDBID {
+			targetDB = catalogkeys.DefaultDatabaseName
+		} else if descriptor.GetParentID() == postgresDBID {
+			targetDB = catalogkeys.PgDatabaseName
+		}
+		return targetDB, nil
+	}
+
+	database, ok := databasesByID[descriptor.GetParentID()]
+	if !ok {
+		return "", errors.Errorf("no database with ID %d in backup for object %q (%d)",
+			descriptor.GetParentID(), descriptor.GetName(), descriptor.GetID())
+	}
+	return database.Name, nil
 }
 
 // maybeUpgradeTableDescsInBackupManifests updates the backup descriptors'


### PR DESCRIPTION
Previously, restoring a cluster backup that contained user defined
schemas or a user defined type in defaultdb would fail.

Fixes #55179.

Release note (bug fix): Previously, restoring a cluster backup that
contained user defined schemas or user defined type in defaultdb would
fail.