### PR TITLE
util: introduce ConstantWithTestValue; use in sql

### DIFF
--- a/build/teamcity-test-constants.sh
+++ b/build/teamcity-test-constants.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This test configuration runs all unit tests with the metamorphic build
+# tag enabled, which varies some constants in the code to try to tickle edge
+# conditions.
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+export TMPDIR=$PWD/artifacts/test
+mkdir -p "$TMPDIR"
+
+tc_start_block "Compile C dependencies"
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artifacts/c-build.log && false)
+rm artifacts/c-build.log
+tc_end_block "Compile C dependencies"
+
+tc_start_block "Run Go tests with metamorphic build tag"
+run_json_test build/builder.sh stdbuf -oL -eL make test GOTESTFLAGS=-json TESTFLAGS='-v' TAGS=metamorphic
+tc_end_block "Run Go tests with metamorphic build tag"

--- a/pkg/sql/mutations/mutations_util.go
+++ b/pkg/sql/mutations/mutations_util.go
@@ -14,11 +14,16 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 var maxBatchSize int64 = defaultMaxBatchSize
 
-const defaultMaxBatchSize = 10000
+var defaultMaxBatchSize = int64(util.ConstantWithMetamorphicTestRange(
+	10000, /* defaultValue */
+	1,     /* min */
+	10000, /* max */
+))
 
 // MaxBatchSize returns the max number of entries in the KV batch for a
 // mutation operation (delete, insert, update, upsert) - including secondary

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -29,7 +29,10 @@ import (
 // On a single node, 1000 was enough to avoid any performance degradation. On
 // multi-node clusters, we want bigger chunks to make up for the higher latency.
 // TODO(radu): parameters like this should be configurable
-var kvBatchSize int64 = 10000
+var kvBatchSize int64 = int64(util.ConstantWithMetamorphicTestValue(
+	10000, /* defaultValue */
+	1,     /* metamorphicValue */
+))
 
 // TestingSetKVBatchSize changes the kvBatchFetcher batch size, and returns a function that restores it.
 // This is to be used only in tests - we have no test coverage for arbitrary kv batch sizes at this time.

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -223,7 +224,10 @@ type DatumRowConverter struct {
 	FractionFn     func() float32
 }
 
-var kvDatumRowConverterBatchSize = 5000
+var kvDatumRowConverterBatchSize = util.ConstantWithMetamorphicTestValue(
+	5000, /* defaultValue */
+	1,    /* metamorphicValue */
+)
 
 // TestingSetDatumRowConverterBatchSize sets kvDatumRowConverterBatchSize and returns function to
 // reset this setting back to its old value.

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -100,6 +100,11 @@ func NewRowContainerWithCapacity(
 	return c
 }
 
+var rowsPerChunkShift = uint(util.ConstantWithMetamorphicTestValue(
+	6, /* defaultValue */
+	1, /* metamorphicValue */
+))
+
 // Init can be used instead of NewRowContainer if we have a RowContainer that is
 // already part of an on-heap structure.
 func (c *RowContainer) Init(acc mon.BoundAccount, ti colinfo.ColTypeInfo, rowCapacity int) {
@@ -117,7 +122,7 @@ func (c *RowContainer) Init(acc mon.BoundAccount, ti colinfo.ColTypeInfo, rowCap
 		c.rowsPerChunkShift = 64 - uint(bits.LeadingZeros64(uint64(rowCapacity-1)))
 	} else if nCols != 0 {
 		// If the rows have columns, we use 64 rows per chunk.
-		c.rowsPerChunkShift = 6
+		c.rowsPerChunkShift = rowsPerChunkShift
 	} else {
 		// If there are no columns, every row gets mapped to the first chunk,
 		// which ends up being a zero-length slice because each row contains no

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -41,7 +41,10 @@ import (
 // higher scan throughput of larger batches and the cost of spilling the
 // scanned rows to disk. The spilling cost will probably be dominated by
 // the de-duping cost, since it incurs a read.
-const invertedJoinerBatchSize = 100
+var invertedJoinerBatchSize = util.ConstantWithMetamorphicTestValue(
+	100, /* defaultValue */
+	1,   /* metamorphicValue */
+)
 
 // invertedJoinerState represents the state of the processor.
 type invertedJoinerState int

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -258,7 +258,10 @@ type zigzagJoiner struct {
 // at a time. Increasing this will improve performance for when matched rows
 // are grouped together, but increasing this too much will result in fetching
 // too many rows and therefore skipping less rows.
-const zigzagJoinerBatchSize = 5
+var zigzagJoinerBatchSize = int64(util.ConstantWithMetamorphicTestValue(
+	5, /* defaultValue */
+	1, /* metamorphicValue */
+))
 
 var _ execinfra.Processor = &zigzagJoiner{}
 var _ execinfra.RowSource = &zigzagJoiner{}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// ConstantWithMetamorphicTestValue should be used to initialize "magic constants" that
+// should be varied during test scenarios to check for bugs at boundary
+// conditions. When built with the test_constants build tag, the test value
+// will be used. In all other cases, the production value will be used.
+// The constant must be a "metamorphic variable": changing it cannot affect the
+// output of any SQL DMLs. It can only affect the way in which the data is
+// retrieved or processed, because otherwise the main test corpus would fail if
+// this flag were enabled.
+//
+// An example of a "magic constant" that behaves this way is a batch size. Batch
+// sizes tend to present testing problems, because often the logic that deals
+// with what to do when a batch is finished is less likely to be exercised by
+// simple unit tests that don't use enough data to fill up a batch.
+//
+// For example, instead of writing:
+//
+// const batchSize = 64
+//
+// you should write:
+//
+// var batchSize = util.ConstantWithMetamorphicTestValue(64, 1)
+//
+// This will give your code a batch size of 1 in the test_constants build
+// configuration, increasing the amount of exercise the edge conditions get.
+func ConstantWithMetamorphicTestValue(defaultValue, metamorphicValue int) int {
+	if metamorphicBuild {
+		logMetamorphicValue(metamorphicValue)
+		return metamorphicValue
+	}
+	return defaultValue
+}
+
+// rng is initialized to a rand.Rand if metamorphicBuild is enabled.
+var rng *rand.Rand
+
+func init() {
+	if metamorphicBuild {
+		rng, _ = randutil.NewPseudoRand()
+	}
+}
+
+// ConstantWithMetamorphicTestRange is like ConstantWithMetamorphicTestValue
+// except instead of returning a single metamorphic test value, it returns a
+// random test value in a range.
+func ConstantWithMetamorphicTestRange(defaultValue, min, max int) int {
+	if metamorphicBuild {
+		ret := int(rng.Int31())%(max-min) + min
+		logMetamorphicValue(ret)
+		return ret
+	}
+	return defaultValue
+}
+
+func logMetamorphicValue(value int) {
+	fmt.Fprintf(os.Stderr, "initialized metamorphic constant with value %d: %s",
+		value, GetSmallTrace(1))
+}

--- a/pkg/util/metamorphic_off.go
+++ b/pkg/util/metamorphic_off.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// -build metamorphic
+
+package util
+
+// metamorphicBuild is a flag that is set to true if the binary was compiled with
+// the test_constants build tag. This flag can be used to enable expensive
+// checks, test randomizations, or other metamorphic-style perturbations that
+// will not affect test results but will exercise different parts of the code.
+const metamorphicBuild = false

--- a/pkg/util/metamorphic_on.go
+++ b/pkg/util/metamorphic_on.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build metamorphic
+
+package util
+
+// metamorphicBuild is a flag that is set to true if the binary was compiled with
+// the test_constants build tag. This flag can be used to enable expensive
+// checks, test randomizations, or other metamorphic-style perturbations that
+// will not affect test results but will exercise different parts of the code.
+const metamorphicBuild = true

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -20,8 +20,7 @@ import (
 func TestDepAllowlist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// We want workload to be lightweight. If you need to add a package to this
-	// set of deps, run it by danhhz first.
+	// We want workload to be lightweight.
 	buildutil.VerifyTransitiveAllowlist(t, "github.com/cockroachdb/cockroach/pkg/workload",
 		[]string{
 			`github.com/cockroachdb/cockroach/pkg/build`,
@@ -32,6 +31,7 @@ func TestDepAllowlist(t *testing.T) {
 			`github.com/cockroachdb/cockroach/pkg/sql/lex`,
 			`github.com/cockroachdb/cockroach/pkg/sql/oidext`,
 			`github.com/cockroachdb/cockroach/pkg/sql/types`,
+			`github.com/cockroachdb/cockroach/pkg/util`,
 			`github.com/cockroachdb/cockroach/pkg/util/arith`,
 			`github.com/cockroachdb/cockroach/pkg/util/bufalloc`,
 			`github.com/cockroachdb/cockroach/pkg/util/duration`,


### PR DESCRIPTION
This commit adds a new function called ConstantWithTestValue that is
designed to be used to initialize "magic constants", like batch sizes,
that cause edge conditions in the code.

ConstantWithTestValue should be used to initialize "magic constants" that
should be varied during test scenarios to check for bugs at boundary
conditions. When built with the test_constants build tag, the test value
will be used. In all other cases, the production value will be used.

An example of a "magic constant" that behaves this way is a batch size. Batch
sizes tend to present testing problems, because often the logic that deals
with what to do when a batch is finished is less likely to be exercised by
simple unit tests that don't use enough data to fill up a batch.

For example, instead of writing:

```
const batchSize = 64
```

you should write:

```
var batchSize = util.ConstantWithTestValue(64, 1)
```

This will give your code a batch size of 1 in the test_constants build
configuration, increasing the amount of exercise the edge conditions get.

This commit also adds several uses of `ConstantWithTestValue` in the SQL
package. One of them in particular (the datum row container chunk size)
was tailored to catch #55140.

Release note: None