### PR TITLE
opt: improve various composite-ness checks

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -29,7 +29,7 @@ project
  │    ├── project
  │    │    ├── columns: column7:7(bool!null) column9:9(string!null) x:1(int!null) y:2(int) z:3(float!null) s:4(string!null)
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (1)-->(2-4,7), (3,4)-->(1,2)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,7), (3,4)-->(1,2,7), (3)-->(7)
  │    │    ├── prune: (1-4,7,9)
  │    │    ├── interesting orderings: (+1) (-4,+3,+1)
  │    │    ├── select

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -359,6 +359,26 @@ project
       └── cast: STRING [as=d:6, type=string, outer=(4), immutable]
            └── variable: xysd.d:4 [type=decimal]
 
+# We have the FD d --> d+1.
+build
+SELECT d, d+1 FROM xysd
+----
+project
+ ├── columns: d:4(decimal!null) "?column?":6(decimal!null)
+ ├── immutable
+ ├── fd: (4)-->(6)
+ ├── prune: (4,6)
+ ├── scan xysd
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) crdb_internal_mvcc_timestamp:5(decimal)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+ │    ├── prune: (1-5)
+ │    └── interesting orderings: (+1) (-3,+4,+1)
+ └── projections
+      └── plus [as="?column?":6, type=decimal, outer=(4), immutable]
+           ├── variable: d:4 [type=decimal]
+           └── const: 1 [type=decimal]
+
 # We have the equality relation between the synthesized column and the column
 # it refers to.
 norm

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
@@ -62,6 +62,7 @@ sort
       │    ├── columns: column20:20(float!null) column22:22(float!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null)
       │    ├── immutable
       │    ├── stats: [rows=5909394.86, distinct(5)=50, null(5)=0, distinct(6)=925955, null(6)=0, distinct(7)=11, null(7)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(20)=5909394.86, null(20)=0, distinct(22)=5909394.86, null(22)=0, distinct(9,10)=6, null(9,10)=0]
+      │    ├── fd: (6,7)-->(20)
       │    ├── select
       │    │    ├── save-table-name: q1_select_4
       │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1629,7 +1629,7 @@ project
       ├── project
       │    ├── columns: column7:7 column9:9!null k:1!null i:2!null f:3
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2,3,7), (2,3)~~>(1), (2)-->(9)
+      │    ├── fd: (1)-->(2,3), (2,3)~~>(1), (3)-->(7), (2)-->(9)
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2!null f:3
       │    │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -729,7 +729,7 @@ project
 # Ensure that we do not map filters for types with composite key encoding.
 norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT *
-FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y)WHERE x=y AND x::text = '1.0'
+FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y) WHERE x=y AND x::text = '1.0'
 ----
 inner-join (hash)
  ├── columns: x:1!null y:2!null
@@ -752,6 +752,41 @@ inner-join (hash)
  │    ├── cardinality: [2 - 2]
  │    ├── (1.00,)
  │    └── (2.00,)
+ └── filters
+      └── column1:1 = column1:2 [outer=(1,2), immutable, constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+
+# Remap composite variables if filters are not composite sensitive.
+norm expect=PushFilterIntoJoinLeftAndRight
+SELECT *
+FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y) WHERE x=y AND x >= 1
+----
+inner-join (hash)
+ ├── columns: x:1!null y:2!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── fd: (1)==(2), (2)==(1)
+ ├── select
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [0 - 2]
+ │    ├── immutable
+ │    ├── values
+ │    │    ├── columns: column1:1!null
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── (1.0,)
+ │    │    └── (2.0,)
+ │    └── filters
+ │         └── column1:1 >= 1 [outer=(1), immutable, constraints=(/1: [/1 - ]; tight)]
+ ├── select
+ │    ├── columns: column1:2!null
+ │    ├── cardinality: [0 - 2]
+ │    ├── immutable
+ │    ├── values
+ │    │    ├── columns: column1:2!null
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── (1.00,)
+ │    │    └── (2.00,)
+ │    └── filters
+ │         └── column1:2 >= 1 [outer=(2), immutable, constraints=(/2: [/1 - ]; tight)]
  └── filters
       └── column1:1 = column1:2 [outer=(1,2), immutable, constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -250,6 +250,7 @@ project
  ├── columns: f:3 r:7
  ├── cardinality: [0 - 5]
  ├── immutable
+ ├── fd: (3)-->(7)
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2 f:3
@@ -375,6 +376,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET
 project
  ├── columns: f:3 r:7
  ├── immutable
+ ├── fd: (3)-->(7)
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2 f:3
@@ -434,6 +436,7 @@ project
  ├── columns: f:3 r:7
  ├── cardinality: [0 - 10]
  ├── immutable
+ ├── fd: (3)-->(7)
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2 f:3

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -308,6 +308,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, k FROM a GROUP BY f, k HAVING sum(k)=100) a
 project
  ├── columns: f:3 r:7
  ├── immutable
+ ├── fd: (3)-->(7)
  ├── select
  │    ├── columns: k:1!null f:3 sum:6!null
  │    ├── immutable
@@ -436,6 +437,7 @@ project
  ├── columns: f:3 r:6
  ├── cardinality: [0 - 5]
  ├── immutable
+ ├── fd: (3)-->(6)
  ├── limit
  │    ├── columns: f:3 s:4
  │    ├── cardinality: [0 - 5]
@@ -678,6 +680,7 @@ project
  ├── columns: f:3 r:6
  ├── cardinality: [0 - 5]
  ├── immutable
+ ├── fd: (3)-->(6)
  ├── offset
  │    ├── columns: f:3 s:4
  │    ├── cardinality: [0 - 5]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -548,6 +548,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i HAVING sum(f)=10.0) 
 project
  ├── columns: f:3 r:8
  ├── immutable
+ ├── fd: (3)-->(8)
  ├── select
  │    ├── columns: i:2 f:3 sum:7!null
  │    ├── key: (2,3)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1893,8 +1893,9 @@ except
       └── filters
            └── (1 / 0) > 0 [immutable]
 
-norm
-SELECT * FROM ((values (1.0::decimal)) EXCEPT (values (1.00::decimal))) WHERE column1::string != '1.00';
+# The filter is composite-sensitive.
+norm expect-not=PushFilterIntoSetOp
+SELECT * FROM ((VALUES (1.0::DECIMAL)) EXCEPT (VALUES (1.00::DECIMAL))) WHERE column1::STRING != '1.00';
 ----
 select
  ├── columns: column1:1!null
@@ -1921,3 +1922,26 @@ select
  │         └── (1.00,)
  └── filters
       └── column1:1::STRING != '1.00' [outer=(1), immutable]
+
+# The filter is not composite-sensitive (even if it involves decimals) and can be pushed down.
+norm expect=PushFilterIntoSetOp
+SELECT * FROM ((VALUES (1.0::DECIMAL)) EXCEPT (VALUES (1.00::DECIMAL))) WHERE column1 > 0;
+----
+except
+ ├── columns: column1:1!null
+ ├── left columns: column1:1!null
+ ├── right columns: column1:2
+ ├── cardinality: [0 - 1]
+ ├── key: (1)
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (1.0,)
+ └── values
+      ├── columns: column1:2!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(2)
+      └── (1.00,)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -55,6 +55,7 @@ sort
       ├── project
       │    ├── columns: column20:20!null column22:22!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null
       │    ├── immutable
+      │    ├── fd: (6,7)-->(20)
       │    ├── select
       │    │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_tax:8!null l_returnflag:9!null l_linestatus:10!null l_shipdate:11!null
       │    │    ├── scan lineitem

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -47,10 +47,12 @@ group-by
  ├── sort
  │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null column20:20!null column22:22!null
  │    ├── immutable
+ │    ├── fd: (6,7)-->(20)
  │    ├── ordering: +9,+10
  │    └── project
  │         ├── columns: column20:20!null column22:22!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null
  │         ├── immutable
+ │         ├── fd: (6,7)-->(20)
  │         ├── select
  │         │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_tax:8!null l_returnflag:9!null l_linestatus:10!null l_shipdate:11!null
  │         │    ├── scan lineitem

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -173,13 +173,13 @@ sort (segmented)
  ├── columns: x:1!null computed:6!null y:2!null
  ├── immutable
  ├── key: (1,2)
- ├── fd: (1,2)-->(6)
+ ├── fd: (2)-->(6)
  ├── ordering: +1,+6
  └── project
       ├── columns: computed:6!null x:1!null y:2!null
       ├── immutable
       ├── key: (1,2)
-      ├── fd: (1,2)-->(6)
+      ├── fd: (2)-->(6)
       ├── ordering: +1
       ├── scan a
       │    ├── columns: x:1!null y:2!null


### PR DESCRIPTION
#### opt: improve composite check for PushFilterIntoSetOp

Use `CanBeCompositeSensitive` instead of disallowing any filters
involving composite columns.

Release note: None

#### opt: improve composite check for Project FDs

Release note: None

#### opt: improve composite check for join filter remapping

Use CanBeCompositeSensitive to allow remapping insensitive join
filters.

Release note: None
