### PR TITLE
build: bump timeout for SQL Race Logic Test to 24 hours

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,7 +8,7 @@ maybe_ccache
 
 mkdir -p artifacts
 
-TESTTIMEOUT=8h
+TESTTIMEOUT=24h
 
 run_json_test build/builder.sh \
   stdbuf -oL -eL \


### PR DESCRIPTION
The test is still timing out after 8 hours, so this commit bumps the
timeout to 24 hours. If this doesn't fix it, I will try something else
like disabling the problematic tests under race.

Release note: None