### PR TITLE
server, storage: Throw warning on slow log write, fatal on engine disk stall

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -529,6 +529,8 @@ type TempStorageConfig struct {
 	Mon *mon.BytesMonitor
 	// Spec stores the StoreSpec this TempStorageConfig will use.
 	Spec StoreSpec
+	// Settings stores the cluster.Settings this TempStoreConfig will use.
+	Settings *cluster.Settings
 }
 
 // ExternalIODirConfig describes various configuration options pertaining
@@ -578,6 +580,7 @@ func TempStorageConfigFromEnv(
 		InMemory: inMem,
 		Mon:      monitor,
 		Spec:     useStore,
+		Settings: st,
 	}
 }
 

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -191,6 +191,7 @@ func DefaultTestTempStorageConfigWithSize(
 	return TempStorageConfig{
 		InMemory: true,
 		Mon:      monitor,
+		Settings: st,
 	}
 }
 

--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -22,7 +23,11 @@ import (
 // startAssertEngineHealth starts a goroutine that periodically verifies that
 // syncing the engines is possible within maxSyncDuration. If not,
 // the process is terminated (with an attempt at a descriptive message).
-func (n *Node) startAssertEngineHealth(ctx context.Context, engines []storage.Engine) {
+func (n *Node) startAssertEngineHealth(
+	ctx context.Context, engines []storage.Engine, settings *cluster.Settings,
+) {
+	maxSyncDuration := storage.MaxSyncDuration.Get(&settings.SV)
+	fatalOnExceeded := storage.MaxSyncDurationFatalOnExceeded.Get(&settings.SV)
 	n.stopper.RunWorker(ctx, func(ctx context.Context) {
 		t := timeutil.NewTimer()
 		t.Reset(0)
@@ -32,7 +37,7 @@ func (n *Node) startAssertEngineHealth(ctx context.Context, engines []storage.En
 			case <-t.C:
 				t.Read = true
 				t.Reset(10 * time.Second)
-				n.assertEngineHealth(ctx, engines, storage.MaxSyncDuration)
+				n.assertEngineHealth(ctx, engines, maxSyncDuration, fatalOnExceeded)
 			case <-n.stopper.ShouldQuiesce():
 				return
 			}
@@ -46,7 +51,7 @@ func guaranteedExitFatal(ctx context.Context, msg string, args ...interface{}) {
 }
 
 func (n *Node) assertEngineHealth(
-	ctx context.Context, engines []storage.Engine, maxDuration time.Duration,
+	ctx context.Context, engines []storage.Engine, maxDuration time.Duration, fatalOnExceeded bool,
 ) {
 	for _, eng := range engines {
 		func() {
@@ -54,7 +59,7 @@ func (n *Node) assertEngineHealth(
 				n.metrics.DiskStalls.Inc(1)
 				stats := "\n" + eng.GetCompactionStats()
 				logger := log.Warningf
-				if storage.MaxSyncDurationFatalOnExceeded {
+				if fatalOnExceeded {
 					logger = guaranteedExitFatal
 				}
 				// NB: the disk-stall-detected roachtest matches on this message.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1477,7 +1477,7 @@ func TestSupportsPrev(t *testing.T) {
 		})
 	}
 	t.Run("pebble", func(t *testing.T) {
-		eng := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20)
+		eng := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
 		defer eng.Close()
 		runTest(t, eng, engineTest{
 			engineIterSupportsPrev:   true,

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -31,7 +31,7 @@ func NewInMem(
 	case enginepb.EngineTypeDefault:
 		fallthrough
 	case enginepb.EngineTypePebble:
-		return newPebbleInMem(ctx, attrs, cacheSize)
+		return newPebbleInMem(ctx, attrs, cacheSize, nil /* settings */)
 	case enginepb.EngineTypeRocksDB:
 		return newRocksDBInMem(attrs, cacheSize)
 	}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -87,7 +87,7 @@ func createTestRocksDBEngine() Engine {
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
 func createTestPebbleEngine() Engine {
-	return newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20)
+	return newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
 }
 
 var mvccEngineImpls = []struct {

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -74,6 +74,7 @@ func storageConfigFromTempStorageConfigAndStoreSpec(
 		Dir:   config.Path,
 		// MaxSize doesn't matter for temp storage - it's not enforced in any way.
 		MaxSize:         0,
+		Settings:        config.Settings,
 		UseFileRegistry: spec.UseFileRegistry,
 		ExtraOptions:    spec.ExtraOptions,
 	}


### PR DESCRIPTION

A previous change disabled the fataling of the Cockroach process
when a disk stall was detected. This change reverts that, as Pebble's
disk stall detection is closer to actual disk operations and should be
less likely to find spurious disk slowdowns.

To only conservatively respond to disk stalls, this change also bumps
up the stall fatal threshold to 60s, up from 30s.

It also makes the same change to the log flusher; the threshold has
gone up to 60s and a new warning threshold of 10s has been added
to match the semantics from Pebble's disk stall detection.

Finally, the node_engine_health goroutine is disabled on Pebble,
as it's redundant there.

Release note (general change): Detect stalled disk operations better
and crash the process if a disk operation is taking longer than
a minute.