### PR TITLE
opt: clean up optbuilder column ordinals assumption

### DIFF
--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -322,8 +322,9 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	on := make(memo.FiltersExpr, numFKCols)
 	for i := range on {
 		tabOrd := fk.OriginColumnOrdinal(childTable, i)
+		col := outScope.getColumnForTableOrdinal(tabOrd)
 		on[i] = b.factory.ConstructFiltersItem(b.factory.ConstructEq(
-			b.factory.ConstructVariable(outScope.cols[tabOrd].id),
+			b.factory.ConstructVariable(col.id),
 			b.factory.ConstructVariable(outCols[i]),
 		))
 	}
@@ -629,8 +630,9 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	on := make(memo.FiltersExpr, numFKCols)
 	for i := range on {
 		tabOrd := fk.OriginColumnOrdinal(childTable, i)
+		col := outScope.getColumnForTableOrdinal(tabOrd)
 		on[i] = f.ConstructFiltersItem(f.ConstructEq(
-			f.ConstructVariable(outScope.cols[tabOrd].id),
+			f.ConstructVariable(col.id),
 			f.ConstructVariable(outColsOld[i]),
 		))
 	}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -315,12 +315,10 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		// key columns.
 		primaryIndex := mb.tab.Index(cat.PrimaryIndex)
 		for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
-			pkCol := mb.outScope.cols[primaryIndex.Column(i).Ordinal()]
-
 			// If the primary key column is hidden, then we don't need to use it
 			// for the distinct on.
-			if !pkCol.hidden {
-				pkCols.Add(pkCol.id)
+			if col := primaryIndex.Column(i); !col.IsHidden() {
+				pkCols.Add(mb.fetchColIDs[col.Ordinal()])
 			}
 		}
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -316,6 +316,17 @@ func (s *scope) getColumn(col opt.ColumnID) *scopeColumn {
 	return nil
 }
 
+// getColumnForTableOrdinal returns the column with a specific tableOrdinal
+// value, or nil if it doesn't exist.
+func (s *scope) getColumnForTableOrdinal(tabOrd int) *scopeColumn {
+	for i := range s.cols {
+		if s.cols[i].tableOrdinal == tabOrd {
+			return &s.cols[i]
+		}
+	}
+	return nil
+}
+
 func (s *scope) makeColumnTypes() []*types.T {
 	res := make([]*types.T, len(s.cols))
 	for i := range res {


### PR DESCRIPTION
I stumbled upon some optbuilder code that still assumes a 1-to-1
mapping between ordinary columns and scan scope columns. This change
updates that code to support the generalized catalog interface. Note
that the bug is inconsequential with the current catalog
implementations.

Release note: None