### PR TITLE
opt: add "virtual computed" columns to the catalog

### DIFF
--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -98,7 +98,7 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 	}
 	for ord, ok := cols.Next(0); ok; ord, ok = cols.Next(ord + 1) {
 		col := table.Column(ord)
-		if col.Kind() == cat.Virtual {
+		if col.Kind() == cat.VirtualInverted {
 			col = table.Column(col.InvertedSourceColumnOrdinal())
 		}
 		colCfg.wantedColumns = append(colCfg.wantedColumns, tree.ColumnID(col.ColID()))

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -31,8 +31,8 @@ type Column struct {
 	datumType                   *types.T
 	nullable                    bool
 	hidden                      bool
-	defaultExpr                 *string
-	computedExpr                *string
+	defaultExpr                 string
+	computedExpr                string
 	invertedSourceColumnOrdinal int
 }
 
@@ -98,7 +98,7 @@ func (c *Column) IsHidden() bool {
 // HasDefault returns true if the column has a default value. DefaultExprStr
 // will be set to the SQL expression string in that case.
 func (c *Column) HasDefault() bool {
-	return c.defaultExpr != nil
+	return c.defaultExpr != ""
 }
 
 // DefaultExprStr is set to the SQL expression string that describes the
@@ -106,13 +106,13 @@ func (c *Column) HasDefault() bool {
 // the column when inserting a row. Default values cannot depend on other
 // columns.
 func (c *Column) DefaultExprStr() string {
-	return *c.defaultExpr
+	return c.defaultExpr
 }
 
 // IsComputed returns true if the column is a computed value. ComputedExprStr
 // will be set to the SQL expression string in that case.
 func (c *Column) IsComputed() bool {
-	return c.computedExpr != nil
+	return c.computedExpr != ""
 }
 
 // ComputedExprStr is set to the SQL expression string that describes the
@@ -121,7 +121,7 @@ func (c *Column) IsComputed() bool {
 // columns, but they can depend on all other columns, including columns with
 // default values.
 func (c *Column) ComputedExprStr() string {
-	return *c.computedExpr
+	return c.computedExpr
 }
 
 // InvertedSourceColumnOrdinal is used for virtual columns that are part
@@ -186,8 +186,16 @@ func (c *Column) InitNonVirtual(
 	c.datumType = datumType
 	c.nullable = nullable
 	c.hidden = hidden
-	c.defaultExpr = defaultExpr
-	c.computedExpr = computedExpr
+	if defaultExpr != nil {
+		c.defaultExpr = *defaultExpr
+	} else {
+		c.defaultExpr = ""
+	}
+	if computedExpr != nil {
+		c.computedExpr = *computedExpr
+	} else {
+		c.computedExpr = ""
+	}
 	c.invertedSourceColumnOrdinal = -1
 }
 
@@ -203,7 +211,7 @@ func (c *Column) InitVirtual(
 	c.datumType = datumType
 	c.nullable = nullable
 	c.hidden = true
-	c.defaultExpr = nil
-	c.computedExpr = nil
+	c.defaultExpr = ""
+	c.computedExpr = ""
 	c.invertedSourceColumnOrdinal = invertedSourceColumnOrdinal
 }

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -307,8 +307,10 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 		fmt.Fprintf(buf, " [mutation]")
 	case System:
 		fmt.Fprintf(buf, " [system]")
-	case Virtual:
-		fmt.Fprintf(buf, " [virtual]")
+	case VirtualInverted:
+		fmt.Fprintf(buf, " [virtual-inverted]")
+	case VirtualComputed:
+		fmt.Fprintf(buf, " [virtual-computed]")
 	}
 }
 

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -196,7 +196,7 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 			if (kind == cat.Ordinary || kind == cat.WriteOnly) && t.InsertCols[i] == 0 {
 				panic(errors.AssertionFailedf("insert values not provided for all table columns"))
 			}
-			if (kind == cat.System || kind == cat.Virtual) && t.InsertCols[i] != 0 {
+			if (kind == cat.System || kind.IsVirtual()) && t.InsertCols[i] != 0 {
 				panic(errors.AssertionFailedf("system or virtual column found in insertion columns"))
 			}
 		}

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -285,9 +285,10 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations: false,
-			includeSystem:    false,
-			includeVirtual:   false,
+			includeMutations:       false,
+			includeSystem:          false,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -530,9 +531,10 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations: false,
-			includeSystem:    false,
-			includeVirtual:   false,
+			includeMutations:       false,
+			includeSystem:          false,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -373,7 +373,7 @@ func (mb *mutationBuilder) needExistingRows() bool {
 			// #1: Don't consider key columns.
 			continue
 		}
-		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind == cat.Virtual {
+		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind.IsVirtual() {
 			// #2: Don't consider system or virtual columns.
 			continue
 		}
@@ -701,9 +701,10 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		fetchScope := mb.b.buildScan(
 			mb.b.addTable(mb.tab, &mb.alias),
 			tableOrdinals(mb.tab, columnKinds{
-				includeMutations: false,
-				includeSystem:    false,
-				includeVirtual:   false,
+				includeMutations:       false,
+				includeSystem:          false,
+				includeVirtualInverted: false,
+				includeVirtualComputed: false,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,
@@ -903,9 +904,10 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	fetchScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations: true,
-			includeSystem:    true,
-			includeVirtual:   false,
+			includeMutations:       true,
+			includeSystem:          true,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -1248,9 +1250,10 @@ func (mb *mutationBuilder) arbiterIndexes(
 		if tableScope == nil {
 			tableScope = mb.b.buildScan(
 				tabMeta, tableOrdinals(tabMeta.Table, columnKinds{
-					includeMutations: false,
-					includeSystem:    false,
-					includeVirtual:   false,
+					includeMutations:       false,
+					includeSystem:          false,
+					includeVirtualInverted: false,
+					includeVirtualComputed: false,
 				}),
 				nil, /* indexFlags */
 				noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -254,9 +254,10 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	scanScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations: true,
-			includeSystem:    true,
-			includeVirtual:   false,
+			includeMutations:       true,
+			includeSystem:          true,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		}),
 		indexFlags,
 		noRowLocking,
@@ -366,9 +367,10 @@ func (mb *mutationBuilder) buildInputForDelete(
 	scanScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations: true,
-			includeSystem:    true,
-			includeVirtual:   false,
+			includeMutations:       true,
+			includeSystem:          true,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		}),
 		indexFlags,
 		noRowLocking,
@@ -565,7 +567,7 @@ func (mb *mutationBuilder) addSynthesizedCols(colIDs opt.ColList, addCol func(co
 			continue
 		}
 		// Skip system and virtual columns.
-		if kind == cat.System || kind == cat.Virtual {
+		if kind == cat.System || kind.IsVirtual() {
 			continue
 		}
 		// Skip columns that are already specified.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -114,9 +114,10 @@ func (b *Builder) buildDataSource(
 			return b.buildScan(
 				tabMeta,
 				tableOrdinals(t, columnKinds{
-					includeMutations: false,
-					includeSystem:    true,
-					includeVirtual:   false,
+					includeMutations:       false,
+					includeSystem:          true,
+					includeVirtualInverted: false,
+					includeVirtualComputed: false,
 				}),
 				indexFlags, locking, inScope,
 			)
@@ -397,9 +398,10 @@ func (b *Builder) buildScanFromTableRef(
 		ordinals = resolveNumericColumnRefs(tab, ref.Columns)
 	} else {
 		ordinals = tableOrdinals(tab, columnKinds{
-			includeMutations: false,
-			includeSystem:    true,
-			includeVirtual:   false,
+			includeMutations:       false,
+			includeSystem:          true,
+			includeVirtualInverted: false,
+			includeVirtualComputed: false,
 		})
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -25,11 +25,11 @@ TABLE kj
  ├── k int not null
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual]
+ ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
  ├── INDEX primary
  │    └── k int not null
  └── INVERTED INDEX secondary
-      ├── j_inverted_key jsonb not null [hidden] [virtual]
+      ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
       └── k int not null
 
 build

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -682,8 +682,11 @@ type columnKinds struct {
 	// If true, include system columns.
 	includeSystem bool
 
-	// If true, include virtual columns.
-	includeVirtual bool
+	// If true, include virtual inverted index columns.
+	includeVirtualInverted bool
+
+	// If true, include virtual computed columns.
+	includeVirtualComputed bool
 }
 
 // tableOrdinals returns a slice of ordinals that correspond to table columns of
@@ -691,11 +694,12 @@ type columnKinds struct {
 func tableOrdinals(tab cat.Table, k columnKinds) []int {
 	n := tab.ColumnCount()
 	shouldInclude := [...]bool{
-		cat.Ordinary:   true,
-		cat.WriteOnly:  k.includeMutations,
-		cat.DeleteOnly: k.includeMutations,
-		cat.System:     k.includeSystem,
-		cat.Virtual:    k.includeVirtual,
+		cat.Ordinary:        true,
+		cat.WriteOnly:       k.includeMutations,
+		cat.DeleteOnly:      k.includeMutations,
+		cat.System:          k.includeSystem,
+		cat.VirtualInverted: k.includeVirtualInverted,
+		cat.VirtualComputed: k.includeVirtualComputed,
 	}
 	ordinals := make([]int, 0, n)
 	for i := 0; i < n; i++ {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -567,7 +567,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 		}
 		// Add the rest of the columns in the table.
 		for i, col := range tt.Columns {
-			if !pkOrdinals.Contains(i) && col.Kind() != cat.Virtual {
+			if !pkOrdinals.Contains(i) && !col.Kind().IsVirtual() {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}
 		}
@@ -686,7 +686,7 @@ func (ti *Index) addColumn(
 		// TODO(radu,mjibson): update this when the corresponding type in the real
 		// catalog is fixed (see sql.newOptTable).
 		typ := tt.Columns[ordinal].DatumType()
-		col.InitVirtual(
+		col.InitVirtualInverted(
 			len(tt.Columns),
 			tree.Name(name+"_inverted_key"),
 			typ,

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -177,15 +177,15 @@ TABLE inv
  ├── j jsonb
  ├── g geometry
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual]
- ├── g_inverted_key geometry not null [hidden] [virtual]
+ ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
  ├── INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [hidden] [virtual]
+ │    ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
  │    └── k int not null
  └── INVERTED INDEX secondary
-      ├── g_inverted_key geometry not null [hidden] [virtual]
+      ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
       └── k int not null
 
 # Table with inverted indexes and implicit primary index.
@@ -208,13 +208,13 @@ TABLE inv2
  ├── g geometry
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual]
- ├── g_inverted_key geometry not null [hidden] [virtual]
+ ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
  ├── INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [hidden] [virtual]
+ │    ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── INVERTED INDEX secondary
-      ├── g_inverted_key geometry not null [hidden] [virtual]
+      ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
       └── rowid int not null default (unique_rowid()) [hidden]

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -737,7 +737,7 @@ func newOptTable(
 			// read data directly into a DBytes (i.e., don't call
 			// encoding.DecodeBytesAscending).
 			typ := ot.Column(invertedSourceColOrdinal).DatumType()
-			virtualCol.InitVirtual(
+			virtualCol.InitVirtualInverted(
 				virtualColOrd,
 				tree.Name(string(ot.Column(invertedSourceColOrdinal).ColName())+"_inverted_key"),
 				typ,


### PR DESCRIPTION
#### cat: don't store pointers to strings

Store strings instead of pointers for default and computed
expressions. We use the empty string instead of nil.

Release note: None

#### cat: add "virtual computed" columns

This change splits the Virtual column kind into the existing
VirtualInverted and a new VirtualComputed kind. The latter is a
virtual column that corresponds to an expression, to be used for
expression-based indexes.

Release note: None