### PR TITLE
sql/catalog/*desc: add redacted log support

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -20,6 +20,11 @@ pkg/sql/catalog/descpb/structured.go | `DescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `IndexDescriptorVersion`
 pkg/sql/catalog/descpb/structured.go | `ColumnID`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
+pkg/sql/catalog/descpb/structured.go | `ConstraintValidity`
+pkg/sql/catalog/descpb/structured.go | `DescriptorMutation_Direction`
+pkg/sql/catalog/descpb/structured.go | `DescriptorMutation_State`
+pkg/sql/catalog/descpb/structured.go | `DescriptorState`
+pkg/sql/catalog/descpb/structured.go | `ConstraintType`
 pkg/sql/sem/tree/table_ref.go | `ID`
 pkg/sql/sem/tree/table_ref.go | `ColumnID`
 pkg/storage/enginepb/mvcc3.go | `MVCCStatsDelta`

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/redact"
 )
 
 var _ catalog.DatabaseDescriptor = (*Immutable)(nil)
@@ -92,6 +93,24 @@ func NewExistingMutable(desc descpb.DatabaseDescriptor) *Mutable {
 		Immutable:      makeImmutable(*protoutil.Clone(&desc).(*descpb.DatabaseDescriptor)),
 		ClusterVersion: NewImmutable(desc),
 	}
+}
+
+// SafeMessage makes Immutable a SafeMessager.
+func (desc *Immutable) SafeMessage() string {
+	return formatSafeMessage("dbdesc.Immutable", desc)
+}
+
+// SafeMessage makes Mutable a SafeMessager.
+func (desc *Mutable) SafeMessage() string {
+	return formatSafeMessage("dbdesc.Mutable", desc)
+}
+
+func formatSafeMessage(typeName string, desc catalog.DatabaseDescriptor) string {
+	var buf redact.StringBuilder
+	buf.Print(typeName + ": {")
+	catalog.FormatSafeDescriptorProperties(&buf, desc)
+	buf.Print("}")
+	return buf.String()
 }
 
 // TypeName returns the plain type of this descriptor.

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -305,3 +305,18 @@ var AnonymousTable = tree.TableName{}
 func (opts *TableDescriptor_SequenceOpts) HasOwner() bool {
 	return !opts.SequenceOwner.Equal(TableDescriptor_SequenceOpts_SequenceOwner{})
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (ConstraintValidity) SafeValue() {}
+
+// SafeValue implements the redact.SafeValue interface.
+func (DescriptorMutation_Direction) SafeValue() {}
+
+// SafeValue implements the redact.SafeValue interface.
+func (DescriptorMutation_State) SafeValue() {}
+
+// SafeValue implements the redact.SafeValue interface.
+func (DescriptorState) SafeValue() {}
+
+// SafeValue implements the redact.SafeValue interface.
+func (ConstraintType) SafeValue() {}

--- a/pkg/sql/catalog/descriptor_test.go
+++ b/pkg/sql/catalog/descriptor_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestFormatSafeDescriptorProperties(t *testing.T) {
+	for _, tc := range []struct {
+		desc catalog.Descriptor
+		exp  string
+	}{
+		{
+			desc: tabledesc.NewImmutable(descpb.TableDescriptor{
+				ID:       27,
+				Version:  2,
+				ParentID: 12,
+				State:    descpb.DescriptorState_ADD,
+			}),
+			exp: "ID: 27, Version: 2, ModificationTime: \"0,0\", ParentID: 12, ParentSchemaID: 29, State: ADD",
+		},
+		{
+			desc: schemadesc.NewImmutable(descpb.SchemaDescriptor{
+				ID:            12,
+				Version:       1,
+				ParentID:      2,
+				State:         descpb.DescriptorState_OFFLINE,
+				OfflineReason: "foo",
+			}),
+			exp: "ID: 12, Version: 1, ModificationTime: \"0,0\", ParentID: 2, State: OFFLINE, OfflineReason: \"foo\"",
+		},
+		{
+			desc: dbdesc.NewCreatedMutable(descpb.DatabaseDescriptor{
+				ID:      12,
+				Version: 1,
+				State:   descpb.DescriptorState_PUBLIC,
+			}),
+			exp: "ID: 12, Version: 1, IsUncommitted: true, ModificationTime: \"0,0\", State: PUBLIC",
+		},
+		{
+			desc: func() catalog.Descriptor {
+				desc := tabledesc.NewExistingMutable(descpb.TableDescriptor{
+					ID:                      27,
+					Version:                 2,
+					ParentID:                12,
+					UnexposedParentSchemaID: 51,
+					State:                   descpb.DescriptorState_PUBLIC,
+				})
+				desc.MaybeIncrementVersion()
+				desc.AddDrainingName(descpb.NameInfo{
+					ParentID:       12,
+					ParentSchemaID: 51,
+				})
+				return desc.ImmutableCopy()
+			}(),
+			exp: "ID: 27, Version: 3, IsUncommitted: true, ModificationTime: \"0,0\", ParentID: 12, ParentSchemaID: 51, State: PUBLIC, NumDrainingNames: 1",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			var buf redact.StringBuilder
+			catalog.FormatSafeDescriptorProperties(&buf, tc.desc)
+			redacted := string(buf.RedactableString().Redact())
+			require.Equal(t, tc.exp, redacted)
+			var m map[string]interface{}
+			require.NoError(t, yaml.UnmarshalStrict([]byte("{"+redacted+"}"), &m))
+		})
+	}
+}

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemadesc_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSafeMessage(t *testing.T) {
+	for _, tc := range []struct {
+		desc catalog.SchemaDescriptor
+		exp  string
+	}{
+		{
+			desc: schemadesc.NewImmutable(descpb.SchemaDescriptor{
+				ID:            12,
+				Version:       1,
+				ParentID:      2,
+				State:         descpb.DescriptorState_OFFLINE,
+				OfflineReason: "foo",
+			}),
+			exp: "schemadesc.Immutable: {ID: 12, Version: 1, ModificationTime: \"0,0\", ParentID: 2, State: OFFLINE, OfflineReason: \"foo\"}",
+		},
+		{
+			desc: schemadesc.NewCreatedMutable(descpb.SchemaDescriptor{
+				ID:            42,
+				Version:       1,
+				ParentID:      2,
+				State:         descpb.DescriptorState_OFFLINE,
+				OfflineReason: "bar",
+			}),
+			exp: "schemadesc.Mutable: {ID: 42, Version: 1, IsUncommitted: true, ModificationTime: \"0,0\", ParentID: 2, State: OFFLINE, OfflineReason: \"bar\"}",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			redacted := string(redact.Sprint(tc.desc).Redact())
+			require.Equal(t, tc.exp, redacted)
+			{
+				var m map[string]interface{}
+				require.NoError(t, yaml.UnmarshalStrict([]byte(redacted), &m))
+			}
+		})
+	}
+}

--- a/pkg/sql/catalog/tabledesc/safe_format.go
+++ b/pkg/sql/catalog/tabledesc/safe_format.go
@@ -1,0 +1,387 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tabledesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/redact"
+)
+
+// SafeMessage makes Immutable a SafeMessager.
+func (desc *Immutable) SafeMessage() string {
+	return formatSafeTableDesc("tabledesc.Immutable", desc)
+}
+
+// SafeMessage makes Mutable a SafeMessager.
+func (desc *Mutable) SafeMessage() string {
+	return formatSafeTableDesc("tabledesc.Mutable", desc)
+}
+
+func formatSafeTableDesc(typeName string, desc catalog.TableDescriptor) string {
+	var buf redact.StringBuilder
+	buf.Printf(typeName + ": {")
+	formatSafeTableProperties(&buf, desc)
+	buf.Printf("}")
+	return buf.String()
+}
+func formatSafeTableProperties(w *redact.StringBuilder, desc catalog.TableDescriptor) {
+	catalog.FormatSafeDescriptorProperties(w, desc)
+	if desc.IsTemporary() {
+		w.Printf(", Temporary: true")
+	}
+	if desc.IsView() {
+		w.Printf(", View: true")
+	}
+	if desc.IsSequence() {
+		w.Printf(", Sequence: true")
+	}
+	if desc.IsVirtualTable() {
+		w.Printf(", Virtual: true")
+	}
+	formatSafeTableColumns(w, desc)
+	formatSafeTableColumnFamilies(w, desc)
+	formatSafeTableMutationJobs(w, desc)
+	formatSafeMutations(w, desc)
+	formatSafeTableIndexes(w, desc)
+	formatSafeTableConstraints(w, desc)
+	// TODO(ajwerner): Expose OID hashing so that privileges can be displayed
+	// reasonably
+}
+
+func formatSafeTableColumns(w *redact.StringBuilder, desc catalog.TableDescriptor) {
+	var printed bool
+	formatColumn := func(c *descpb.ColumnDescriptor, m *descpb.DescriptorMutation) {
+		if printed {
+			w.Printf(", ")
+		}
+		formatSafeColumn(w, c, m)
+		printed = true
+	}
+	td := desc.TableDesc()
+	w.Printf(", NextColumnID: %d", td.NextColumnID)
+	w.Printf(", Columns: [")
+	for i := range td.Columns {
+		formatColumn(&td.Columns[i], nil)
+	}
+	w.Printf("]")
+}
+
+func formatSafeColumn(
+	w *redact.StringBuilder, c *descpb.ColumnDescriptor, m *descpb.DescriptorMutation,
+) {
+	w.Printf("{ID: %d, TypeID: %d", c.ID, c.Type.InternalType.Oid)
+	w.Printf(", Null: %t", c.Nullable)
+	if c.Hidden {
+		w.Printf(", Hidden: true")
+	}
+	if c.HasDefault() {
+		w.Printf(", HasDefault: true")
+	}
+	if c.IsComputed() {
+		w.Printf(", IsComputed: true")
+	}
+	if c.AlterColumnTypeInProgress {
+		w.Printf(", AlterColumnTypeInProgress: t")
+	}
+	if len(c.OwnsSequenceIds) > 0 {
+		w.Printf(", OwnsSequenceIDs: ")
+		formatSafeIDs(w, c.OwnsSequenceIds)
+	}
+	if len(c.UsesSequenceIds) > 0 {
+		w.Printf(", UsesSequenceIDs: ")
+		formatSafeIDs(w, c.UsesSequenceIds)
+	}
+	if m != nil {
+		w.Printf(", State: %s, MutationID: %d", m.Direction, m.MutationID)
+	}
+	w.Printf("}")
+}
+
+func formatSafeTableIndexes(w *redact.StringBuilder, desc catalog.TableDescriptor) {
+	td := desc.TableDesc()
+	w.Printf(", PrimaryIndex: %d", td.PrimaryIndex.ID)
+	w.Printf(", NextIndexID: %d", td.NextIndexID)
+	w.Printf(", Indexes: [")
+	formatSafeIndex(w, &td.PrimaryIndex, nil)
+	for i := range td.Indexes {
+		w.Printf(", ")
+		formatSafeIndex(w, &td.Indexes[i], nil)
+	}
+	w.Printf("]")
+}
+
+func formatSafeIndex(
+	w *redact.StringBuilder, idx *descpb.IndexDescriptor, mut *descpb.DescriptorMutation,
+) {
+	w.Printf("{")
+	w.Printf("ID: %d", idx.ID)
+	w.Printf(", Unique: %t", idx.Unique)
+	if idx.Predicate != "" {
+		w.Printf(", Partial: true")
+	}
+	if !idx.Interleave.Equal(&descpb.InterleaveDescriptor{}) {
+		w.Printf(", InterleaveParents: [")
+		for i := range idx.Interleave.Ancestors {
+			a := &idx.Interleave.Ancestors[i]
+			if i > 0 {
+				w.Printf(", ")
+			}
+			w.Printf("{TableID: %d, IndexID: %d}", a.TableID, a.IndexID)
+		}
+		w.Printf("]")
+	}
+	if len(idx.InterleavedBy) > 0 {
+		w.Printf(", InterleaveChildren: [")
+		for i := range idx.InterleavedBy {
+			a := &idx.InterleavedBy[i]
+			if i > 0 {
+				w.Printf(", ")
+			}
+			w.Printf("{TableID: %d, IndexID: %d}", a.Table, a.Index)
+		}
+		w.Printf("]")
+	}
+	w.Printf(", Columns: [")
+	for i := range idx.ColumnIDs {
+		if i > 0 {
+			w.Printf(", ")
+		}
+		w.Printf("{ID: %d, Dir: %s}", idx.ColumnIDs[i], idx.ColumnDirections[i])
+	}
+	w.Printf("]")
+	if len(idx.ExtraColumnIDs) > 0 {
+		w.Printf(", ExtraColumns: ")
+		formatSafeColumnIDs(w, idx.ExtraColumnIDs)
+	}
+	if len(idx.StoreColumnIDs) > 0 {
+		w.Printf(", StoreColumns: ")
+		formatSafeColumnIDs(w, idx.StoreColumnIDs)
+	}
+	if mut != nil {
+		w.Printf(", State: %s, MutationID: %d", mut.Direction, mut.MutationID)
+	}
+	w.Printf("}")
+}
+
+func formatSafeTableConstraints(w *redact.StringBuilder, desc catalog.TableDescriptor) {
+	td := desc.TableDesc()
+	formatSafeTableChecks(w, td.Checks)
+	formatSafeTableFKs(w, "InboundFKs", td.InboundFKs)
+	formatSafeTableFKs(w, "OutboundFKs", td.OutboundFKs)
+}
+
+func formatSafeTableFKs(
+	w *redact.StringBuilder, fksType string, fks []descpb.ForeignKeyConstraint,
+) {
+	for i := range fks {
+		w.Printf(", ")
+		if i == 0 {
+			w.Printf(fksType)
+			w.Printf(": [")
+		}
+		fk := &fks[i]
+		formatSafeFK(w, fk, nil)
+	}
+	if len(fks) > 0 {
+		w.Printf("]")
+	}
+}
+
+func formatSafeFK(
+	w *redact.StringBuilder, fk *descpb.ForeignKeyConstraint, m *descpb.DescriptorMutation,
+) {
+	w.Printf("{OriginTableID: %d", fk.OriginTableID)
+	w.Printf(", OriginColumns: ")
+	formatSafeColumnIDs(w, fk.OriginColumnIDs)
+	w.Printf(", ReferencedTableID: %d", fk.ReferencedTableID)
+	w.Printf(", ReferencedColumnIDs: ")
+	formatSafeColumnIDs(w, fk.ReferencedColumnIDs)
+	w.Printf(", Validity: %s", fk.Validity.String())
+	if m != nil {
+		w.Printf(", State: %s, MutationID: %d", m.Direction, m.MutationID)
+	}
+	w.Printf("}")
+}
+
+func formatSafeTableChecks(
+	w *redact.StringBuilder, checks []*descpb.TableDescriptor_CheckConstraint,
+) {
+	for i, c := range checks {
+		if i == 0 {
+			w.Printf(", Checks: [")
+		} else {
+			w.Printf(", ")
+		}
+		formatSafeCheck(w, c, nil)
+	}
+	if len(checks) > 0 {
+		w.Printf("]")
+	}
+}
+
+func formatSafeTableColumnFamilies(w *redact.StringBuilder, desc catalog.TableDescriptor) {
+	td := desc.TableDesc()
+	w.Printf(", NextFamilyID: %d", td.NextFamilyID)
+	for i := range td.Families {
+		w.Printf(", ")
+		if i == 0 {
+			w.Printf("Families: [")
+		}
+		formatSafeTableColumnFamily(w, &td.Families[i])
+	}
+	if len(td.Families) > 0 {
+		w.Printf("]")
+	}
+}
+
+func formatSafeTableColumnFamily(w *redact.StringBuilder, f *descpb.ColumnFamilyDescriptor) {
+	w.Printf("{")
+	w.Printf("ID: %d", f.ID)
+	w.Printf(", Columns: ")
+	formatSafeColumnIDs(w, f.ColumnIDs)
+	w.Printf("}")
+}
+
+func formatSafeTableMutationJobs(w *redact.StringBuilder, td catalog.TableDescriptor) {
+	mutationJobs := td.GetMutationJobs()
+	for i := range mutationJobs {
+		w.Printf(", ")
+		if i == 0 {
+			w.Printf("MutationJobs: [")
+		}
+		m := &mutationJobs[i]
+		w.Printf("{MutationID: %d, JobID: %d}", m.MutationID, m.JobID)
+	}
+	if len(mutationJobs) > 0 {
+		w.Printf("]")
+	}
+}
+
+func formatSafeMutations(w *redact.StringBuilder, td catalog.TableDescriptor) {
+	mutations := td.TableDesc().Mutations
+	for i := range mutations {
+		w.Printf(", ")
+		m := &mutations[i]
+		if i == 0 {
+			w.Printf("Mutations: [")
+		}
+		formatSafeMutation(w, m)
+	}
+	if len(mutations) > 0 {
+		w.Printf("]")
+	}
+}
+
+func formatSafeMutation(w *redact.StringBuilder, m *descpb.DescriptorMutation) {
+	w.Printf("{MutationID: %d", m.MutationID)
+	w.Printf(", Direction: %s", m.Direction)
+	w.Printf(", State: %s", m.State)
+	switch md := m.Descriptor_.(type) {
+	case *descpb.DescriptorMutation_Constraint:
+		w.Printf(", ConstraintType: %s", md.Constraint.ConstraintType)
+		if md.Constraint.NotNullColumn != 0 {
+			w.Printf(", NotNullColumn: %d", md.Constraint.NotNullColumn)
+		}
+		switch {
+		case !md.Constraint.ForeignKey.Equal(&descpb.ForeignKeyConstraint{}):
+			w.Printf(", ForeignKey: ")
+			formatSafeFK(w, &md.Constraint.ForeignKey, m)
+		case !md.Constraint.Check.Equal(&descpb.TableDescriptor_CheckConstraint{}):
+			w.Printf(", Check: ")
+			formatSafeCheck(w, &md.Constraint.Check, m)
+		}
+	case *descpb.DescriptorMutation_Index:
+		w.Printf(", Index: ")
+		formatSafeIndex(w, md.Index, m)
+	case *descpb.DescriptorMutation_Column:
+		w.Printf(", Column: ")
+		formatSafeColumn(w, md.Column, m)
+	case *descpb.DescriptorMutation_PrimaryKeySwap:
+		w.Printf(", PrimaryKeySwap: {")
+		w.Printf("OldPrimaryIndexID: %d", md.PrimaryKeySwap.OldPrimaryIndexId)
+		w.Printf(", OldIndexes: ")
+		formatSafeIndexIDs(w, md.PrimaryKeySwap.NewIndexes)
+		w.Printf("NewPrimaryIndexID: %d", md.PrimaryKeySwap.NewPrimaryIndexId)
+		w.Printf(", NewIndexes: ")
+		formatSafeIndexIDs(w, md.PrimaryKeySwap.NewIndexes)
+		w.Printf("}")
+	case *descpb.DescriptorMutation_ComputedColumnSwap:
+		w.Printf(", ComputedColumnSwap: {OldColumnID: %d, NewColumnID: %d}",
+			md.ComputedColumnSwap.OldColumnId, md.ComputedColumnSwap.NewColumnId)
+	case *descpb.DescriptorMutation_MaterializedViewRefresh:
+		w.Printf(", MaterializedViewRefresh: {")
+		w.Printf("NewPrimaryIndex: ")
+		formatSafeIndex(w, &md.MaterializedViewRefresh.NewPrimaryIndex, m)
+		w.Printf(", NewIndexes: [")
+		for i := range md.MaterializedViewRefresh.NewIndexes {
+			if i > 0 {
+				w.Printf(", ")
+			}
+			formatSafeIndex(w, &md.MaterializedViewRefresh.NewIndexes[i], m)
+		}
+		w.Printf("]")
+		w.Printf(", AsOf: %s, ShouldBackfill: %b",
+			md.MaterializedViewRefresh.AsOf, md.MaterializedViewRefresh.ShouldBackfill)
+		w.Printf("}")
+	}
+	w.Printf("}")
+}
+
+func formatSafeCheck(
+	w *redact.StringBuilder, c *descpb.TableDescriptor_CheckConstraint, m *descpb.DescriptorMutation,
+) {
+	// TODO(ajwerner): expose OID hashing to get the OID for the
+	// constraint.
+	w.Printf("{Columns: ")
+	formatSafeColumnIDs(w, c.ColumnIDs)
+	w.Printf(", Validity: %s", c.Validity.String())
+	if c.Hidden {
+		w.Printf(", Hidden: true")
+	}
+	if m != nil {
+		w.Printf(", State: %s, MutationID: %d", m.Direction, m.MutationID)
+	}
+	w.Printf("}")
+}
+
+func formatSafeColumnIDs(w *redact.StringBuilder, colIDs []descpb.ColumnID) {
+	w.Printf("[")
+	for i, colID := range colIDs {
+		if i > 0 {
+			w.Printf(", ")
+		}
+		w.Printf("%d", colID)
+	}
+	w.Printf("]")
+}
+
+func formatSafeIndexIDs(w *redact.StringBuilder, indexIDs []descpb.IndexID) {
+	w.Printf("[")
+	for i, idxID := range indexIDs {
+		if i > 0 {
+			w.Printf(", ")
+		}
+		w.Printf("%d", idxID)
+	}
+	w.Printf("]")
+}
+
+func formatSafeIDs(w *redact.StringBuilder, ids []descpb.ID) {
+	w.Printf("[")
+	for i, id := range ids {
+		if i > 0 {
+			w.Printf(", ")
+		}
+		w.Printf("%d", id)
+	}
+	w.Printf("]")
+}

--- a/pkg/sql/catalog/tabledesc/safe_format_test.go
+++ b/pkg/sql/catalog/tabledesc/safe_format_test.go
@@ -1,0 +1,262 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tabledesc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSafeMessage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// TODO(ajwerner): Finish testing all of the cases.
+	ctx := context.Background()
+	for _, tc := range []struct {
+		id       descpb.ID
+		parentID descpb.ID
+		schema   string
+		f        func(mutable *tabledesc.Mutable) catalog.TableDescriptor
+		exp      string
+	}{
+		{
+			id:       12,
+			parentID: 21,
+			schema:   "CREATE TABLE foo ()",
+			exp: "tabledesc.Mutable: {" +
+				"ID: 12, Version: 1, IsUncommitted: true, " +
+				"ModificationTime: \"0,0\", " +
+				"ParentID: 21, ParentSchemaID: 29, " +
+				"State: PUBLIC, " +
+				"NextColumnID: 2, " +
+				"Columns: [{ID: 1, TypeID: 20, Null: false, Hidden: true, HasDefault: true}], " +
+				"NextFamilyID: 1, " +
+				"Families: [{ID: 0, Columns: [1]}], " +
+				"PrimaryIndex: 1, " +
+				"NextIndexID: 2, " +
+				"Indexes: [{ID: 1, Unique: true, Columns: [{ID: 1, Dir: ASC}]}]" +
+				"}",
+		},
+		{
+			id:       12,
+			parentID: 21,
+			schema:   "CREATE TABLE foo (i INT PRIMARY KEY, j INT, j_str STRING AS (j::STRING) STORED, INDEX (j_str))",
+			exp: `tabledesc.Immutable: {` +
+				`ID: 12, Version: 1, ModificationTime: "1.000000000,0", ` +
+				`ParentID: 21, ParentSchemaID: 29, State: PUBLIC, ` +
+				`NextColumnID: 6, ` +
+				`Columns: [` +
+				`{ID: 1, TypeID: 20, Null: false}, ` +
+				`{ID: 2, TypeID: 20, Null: true}, ` +
+				`{ID: 3, TypeID: 25, Null: true, IsComputed: true}` +
+				`], ` +
+				`NextFamilyID: 1, ` +
+				`Families: [{ID: 0, Columns: [1, 2, 3, 5]}], ` +
+				`MutationJobs: [` +
+				`{MutationID: 1, JobID: 12345}, ` +
+				`{MutationID: 2, JobID: 67890}, ` +
+				`{MutationID: 3, JobID: 1234}` +
+				`], ` +
+				`Mutations: [` +
+				`{MutationID: 1, Direction: ADD, State: DELETE_AND_WRITE_ONLY, ConstraintType: FOREIGN_KEY, ForeignKey: {OriginTableID: 12, OriginColumns: [2], ReferencedTableID: 2, ReferencedColumnIDs: [3], Validity: Unvalidated, State: ADD, MutationID: 1}}, ` +
+				`{MutationID: 2, Direction: ADD, State: DELETE_ONLY, Column: {ID: 5, TypeID: 20, Null: false, State: ADD, MutationID: 2}}, ` +
+				`{MutationID: 3, Direction: ADD, State: DELETE_ONLY, ConstraintType: CHECK, NotNullColumn: 2, Check: {Columns: [2], Validity: Unvalidated, State: ADD, MutationID: 3}}, ` +
+				`{MutationID: 3, Direction: ADD, State: DELETE_ONLY, Index: {ID: 3, Unique: false, Columns: [{ID: 3, Dir: ASC}, {ID: 2, Dir: DESC}], ExtraColumns: [1], StoreColumns: [5], State: ADD, MutationID: 3}}` +
+				`], ` +
+				`PrimaryIndex: 1, ` +
+				`NextIndexID: 4, ` +
+				`Indexes: [` +
+				`{ID: 1, Unique: true, Columns: [{ID: 1, Dir: ASC}]}, ` +
+				`{ID: 2, Unique: false, Columns: [{ID: 3, Dir: ASC}], ExtraColumns: [1]}` +
+				`], ` +
+				`Checks: [` +
+				`{Columns: [2], Validity: Validated}` +
+				`], ` +
+				`InboundFKs: [` +
+				`{OriginTableID: 2, OriginColumns: [3], ReferencedTableID: 12, ReferencedColumnIDs: [2], Validity: Validated}` +
+				`], ` +
+				`OutboundFKs: [` +
+				`{OriginTableID: 12, OriginColumns: [2], ReferencedTableID: 3, ReferencedColumnIDs: [1], Validity: Validated}` +
+				`]}`,
+			f: func(mutable *tabledesc.Mutable) catalog.TableDescriptor {
+				// Add foreign key constraints and foreign key constraints and
+				// various mutations.
+				mutable.Checks = append(mutable.Checks, &descpb.TableDescriptor_CheckConstraint{
+					Name:      "check",
+					Expr:      "j > 0",
+					Validity:  descpb.ConstraintValidity_Validated,
+					ColumnIDs: []descpb.ColumnID{2},
+				})
+				mutable.InboundFKs = append(mutable.InboundFKs, descpb.ForeignKeyConstraint{
+					Name:                "inbound_fk",
+					OriginTableID:       2,
+					OriginColumnIDs:     []descpb.ColumnID{3},
+					ReferencedColumnIDs: []descpb.ColumnID{2},
+					ReferencedTableID:   12,
+					Validity:            descpb.ConstraintValidity_Validated,
+					OnDelete:            descpb.ForeignKeyReference_CASCADE,
+					Match:               descpb.ForeignKeyReference_PARTIAL,
+				})
+				mutable.OutboundFKs = append(mutable.OutboundFKs, descpb.ForeignKeyConstraint{
+					Name:                "outbound_fk",
+					OriginTableID:       12,
+					OriginColumnIDs:     []descpb.ColumnID{2},
+					ReferencedColumnIDs: []descpb.ColumnID{1},
+					ReferencedTableID:   3,
+					Validity:            descpb.ConstraintValidity_Validated,
+					OnDelete:            descpb.ForeignKeyReference_SET_DEFAULT,
+					Match:               descpb.ForeignKeyReference_SIMPLE,
+				})
+
+				mutable.Mutations = append(mutable.Mutations, descpb.DescriptorMutation{
+					State: descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+					Descriptor_: &descpb.DescriptorMutation_Constraint{
+						Constraint: &descpb.ConstraintToUpdate{
+							ConstraintType: descpb.ConstraintToUpdate_FOREIGN_KEY,
+							Name:           "outbound_fk_mutation",
+							ForeignKey: descpb.ForeignKeyConstraint{
+								Name:                "outbound_fk_mutation",
+								OriginTableID:       12,
+								OriginColumnIDs:     []descpb.ColumnID{2},
+								ReferencedTableID:   2,
+								ReferencedColumnIDs: []descpb.ColumnID{3},
+								Validity:            descpb.ConstraintValidity_Unvalidated,
+								OnDelete:            descpb.ForeignKeyReference_SET_NULL,
+								Match:               descpb.ForeignKeyReference_FULL,
+							},
+						},
+					},
+					Direction:  descpb.DescriptorMutation_ADD,
+					MutationID: 1,
+				},
+					descpb.DescriptorMutation{
+						State: descpb.DescriptorMutation_DELETE_ONLY,
+						Descriptor_: &descpb.DescriptorMutation_Column{
+							Column: &descpb.ColumnDescriptor{
+								ID:   5,
+								Name: "c",
+								Type: types.Int,
+							},
+						},
+						Direction:  descpb.DescriptorMutation_ADD,
+						MutationID: 2,
+					},
+					descpb.DescriptorMutation{
+						State: descpb.DescriptorMutation_DELETE_ONLY,
+						Descriptor_: &descpb.DescriptorMutation_Constraint{
+							Constraint: &descpb.ConstraintToUpdate{
+								ConstraintType: descpb.ConstraintToUpdate_CHECK,
+								Name:           "check_not_null",
+								Check: descpb.TableDescriptor_CheckConstraint{
+									Name:                "check_not_null",
+									Validity:            descpb.ConstraintValidity_Unvalidated,
+									ColumnIDs:           []descpb.ColumnID{2},
+									IsNonNullConstraint: true,
+								},
+								NotNullColumn: 2,
+							},
+						},
+						Direction:  descpb.DescriptorMutation_ADD,
+						MutationID: 3,
+					},
+					descpb.DescriptorMutation{
+						State: descpb.DescriptorMutation_DELETE_ONLY,
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID:             3,
+								Name:           "check_not_null",
+								ColumnIDs:      []descpb.ColumnID{3, 2},
+								ExtraColumnIDs: []descpb.ColumnID{1},
+								StoreColumnIDs: []descpb.ColumnID{5},
+								ColumnNames:    []string{"j_str", "j"},
+								ColumnDirections: []descpb.IndexDescriptor_Direction{
+									descpb.IndexDescriptor_ASC,
+									descpb.IndexDescriptor_DESC,
+								},
+								StoreColumnNames: []string{"c"},
+							},
+						},
+						Direction:  descpb.DescriptorMutation_ADD,
+						MutationID: 3,
+					})
+				mutable.MutationJobs = append(mutable.MutationJobs,
+					descpb.TableDescriptor_MutationJob{
+						MutationID: 1,
+						JobID:      12345,
+					},
+					descpb.TableDescriptor_MutationJob{
+						MutationID: 2,
+						JobID:      67890,
+					},
+					descpb.TableDescriptor_MutationJob{
+						MutationID: 3,
+						JobID:      1234,
+					},
+				)
+				mutable.NextColumnID = 6
+				mutable.NextIndexID = 4
+				mutable.Families[0].ColumnNames = append(mutable.Families[0].ColumnNames, "c")
+				mutable.Families[0].ColumnIDs = append(mutable.Families[0].ColumnIDs, 5)
+				mutable.ModificationTime = hlc.Timestamp{WallTime: 1e9}
+				mutable.ClusterVersion = *mutable.TableDesc()
+				return mutable.ImmutableCopy().(catalog.TableDescriptor)
+			},
+		},
+		{
+			id:       12,
+			parentID: 21,
+			schema:   "CREATE TABLE foo ()",
+			exp: "tabledesc.Immutable: {" +
+				"ID: 12, Version: 1, " +
+				"ModificationTime: \"0,0\", " +
+				"ParentID: 21, ParentSchemaID: 29, " +
+				"State: PUBLIC, " +
+				"NextColumnID: 2, " +
+				"Columns: [{ID: 1, TypeID: 20, Null: false, Hidden: true, HasDefault: true}], " +
+				"NextFamilyID: 1, " +
+				"Families: [{ID: 0, Columns: [1]}], " +
+				"PrimaryIndex: 1, " +
+				"NextIndexID: 2, " +
+				"Indexes: [{ID: 1, Unique: true, Columns: [{ID: 1, Dir: ASC}]}]" +
+				"}",
+			f: func(mutable *tabledesc.Mutable) catalog.TableDescriptor {
+				mutable.ClusterVersion = *mutable.TableDesc()
+				return mutable.ImmutableCopy().(catalog.TableDescriptor)
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			desc, err := sql.CreateTestTableDescriptor(ctx, tc.parentID, tc.id, tc.schema, &descpb.PrivilegeDescriptor{})
+			require.NoError(t, err)
+			var td catalog.TableDescriptor
+			if tc.f != nil {
+				td = tc.f(desc)
+			} else {
+				td = desc
+			}
+			redacted := string(redact.Sprint(td).Redact())
+			require.NoError(t, desc.ValidateTable(ctx))
+			require.Equal(t, tc.exp, redacted)
+			var m map[string]interface{}
+			require.NoError(t, yaml.UnmarshalStrict([]byte(redacted), &m), redacted)
+		})
+	}
+}

--- a/pkg/sql/catalog/typedesc/safe_format.go
+++ b/pkg/sql/catalog/typedesc/safe_format.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package typedesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/redact"
+)
+
+// SafeMessage makes Immutable a SafeMessager.
+func (desc *Immutable) SafeMessage() string {
+	return formatSafeType("typedesc.Immutable", desc)
+}
+
+// SafeMessage makes Mutable a SafeMessager.
+func (desc *Mutable) SafeMessage() string {
+	return formatSafeType("typedesc.Mutable", desc)
+}
+
+func formatSafeType(typeName string, desc catalog.TypeDescriptor) string {
+	var buf redact.StringBuilder
+	buf.Printf(typeName + ": {")
+	formatSafeTypeProperties(&buf, desc)
+	buf.Printf("}")
+	return buf.String()
+}
+
+func formatSafeTypeProperties(w *redact.StringBuilder, desc catalog.TypeDescriptor) {
+	catalog.FormatSafeDescriptorProperties(w, desc)
+	td := desc.TypeDesc()
+	w.Printf(", Kind: %s", td.Kind)
+	if len(td.EnumMembers) > 0 {
+		w.Printf(", NumEnumMembers: %d", len(td.EnumMembers))
+	}
+	if td.Alias != nil {
+		w.Printf(", Alias: %d", td.Alias.Oid())
+	}
+	if td.ArrayTypeID != 0 {
+		w.Printf(", ArrayTypeID: %d", td.ArrayTypeID)
+	}
+	for i := range td.ReferencingDescriptorIDs {
+		w.Printf(", ")
+		if i == 0 {
+			w.Printf("ReferencingDescriptorIDs: [")
+		}
+		w.Printf("%d", td.ReferencingDescriptorIDs[i])
+	}
+	if len(td.ReferencingDescriptorIDs) > 0 {
+		w.Printf("]")
+	}
+}

--- a/pkg/sql/catalog/typedesc/safe_format_test.go
+++ b/pkg/sql/catalog/typedesc/safe_format_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package typedesc_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSafeMessage(t *testing.T) {
+	for _, tc := range []struct {
+		desc catalog.TypeDescriptor
+		exp  string
+	}{
+		{
+			desc: typedesc.NewImmutable(descpb.TypeDescriptor{
+				Name:    "foo",
+				ID:      21,
+				Version: 3,
+				DrainingNames: []descpb.NameInfo{
+					{
+						ParentID:       2,
+						ParentSchemaID: 29,
+						Name:           "bar",
+					},
+				},
+				Privileges:               &descpb.PrivilegeDescriptor{},
+				ParentID:                 2,
+				ParentSchemaID:           29,
+				ArrayTypeID:              117,
+				State:                    descpb.DescriptorState_PUBLIC,
+				Kind:                     descpb.TypeDescriptor_ALIAS,
+				ReferencingDescriptorIDs: []descpb.ID{73, 37},
+			}),
+			exp: `typedesc.Immutable: {ID: 21, Version: 3, ModificationTime: "0,0", ` +
+				`ParentID: 2, ParentSchemaID: 29, State: PUBLIC, NumDrainingNames: 1, ` +
+				`Kind: ALIAS, ArrayTypeID: 117, ReferencingDescriptorIDs: [73, 37]}`,
+		},
+		{
+			desc: typedesc.NewImmutable(descpb.TypeDescriptor{
+				Name:    "foo",
+				ID:      21,
+				Version: 3,
+				DrainingNames: []descpb.NameInfo{
+					{
+						ParentID:       2,
+						ParentSchemaID: 29,
+						Name:           "bar",
+					},
+				},
+				Privileges:               &descpb.PrivilegeDescriptor{},
+				ParentID:                 2,
+				ParentSchemaID:           29,
+				ArrayTypeID:              117,
+				State:                    descpb.DescriptorState_PUBLIC,
+				Kind:                     descpb.TypeDescriptor_ENUM,
+				ReferencingDescriptorIDs: []descpb.ID{73, 37},
+				EnumMembers: []descpb.TypeDescriptor_EnumMember{
+					{},
+				},
+			}),
+			exp: `typedesc.Immutable: {ID: 21, Version: 3, ModificationTime: "0,0", ` +
+				`ParentID: 2, ParentSchemaID: 29, State: PUBLIC, NumDrainingNames: 1, ` +
+				`Kind: ENUM, NumEnumMembers: 1, ArrayTypeID: 117, ReferencingDescriptorIDs: [73, 37]}`,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			redacted := string(redact.Sprint(tc.desc).Redact())
+			require.Equal(t, tc.exp, redacted)
+			{
+				var m map[string]interface{}
+				require.NoError(t, yaml.UnmarshalStrict([]byte(redacted), &m))
+			}
+		})
+	}
+}


### PR DESCRIPTION
See individual commits. This PR ended up being much more toil that I had anticipated. I generally regret having done it and fear that I've missed some things. That being said, I think it's a valuable contribution even if we ultimately do replace it with something more reflective and programmatic.

Fixes #51239. 

Release note: None.