### PR TITLE
util/mon: log monitor stops with max usage of at least 100KB

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -391,10 +391,12 @@ func (mm *BytesMonitor) Stop(ctx context.Context) {
 	mm.doStop(ctx, true)
 }
 
+const bytesMaxUsageLoggingThreshold = 100 * 1024
+
 func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	// NB: No need to lock mm.mu here, when StopMonitor() is called the
 	// monitor is not shared any more.
-	if log.V(1) {
+	if log.V(1) && mm.mu.maxAllocated >= bytesMaxUsageLoggingThreshold {
 		log.InfofDepth(ctx, 1, "%s, bytes usage max %s",
 			mm.name,
 			humanizeutil.IBytes(mm.mu.maxAllocated))


### PR DESCRIPTION
If we enable verbose logging as `vmodule=bytes_usage=1`, all monitors
upon their stop will print the maximum usage (apart from a few other log
messages during their operation). However, most of the closing messages
will come from internal monitors that used very little memory (usually
up to 40KB) that just spam the logs. Assuming that one turns the verbose
logging when there is a big memory user, that spam can be annoying to
see, so this commit hides all logs of less than 100KB in max usage.

That number is hard-coded, and I find that acceptable. An alternative
could be introducing an environment variable to control it, but I think
it's not worth it.

Not sure whether this deserves a release note or not.

Release note: None