### PR TITLE
sql: support pg_column_size

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2731,6 +2731,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="oid"></a><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
 </span></td></tr>
+<tr><td><a name="pg_column_size"></a><code>pg_column_size(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return size in bytes of the column provided as an argument</p>
+</span></td></tr>
 <tr><td><a name="pg_sleep"></a><code>pg_sleep(seconds: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>pg_sleep makes the current session’s process sleep until seconds seconds have elapsed. seconds is a value of type double precision, so fractional-second delays can be specified.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -33,3 +33,50 @@ query T
 SELECT format_type(152100, 0)
 ----
 unknown (OID=152100)
+
+subtest pg_column_size
+
+query I
+SELECT pg_column_size(1::float)
+----
+9
+
+query I
+SELECT pg_column_size(1::int)
+----
+2
+
+query I
+SELECT pg_column_size((1, 1))
+----
+7
+
+query I
+SELECT pg_column_size('{}'::json)
+----
+7
+
+query I
+SELECT pg_column_size('')
+----
+2
+
+query I
+SELECT pg_column_size('a')
+----
+3
+
+query I
+SELECT pg_column_size((1,'a'))
+----
+8
+
+query I
+SELECT pg_column_size(true)
+----
+1
+
+query I
+SELECT pg_column_size(NULL::int)
+----
+NULL


### PR DESCRIPTION
This commit adds `pg_column_size` builtin command to measure number of
bytes allocated by datum.

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note (sql change): enable pg_column_size builtin command to
count amount of bytes stored by column