### PR TITLE
sql - Add optional PRIVILEGES keyword in GRANT ALL and REVOKE ALL

### DIFF
--- a/docs/generated/sql/bnf/grant_privileges.bnf
+++ b/docs/generated/sql/bnf/grant_privileges.bnf
@@ -1,6 +1,6 @@
 grant_stmt ::=
-	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
+	'GRANT' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	 
-	| 'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'TYPE' target_types 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
-	| 'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'SCHEMA' schema_name_list 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
+	| 'GRANT' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'TYPE' target_types 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
+	| 'GRANT' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'SCHEMA' schema_name_list 'TO' ( ( user_name ) ( ( ',' user_name ) )* )

--- a/docs/generated/sql/bnf/revoke_privileges.bnf
+++ b/docs/generated/sql/bnf/revoke_privileges.bnf
@@ -1,6 +1,6 @@
 revoke_stmt ::=
-	'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
+	'REVOKE' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	
-	| 'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'TYPE' target_types 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
-	| 'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'SCHEMA' schema_name_list 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
+	| 'REVOKE' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'TYPE' target_types 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
+	| 'REVOKE' ( 'ALL' opt_privileges_clause | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' 'SCHEMA' schema_name_list 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -279,7 +279,7 @@ name ::=
 	| col_name_keyword
 
 privileges ::=
-	'ALL'
+	'ALL' opt_privileges_clause
 	| privilege_list
 
 targets ::=
@@ -963,6 +963,7 @@ unreserved_keyword ::=
 	| 'PREPARE'
 	| 'PRESERVE'
 	| 'PRIORITY'
+	| 'PRIVILEGES'
 	| 'PUBLIC'
 	| 'PUBLICATION'
 	| 'QUERIES'
@@ -1129,6 +1130,10 @@ col_name_keyword ::=
 	| 'VARCHAR'
 	| 'VIRTUAL'
 	| 'WORK'
+
+opt_privileges_clause ::=
+	'PRIVILEGES'
+	| 
 
 complex_table_pattern ::=
 	complex_db_object_name

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -36,7 +36,7 @@ statement ok
 INSERT INTO system.users VALUES('test-user','');
 
 statement ok
-GRANT ALL ON DATABASE a TO readwrite, "test-user"
+GRANT ALL PRIVILEGES ON DATABASE a TO readwrite, "test-user"
 
 statement error syntax error
 GRANT SELECT,ALL ON DATABASE a TO readwrite
@@ -194,7 +194,7 @@ a  public              test-user  CREATE
 a  public              test-user  GRANT
 
 statement ok
-REVOKE ALL ON DATABASE a FROM "test-user"
+REVOKE ALL PRIVILEGES ON DATABASE a FROM "test-user"
 
 query TTTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -32,7 +32,8 @@ import (
 )
 
 // TestParse verifies that we can parse the supplied SQL and regenerate the SQL
-// string from the syntax tree.
+// string from the syntax tree.  If the supplied SQL generates a different string
+// from the sytnax tree, use TestParse2 below.
 func TestParse(t *testing.T) {
 	testData := []struct {
 		sql string
@@ -2612,6 +2613,14 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 
 		{`REASSIGN OWNED BY CURRENT_USER TO foo`, `REASSIGN OWNED BY "current_user" TO foo`},
 		{`REASSIGN OWNED BY SESSION_USER TO foo`, `REASSIGN OWNED BY "session_user" TO foo`},
+
+		// Validate that GRANT and REVOKE can accept optional PRIVILEGES syntax
+		{`GRANT ALL PRIVILEGES ON DATABASE foo TO root`, `GRANT ALL ON DATABASE foo TO root`},
+		{`GRANT ALL PRIVILEGES ON TABLE foo TO root`, `GRANT ALL ON TABLE foo TO root`},
+		{`GRANT ALL PRIVILEGES ON SCHEMA foo TO root`, `GRANT ALL ON SCHEMA foo TO root`},
+		{`REVOKE ALL PRIVILEGES ON DATABASE foo FROM root`, `REVOKE ALL ON DATABASE foo FROM root`},
+		{`REVOKE ALL PRIVILEGES ON TABLE foo FROM root`, `REVOKE ALL ON TABLE foo FROM root`},
+		{`REVOKE ALL PRIVILEGES ON SCHEMA foo FROM root`, `REVOKE ALL ON SCHEMA foo FROM root`},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -639,7 +639,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 
 %token <str> PARENT PARTIAL PARTITION PARTITIONS PASSWORD PAUSE PAUSED PHYSICAL PLACING
 %token <str> PLAN PLANS POINT POINTM POINTZ POINTZM POLYGON POLYGONM POLYGONZ POLYGONZM
-%token <str> POSITION PRECEDING PRECISION PREPARE PRESERVE PRIMARY PRIORITY
+%token <str> POSITION PRECEDING PRECISION PREPARE PRESERVE PRIMARY PRIORITY PRIVILEGES
 %token <str> PROCEDURAL PUBLIC PUBLICATION
 
 %token <str> QUERIES QUERY
@@ -970,6 +970,7 @@ func (u *sqlSymUnion) refreshDataOption() tree.RefreshDataOption {
 %type <tree.RangePartition> range_partition
 %type <[]tree.RangePartition> range_partitions
 %type <empty> opt_all_clause
+%type <empty> opt_privileges_clause
 %type <bool> distinct_clause
 %type <tree.DistinctOn> distinct_on_clause
 %type <tree.NameList> opt_column_list insert_column_list opt_stats_columns
@@ -3689,7 +3690,7 @@ deallocate_stmt:
 // %Category: Priv
 // %Text:
 // Grant privileges:
-//   GRANT {ALL | <privileges...> } ON <targets...> TO <grantees...>
+//   GRANT {ALL [PRIVILEGES] | <privileges...> } ON <targets...> TO <grantees...>
 // Grant role membership:
 //   GRANT <roles...> TO <grantees...> [WITH ADMIN OPTION]
 //
@@ -3779,9 +3780,9 @@ revoke_stmt:
   }
 | REVOKE error // SHOW HELP: REVOKE
 
-// ALL is always by itself.
+// ALL can either be by itself, or with the optional PRIVILEGES keyword (which no-ops)
 privileges:
-  ALL
+  ALL opt_privileges_clause
   {
     $$.val = privilege.List{privilege.ALL}
   }
@@ -8024,6 +8025,10 @@ opt_all_clause:
   ALL {}
 | /* EMPTY */ {}
 
+opt_privileges_clause:
+  PRIVILEGES {}
+| /* EMPTY */ {}
+
 opt_sort_clause:
   sort_clause
   {
@@ -11731,6 +11736,7 @@ unreserved_keyword:
 | PREPARE
 | PRESERVE
 | PRIORITY
+| PRIVILEGES
 | PUBLIC
 | PUBLICATION
 | QUERIES


### PR DESCRIPTION
Postgres provides the ability to specify "PRIVILEGES" after GRANT ALL
and REVOKE ALL so that it's clear that the command relates to privilges.
Until now we haven't provided that ability.  This change brings our
grant/revoke syntax closer inline with Postgres.

Release note (sql change): Add the ability to optionally specify the
PRIVILEGES keyword when issuing the GRANT ALL or REVOKE ALL command.

Before, a statement like the following would fail with a syntax error,
(even though it's allowed in Postgres):

GRANT ALL PRIVILEGES ON DATABASE a TO user1

This commit allows for the above syntax in CRDB.