### PR TITLE
partialidx: fix cache clearing in benchmark

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -147,6 +147,11 @@ func (im *Implicator) Init(f *norm.Factory, md *opt.Metadata, evalCtx *tree.Eval
 	im.evalCtx = evalCtx
 }
 
+// ClearCache empties the Implicator's constraint cache.
+func (im *Implicator) ClearCache() {
+	im.constraintCache = nil
+}
+
 // FiltersImplyPredicate attempts to prove that a partial index predicate is
 // implied by the given filters. If implication is proven, the function returns
 // the remaining filters (which when applied on top of a partial index scan,

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -279,13 +279,14 @@ func BenchmarkImplicator(b *testing.B) {
 		}
 
 		im := partialidx.Implicator{}
+		im.Init(&f, md, &evalCtx)
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				// Reset the implicator every 10 iterations to simulate its
 				// cache being used multiple times during repetitive calls to
 				// FiltersImplyPredicate during xform rules.
 				if i%10 == 0 {
-					im.Init(&f, md, &evalCtx)
+					im.ClearCache()
 				}
 				_, _ = im.FiltersImplyPredicate(filters, pred)
 			}


### PR DESCRIPTION
The TestImplicator benchmark is supposed to clear the Implicator
constraint cache every ten iterations. This is meant to simulate
real-world use where implication would be attempted several times with
similar filter and predicate expressions during the exploration phase of
a single query. This commit fixes the benchmark to actually clear the
cache.

Release note: None