### PR TITLE
release-20.2: backupccl: add system.role_options to cluster backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -77,6 +77,7 @@ var fullClusterSystemTables = []string{
 	// Rest of system tables.
 	systemschema.LocationsTable.Name,
 	systemschema.RoleMembersTable.Name,
+	systemschema.RoleOptionsTable.Name,
 	systemschema.UITable.Name,
 	systemschema.CommentsTable.Name,
 	systemschema.JobsTable.Name,

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -66,6 +66,7 @@ FROM system.jobs
 	}
 	for i := 0; i < numUsers; i++ {
 		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
+		sqlDB.Exec(t, fmt.Sprintf("ALTER USER maxroach%d CREATEDB", i))
 	}
 	// Populate system.zones.
 	sqlDB.Exec(t, `ALTER TABLE data.bank CONFIGURE ZONE USING gc.ttlseconds = 3600`)
@@ -138,6 +139,7 @@ FROM system.jobs
 			systemschema.CommentsTable.Name,
 			systemschema.LocationsTable.Name,
 			systemschema.RoleMembersTable.Name,
+			systemschema.RoleOptionsTable.Name,
 			systemschema.SettingsTable.Name,
 			systemschema.TableStatisticsTable.Name,
 			systemschema.UITable.Name,
@@ -477,6 +479,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				{"jobs"},
 				{"locations"},
 				{"role_members"},
+				{"role_options"},
 				{"scheduled_jobs"},
 				{"settings"},
 				{"ui"},
@@ -518,6 +521,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				{"jobs"},
 				{"locations"},
 				{"role_members"},
+				{"role_options"},
 				{"scheduled_jobs"},
 				{"settings"},
 				{"ui"},
@@ -559,6 +563,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				{"jobs"},
 				{"locations"},
 				{"role_members"},
+				{"role_options"},
 				{"scheduled_jobs"},
 				{"settings"},
 				{"ui"},


### PR DESCRIPTION
Backport 1/1 commits from #55189.

/cc @cockroachdb/release

---

Previously, the role_options system table was not included in cluster
backups. This commit adds this table.

Fixes #55188.

Release note (bug fix): Options set on users (e.g. ALTER USER u
CREATEDB) were not included in cluster backups and thus not restored.
Role options were introduced in 20.2.
