### PR TITLE
roachtest: revive tpcc/mixed-headroom/n5cpu16

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -226,11 +226,9 @@ func registerTPCC(r *testRegistry) {
 		// w=headroom runs tpcc for a semi-extended period with some amount of
 		// headroom, more closely mirroring a real production deployment than
 		// running with the max supported warehouses.
-		Name:  "tpcc/headroom/" + headroomSpec.String(),
-		Owner: OwnerKV,
-		// TODO(dan): Backfill tpccSupportedWarehouses and remove this "v2.1.0"
-		// minimum on gce.
-		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
+		Name:       "tpcc/headroom/" + headroomSpec.String(),
+		Owner:      OwnerKV,
+		MinVersion: "v19.1.0",
 		Tags:       []string{`default`, `release_qualification`},
 		Cluster:    headroomSpec,
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -251,11 +249,9 @@ func registerTPCC(r *testRegistry) {
 		// mixed-headroom is similar to w=headroom, but with an additional node
 		// and on a mixed version cluster. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
-		Name:  "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
-		Owner: OwnerKV,
-		// TODO(dan): Backfill tpccSupportedWarehouses and remove this "v2.1.0"
-		// minimum on gce.
-		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
+		Name:       "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
+		Owner:      OwnerKV,
+		MinVersion: "v19.1.0",
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
 		Tags:    []string{`default`},
@@ -284,7 +280,7 @@ func registerTPCC(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "tpcc-nowait/nodes=3/w=1",
 		Owner:      OwnerKV,
-		MinVersion: maybeMinVersionForFixturesImport(cloud),
+		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
@@ -298,7 +294,7 @@ func registerTPCC(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "weekly/tpcc/headroom",
 		Owner:      OwnerKV,
-		MinVersion: maybeMinVersionForFixturesImport(cloud),
+		MinVersion: "v19.1.0",
 		Tags:       []string{`weekly`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Timeout:    time.Duration(6*24)*time.Hour + time.Duration(10)*time.Minute,
@@ -315,8 +311,8 @@ func registerTPCC(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "tpcc/w=100/nodes=3/chaos=true",
 		Owner:      OwnerKV,
+		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4),
-		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
@@ -343,8 +339,8 @@ func registerTPCC(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "tpcc/interleaved/nodes=3/cpu=16/w=500",
 		Owner:      OwnerSQLExec,
-		Cluster:    makeClusterSpec(4, cpu(16)),
 		MinVersion: "v20.1.0",
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Timeout:    6 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			skip.WithIssue(t, 53886)
@@ -417,36 +413,11 @@ func registerTPCC(r *testRegistry) {
 	})
 }
 
-func maxVersion(vers ...string) string {
-	var max *version.Version
-	for _, v := range vers {
-		v, err := version.Parse(v)
-		if err != nil {
-			continue
-		}
-		if max == nil || v.AtLeast(max) {
-			max = v
-		}
-	}
-	if max == nil {
-		return ""
-	}
-	return max.String()
-}
-
 func gceOrAws(cloud string, gce, aws int) int {
 	if cloud == "aws" {
 		return aws
 	}
 	return gce
-}
-
-func maybeMinVersionForFixturesImport(cloud string) string {
-	const minVersionForFixturesImport = "v19.1.0"
-	if cloud == "aws" {
-		return minVersionForFixturesImport
-	}
-	return ""
 }
 
 // tpccBenchDistribution represents a distribution of nodes in a tpccbench
@@ -592,7 +563,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 
 	minVersion := b.MinVersion
 	if minVersion == "" {
-		minVersion = maybeMinVersionForFixturesImport(cloud)
+		minVersion = "v19.1.0" // needed for import
 	}
 
 	r.Add(testSpec{

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -31,7 +31,7 @@ type tpchBenchSpec struct {
 	url             string
 	numRunsPerQuery int
 	// minVersion specifies the minimum version of CRDB nodes. If omitted, it
-	// will default to maybeMinVersionForFixturesImport.
+	// will default to v19.1.0.
 	minVersion string
 	// maxLatency is the expected maximum time that a query will take to execute
 	// needed to correctly initialize histograms.
@@ -159,7 +159,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 	numNodes := b.Nodes + 1
 	minVersion := b.minVersion
 	if minVersion == `` {
-		minVersion = maybeMinVersionForFixturesImport(cloud)
+		minVersion = "v19.1.0" // needed for import
 	}
 
 	r.Add(testSpec{


### PR DESCRIPTION
### roachtest: run tpcc import on node with cockroach instance

Fixes #55241.
Fixes #55242.

This ensures that the workload version matches the gateway version in a mixed version cluster.

### roachtest: bump tpcc/mixed-headroom/n5cpu16 min version

Fixes #55023.