### PR TITLE
roachtest: remove --tolerate-errors from schema change

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -47,22 +47,21 @@ func uploadAndInitSchemaChangeWorkload() versionStep {
 	}
 }
 
-func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep {
+func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int, v string) versionStep {
 	var numFeatureRuns int
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		numFeatureRuns++
 		t.l.Printf("Workload step run: %d", numFeatureRuns)
+
 		runCmd := []string{
 			"./workload run schemachange --verbose=1",
-			// The workload is still in development and occasionally discovers schema
-			// change errors so for now we don't fail on them but only on panics, server
-			// crashes, deadlocks, etc.
-			// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
-			// is closed.
-			"--tolerate-errors=true",
 			fmt.Sprintf("--max-ops %d", maxOps),
 			fmt.Sprintf("--concurrency %d", concurrency),
 			fmt.Sprintf("{pgurl:1-%d}", u.c.spec.NodeCount),
+		}
+		// Prior to v20.2, schemachange workloads can run into uncategorized errors.
+		if !version.MustParse("v" + v).AtLeast(version.MustParse("v20.2.0")) {
+			runCmd = append(runCmd, "--tolerate-errors=true")
 		}
 		u.c.Run(ctx, u.c.Node(loadNode), runCmd...)
 	}
@@ -84,7 +83,12 @@ func runSchemaChangeMixedVersions(
 	// An empty string will lead to the cockroach binary specified by flag
 	// `cockroach` to be used.
 	const mainVersion = ""
-	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().randNode()[0], maxOps, concurrency)
+	schemaChangeStep := runSchemaChangeWorkloadStep(
+		c.All().randNode()[0],
+		maxOps,
+		concurrency,
+		predecessorVersion,
+	)
 	if buildVersion.Major() < 20 {
 		// Schema change workload is meant to run only on versions 19.2 or higher.
 		// If the main version is below 20.1 then then predecessor version will be

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -87,12 +87,6 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps,
 
 	runCmd := []string{
 		"./workload run schemachange --verbose=1",
-		// The workload is still in development and occasionally discovers schema
-		// change errors so for now we don't fail on them but only on panics, server
-		// crashes, deadlocks, etc.
-		// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
-		// is closed.
-		"--tolerate-errors=true",
 		// Save the histograms so that they can be reported to https://roachperf.crdb.dev/.
 		" --histograms=" + perfArtifactsDir + "/stats.json",
 		fmt.Sprintf("--max-ops %d", maxOps),

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -104,7 +104,12 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, buildVersion ve
 	}
 
 	testFeaturesStep := versionUpgradeTestFeatures.step(c.All())
-	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().randNode()[0], 10 /* maxOps */, 2 /* concurrency */)
+	schemaChangeStep := runSchemaChangeWorkloadStep(
+		c.All().randNode()[0],
+		10, /* maxOps */
+		2,  /* concurrency */
+		predecessorVersion,
+	)
 	backupStep := func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		// This check was introduced for the system.tenants table and the associated
 		// changes to full-cluster backup to include tenants. It mostly wants to


### PR DESCRIPTION
I was able to run this for ~1 hour successfully locally.

Resolves #47430 (not sure if I'm missing something here)

Release note: None