### PR TITLE
server: avoid log spam related to invalid web session cookies

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -474,7 +474,9 @@ func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		ctx = context.WithValue(ctx, webSessionIDKey{}, cookie.ID)
 		req = req.WithContext(ctx)
 	} else if !am.allowAnonymous {
-		log.Infof(req.Context(), "web session error: %s", err)
+		if log.V(1) {
+			log.Infof(req.Context(), "web session error: %v", err)
+		}
 		http.Error(w, "a valid authentication cookie is required", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
Fixes  #42161

Prior to this change, any type of error during the authentication of
HTTP requests was logged in addition to reporting 403 to the web
client.

This was causing excessive log spam, which made the troubleshooting of
actual problems more difficult:

- a message would be logged for browsers that tried a request the
  first time to determine whether the session was authenticated
  already (this is done when loading the UI screen the first time in
  the browser).

- a message would be logged every time a browser presented an expired
  cookie.

- a message would be logged every time a browser would reuse the
  cookie from one cluster when connecting to another, for example when
  cycling through development clusters on the same IP address.

Arguably, none of these log messages provide anything actionable
during regular cluster operation or testing, and instead they pollute
the log file and make the identification of actual errors more
difficult.

Therefore, this patch removes this logging from the common case.
Assuming that a future UI engineer may want to inspect the authn
errors during development, the logging remains, now hidden behind
`log.V(1)`.

Release note (security update): CockroachDB does not any more report
the use of expired or invalid web auth cookies in the log file by
default.