### PR TITLE
release-20.2: reduce log spam

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -500,7 +500,9 @@ func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		ctx = context.WithValue(ctx, webSessionIDKey{}, cookie.ID)
 		req = req.WithContext(ctx)
 	} else if !am.allowAnonymous {
-		log.Infof(req.Context(), "web session error: %s", err)
+		if log.V(1) {
+			log.Infof(req.Context(), "web session error: %v", err)
+		}
 		http.Error(w, "a valid authentication cookie is required", http.StatusUnauthorized)
 		return
 	}

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -27,7 +27,9 @@ import (
 // ErrCannotReuseClientConn is returned when a failed connection is
 // being reused. We require that new connections be created with
 // pkg/rpc.GRPCDial instead.
-var ErrCannotReuseClientConn = errors.New("cannot reuse client connection")
+var ErrCannotReuseClientConn = errors.New(errCannotReuseClientConnMsg)
+
+const errCannotReuseClientConnMsg = "cannot reuse client connection"
 
 type localRequestKey struct{}
 

--- a/pkg/util/grpcutil/log_test.go
+++ b/pkg/util/grpcutil/log_test.go
@@ -11,7 +11,6 @@
 package grpcutil
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -20,38 +19,31 @@ import (
 )
 
 func TestShouldPrint(t *testing.T) {
-	const duration = 100 * time.Millisecond
-
-	argRe, err := regexp.Compile("[a-z][0-9]")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	testutils.RunTrueAndFalse(t, "argsMatch", func(t *testing.T, argsMatch bool) {
-		msg := "baz"
+		msg := "blablabla"
 		if argsMatch {
-			msg = "a1"
+			msg = "grpc: addrConn.createTransport failed to connect to 127.0.0.1:1234 (connection refused)"
 		}
 
 		args := []interface{}{msg}
 		curriedShouldPrint := func() bool {
-			return shouldPrint(argRe, duration, args...)
+			return shouldPrintWarning(args...)
 		}
 
 		// First call should always print.
 		if !curriedShouldPrint() {
-			t.Error("expected first call to print")
+			t.Error("1st call: should print expected true, got false")
 		}
 
 		// Should print if non-matching.
 		alwaysPrint := !argsMatch
 		if alwaysPrint {
 			if !curriedShouldPrint() {
-				t.Error("expected second call to print")
+				t.Error("2nd call: should print expected true, got false")
 			}
 		} else {
 			if curriedShouldPrint() {
-				t.Error("unexpected second call to print")
+				t.Error("2nd call: should print expected false, got true")
 			}
 		}
 
@@ -63,7 +55,7 @@ func TestShouldPrint(t *testing.T) {
 			spamMu.Unlock()
 		}
 		if !curriedShouldPrint() {
-			t.Error("expected third call to print")
+			t.Error("3rd call (after reset): should print expected true, got false")
 		}
 	})
 }

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -54,7 +54,7 @@ func ListenAndServeGRPC(
 	return ln, nil
 }
 
-var httpLogger = log.NewStdLogger(log.Severity_ERROR, "httpLogger")
+var httpLogger = log.NewStdLogger(log.Severity_ERROR, "net/http")
 
 // Server is a thin wrapper around http.Server. See MakeServer for more detail.
 type Server struct {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server: avoid log spam related to invalid web session cookies" (#55259)
  * 3/3 commits from "grpcutil,log: avoid log spam related to TCP probes" (#55279)

Please see individual PRs for details.

/cc @cockroachdb/release
