### PR TITLE
sql: do not inherit role options

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -161,6 +161,17 @@ GRANT ALL ON DATABASE d TO new_role
 statement ok
 DROP TABLE d.t
 
+# However the CREATEDB privilege is not inherited.
+statement error permission denied to rename database
+ALTER DATABASE d RENAME TO d2
+
+user root
+
+statement ok
+ALTER USER testuser2 WITH CREATEDB
+
+user testuser2
+
 statement ok
 ALTER DATABASE d RENAME TO d2
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -891,7 +891,7 @@ ALTER ROLE rolewithcreate WITH NOCREATEROLE
 user root
 
 statement ok
-GRANT rolewithcreate TO testuser
+ALTER USER testuser CREATEROLE
 
 user testuser
 
@@ -926,17 +926,10 @@ statement ok
 ALTER ROLE rolewithcreate WITH NOCREATEROLE
 
 statement ok
-ALTER ROLE rolewithcreate NOCREATEROLE
+ALTER USER testuser NOCREATEROLE
 
 statement error pq: cannot edit admin role
 ALTER ROLE admin with NOCREATEROLE
-
-query TTB colnames
-SELECT * FROM system.role_members
-----
-role      member    isAdmin
-admin     root      true
-rolewithcreate  testuser  false
 
 # testuser should no longer have CREATEROLE privileges
 
@@ -971,44 +964,21 @@ ALTER ROLE IF EXISTS rolek CREATEROLE
 statement ok
 ALTER USER IF EXISTS rolek NOCREATEROLE
 
-statement ok
-ALTER USER rolewithcreate WITH NOCREATEROLE
-
-statement ok
-ALTER ROLE rolewithcreate CREATEROLE
-
-user testuser
-
-statement ok
-CREATE ROLE IF NOT EXISTS rolei WITH NOCREATEROLE
-
-statement ok
-DROP ROLE rolewithcreate
-
-statement error pq: user testuser does not have CREATEROLE privilege
-CREATE ROLE rolewithcreate
-
-statement error pq: user testuser does not have CREATEROLE privilege
-CREATE ROLE IF NOT EXISTS roleh WITH CREATEROLE
-
-# Testing nested role privilege
+# Role options should not be inherited.
 user root
-
-statement ok
-CREATE USER childrole WITH NOCREATEROLE
 
 statement ok
 CREATE ROLE parentrole WITH CREATEROLE
 
 statement ok
-GRANT parentrole TO childrole
+ALTER USER testuser WITH NOCREATEROLE
 
 statement ok
-GRANT childrole to testuser
+GRANT parentrole TO testuser
 
 user testuser
 
-statement ok
+statement error pq: user testuser does not have CREATEROLE privilege
 CREATE ROLE rolej
 
 # Testing LOGIN and VALID UNTIL role privilege
@@ -1063,9 +1033,6 @@ CREATE ROLE thisshouldntwork LOGIN NOLOGIN
 
 statement error pq: redundant role options
 CREATE ROLE thisshouldntwork LOGIN LOGIN
-
-statement ok
-DROP ROLE childrole
 
 statement ok
 DROP ROLE parentrole
@@ -1216,12 +1183,9 @@ subtest createlogin_privilege
 user root
 
 statement ok
-CREATE ROLE pseudo_admin;
-  ALTER ROLE pseudo_admin CREATEROLE;
+ALTER USER testuser CREATEROLE;
   DROP USER testuser2;
   DROP USER testuser3;
-  ALTER USER testuser NOCREATEROLE;
-  GRANT pseudo_admin TO testuser
 
 user testuser
 
@@ -1288,7 +1252,7 @@ CREATE ROLE otherrole2 LOGIN
 user root
 
 statement ok
-ALTER ROLE pseudo_admin CREATELOGIN
+ALTER ROLE testuser CREATELOGIN
 
 user testuser
 
@@ -1340,12 +1304,12 @@ CREATE ROLE otherrole4 LOGIN
 user root
 
 statement ok
-ALTER ROLE pseudo_admin NOCREATELOGIN
+ALTER USER testuser NOCREATELOGIN
 
 user testuser
 
 statement error user testuser does not have CREATELOGIN privilege
-CREATE USER testuser4 WITH PASSWORD 'abc'
+CREATE USER testuser5 WITH PASSWORD 'abc'
 
 statement error user testuser does not have CREATELOGIN privilege
 ALTER USER testuser2 WITH PASSWORD 'abc'


### PR DESCRIPTION
Previously, if a role had a role-level option like CREATEROLE, users who
were granted this role would inherit that privilege. This is
incompatible with Postgres, where such options are not inherited and
must be set explicitly on each user. I changed our behavior to match
Postgres.

The only role option this affects which is present in v20.1 is
CREATEROLE. This also affects all the new role options we added in
v20.2, such as CREATEDB.

Note that this does not affect privileges on database objects, e.g. the
SELECT privilege on a table. These continue to be inherited.

Fixes #53480

Release note (backward-incompatible change): For PostgreSQL
compatibility, the CREATEROLE privilege is no longer inherited by
children of a role which has that privilege. For example, say we run
these statements:
```
CREATE ROLE parent WITH CREATEROLE;
CREATE ROLE child;
GRANT parent TO child;
```
Previously, the child role would have the CREATEROLE privilege. Now it
will not. In order to grant this privilege to the child role, it is
necessary to run `ALTER ROLE child WITH CREATEROLE`.