### PR TITLE
cmd/roachprod: fix default AWS AMI

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -706,7 +706,7 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 		"--associate-public-ip-address",
 		"--count", "1",
 		"--instance-type", machineType,
-		"--image-id", withFlagOverride(az.region.Name, &p.opts.ImageAMI),
+		"--image-id", withFlagOverride(az.region.AMI, &p.opts.ImageAMI),
 		"--key-name", keyName,
 		"--region", az.region.Name,
 		"--security-group-ids", az.region.SecurityGroup,


### PR DESCRIPTION
1b5fd5798e16d4543f5364f1f5a80edb2d381111 inadvertently set the default
AWS AMI to a region name, not the region's AMI ID.

Discovered through the Pebble Nightly.

Release note: none