### PR TITLE
backupccl: specify target SST size in backup

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -138,6 +139,7 @@ func runBackupProcessor(
 	// TODO(pbardea): Check to see if this benefits from any tuning (e.g. +1, or
 	//  *2). See #49798.
 	numSenders := int(kvserver.ExportRequestsLimit.Get(&settings.SV)) * 2
+	targetFileSize := storageccl.ExportRequestTargetFileSize.Get(&settings.SV)
 
 	// For all backups, partitioned or not, the main BACKUP manifest is stored at
 	// details.URI.
@@ -180,6 +182,7 @@ func runBackupProcessor(
 					EnableTimeBoundIteratorOptimization: useTBI.Get(&settings.SV),
 					MVCCFilter:                          spec.MVCCFilter,
 					Encryption:                          spec.Encryption,
+					TargetFileSize:                      targetFileSize,
 				}
 
 				// If we're doing re-attempts but are not yet in the priority regime,


### PR DESCRIPTION
Previously, backup was not specifying a target file size in its
ExportRequests, this would cause potentially large spans to be iterated
over, stored in memory and then written to ExternalStorage. This change
allows the target file size to be controlled by the
kv.bulk_sst.target_size cluster setting.

Fixes #55287.

Release note: None