### PR TITLE
release-20.2: backupccl: fix TableDescriptor type assertion

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -357,9 +357,10 @@ func descriptorsMatchingTargets(
 			if !found {
 				return ret, doesNotExistErr
 			}
-			tableDesc := descI.(catalog.TableDescriptor)
-			// If tableDesc is nil, then we resolved a type instead, so error out.
-			if tableDesc == nil {
+			tableDesc, isTable := descI.(catalog.TableDescriptor)
+			// If the type assertion didn't work, then we resolved a type instead, so
+			// error out.
+			if !isTable {
 				return ret, doesNotExistErr
 			}
 


### PR DESCRIPTION
Backport 1/1 commits from #55190.

/cc @cockroachdb/release

---

During an earlier refactor, this type assertion was not updated. I
discovered this because of a panic happening in RandomSyntaxTests.

Release note: None
