### PR TITLE
release-20.1: colexec: account for some things during the hash aggregation

### DIFF
--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -207,6 +207,11 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// current value is non-null, then we can pick the current value to be the
 		// output.
 		val := execgen.UNSAFEGET(col, i)
+		// {{if eq .LTyp.String "Bytes"}}
+		// a.curAgg might be holding on to val for a long time (in case of the
+		// hash aggregation), so we should account for it.
+		a.allocator.AdjustMemoryUsage(int64(len(val) - len(a.curAgg)))
+		// {{end}}
 		execgen.COPYVAL(a.curAgg, val)
 		a.foundNonNullForCurrentGroup = true
 	}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -524,6 +524,7 @@ func (v *hashAggFuncs) compute(b coldata.Batch, aggCols [][]uint32) {
 // 'sum' aggregation on ints and decimals with varying group sizes (powers of 2
 // from 1 to 4096).
 const hashAggFuncsAllocSize = 64
+const hashAggFuncsSliceOverhead = int64(unsafe.Sizeof([]hashAggFuncs{}))
 
 // hashAggFuncsAlloc is a utility struct that batches allocations of
 // hashAggFuncs.
@@ -534,7 +535,7 @@ type hashAggFuncsAlloc struct {
 
 func (a *hashAggFuncsAlloc) newHashAggFuncs() *hashAggFuncs {
 	if len(a.buf) == 0 {
-		a.allocator.AdjustMemoryUsage(int64(hashAggFuncsAllocSize * sizeOfHashAggFuncs))
+		a.allocator.AdjustMemoryUsage(hashAggFuncsSliceOverhead + int64(hashAggFuncsAllocSize*sizeOfHashAggFuncs))
 		a.buf = make([]hashAggFuncs, hashAggFuncsAllocSize)
 	}
 	ret := &a.buf[0]


### PR DESCRIPTION
Previously, we didn't account for several things during the hash
aggregation:
- any_not_null and min/max aggregates can hold on to byte slices of
arbitrary size for a long time (namely, until the input to the
aggregation has been fully consumed)
- we didn't account for the overhead of a slice of `hashAggFuncs` which
can become non-trivial when there are many buckets (32 bytes for 25
million groups does add up).

Both of these are now fixed. Note that still there is one other usage
that we don't account for - that's `map` for hash code to sels slot.
The issue is that we cannot get its usage precisely, the estimation is
non-trivial, and the code has been refactored in 20.2, so we'll just
keep it as is on 20.1.

Addresses: #54360.

Release note (bug fix): CockroachDB previously didn't account for all
the memory used by the vectorized hash aggregation which could lead to
an OOM crash. Note that this could only happen with `vectorize=on`.