### PR TITLE
sql: disallow txn stats collection if stat collection threshold is set

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -70,7 +70,7 @@
 <tr><td><code>sql.metrics.statement_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-statement query statistics</td></tr>
 <tr><td><code>sql.metrics.statement_details.plan_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>periodically save a logical plan for each fingerprint</td></tr>
 <tr><td><code>sql.metrics.statement_details.plan_collection.period</code></td><td>duration</td><td><code>5m0s</code></td><td>the time until a new logical plan is collected</td></tr>
-<tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
+<tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.</td></tr>
 <tr><td><code>sql.metrics.transaction_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-application transaction statistics</td></tr>
 <tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
 <tr><td><code>sql.spatial.experimental_box2d_comparison_operators.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enables the use of certain experimental box2d comparison operators</td></tr>

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -124,7 +124,8 @@ var txnStatsEnable = settings.RegisterPublicBoolSetting(
 // consumed by a SQL statement before it is collected for statistics reporting.
 var sqlStatsCollectionLatencyThreshold = settings.RegisterPublicDurationSetting(
 	"sql.metrics.statement_details.threshold",
-	"minimum execution time to cause statistics to be collected",
+	"minimum execution time to cause statement statistics to be collected. "+
+		"If configured, no transaction stats are collected.",
 	0,
 )
 
@@ -400,10 +401,11 @@ func (a *appStats) recordTransaction(
 	if !txnStatsEnable.Get(&a.st.SV) {
 		return
 	}
-	// Only collect stats if the transaction service time is above the configured
-	// stats collection latency threshold.
+	// Do not collect transaction statistics if the stats collection latency
+	// threshold is set, since our transaction UI relies on having stats for every
+	// statement in the transaction.
 	t := sqlStatsCollectionLatencyThreshold.Get(&a.st.SV)
-	if t > 0 && t.Seconds() >= serviceLat.Seconds() {
+	if t > 0 {
 		return
 	}
 


### PR DESCRIPTION
Previously, when a transaction was comprised of statements that
overshot the configured `sql.metrics.statement_details.threshold`, we
would record the statementID for the txn even though there was no
record of the statementID in the statement stats. This could prove
confusing. This patch blanket disallows txn stats collection if the
cluster setting is configured.

Closes #54697

Release note (admin ui change): Transaction statistics are no longer
recorded if the `sql.metrics.statement_details.threshold` cluster
setting has been enabled.