### PR TITLE
col*: properly account for the memory used by variably-sized datums

### DIFF
--- a/pkg/col/coldata/datum_vec.go
+++ b/pkg/col/coldata/datum_vec.go
@@ -47,4 +47,7 @@ type DatumVec interface {
 	// UnmarshalTo unmarshals the byte representation of a datum and sets it at
 	// index i.
 	UnmarshalTo(i int, b []byte) error
+	// Size returns the total memory footprint of the vector (including the
+	// internal memory used by tree.Datums) in bytes.
+	Size() uintptr
 }

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -12,6 +12,7 @@ package coldataext
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -158,11 +159,34 @@ func (dv *datumVec) MarshalAt(i int) ([]byte, error) {
 }
 
 // UnmarshalTo implements coldata.DatumVec interface.
-// index i.
 func (dv *datumVec) UnmarshalTo(i int, b []byte) error {
 	var err error
 	dv.data[i], _, err = rowenc.DecodeTableValue(&dv.da, dv.t, b)
 	return err
+}
+
+const sizeOfDatum = unsafe.Sizeof(tree.Datum(nil))
+
+// Size implements coldata.DatumVec interface.
+func (dv *datumVec) Size() uintptr {
+	// Note that we don't account for the overhead of datumVec struct, and the
+	// calculations are such that they are in line with
+	// colmem.EstimateBatchSizeBytes.
+	count := uintptr(dv.Cap())
+	size := sizeOfDatum * count
+	if datumSize, variable := tree.DatumTypeSize(dv.t); variable {
+		for _, d := range dv.data {
+			if d != nil {
+				size += d.Size()
+			}
+		}
+		// The elements in dv.data[len:cap] range are accounted with the
+		// default datum size for the type.
+		size += (count - uintptr(dv.Len())) * datumSize
+	} else {
+		size += datumSize * count
+	}
+	return size
 }
 
 // assertValidDatum asserts that the given datum is valid to be stored in this

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -57,7 +57,9 @@ func NewVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *VecToDatumC
 }
 
 // ConvertBatchAndDeselect converts the selected vectors from the batch while
-// performing a deselection step.
+// performing a deselection step. It doesn't account for the memory used by the
+// newly created tree.Datums, so it is up to the caller to do the memory
+// accounting.
 // NOTE: converted columns are "dense" in regards to the selection vector - if
 // there was a selection vector on the batch, only elements that were selected
 // are converted, so in order to access the tuple at position tupleIdx, use
@@ -95,7 +97,9 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 }
 
 // ConvertBatch converts the selected vectors from the batch *without*
-// performing a deselection step.
+// performing a deselection step. It doesn't account for the memory used by the
+// newly created tree.Datums, so it is up to the caller to do the memory
+// accounting.
 // NOTE: converted columns are "sparse" in regards to the selection vector - if
 // there was a selection vector, only elements that were selected are
 // converted, but the results are put at position sel[tupleIdx], so use
@@ -106,7 +110,8 @@ func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
 }
 
 // ConvertVecs converts the selected vectors from vecs *without* performing a
-// deselection step.
+// deselection step. It doesn't account for the memory used by the newly
+// created tree.Datums, so it is up to the caller to do the memory accounting.
 // Note that this method is equivalent to ConvertBatch with the only difference
 // being the fact that it takes in a "disassembled" batch and not coldata.Batch.
 // Consider whether you should be using ConvertBatch instead.
@@ -152,7 +157,8 @@ func (c *VecToDatumConverter) GetDatumColumn(colIdx int) tree.Datums {
 // ColVecToDatumAndDeselect converts a vector of coldata-represented values in
 // col into tree.Datum representation while performing a deselection step.
 // length specifies the number of values to be converted and sel is an optional
-// selection vector.
+// selection vector. It doesn't account for the memory used by the newly
+// created tree.Datums, so it is up to the caller to do the memory accounting.
 func ColVecToDatumAndDeselect(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {
@@ -593,7 +599,9 @@ func ColVecToDatumAndDeselect(
 }
 
 // ColVecToDatum converts a vector of coldata-represented values in col into
-// tree.Datum representation *without* performing a deselection step.
+// tree.Datum representation *without* performing a deselection step. It
+// doesn't account for the memory used by the newly created tree.Datums, so it
+// is up to the caller to do the memory accounting.
 func ColVecToDatum(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -60,7 +60,9 @@ func NewVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *VecToDatumC
 }
 
 // ConvertBatchAndDeselect converts the selected vectors from the batch while
-// performing a deselection step.
+// performing a deselection step. It doesn't account for the memory used by the
+// newly created tree.Datums, so it is up to the caller to do the memory
+// accounting.
 // NOTE: converted columns are "dense" in regards to the selection vector - if
 // there was a selection vector on the batch, only elements that were selected
 // are converted, so in order to access the tuple at position tupleIdx, use
@@ -98,7 +100,9 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 }
 
 // ConvertBatch converts the selected vectors from the batch *without*
-// performing a deselection step.
+// performing a deselection step. It doesn't account for the memory used by the
+// newly created tree.Datums, so it is up to the caller to do the memory
+// accounting.
 // NOTE: converted columns are "sparse" in regards to the selection vector - if
 // there was a selection vector, only elements that were selected are
 // converted, but the results are put at position sel[tupleIdx], so use
@@ -109,7 +113,8 @@ func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
 }
 
 // ConvertVecs converts the selected vectors from vecs *without* performing a
-// deselection step.
+// deselection step. It doesn't account for the memory used by the newly
+// created tree.Datums, so it is up to the caller to do the memory accounting.
 // Note that this method is equivalent to ConvertBatch with the only difference
 // being the fact that it takes in a "disassembled" batch and not coldata.Batch.
 // Consider whether you should be using ConvertBatch instead.
@@ -155,7 +160,8 @@ func (c *VecToDatumConverter) GetDatumColumn(colIdx int) tree.Datums {
 // ColVecToDatumAndDeselect converts a vector of coldata-represented values in
 // col into tree.Datum representation while performing a deselection step.
 // length specifies the number of values to be converted and sel is an optional
-// selection vector.
+// selection vector. It doesn't account for the memory used by the newly
+// created tree.Datums, so it is up to the caller to do the memory accounting.
 func ColVecToDatumAndDeselect(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {
@@ -172,7 +178,9 @@ func ColVecToDatumAndDeselect(
 }
 
 // ColVecToDatum converts a vector of coldata-represented values in col into
-// tree.Datum representation *without* performing a deselection step.
+// tree.Datum representation *without* performing a deselection step. It
+// doesn't account for the memory used by the newly created tree.Datums, so it
+// is up to the caller to do the memory accounting.
 func ColVecToDatum(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {


### PR DESCRIPTION
We rely on `Allocator.PerformOperation` to measure the difference in the
footprint of the batches so that we can account for the increased usage
accordingly. That method internally uses an estimation to get the
footprint (except for flat bytes), and this works well in many cases
except for the case of variably-sized `tree.Datum`s (which could be
present in datum-backed vectors). Previously, we would not account for
that memory precisely, and it is now fixed.

Additionally, this commit clarifies that `ConvertBatch*` method of
`colconv` package don't account for the memory used by the newly created
datums and fixes missing calls to `PerformOperation` in a tuple
projection operator and in the hash aggregator (the latter is not too
important though since we're reusing the same batch for buffering
a limited number of tuples).

Fixes: #55201.

Release note: None