### PR TITLE
release-20.2: sql: save the ID for all the temp schemas created by a session

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -624,10 +624,9 @@ func (p *planner) HasOwnershipOnSchema(ctx context.Context, schemaID descpb.ID) 
 	case catalog.SchemaVirtual:
 		// Cannot drop on virtual schemas.
 	case catalog.SchemaTemporary:
-		// The user only owns the temporary schema that corresponds to the
-		// TemporarySchemaID in the sessionData.
+		// The user owns all the temporary schemas that they created in the session.
 		hasOwnership = p.SessionData() != nil &&
-			p.SessionData().TemporarySchemaID == uint32(resolvedSchema.ID)
+			p.SessionData().IsTemporarySchemaID(uint32(resolvedSchema.ID))
 	case catalog.SchemaUserDefined:
 		hasOwnership, err = p.HasOwnership(ctx, resolvedSchema.Desc)
 		if err != nil {

--- a/pkg/sql/catalog/accessors/logical_schema_accessors.go
+++ b/pkg/sql/catalog/accessors/logical_schema_accessors.go
@@ -128,7 +128,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 			if flags.RequireMutable {
 				return nil, errors.Newf("cannot use mutable descriptor of aliased type %s.%s", schema, object)
 			}
-			return typedesc.MakeSimpleAlias(alias), nil
+			return typedesc.MakeSimpleAlias(alias, keys.PublicSchemaID), nil
 		}
 	}
 

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -40,14 +40,18 @@ var _ catalog.MutableDescriptor = (*Mutable)(nil)
 // MakeSimpleAlias creates a type descriptor that is an alias for the input
 // type. It is intended to be used as an intermediate for name resolution, and
 // should not be serialized and stored on disk.
-func MakeSimpleAlias(typ *types.T) *Immutable {
+func MakeSimpleAlias(typ *types.T, parentSchemaID descpb.ID) *Immutable {
 	return NewImmutable(descpb.TypeDescriptor{
+		// TODO(#sql-features): this should be attached to the current database.
+		// We don't have a way of doing this yet (and virtual tables use some
+		// fake magic).
 		ParentID:       descpb.InvalidID,
-		ParentSchemaID: descpb.InvalidID,
+		ParentSchemaID: parentSchemaID,
 		Name:           typ.Name(),
-		ID:             descpb.InvalidID,
-		Kind:           descpb.TypeDescriptor_ALIAS,
-		Alias:          typ,
+		// TODO(#sql-features): give this a hardcoded alias.
+		ID:    descpb.InvalidID,
+		Kind:  descpb.TypeDescriptor_ALIAS,
+		Alias: typ,
 	})
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2071,8 +2071,11 @@ func (m *sessionDataMutator) SetTemporarySchemaName(scName string) {
 	m.data.SearchPath = m.data.SearchPath.WithTemporarySchemaName(scName)
 }
 
-func (m *sessionDataMutator) SetTemporarySchemaID(id uint32) {
-	m.data.TemporarySchemaID = id
+func (m *sessionDataMutator) SetTemporarySchemaIDForDatabase(dbID uint32, tempSchemaID uint32) {
+	if m.data.DatabaseIDToTempSchemaID == nil {
+		m.data.DatabaseIDToTempSchemaID = make(map[uint32]uint32)
+	}
+	m.data.DatabaseIDToTempSchemaID[dbID] = tempSchemaID
 }
 
 func (m *sessionDataMutator) SetDefaultIntSize(size int) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -337,6 +337,9 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.SearchPath != nil {
 		sd.SearchPath = *o.SearchPath
 	}
+	if o.DatabaseIDToTempSchemaID != nil {
+		sd.DatabaseIDToTempSchemaID = o.DatabaseIDToTempSchemaID
+	}
 }
 
 func (ie *InternalExecutor) maybeRootSessionDataOverride(

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -263,3 +263,25 @@ ALTER TABLE persistent_48233 RENAME TO pg_temp.pers_48233
 query T
 SELECT schema_name FROM information_schema.schemata WHERE crdb_is_user_defined = 'YES'
 ----
+
+subtest test_53163
+statement ok
+CREATE DATABASE second_db
+
+statement ok
+USE second_db
+
+statement ok
+CREATE TEMP TABLE a(a INT)
+
+statement ok
+USE test
+
+statement ok
+CREATE TEMP VIEW a_view AS SELECT a FROM second_db.pg_temp.a
+
+statement ok
+grant testuser to root
+
+statement ok
+ALTER TABLE second_db.pg_temp.a OWNER TO testuser

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -23,6 +23,9 @@ type InternalExecutorOverride struct {
 	ApplicationName string
 	// SearchPath represents the namespaces to search in.
 	SearchPath *SearchPath
+	// DatabaseIDToTempSchemaID represents the mapping for temp schemas used which
+	// allows temporary schema resolution by ID.
+	DatabaseIDToTempSchemaID map[uint32]uint32
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -63,10 +63,10 @@ type SessionData struct {
 	SerialNormalizationMode SerialNormalizationMode
 	// SearchPath is a list of namespaces to search builtins in.
 	SearchPath SearchPath
-	// TemporarySchemaID is the ID of the current session's temporary schema,
-	// if it exists. It is a descpb.ID, but cannot be stored as one due to
-	// packaging dependencies.
-	TemporarySchemaID uint32
+	// DatabaseIDToTempSchemaID stores the temp schema ID for every database that
+	// has created a temporary schema. The mapping is from descpb.ID -> desscpb.ID,
+	// but cannot be stored as such due to package dependencies.
+	DatabaseIDToTempSchemaID map[uint32]uint32
 	// StmtTimeout is the duration a query is permitted to run before it is
 	// canceled by the session. If set to 0, there is no timeout.
 	StmtTimeout time.Duration
@@ -152,6 +152,25 @@ type SessionData struct {
 	SynchronousCommit bool
 	// EnableSeqScan is a dummy setting for the enable_seqscan var.
 	EnableSeqScan bool
+}
+
+// IsTemporarySchemaID returns true if the given ID refers to any of the temp
+// schemas created by the session.
+func (s *SessionData) IsTemporarySchemaID(ID uint32) bool {
+	for _, tempSchemaID := range s.DatabaseIDToTempSchemaID {
+		if tempSchemaID == ID {
+			return true
+		}
+	}
+	return false
+}
+
+// GetTemporarySchemaIDForDb returns the schemaID for the temporary schema if
+// one exists for the DB. The second return value communicates the existence of
+// the temp schema for that DB.
+func (s *SessionData) GetTemporarySchemaIDForDb(dbID uint32) (uint32, bool) {
+	schemaID, found := s.DatabaseIDToTempSchemaID[dbID]
+	return schemaID, found
 }
 
 // DataConversionConfig contains the parameters that influence

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -362,7 +362,7 @@ func (v virtualSchemaEntry) GetObjectByName(
 		}
 
 		return virtualTypeEntry{
-			desc:    typedesc.MakeSimpleAlias(typ),
+			desc:    typedesc.MakeSimpleAlias(typ, catconstants.PgCatalogID),
 			mutable: flags.RequireMutable,
 		}, nil
 	default:


### PR DESCRIPTION
Backport 1/1 commits from #54636.

/cc @cockroachdb/release

---

Previously, we would only save the temporary schema ID for the most
recently created temporary schema. This meant that `ResolveSchemaByID`
couldn't identify any other temporary schemas. This caused descirptor
not found errors when referencing schema's across database lines.

This patch adds a map from database ID to temp schema ID for all temp
schemas which replaces the solitary temp schema ID tracking on
sessiondata.

Fixes #53163

Release note (bug fix): cross database temp schemas can now be
resolved properly
