### PR TITLE
backupccl: add system.role_options to cluster backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -78,6 +78,7 @@ var fullClusterSystemTables = []string{
 	// Rest of system tables.
 	systemschema.LocationsTable.Name,
 	systemschema.RoleMembersTable.Name,
+	systemschema.RoleOptionsTable.Name,
 	systemschema.UITable.Name,
 	systemschema.CommentsTable.Name,
 	systemschema.JobsTable.Name,

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -67,6 +67,7 @@ FROM system.jobs
 	}
 	for i := 0; i < numUsers; i++ {
 		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
+		sqlDB.Exec(t, fmt.Sprintf("ALTER USER maxroach%d CREATEDB", i))
 	}
 	// Populate system.zones.
 	sqlDB.Exec(t, `ALTER TABLE data.bank CONFIGURE ZONE USING gc.ttlseconds = 3600`)
@@ -139,6 +140,7 @@ FROM system.jobs
 			systemschema.CommentsTable.Name,
 			systemschema.LocationsTable.Name,
 			systemschema.RoleMembersTable.Name,
+			systemschema.RoleOptionsTable.Name,
 			systemschema.SettingsTable.Name,
 			systemschema.TableStatisticsTable.Name,
 			systemschema.UITable.Name,
@@ -478,6 +480,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				{"jobs"},
 				{"locations"},
 				{"role_members"},
+				{"role_options"},
 				{"scheduled_jobs"},
 				{"settings"},
 				{"ui"},
@@ -519,6 +522,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				{"jobs"},
 				{"locations"},
 				{"role_members"},
+				{"role_options"},
 				{"scheduled_jobs"},
 				{"settings"},
 				{"ui"},


### PR DESCRIPTION
Previously, the role_options system table was not included in cluster
backups. This commit adds this table.

Fixes #55188.

Release note (bug fix): Options set on users (e.g. ALTER USER u
CREATEDB) were not included in cluster backups and thus not restored.
Role options were introduced in 20.2.