### PR TITLE
build: fix teamcity-opttest.sh to remove unbound variable TESTTIMEOUT

### DIFF
--- a/build/teamcity-opttest.sh
+++ b/build/teamcity-opttest.sh
@@ -25,7 +25,6 @@ run_json_test build/builder.sh \
   GOTESTFLAGS=-json \
   TAGS=fast_int_set_large \
   PKG=./pkg/sql/opt... \
-  TESTTIMEOUT="${TESTTIMEOUT}" \
   TESTFLAGS='-v'
 tc_end_block "Run opt tests with fast_int_set_large"
 
@@ -37,6 +36,5 @@ run_json_test build/builder.sh \
   GOTESTFLAGS=-json \
   TAGS=fast_int_set_small \
   PKG=./pkg/sql/opt... \
-  TESTTIMEOUT="${TESTTIMEOUT}" \
   TESTFLAGS='-v'
 tc_end_block "Run opt tests with fast_int_set_small"


### PR DESCRIPTION
This commit updates the `teamcity-opttest.sh` script to remove references
to the unbound variable `TESTTIMEOUT`. The default timeout of 30m should
be sufficient for this test.

Release note: None