### PR TITLE
sql: fix JSON fetch value operator evaluation

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -761,8 +761,11 @@ func executeBinOpOnDatums(prelude, targetElem, leftColdataExtDatum, rightDatumEl
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
+			if _res == tree.DNull {
+				_outNulls.SetNull(%s)
+			}
 			%s
-		`, prelude, leftColdataExtDatum, rightDatumElem,
+		`, prelude, leftColdataExtDatum, rightDatumElem, idxVariable,
 		set(typeconv.DatumVecCanonicalTypeFamily, vecVariable, idxVariable, "_res"),
 	)
 }

--- a/pkg/sql/colexec/like_ops.eg.go
+++ b/pkg/sql/colexec/like_ops.eg.go
@@ -129,6 +129,11 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -153,8 +158,12 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -172,6 +181,11 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = bytes.HasPrefix(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -302,6 +316,11 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -326,8 +345,12 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -345,6 +368,11 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = bytes.HasSuffix(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -475,6 +503,11 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -499,8 +532,12 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -518,6 +555,11 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = bytes.Contains(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -648,6 +690,11 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -672,8 +719,12 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -691,6 +742,11 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Match(arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -821,6 +877,11 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -845,8 +906,12 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -864,6 +929,11 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -994,6 +1064,11 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1018,8 +1093,12 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1037,6 +1116,11 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1167,6 +1251,11 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1191,8 +1280,12 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1210,6 +1303,11 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = !bytes.Contains(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1340,6 +1438,11 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1364,8 +1467,12 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1383,6 +1490,11 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = !p.constArg.Match(arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -56,6 +56,11 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -82,8 +87,12 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -103,6 +112,11 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -141,6 +155,11 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -167,8 +186,12 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -188,6 +211,11 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -226,6 +254,11 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -252,8 +285,12 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -273,6 +310,11 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -311,6 +353,11 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -337,8 +384,12 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -358,6 +409,11 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -396,6 +452,11 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -422,8 +483,12 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -443,6 +508,11 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -481,6 +551,11 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -507,8 +582,12 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -528,6 +607,11 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -566,6 +650,11 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -592,8 +681,12 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -613,6 +706,11 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -651,6 +749,11 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -677,8 +780,12 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -698,6 +805,11 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -736,6 +848,11 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -762,8 +879,12 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -783,6 +904,11 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -821,6 +947,11 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -834,6 +965,9 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -850,13 +984,20 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -866,6 +1007,9 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -880,10 +1024,18 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -922,6 +1074,11 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -948,8 +1105,12 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -969,6 +1130,11 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1007,6 +1173,11 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1033,8 +1204,12 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1054,6 +1229,11 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1092,6 +1272,11 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1118,8 +1303,12 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1139,6 +1328,11 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1177,6 +1371,11 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1203,8 +1402,12 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1224,6 +1427,11 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1262,6 +1470,11 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1288,8 +1501,12 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1309,6 +1526,11 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1347,6 +1569,11 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1373,8 +1600,12 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1394,6 +1625,11 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1432,6 +1668,11 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1458,8 +1699,12 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1479,6 +1724,11 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1517,6 +1767,11 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1543,8 +1798,12 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1564,6 +1823,11 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1602,6 +1866,11 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1628,8 +1897,12 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1649,6 +1922,11 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1687,6 +1965,11 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1700,6 +1983,9 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -1716,13 +2002,20 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1732,6 +2025,9 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -1746,10 +2042,18 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1788,6 +2092,11 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1814,8 +2123,12 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1835,6 +2148,11 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1873,6 +2191,11 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1899,8 +2222,12 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1920,6 +2247,11 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1958,6 +2290,11 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1984,8 +2321,12 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2005,6 +2346,11 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2043,6 +2389,11 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2069,8 +2420,12 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2090,6 +2445,11 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2128,6 +2488,11 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2154,8 +2519,12 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2175,6 +2544,11 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2213,6 +2587,11 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2239,8 +2618,12 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2260,6 +2643,11 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2298,6 +2686,11 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2324,8 +2717,12 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2345,6 +2742,11 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2383,6 +2785,11 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2409,8 +2816,12 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2430,6 +2841,11 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2468,6 +2884,11 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2494,8 +2915,12 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2515,6 +2940,11 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2553,6 +2983,11 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2566,6 +3001,9 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -2582,13 +3020,20 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2598,6 +3043,9 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -2612,10 +3060,18 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2654,6 +3110,11 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2694,8 +3155,12 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2729,6 +3194,11 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2767,6 +3237,11 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2807,8 +3282,12 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2842,6 +3321,11 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2880,6 +3364,11 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2920,8 +3409,12 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2955,6 +3448,11 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2993,6 +3491,11 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3031,8 +3534,12 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3064,6 +3571,11 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3102,6 +3614,11 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3140,8 +3657,12 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3173,6 +3694,11 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3211,6 +3737,11 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3249,8 +3780,12 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3282,6 +3817,11 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3320,6 +3860,11 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3358,8 +3903,12 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3391,6 +3940,11 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3429,6 +3983,11 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3471,8 +4030,12 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3508,6 +4071,11 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3546,6 +4114,11 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3565,6 +4138,9 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -3587,13 +4163,20 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3609,6 +4192,9 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -3629,10 +4215,18 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3671,6 +4265,11 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3709,8 +4308,12 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3742,6 +4345,11 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3780,6 +4388,11 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3818,8 +4431,12 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3851,6 +4468,11 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3889,6 +4511,11 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3927,8 +4554,12 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3960,6 +4591,11 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3998,6 +4634,11 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4040,8 +4681,12 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4077,6 +4722,11 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4115,6 +4765,11 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4134,6 +4789,9 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4156,13 +4814,20 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4178,6 +4843,9 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4198,10 +4866,18 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4240,6 +4916,11 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4278,8 +4959,12 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4311,6 +4996,11 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4349,6 +5039,11 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4387,8 +5082,12 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4420,6 +5119,11 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4458,6 +5162,11 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4496,8 +5205,12 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4529,6 +5242,11 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4567,6 +5285,11 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4609,8 +5332,12 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4646,6 +5373,11 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4684,6 +5416,11 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4703,6 +5440,9 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4725,13 +5465,20 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4747,6 +5494,9 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4767,10 +5517,18 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4809,6 +5567,11 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4841,8 +5604,12 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4868,6 +5635,11 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4906,6 +5678,11 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4928,8 +5705,12 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4945,6 +5726,11 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4983,6 +5769,11 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5005,8 +5796,12 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5022,6 +5817,11 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5060,6 +5860,11 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5082,8 +5887,12 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5099,6 +5908,11 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 				projCol[i] = p.constArg.Add(arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5137,6 +5951,11 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5156,6 +5975,9 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5178,13 +6000,20 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5200,6 +6029,9 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5220,10 +6052,18 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5262,6 +6102,11 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5279,6 +6124,9 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5299,13 +6147,20 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5319,6 +6174,9 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5337,10 +6195,18 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5379,6 +6245,11 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5396,6 +6267,9 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5416,13 +6290,20 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5436,6 +6317,9 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5454,10 +6338,18 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5496,6 +6388,11 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5513,6 +6410,9 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5533,13 +6433,20 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5553,6 +6460,9 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5571,10 +6481,18 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5613,6 +6531,11 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5630,6 +6553,9 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5650,13 +6576,20 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5670,6 +6603,9 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5688,10 +6624,18 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5730,6 +6674,11 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5770,8 +6719,12 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5805,6 +6758,11 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5843,6 +6801,11 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5883,8 +6846,12 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5918,6 +6885,11 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5956,6 +6928,11 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5996,8 +6973,12 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6031,6 +7012,11 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6069,6 +7055,11 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6107,8 +7098,12 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6140,6 +7135,11 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6178,6 +7178,11 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6216,8 +7221,12 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6249,6 +7258,11 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6287,6 +7301,11 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6325,8 +7344,12 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6358,6 +7381,11 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6396,6 +7424,11 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6434,8 +7467,12 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6467,6 +7504,11 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6505,6 +7547,11 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6547,8 +7594,12 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6584,6 +7635,11 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6622,6 +7678,11 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6641,6 +7702,9 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -6663,13 +7727,20 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6685,6 +7756,9 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -6705,10 +7779,18 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6747,6 +7829,11 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6785,8 +7872,12 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6818,6 +7909,11 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6856,6 +7952,11 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6894,8 +7995,12 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6927,6 +8032,11 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6965,6 +8075,11 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7003,8 +8118,12 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7036,6 +8155,11 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7074,6 +8198,11 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7116,8 +8245,12 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7153,6 +8286,11 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7191,6 +8329,11 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7210,6 +8353,9 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -7232,13 +8378,20 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7254,6 +8407,9 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -7274,10 +8430,18 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7316,6 +8480,11 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7354,8 +8523,12 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7387,6 +8560,11 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7425,6 +8603,11 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7463,8 +8646,12 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7496,6 +8683,11 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7534,6 +8726,11 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7572,8 +8769,12 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7605,6 +8806,11 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7643,6 +8849,11 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7685,8 +8896,12 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7722,6 +8937,11 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7760,6 +8980,11 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7779,6 +9004,9 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -7801,13 +9029,20 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7823,6 +9058,9 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -7843,10 +9081,18 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7885,6 +9131,11 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7917,8 +9168,12 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7944,6 +9199,11 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7982,6 +9242,11 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8010,8 +9275,12 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8033,6 +9302,11 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8071,6 +9345,11 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8093,8 +9372,12 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8110,6 +9393,11 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 				projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8148,6 +9436,11 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8170,8 +9463,12 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8187,6 +9484,11 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = p.constArg.Sub(arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8225,6 +9527,11 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8244,6 +9551,9 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8266,13 +9576,20 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8288,6 +9605,9 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8308,10 +9628,18 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8350,6 +9678,11 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8363,6 +9696,9 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8379,13 +9715,20 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8395,6 +9738,9 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8409,10 +9755,18 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8451,6 +9805,11 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8468,6 +9827,9 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8488,13 +9850,20 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8508,6 +9877,9 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8526,10 +9898,18 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8568,6 +9948,11 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8585,6 +9970,9 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8607,13 +9995,20 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8627,6 +10022,9 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8647,10 +10045,18 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8689,6 +10095,11 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8706,6 +10117,9 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8726,13 +10140,20 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8746,6 +10167,9 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8764,10 +10188,18 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8806,6 +10238,11 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8823,6 +10260,9 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8843,13 +10283,20 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8863,6 +10310,9 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8881,10 +10331,18 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8923,6 +10381,11 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8940,6 +10403,9 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8960,13 +10426,20 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8980,6 +10453,9 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8998,10 +10474,18 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9040,6 +10524,11 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9080,8 +10569,12 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9115,6 +10608,11 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9153,6 +10651,11 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9193,8 +10696,12 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9228,6 +10735,11 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9266,6 +10778,11 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9306,8 +10823,12 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9341,6 +10862,11 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9379,6 +10905,11 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9417,8 +10948,12 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9450,6 +10985,11 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9488,6 +11028,11 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9520,8 +11065,12 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9547,6 +11096,11 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = arg.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9585,6 +11139,11 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9639,8 +11198,12 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9688,6 +11251,11 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9726,6 +11294,11 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9780,8 +11353,12 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9829,6 +11406,11 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9867,6 +11449,11 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9921,8 +11508,12 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9970,6 +11561,11 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10008,6 +11604,11 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10050,8 +11651,12 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10087,6 +11692,11 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10125,6 +11735,11 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10147,8 +11762,12 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10164,6 +11783,11 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10202,6 +11826,11 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10256,8 +11885,12 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10305,6 +11938,11 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10343,6 +11981,11 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10397,8 +12040,12 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10446,6 +12093,11 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10484,6 +12136,11 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10538,8 +12195,12 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10587,6 +12248,11 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10625,6 +12291,11 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10667,8 +12338,12 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10704,6 +12379,11 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10742,6 +12422,11 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10764,8 +12449,12 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10781,6 +12470,11 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10819,6 +12513,11 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10873,8 +12572,12 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10922,6 +12625,11 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10960,6 +12668,11 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11014,8 +12727,12 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11063,6 +12780,11 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11101,6 +12823,11 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11155,8 +12882,12 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11204,6 +12935,11 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11242,6 +12978,11 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11284,8 +13025,12 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11321,6 +13066,11 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11359,6 +13109,11 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11381,8 +13136,12 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11398,6 +13157,11 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11436,6 +13200,11 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11468,8 +13237,12 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11495,6 +13268,11 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11533,6 +13311,11 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11555,8 +13338,12 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11572,6 +13359,11 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11610,6 +13402,11 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11632,8 +13429,12 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11649,6 +13450,11 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11687,6 +13493,11 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11709,8 +13520,12 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11726,6 +13541,11 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11764,6 +13584,11 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11786,8 +13611,12 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11803,6 +13632,11 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11841,6 +13675,11 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11863,8 +13702,12 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11880,6 +13723,11 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11918,6 +13766,11 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11950,8 +13803,12 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11977,6 +13834,11 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = p.constArg.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12015,6 +13877,11 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12063,8 +13930,12 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12106,6 +13977,11 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12144,6 +14020,11 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12192,8 +14073,12 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12235,6 +14120,11 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12273,6 +14163,11 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12321,8 +14216,12 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12364,6 +14263,11 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12402,6 +14306,11 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12448,8 +14357,12 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12489,6 +14402,11 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12527,6 +14445,11 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12573,8 +14496,12 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12614,6 +14541,11 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12652,6 +14584,11 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12698,8 +14635,12 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12739,6 +14680,11 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12777,6 +14723,11 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12823,8 +14774,12 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12864,6 +14819,11 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12902,6 +14862,11 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12952,8 +14917,12 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12997,6 +14966,11 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13035,6 +15009,11 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13081,8 +15060,12 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13122,6 +15105,11 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13160,6 +15148,11 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13206,8 +15199,12 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13247,6 +15244,11 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13285,6 +15287,11 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13331,8 +15338,12 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13372,6 +15383,11 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13410,6 +15426,11 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13460,8 +15481,12 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13505,6 +15530,11 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13543,6 +15573,11 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13589,8 +15624,12 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13630,6 +15669,11 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13668,6 +15712,11 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13714,8 +15763,12 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13755,6 +15808,11 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13793,6 +15851,11 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13839,8 +15902,12 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13880,6 +15947,11 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13918,6 +15990,11 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13968,8 +16045,12 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14013,6 +16094,11 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14051,6 +16137,11 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14091,8 +16182,12 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14126,6 +16221,11 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14164,6 +16264,11 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14194,8 +16299,12 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14219,6 +16328,11 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Div(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14257,6 +16371,11 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14287,8 +16406,12 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14312,6 +16435,11 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.DivFloat(float64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14350,6 +16478,11 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14398,8 +16531,12 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14441,6 +16578,11 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14479,6 +16621,11 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14527,8 +16674,12 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14570,6 +16721,11 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14608,6 +16764,11 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14656,8 +16817,12 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14699,6 +16864,11 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14737,6 +16907,11 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14783,8 +16958,12 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14824,6 +17003,11 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14862,6 +17046,11 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14898,8 +17087,12 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14929,6 +17122,11 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14967,6 +17165,11 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15003,8 +17206,12 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15034,6 +17241,11 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15072,6 +17284,11 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15108,8 +17325,12 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15139,6 +17360,11 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15177,6 +17403,11 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15227,8 +17458,12 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15272,6 +17507,11 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15310,6 +17550,11 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15346,8 +17591,12 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15377,6 +17626,11 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15415,6 +17669,11 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15451,8 +17710,12 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15482,6 +17745,11 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15520,6 +17788,11 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15556,8 +17829,12 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15587,6 +17864,11 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15625,6 +17907,11 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15675,8 +17962,12 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15720,6 +18011,11 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15758,6 +18054,11 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15794,8 +18095,12 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15825,6 +18130,11 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15863,6 +18173,11 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15899,8 +18214,12 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15930,6 +18249,11 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15968,6 +18292,11 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16004,8 +18333,12 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16035,6 +18368,11 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16073,6 +18411,11 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16123,8 +18466,12 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16168,6 +18515,11 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16206,6 +18558,11 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16246,8 +18603,12 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16281,6 +18642,11 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16319,6 +18685,11 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16367,8 +18738,12 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16410,6 +18785,11 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16448,6 +18828,11 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16496,8 +18881,12 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16539,6 +18928,11 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16577,6 +18971,11 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16625,8 +19024,12 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16668,6 +19071,11 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16706,6 +19114,11 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16752,8 +19165,12 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16793,6 +19210,11 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16831,6 +19253,11 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16867,8 +19294,12 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16898,6 +19329,11 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16936,6 +19372,11 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16972,8 +19413,12 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17003,6 +19448,11 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17041,6 +19491,11 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17077,8 +19532,12 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17108,6 +19567,11 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17146,6 +19610,11 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17196,8 +19665,12 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17241,6 +19714,11 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17279,6 +19757,11 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17315,8 +19798,12 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17346,6 +19833,11 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17384,6 +19876,11 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17420,8 +19917,12 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17451,6 +19952,11 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17489,6 +19995,11 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17525,8 +20036,12 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17556,6 +20071,11 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17594,6 +20114,11 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17644,8 +20169,12 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17689,6 +20218,11 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17727,6 +20261,11 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17763,8 +20302,12 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17794,6 +20337,11 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17832,6 +20380,11 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17868,8 +20421,12 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17899,6 +20456,11 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17937,6 +20499,11 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17973,8 +20540,12 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18004,6 +20575,11 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18042,6 +20618,11 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18092,8 +20673,12 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18137,6 +20722,11 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18175,6 +20765,11 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18215,8 +20810,12 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18250,6 +20849,11 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18288,6 +20892,11 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18328,8 +20937,12 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18363,6 +20976,11 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18401,6 +21019,11 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18441,8 +21064,12 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18476,6 +21103,11 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18514,6 +21146,11 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18554,8 +21191,12 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18589,6 +21230,11 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18627,6 +21273,11 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18665,8 +21316,12 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18698,6 +21353,11 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18736,6 +21396,11 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18786,8 +21451,12 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18831,6 +21500,11 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18869,6 +21543,11 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18919,8 +21598,12 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18964,6 +21647,11 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19002,6 +21690,11 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19052,8 +21745,12 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19097,6 +21794,11 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19135,6 +21837,11 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19177,8 +21884,12 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19214,6 +21925,11 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19252,6 +21968,11 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19302,8 +22023,12 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19347,6 +22072,11 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19385,6 +22115,11 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19435,8 +22170,12 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19480,6 +22219,11 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19518,6 +22262,11 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19568,8 +22317,12 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19613,6 +22366,11 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19651,6 +22409,11 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19693,8 +22456,12 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19730,6 +22497,11 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19768,6 +22540,11 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19818,8 +22595,12 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19863,6 +22644,11 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19901,6 +22687,11 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19951,8 +22742,12 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19996,6 +22791,11 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20034,6 +22834,11 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20084,8 +22889,12 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20129,6 +22938,11 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20167,6 +22981,11 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20209,8 +23028,12 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20246,6 +23069,11 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20284,6 +23112,11 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20316,8 +23149,12 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20343,6 +23180,11 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20381,6 +23223,11 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20419,8 +23266,12 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20452,6 +23303,11 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20490,6 +23346,11 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20503,6 +23364,9 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -20519,13 +23383,20 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20535,6 +23406,9 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -20549,10 +23423,18 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20591,6 +23473,11 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20629,8 +23516,12 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20662,6 +23553,11 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20700,6 +23596,11 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20738,8 +23639,12 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20771,6 +23676,11 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20809,6 +23719,11 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20847,8 +23762,12 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20880,6 +23799,11 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20918,6 +23842,11 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20956,8 +23885,12 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20989,6 +23922,11 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21027,6 +23965,11 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21065,8 +24008,12 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21098,6 +24045,11 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21136,6 +24088,11 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21174,8 +24131,12 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21207,6 +24168,11 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21245,6 +24211,11 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21283,8 +24254,12 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21316,6 +24291,11 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21354,6 +24334,11 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21392,8 +24377,12 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21425,6 +24414,11 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21463,6 +24457,11 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21501,8 +24500,12 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21534,6 +24537,11 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21572,6 +24580,11 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21589,6 +24602,9 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21609,13 +24625,20 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21629,6 +24652,9 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21647,10 +24673,18 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21689,6 +24723,11 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21706,6 +24745,9 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21726,13 +24768,20 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21746,6 +24795,9 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21764,10 +24816,18 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21806,6 +24866,11 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21823,6 +24888,9 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21843,13 +24911,20 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21863,6 +24938,9 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21881,10 +24959,18 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21923,6 +25009,11 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21961,8 +25052,12 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21994,6 +25089,11 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22032,6 +25132,11 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22070,8 +25175,12 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22103,6 +25212,11 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22141,6 +25255,11 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22179,8 +25298,12 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22212,6 +25335,11 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22250,6 +25378,11 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22288,8 +25421,12 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22321,6 +25458,11 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22359,6 +25501,11 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22397,8 +25544,12 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22430,6 +25581,11 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22468,6 +25624,11 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22506,8 +25667,12 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22539,6 +25704,11 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22577,6 +25747,11 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22615,8 +25790,12 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22648,6 +25827,11 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22686,6 +25870,11 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22724,8 +25913,12 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22757,6 +25950,11 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22795,6 +25993,11 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22833,8 +26036,12 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22866,6 +26073,11 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22904,6 +26116,11 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22921,6 +26138,9 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -22941,13 +26161,20 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22961,6 +26188,9 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -22979,10 +26209,18 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23021,6 +26259,11 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23038,6 +26281,9 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23058,13 +26304,20 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23078,6 +26331,9 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23096,10 +26352,18 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23138,6 +26402,11 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23155,6 +26424,9 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23175,13 +26447,20 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23195,6 +26474,9 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23213,10 +26495,18 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23255,6 +26545,11 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23272,6 +26567,9 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23294,13 +26592,20 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23314,6 +26619,9 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23334,10 +26642,18 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23376,6 +26692,11 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23393,6 +26714,9 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23413,13 +26737,20 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23433,6 +26764,9 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23451,10 +26785,18 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23493,6 +26835,11 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23510,6 +26857,9 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23530,13 +26880,20 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23550,6 +26907,9 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23568,10 +26928,18 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23610,6 +26978,11 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23627,6 +27000,9 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23647,13 +27023,20 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23667,6 +27050,9 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 				_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23685,10 +27071,18 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -58,6 +58,11 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -84,8 +89,12 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -105,6 +114,11 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -143,6 +157,11 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -169,8 +188,12 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -190,6 +213,11 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -228,6 +256,11 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -254,8 +287,12 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -275,6 +312,11 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -313,6 +355,11 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -339,8 +386,12 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -360,6 +411,11 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -398,6 +454,11 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -424,8 +485,12 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -445,6 +510,11 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -483,6 +553,11 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -509,8 +584,12 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -530,6 +609,11 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -568,6 +652,11 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -594,8 +683,12 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -615,6 +708,11 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -653,6 +751,11 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -679,8 +782,12 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -700,6 +807,11 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -738,6 +850,11 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -764,8 +881,12 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -785,6 +906,11 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -823,6 +949,11 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -836,6 +967,9 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -852,13 +986,20 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -868,6 +1009,9 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -882,10 +1026,18 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -924,6 +1076,11 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -950,8 +1107,12 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -971,6 +1132,11 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1009,6 +1175,11 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1035,8 +1206,12 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1056,6 +1231,11 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1094,6 +1274,11 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1120,8 +1305,12 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1141,6 +1330,11 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1179,6 +1373,11 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1205,8 +1404,12 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1226,6 +1429,11 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1264,6 +1472,11 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1290,8 +1503,12 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1311,6 +1528,11 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1349,6 +1571,11 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1375,8 +1602,12 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1396,6 +1627,11 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1434,6 +1670,11 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1460,8 +1701,12 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1481,6 +1726,11 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1519,6 +1769,11 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1545,8 +1800,12 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1566,6 +1825,11 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1604,6 +1868,11 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1630,8 +1899,12 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1651,6 +1924,11 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1689,6 +1967,11 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1702,6 +1985,9 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -1718,13 +2004,20 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1734,6 +2027,9 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -1748,10 +2044,18 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1790,6 +2094,11 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1816,8 +2125,12 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1837,6 +2150,11 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1875,6 +2193,11 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1901,8 +2224,12 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1922,6 +2249,11 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -1960,6 +2292,11 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -1986,8 +2323,12 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2007,6 +2348,11 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2045,6 +2391,11 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2071,8 +2422,12 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2092,6 +2447,11 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2130,6 +2490,11 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2156,8 +2521,12 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2177,6 +2546,11 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2215,6 +2589,11 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2241,8 +2620,12 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2262,6 +2645,11 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2300,6 +2688,11 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2326,8 +2719,12 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2347,6 +2744,11 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2385,6 +2787,11 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2411,8 +2818,12 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2432,6 +2843,11 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2470,6 +2886,11 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2496,8 +2917,12 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2517,6 +2942,11 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2555,6 +2985,11 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2568,6 +3003,9 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -2584,13 +3022,20 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2600,6 +3045,9 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -2614,10 +3062,18 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2656,6 +3112,11 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2696,8 +3157,12 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2731,6 +3196,11 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2769,6 +3239,11 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2809,8 +3284,12 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2844,6 +3323,11 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2882,6 +3366,11 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -2922,8 +3411,12 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2957,6 +3450,11 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -2995,6 +3493,11 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3033,8 +3536,12 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3066,6 +3573,11 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3104,6 +3616,11 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3142,8 +3659,12 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3175,6 +3696,11 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3213,6 +3739,11 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3251,8 +3782,12 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3284,6 +3819,11 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3322,6 +3862,11 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3360,8 +3905,12 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3393,6 +3942,11 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3431,6 +3985,11 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3473,8 +4032,12 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3510,6 +4073,11 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3548,6 +4116,11 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3567,6 +4140,9 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -3589,13 +4165,20 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3611,6 +4194,9 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -3631,10 +4217,18 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3673,6 +4267,11 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3711,8 +4310,12 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3744,6 +4347,11 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3782,6 +4390,11 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3820,8 +4433,12 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3853,6 +4470,11 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -3891,6 +4513,11 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -3929,8 +4556,12 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3962,6 +4593,11 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4000,6 +4636,11 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4042,8 +4683,12 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4079,6 +4724,11 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4117,6 +4767,11 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4136,6 +4791,9 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4158,13 +4816,20 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4180,6 +4845,9 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4200,10 +4868,18 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4242,6 +4918,11 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4280,8 +4961,12 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4313,6 +4998,11 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4351,6 +5041,11 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4389,8 +5084,12 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4422,6 +5121,11 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4460,6 +5164,11 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4498,8 +5207,12 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4531,6 +5244,11 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4569,6 +5287,11 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4611,8 +5334,12 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4648,6 +5375,11 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4686,6 +5418,11 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4705,6 +5442,9 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4727,13 +5467,20 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4749,6 +5496,9 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4769,10 +5519,18 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4811,6 +5569,11 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4843,8 +5606,12 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4870,6 +5637,11 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4908,6 +5680,11 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -4930,8 +5707,12 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4947,6 +5728,11 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -4985,6 +5771,11 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5007,8 +5798,12 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5024,6 +5819,11 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5062,6 +5862,11 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5084,8 +5889,12 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5101,6 +5910,11 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 				projCol[i] = arg.Add(p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5139,6 +5953,11 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5158,6 +5977,9 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5180,13 +6002,20 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5202,6 +6031,9 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5222,10 +6054,18 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5264,6 +6104,11 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5281,6 +6126,9 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5301,13 +6149,20 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5321,6 +6176,9 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5339,10 +6197,18 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5381,6 +6247,11 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5398,6 +6269,9 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5418,13 +6292,20 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5438,6 +6319,9 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5456,10 +6340,18 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5498,6 +6390,11 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5515,6 +6412,9 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5535,13 +6435,20 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5555,6 +6462,9 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5573,10 +6483,18 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5615,6 +6533,11 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5632,6 +6555,9 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5652,13 +6578,20 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5672,6 +6605,9 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5690,10 +6626,18 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5732,6 +6676,11 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5772,8 +6721,12 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5807,6 +6760,11 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5845,6 +6803,11 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5885,8 +6848,12 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5920,6 +6887,11 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -5958,6 +6930,11 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -5998,8 +6975,12 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6033,6 +7014,11 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6071,6 +7057,11 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6109,8 +7100,12 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6142,6 +7137,11 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6180,6 +7180,11 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6218,8 +7223,12 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6251,6 +7260,11 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6289,6 +7303,11 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6327,8 +7346,12 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6360,6 +7383,11 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6398,6 +7426,11 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6436,8 +7469,12 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6469,6 +7506,11 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6507,6 +7549,11 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6549,8 +7596,12 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6586,6 +7637,11 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6624,6 +7680,11 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6643,6 +7704,9 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -6665,13 +7729,20 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6687,6 +7758,9 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -6707,10 +7781,18 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6749,6 +7831,11 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6787,8 +7874,12 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6820,6 +7911,11 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6858,6 +7954,11 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -6896,8 +7997,12 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6929,6 +8034,11 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -6967,6 +8077,11 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7005,8 +8120,12 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7038,6 +8157,11 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7076,6 +8200,11 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7118,8 +8247,12 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7155,6 +8288,11 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7193,6 +8331,11 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7212,6 +8355,9 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -7234,13 +8380,20 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7256,6 +8409,9 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -7276,10 +8432,18 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7318,6 +8482,11 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7356,8 +8525,12 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7389,6 +8562,11 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7427,6 +8605,11 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7465,8 +8648,12 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7498,6 +8685,11 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7536,6 +8728,11 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7574,8 +8771,12 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7607,6 +8808,11 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7645,6 +8851,11 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7687,8 +8898,12 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7724,6 +8939,11 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7762,6 +8982,11 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7781,6 +9006,9 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -7803,13 +9031,20 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7825,6 +9060,9 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -7845,10 +9083,18 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7887,6 +9133,11 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -7919,8 +9170,12 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7946,6 +9201,11 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -7984,6 +9244,11 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8012,8 +9277,12 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8035,6 +9304,11 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8073,6 +9347,11 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8095,8 +9374,12 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8112,6 +9395,11 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 				projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8150,6 +9438,11 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8172,8 +9465,12 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8189,6 +9486,11 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				projCol[i] = arg.Sub(p.constArg)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8227,6 +9529,11 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8246,6 +9553,9 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8268,13 +9578,20 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8290,6 +9607,9 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8310,10 +9630,18 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8352,6 +9680,11 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8365,6 +9698,9 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8381,13 +9717,20 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8397,6 +9740,9 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8411,10 +9757,18 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8453,6 +9807,11 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8470,6 +9829,9 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8490,13 +9852,20 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8510,6 +9879,9 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8528,10 +9900,18 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8570,6 +9950,11 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8587,6 +9972,9 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8607,13 +9995,20 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8627,6 +10022,9 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8645,10 +10043,18 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8687,6 +10093,11 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8704,6 +10115,9 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8724,13 +10138,20 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8744,6 +10165,9 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8762,10 +10186,18 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8804,6 +10236,11 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8821,6 +10258,9 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8841,13 +10281,20 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8861,6 +10308,9 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8879,10 +10329,18 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -8921,6 +10379,11 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -8938,6 +10401,9 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8958,13 +10424,20 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8978,6 +10451,9 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8996,10 +10472,18 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9038,6 +10522,11 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9078,8 +10567,12 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9113,6 +10606,11 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9151,6 +10649,11 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9191,8 +10694,12 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9226,6 +10733,11 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9264,6 +10776,11 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9304,8 +10821,12 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9339,6 +10860,11 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9377,6 +10903,11 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9415,8 +10946,12 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9448,6 +10983,11 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9486,6 +11026,11 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9518,8 +11063,12 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9545,6 +11094,11 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = p.constArg.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9583,6 +11137,11 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9637,8 +11196,12 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9686,6 +11249,11 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9724,6 +11292,11 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9778,8 +11351,12 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9827,6 +11404,11 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -9865,6 +11447,11 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -9919,8 +11506,12 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9968,6 +11559,11 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10006,6 +11602,11 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10048,8 +11649,12 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10085,6 +11690,11 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10123,6 +11733,11 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10145,8 +11760,12 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10162,6 +11781,11 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10200,6 +11824,11 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10254,8 +11883,12 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10303,6 +11936,11 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10341,6 +11979,11 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10395,8 +12038,12 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10444,6 +12091,11 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10482,6 +12134,11 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10536,8 +12193,12 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10585,6 +12246,11 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10623,6 +12289,11 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10665,8 +12336,12 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10702,6 +12377,11 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10740,6 +12420,11 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10762,8 +12447,12 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10779,6 +12468,11 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10817,6 +12511,11 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -10871,8 +12570,12 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10920,6 +12623,11 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -10958,6 +12666,11 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11012,8 +12725,12 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11061,6 +12778,11 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11099,6 +12821,11 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11153,8 +12880,12 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11202,6 +12933,11 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11240,6 +12976,11 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11282,8 +13023,12 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11319,6 +13064,11 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11357,6 +13107,11 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11379,8 +13134,12 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11396,6 +13155,11 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11434,6 +13198,11 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11466,8 +13235,12 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11493,6 +13266,11 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11531,6 +13309,11 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11553,8 +13336,12 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11570,6 +13357,11 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11608,6 +13400,11 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11630,8 +13427,12 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11647,6 +13448,11 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11685,6 +13491,11 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11707,8 +13518,12 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11724,6 +13539,11 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11762,6 +13582,11 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11784,8 +13609,12 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11801,6 +13630,11 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11839,6 +13673,11 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11861,8 +13700,12 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11878,6 +13721,11 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -11916,6 +13764,11 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -11948,8 +13801,12 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11975,6 +13832,11 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				projCol[i] = arg.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12013,6 +13875,11 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12061,8 +13928,12 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12104,6 +13975,11 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12142,6 +14018,11 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12190,8 +14071,12 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12233,6 +14118,11 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12271,6 +14161,11 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12319,8 +14214,12 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12362,6 +14261,11 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12400,6 +14304,11 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12446,8 +14355,12 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12487,6 +14400,11 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12525,6 +14443,11 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12571,8 +14494,12 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12612,6 +14539,11 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12650,6 +14582,11 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12696,8 +14633,12 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12737,6 +14678,11 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12775,6 +14721,11 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12821,8 +14772,12 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12862,6 +14817,11 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -12900,6 +14860,11 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -12950,8 +14915,12 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12995,6 +14964,11 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13033,6 +15007,11 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13079,8 +15058,12 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13120,6 +15103,11 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13158,6 +15146,11 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13204,8 +15197,12 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13245,6 +15242,11 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13283,6 +15285,11 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13329,8 +15336,12 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13370,6 +15381,11 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13408,6 +15424,11 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13458,8 +15479,12 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13503,6 +15528,11 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13541,6 +15571,11 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13587,8 +15622,12 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13628,6 +15667,11 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13666,6 +15710,11 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13712,8 +15761,12 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13753,6 +15806,11 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13791,6 +15849,11 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13837,8 +15900,12 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13878,6 +15945,11 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -13916,6 +15988,11 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -13966,8 +16043,12 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14011,6 +16092,11 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14049,6 +16135,11 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14089,8 +16180,12 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14124,6 +16219,11 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14162,6 +16262,11 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14192,8 +16297,12 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14217,6 +16326,11 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.Div(int64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14255,6 +16369,11 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14285,8 +16404,12 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14310,6 +16433,11 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg.DivFloat(float64(p.constArg))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14348,6 +16476,11 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14396,8 +16529,12 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14439,6 +16576,11 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14477,6 +16619,11 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14525,8 +16672,12 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14568,6 +16719,11 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14606,6 +16762,11 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14654,8 +16815,12 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14697,6 +16862,11 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14735,6 +16905,11 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14781,8 +16956,12 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14822,6 +17001,11 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14860,6 +17044,11 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -14896,8 +17085,12 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14927,6 +17120,11 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -14965,6 +17163,11 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15001,8 +17204,12 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15032,6 +17239,11 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15070,6 +17282,11 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15106,8 +17323,12 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15137,6 +17358,11 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15175,6 +17401,11 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15225,8 +17456,12 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15270,6 +17505,11 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15308,6 +17548,11 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15344,8 +17589,12 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15375,6 +17624,11 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15413,6 +17667,11 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15449,8 +17708,12 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15480,6 +17743,11 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15518,6 +17786,11 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15554,8 +17827,12 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15585,6 +17862,11 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15623,6 +17905,11 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15673,8 +17960,12 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15718,6 +18009,11 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15756,6 +18052,11 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15792,8 +18093,12 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15823,6 +18128,11 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15861,6 +18171,11 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -15897,8 +18212,12 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15928,6 +18247,11 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -15966,6 +18290,11 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16002,8 +18331,12 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16033,6 +18366,11 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16071,6 +18409,11 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16121,8 +18464,12 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16166,6 +18513,11 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16204,6 +18556,11 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16244,8 +18601,12 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16279,6 +18640,11 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16317,6 +18683,11 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16365,8 +18736,12 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16408,6 +18783,11 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16446,6 +18826,11 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16494,8 +18879,12 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16537,6 +18926,11 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16575,6 +18969,11 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16623,8 +19022,12 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16666,6 +19069,11 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16704,6 +19112,11 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16750,8 +19163,12 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16791,6 +19208,11 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16829,6 +19251,11 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16865,8 +19292,12 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16896,6 +19327,11 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -16934,6 +19370,11 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -16970,8 +19411,12 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17001,6 +19446,11 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17039,6 +19489,11 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17075,8 +19530,12 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17106,6 +19565,11 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17144,6 +19608,11 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17194,8 +19663,12 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17239,6 +19712,11 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17277,6 +19755,11 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17313,8 +19796,12 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17344,6 +19831,11 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17382,6 +19874,11 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17418,8 +19915,12 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17449,6 +19950,11 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17487,6 +19993,11 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17523,8 +20034,12 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17554,6 +20069,11 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17592,6 +20112,11 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17642,8 +20167,12 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17687,6 +20216,11 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17725,6 +20259,11 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17761,8 +20300,12 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17792,6 +20335,11 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17830,6 +20378,11 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17866,8 +20419,12 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17897,6 +20454,11 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -17935,6 +20497,11 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -17971,8 +20538,12 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18002,6 +20573,11 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18040,6 +20616,11 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18090,8 +20671,12 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18135,6 +20720,11 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18173,6 +20763,11 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18213,8 +20808,12 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18248,6 +20847,11 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18286,6 +20890,11 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18326,8 +20935,12 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18361,6 +20974,11 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18399,6 +21017,11 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18439,8 +21062,12 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18474,6 +21101,11 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18512,6 +21144,11 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18552,8 +21189,12 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18587,6 +21228,11 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18625,6 +21271,11 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18663,8 +21314,12 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18696,6 +21351,11 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18734,6 +21394,11 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18784,8 +21449,12 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18829,6 +21498,11 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -18867,6 +21541,11 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -18917,8 +21596,12 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18962,6 +21645,11 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19000,6 +21688,11 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19050,8 +21743,12 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19095,6 +21792,11 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19133,6 +21835,11 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19175,8 +21882,12 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19212,6 +21923,11 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19250,6 +21966,11 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19300,8 +22021,12 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19345,6 +22070,11 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19383,6 +22113,11 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19433,8 +22168,12 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19478,6 +22217,11 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19516,6 +22260,11 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19566,8 +22315,12 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19611,6 +22364,11 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19649,6 +22407,11 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19691,8 +22454,12 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19728,6 +22495,11 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19766,6 +22538,11 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19816,8 +22593,12 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19861,6 +22642,11 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -19899,6 +22685,11 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -19949,8 +22740,12 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19994,6 +22789,11 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20032,6 +22832,11 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20082,8 +22887,12 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20127,6 +22936,11 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20165,6 +22979,11 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20207,8 +23026,12 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20244,6 +23067,11 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20282,6 +23110,11 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20314,8 +23147,12 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20341,6 +23178,11 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20379,6 +23221,11 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20417,8 +23264,12 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20450,6 +23301,11 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20488,6 +23344,11 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20501,6 +23362,9 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -20517,13 +23381,20 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20533,6 +23404,9 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -20547,10 +23421,18 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20589,6 +23471,11 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20627,8 +23514,12 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20660,6 +23551,11 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20698,6 +23594,11 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20736,8 +23637,12 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20769,6 +23674,11 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20807,6 +23717,11 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20845,8 +23760,12 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20878,6 +23797,11 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -20916,6 +23840,11 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -20954,8 +23883,12 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20987,6 +23920,11 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21025,6 +23963,11 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21063,8 +24006,12 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21096,6 +24043,11 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21134,6 +24086,11 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21172,8 +24129,12 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21205,6 +24166,11 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21243,6 +24209,11 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21281,8 +24252,12 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21314,6 +24289,11 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21352,6 +24332,11 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21390,8 +24375,12 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21423,6 +24412,11 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21461,6 +24455,11 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21499,8 +24498,12 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21532,6 +24535,11 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21570,6 +24578,11 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21587,6 +24600,9 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21607,13 +24623,20 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21627,6 +24650,9 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21645,10 +24671,18 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21687,6 +24721,11 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21704,6 +24743,9 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21724,13 +24766,20 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21744,6 +24793,9 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21762,10 +24814,18 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21804,6 +24864,11 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21821,6 +24886,9 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -21841,13 +24909,20 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21861,6 +24936,9 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -21879,10 +24957,18 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -21921,6 +25007,11 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -21959,8 +25050,12 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21992,6 +25087,11 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22030,6 +25130,11 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22068,8 +25173,12 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22101,6 +25210,11 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22139,6 +25253,11 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22177,8 +25296,12 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22210,6 +25333,11 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22248,6 +25376,11 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22286,8 +25419,12 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22319,6 +25456,11 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22357,6 +25499,11 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22395,8 +25542,12 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22428,6 +25579,11 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22466,6 +25622,11 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22504,8 +25665,12 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22537,6 +25702,11 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22575,6 +25745,11 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22613,8 +25788,12 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22646,6 +25825,11 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22684,6 +25868,11 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22722,8 +25911,12 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22755,6 +25948,11 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22793,6 +25991,11 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22831,8 +26034,12 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22864,6 +26071,11 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -22902,6 +26114,11 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -22919,6 +26136,9 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -22939,13 +26159,20 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22959,6 +26186,9 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -22977,10 +26207,18 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23019,6 +26257,11 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23036,6 +26279,9 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23056,13 +26302,20 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23076,6 +26329,9 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23094,10 +26350,18 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23136,6 +26400,11 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23153,6 +26422,9 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23173,13 +26445,20 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23193,6 +26472,9 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23211,10 +26493,18 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23253,6 +26543,11 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23270,6 +26565,9 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23290,13 +26588,20 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23310,6 +26615,9 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23328,10 +26636,18 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23370,6 +26686,11 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23387,6 +26708,9 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23407,13 +26731,20 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23427,6 +26758,9 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23445,10 +26779,18 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23487,6 +26829,11 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23504,6 +26851,9 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23524,13 +26874,20 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23544,6 +26901,9 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23562,10 +26922,18 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23604,6 +26972,11 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23621,6 +26994,9 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23641,13 +27017,20 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23661,6 +27044,9 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 				_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23679,10 +27065,18 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23721,6 +27115,11 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23771,8 +27170,12 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23816,6 +27219,11 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23854,6 +27262,11 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -23890,8 +27303,12 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23921,6 +27338,11 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -23959,6 +27381,11 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24005,8 +27432,12 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24046,6 +27477,11 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24084,6 +27520,11 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24130,8 +27571,12 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24171,6 +27616,11 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24209,6 +27659,11 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24255,8 +27710,12 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24296,6 +27755,11 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24334,6 +27798,11 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24384,8 +27853,12 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24429,6 +27902,11 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24467,6 +27945,11 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24501,8 +27984,12 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24530,6 +28017,11 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24568,6 +28060,11 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24624,8 +28121,12 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24675,6 +28176,11 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24713,6 +28219,11 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24769,8 +28280,12 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24820,6 +28335,11 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -24858,6 +28378,11 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -24914,8 +28439,12 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24965,6 +28494,11 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25003,6 +28537,11 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25075,8 +28614,12 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25142,6 +28685,11 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25180,6 +28728,11 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25226,8 +28779,12 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25267,6 +28824,11 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25305,6 +28867,11 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25361,8 +28928,12 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25412,6 +28983,11 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25450,6 +29026,11 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25506,8 +29087,12 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25557,6 +29142,11 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25595,6 +29185,11 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25651,8 +29246,12 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25702,6 +29301,11 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25740,6 +29344,11 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25812,8 +29421,12 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25879,6 +29492,11 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -25917,6 +29535,11 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -25963,8 +29586,12 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26004,6 +29631,11 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26042,6 +29674,11 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26098,8 +29735,12 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26149,6 +29790,11 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26187,6 +29833,11 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26243,8 +29894,12 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26294,6 +29949,11 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26332,6 +29992,11 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26388,8 +30053,12 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26439,6 +30108,11 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26477,6 +30151,11 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26549,8 +30228,12 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26616,6 +30299,11 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26654,6 +30342,11 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26700,8 +30393,12 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26741,6 +30438,11 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26779,6 +30481,11 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -26851,8 +30558,12 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26918,6 +30629,11 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -26956,6 +30672,11 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27028,8 +30749,12 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27095,6 +30820,11 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27133,6 +30863,11 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27205,8 +30940,12 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27272,6 +31011,11 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27310,6 +31054,11 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27382,8 +31131,12 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27449,6 +31202,11 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27487,6 +31245,11 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27537,8 +31300,12 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27582,6 +31349,11 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27620,6 +31392,11 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27668,8 +31445,12 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27711,6 +31492,11 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27749,6 +31535,11 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27783,8 +31574,12 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27812,6 +31607,11 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27850,6 +31650,11 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -27888,8 +31693,12 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27921,6 +31730,11 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -27959,6 +31773,11 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28009,8 +31828,12 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28054,6 +31877,11 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28092,6 +31920,11 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28128,8 +31961,12 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28159,6 +31996,11 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28197,6 +32039,11 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28243,8 +32090,12 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28284,6 +32135,11 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28322,6 +32178,11 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28368,8 +32229,12 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28409,6 +32274,11 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28447,6 +32317,11 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28493,8 +32368,12 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28534,6 +32413,11 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28572,6 +32456,11 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28622,8 +32511,12 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28667,6 +32560,11 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28705,6 +32603,11 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28739,8 +32642,12 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28768,6 +32675,11 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28806,6 +32718,11 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -28862,8 +32779,12 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28913,6 +32834,11 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -28951,6 +32877,11 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29007,8 +32938,12 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29058,6 +32993,11 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29096,6 +33036,11 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29152,8 +33097,12 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29203,6 +33152,11 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29241,6 +33195,11 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29313,8 +33272,12 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29380,6 +33343,11 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29418,6 +33386,11 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29464,8 +33437,12 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29505,6 +33482,11 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29543,6 +33525,11 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29599,8 +33586,12 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29650,6 +33641,11 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29688,6 +33684,11 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29744,8 +33745,12 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29795,6 +33800,11 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29833,6 +33843,11 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -29889,8 +33904,12 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29940,6 +33959,11 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -29978,6 +34002,11 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30050,8 +34079,12 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30117,6 +34150,11 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30155,6 +34193,11 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30201,8 +34244,12 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30242,6 +34289,11 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30280,6 +34332,11 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30336,8 +34393,12 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30387,6 +34448,11 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30425,6 +34491,11 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30481,8 +34552,12 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30532,6 +34607,11 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30570,6 +34650,11 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30626,8 +34711,12 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30677,6 +34766,11 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30715,6 +34809,11 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30787,8 +34886,12 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30854,6 +34957,11 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -30892,6 +35000,11 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -30938,8 +35051,12 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30979,6 +35096,11 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31017,6 +35139,11 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31089,8 +35216,12 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31156,6 +35287,11 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31194,6 +35330,11 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31266,8 +35407,12 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31333,6 +35478,11 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31371,6 +35521,11 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31443,8 +35598,12 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31510,6 +35669,11 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31548,6 +35712,11 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31620,8 +35789,12 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31687,6 +35860,11 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31725,6 +35903,11 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31775,8 +35958,12 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31820,6 +36007,11 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31858,6 +36050,11 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -31906,8 +36103,12 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31949,6 +36150,11 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -31987,6 +36193,11 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32021,8 +36232,12 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32050,6 +36265,11 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32088,6 +36308,11 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32126,8 +36351,12 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32159,6 +36388,11 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32197,6 +36431,11 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32247,8 +36486,12 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32292,6 +36535,11 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32330,6 +36578,11 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32366,8 +36619,12 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32397,6 +36654,11 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32435,6 +36697,11 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32481,8 +36748,12 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32522,6 +36793,11 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32560,6 +36836,11 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32606,8 +36887,12 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32647,6 +36932,11 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32685,6 +36975,11 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32731,8 +37026,12 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32772,6 +37071,11 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32810,6 +37114,11 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32860,8 +37169,12 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32905,6 +37218,11 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -32943,6 +37261,11 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -32977,8 +37300,12 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33006,6 +37333,11 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33044,6 +37376,11 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33100,8 +37437,12 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33151,6 +37492,11 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33189,6 +37535,11 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33245,8 +37596,12 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33296,6 +37651,11 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33334,6 +37694,11 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33390,8 +37755,12 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33441,6 +37810,11 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33479,6 +37853,11 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33551,8 +37930,12 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33618,6 +38001,11 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33656,6 +38044,11 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33702,8 +38095,12 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33743,6 +38140,11 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33781,6 +38183,11 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33837,8 +38244,12 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33888,6 +38299,11 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -33926,6 +38342,11 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -33982,8 +38403,12 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34033,6 +38458,11 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34071,6 +38501,11 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34127,8 +38562,12 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34178,6 +38617,11 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34216,6 +38660,11 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34288,8 +38737,12 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34355,6 +38808,11 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34393,6 +38851,11 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34439,8 +38902,12 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34480,6 +38947,11 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34518,6 +38990,11 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34574,8 +39051,12 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34625,6 +39106,11 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34663,6 +39149,11 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34719,8 +39210,12 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34770,6 +39265,11 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34808,6 +39308,11 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -34864,8 +39369,12 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34915,6 +39424,11 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -34953,6 +39467,11 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35025,8 +39544,12 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35092,6 +39615,11 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35130,6 +39658,11 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35176,8 +39709,12 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35217,6 +39754,11 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35255,6 +39797,11 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35327,8 +39874,12 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35394,6 +39945,11 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35432,6 +39988,11 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35504,8 +40065,12 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35571,6 +40136,11 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35609,6 +40179,11 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35681,8 +40256,12 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35748,6 +40327,11 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35786,6 +40370,11 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -35858,8 +40447,12 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35925,6 +40518,11 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -35963,6 +40561,11 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36013,8 +40616,12 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36058,6 +40665,11 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36096,6 +40708,11 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36144,8 +40761,12 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36187,6 +40808,11 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36225,6 +40851,11 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36259,8 +40890,12 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36288,6 +40923,11 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36326,6 +40966,11 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36364,8 +41009,12 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36397,6 +41046,11 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36435,6 +41089,11 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36485,8 +41144,12 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36530,6 +41193,11 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36568,6 +41236,11 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36604,8 +41277,12 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36635,6 +41312,11 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36673,6 +41355,11 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36719,8 +41406,12 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36760,6 +41451,11 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36798,6 +41494,11 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36844,8 +41545,12 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36885,6 +41590,11 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -36923,6 +41633,11 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -36969,8 +41684,12 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37010,6 +41729,11 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37048,6 +41772,11 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37098,8 +41827,12 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37143,6 +41876,11 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37181,6 +41919,11 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37215,8 +41958,12 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37244,6 +41991,11 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37282,6 +42034,11 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37338,8 +42095,12 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37389,6 +42150,11 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37427,6 +42193,11 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37483,8 +42254,12 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37534,6 +42309,11 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37572,6 +42352,11 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37628,8 +42413,12 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37679,6 +42468,11 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37717,6 +42511,11 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37789,8 +42588,12 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37856,6 +42659,11 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -37894,6 +42702,11 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -37940,8 +42753,12 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37981,6 +42798,11 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38019,6 +42841,11 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38075,8 +42902,12 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38126,6 +42957,11 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38164,6 +43000,11 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38220,8 +43061,12 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38271,6 +43116,11 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38309,6 +43159,11 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38365,8 +43220,12 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38416,6 +43275,11 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38454,6 +43318,11 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38526,8 +43395,12 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38593,6 +43466,11 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38631,6 +43509,11 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38677,8 +43560,12 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38718,6 +43605,11 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38756,6 +43648,11 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38812,8 +43709,12 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38863,6 +43764,11 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -38901,6 +43807,11 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -38957,8 +43868,12 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39008,6 +43923,11 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39046,6 +43966,11 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39102,8 +44027,12 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39153,6 +44082,11 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39191,6 +44125,11 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39263,8 +44202,12 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39330,6 +44273,11 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39368,6 +44316,11 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39414,8 +44367,12 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39455,6 +44412,11 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39493,6 +44455,11 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39565,8 +44532,12 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39632,6 +44603,11 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39670,6 +44646,11 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39742,8 +44723,12 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39809,6 +44794,11 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -39847,6 +44837,11 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -39919,8 +44914,12 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39986,6 +44985,11 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40024,6 +45028,11 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40096,8 +45105,12 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40163,6 +45176,11 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40201,6 +45219,11 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40251,8 +45274,12 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40296,6 +45323,11 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40334,6 +45366,11 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40382,8 +45419,12 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40425,6 +45466,11 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40463,6 +45509,11 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40497,8 +45548,12 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40526,6 +45581,11 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40564,6 +45624,11 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40602,8 +45667,12 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40635,6 +45704,11 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40673,6 +45747,11 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40723,8 +45802,12 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40768,6 +45851,11 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40806,6 +45894,11 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40842,8 +45935,12 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40873,6 +45970,11 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -40911,6 +46013,11 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -40957,8 +46064,12 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40998,6 +46109,11 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41036,6 +46152,11 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41082,8 +46203,12 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41123,6 +46248,11 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41161,6 +46291,11 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41207,8 +46342,12 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41248,6 +46387,11 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41286,6 +46430,11 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41336,8 +46485,12 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41381,6 +46534,11 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41419,6 +46577,11 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41453,8 +46616,12 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41482,6 +46649,11 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41520,6 +46692,11 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41576,8 +46753,12 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41627,6 +46808,11 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41665,6 +46851,11 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41721,8 +46912,12 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41772,6 +46967,11 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41810,6 +47010,11 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -41866,8 +47071,12 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41917,6 +47126,11 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -41955,6 +47169,11 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42027,8 +47246,12 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42094,6 +47317,11 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42132,6 +47360,11 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42178,8 +47411,12 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42219,6 +47456,11 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42257,6 +47499,11 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42313,8 +47560,12 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42364,6 +47615,11 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42402,6 +47658,11 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42458,8 +47719,12 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42509,6 +47774,11 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42547,6 +47817,11 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42603,8 +47878,12 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42654,6 +47933,11 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42692,6 +47976,11 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42764,8 +48053,12 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42831,6 +48124,11 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42869,6 +48167,11 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -42915,8 +48218,12 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42956,6 +48263,11 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -42994,6 +48306,11 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43050,8 +48367,12 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43101,6 +48422,11 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43139,6 +48465,11 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43195,8 +48526,12 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43246,6 +48581,11 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43284,6 +48624,11 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43340,8 +48685,12 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43391,6 +48740,11 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43429,6 +48783,11 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43501,8 +48860,12 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43568,6 +48931,11 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43606,6 +48974,11 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43652,8 +49025,12 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43693,6 +49070,11 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43731,6 +49113,11 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43803,8 +49190,12 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43870,6 +49261,11 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -43908,6 +49304,11 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -43980,8 +49381,12 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44047,6 +49452,11 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44085,6 +49495,11 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44157,8 +49572,12 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44224,6 +49643,11 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44262,6 +49686,11 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44334,8 +49763,12 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44401,6 +49834,11 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44439,6 +49877,11 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44489,8 +49932,12 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44534,6 +49981,11 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44572,6 +50024,11 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44620,8 +50077,12 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44663,6 +50124,11 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44701,6 +50167,11 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44735,8 +50206,12 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44764,6 +50239,11 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44802,6 +50282,11 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44840,8 +50325,12 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44873,6 +50362,11 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -44911,6 +50405,11 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -44961,8 +50460,12 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45006,6 +50509,11 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45044,6 +50552,11 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45080,8 +50593,12 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45111,6 +50628,11 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45149,6 +50671,11 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45195,8 +50722,12 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45236,6 +50767,11 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45274,6 +50810,11 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45320,8 +50861,12 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45361,6 +50906,11 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45399,6 +50949,11 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45445,8 +51000,12 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45486,6 +51045,11 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45524,6 +51088,11 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45574,8 +51143,12 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45619,6 +51192,11 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45657,6 +51235,11 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45691,8 +51274,12 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45720,6 +51307,11 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45758,6 +51350,11 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45814,8 +51411,12 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45865,6 +51466,11 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -45903,6 +51509,11 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -45959,8 +51570,12 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46010,6 +51625,11 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46048,6 +51668,11 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46104,8 +51729,12 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46155,6 +51784,11 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46193,6 +51827,11 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46265,8 +51904,12 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46332,6 +51975,11 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46370,6 +52018,11 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46416,8 +52069,12 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46457,6 +52114,11 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46495,6 +52157,11 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46551,8 +52218,12 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46602,6 +52273,11 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46640,6 +52316,11 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46696,8 +52377,12 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46747,6 +52432,11 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46785,6 +52475,11 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -46841,8 +52536,12 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46892,6 +52591,11 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -46930,6 +52634,11 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47002,8 +52711,12 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47069,6 +52782,11 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47107,6 +52825,11 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47153,8 +52876,12 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47194,6 +52921,11 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47232,6 +52964,11 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47288,8 +53025,12 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47339,6 +53080,11 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47377,6 +53123,11 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47433,8 +53184,12 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47484,6 +53239,11 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47522,6 +53282,11 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47578,8 +53343,12 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47629,6 +53398,11 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47667,6 +53441,11 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47739,8 +53518,12 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47806,6 +53589,11 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47844,6 +53632,11 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -47890,8 +53683,12 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47931,6 +53728,11 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -47969,6 +53771,11 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48041,8 +53848,12 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48108,6 +53919,11 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48146,6 +53962,11 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48218,8 +54039,12 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48285,6 +54110,11 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48323,6 +54153,11 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48395,8 +54230,12 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48462,6 +54301,11 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48500,6 +54344,11 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48572,8 +54421,12 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48639,6 +54492,11 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48677,6 +54535,11 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48727,8 +54590,12 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48772,6 +54639,11 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48810,6 +54682,11 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48858,8 +54735,12 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48901,6 +54782,11 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -48939,6 +54825,11 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -48973,8 +54864,12 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49002,6 +54897,11 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).
@@ -49040,6 +54940,11 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		projVec.Nulls().UnsetNulls()
 	}
 	projCol := projVec.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec.Nulls().MaybeHasNulls() {
 		colNulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
@@ -49078,8 +54983,12 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		colNullsCopy := colNulls.Copy()
-		projVec.SetNulls(&colNullsCopy)
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(colNulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49111,6 +55020,11 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 	// Although we didn't change the length of the batch, it is necessary to set
 	// the length anyway (this helps maintaining the invariant of flat bytes).

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -79,6 +79,11 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -112,7 +117,12 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -136,6 +146,11 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -175,6 +190,11 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -208,7 +228,12 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -232,6 +257,11 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -271,6 +301,11 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -304,7 +339,12 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -328,6 +368,11 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -367,6 +412,11 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -400,7 +450,12 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -424,6 +479,11 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -463,6 +523,11 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -496,7 +561,12 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -520,6 +590,11 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -559,6 +634,11 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -592,7 +672,12 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -616,6 +701,11 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -655,6 +745,11 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -688,7 +783,12 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -712,6 +812,11 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -751,6 +856,11 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -784,7 +894,12 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -808,6 +923,11 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -847,6 +967,11 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -880,7 +1005,12 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -904,6 +1034,11 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -943,6 +1078,11 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -959,6 +1099,9 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -979,12 +1122,20 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -995,6 +1146,9 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -1012,10 +1166,18 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1055,6 +1217,11 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1088,7 +1255,12 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1112,6 +1284,11 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1151,6 +1328,11 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1184,7 +1366,12 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1208,6 +1395,11 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1247,6 +1439,11 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1280,7 +1477,12 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1304,6 +1506,11 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1343,6 +1550,11 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1376,7 +1588,12 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1400,6 +1617,11 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1439,6 +1661,11 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1472,7 +1699,12 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1496,6 +1728,11 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1535,6 +1772,11 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1568,7 +1810,12 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1592,6 +1839,11 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1631,6 +1883,11 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1664,7 +1921,12 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1688,6 +1950,11 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1727,6 +1994,11 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1760,7 +2032,12 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1784,6 +2061,11 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1823,6 +2105,11 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1856,7 +2143,12 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1880,6 +2172,11 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -1919,6 +2216,11 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -1935,6 +2237,9 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -1955,12 +2260,20 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -1971,6 +2284,9 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -1988,10 +2304,18 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2031,6 +2355,11 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2064,7 +2393,12 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2088,6 +2422,11 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2127,6 +2466,11 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2160,7 +2504,12 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2184,6 +2533,11 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2223,6 +2577,11 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2256,7 +2615,12 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2280,6 +2644,11 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2319,6 +2688,11 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2352,7 +2726,12 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2376,6 +2755,11 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2415,6 +2799,11 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2448,7 +2837,12 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2472,6 +2866,11 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2511,6 +2910,11 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2544,7 +2948,12 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2568,6 +2977,11 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2607,6 +3021,11 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2640,7 +3059,12 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2664,6 +3088,11 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2703,6 +3132,11 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2736,7 +3170,12 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2760,6 +3199,11 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2799,6 +3243,11 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2832,7 +3281,12 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2856,6 +3310,11 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -2895,6 +3354,11 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -2911,6 +3375,9 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -2931,12 +3398,20 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -2947,6 +3422,9 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -2964,10 +3442,18 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3007,6 +3493,11 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3054,7 +3545,12 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3092,6 +3588,11 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3131,6 +3632,11 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3178,7 +3684,12 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3216,6 +3727,11 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3255,6 +3771,11 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3302,7 +3823,12 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3340,6 +3866,11 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3379,6 +3910,11 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3424,7 +3960,12 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3460,6 +4001,11 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3499,6 +4045,11 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3544,7 +4095,12 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3580,6 +4136,11 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3619,6 +4180,11 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3664,7 +4230,12 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3700,6 +4271,11 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3739,6 +4315,11 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3784,7 +4365,12 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3820,6 +4406,11 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3859,6 +4450,11 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -3908,7 +4504,12 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -3948,6 +4549,11 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -3987,6 +4593,11 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4009,6 +4620,9 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4035,12 +4649,20 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4057,6 +4679,9 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4080,10 +4705,18 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4123,6 +4756,11 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4168,7 +4806,12 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4204,6 +4847,11 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4243,6 +4891,11 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4288,7 +4941,12 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4324,6 +4982,11 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4363,6 +5026,11 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4408,7 +5076,12 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4444,6 +5117,11 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4483,6 +5161,11 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4532,7 +5215,12 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4572,6 +5260,11 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4611,6 +5304,11 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4633,6 +5331,9 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -4659,12 +5360,20 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4681,6 +5390,9 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -4704,10 +5416,18 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4747,6 +5467,11 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4792,7 +5517,12 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4828,6 +5558,11 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4867,6 +5602,11 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -4912,7 +5652,12 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -4948,6 +5693,11 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -4987,6 +5737,11 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5032,7 +5787,12 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5068,6 +5828,11 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5107,6 +5872,11 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5156,7 +5926,12 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5196,6 +5971,11 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5235,6 +6015,11 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5257,6 +6042,9 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5283,12 +6071,20 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5305,6 +6101,9 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5328,10 +6127,18 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5371,6 +6178,11 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5410,7 +6222,12 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5440,6 +6257,11 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5479,6 +6301,11 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5508,7 +6335,12 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5528,6 +6360,11 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = duration.Add(arg1, arg2)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5567,6 +6404,11 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5596,7 +6438,12 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5616,6 +6463,11 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = duration.Add(arg2, arg1)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5655,6 +6507,11 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5684,7 +6541,12 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5704,6 +6566,11 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Add(arg2)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5743,6 +6610,11 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5765,6 +6637,9 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5791,12 +6666,20 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5813,6 +6696,9 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5836,10 +6722,18 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -5879,6 +6773,11 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -5899,6 +6798,9 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -5923,12 +6825,20 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -5943,6 +6853,9 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -5964,10 +6877,18 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6007,6 +6928,11 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6027,6 +6953,9 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -6051,12 +6980,20 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6071,6 +7008,9 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -6092,10 +7032,18 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6135,6 +7083,11 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6155,6 +7108,9 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -6179,12 +7135,20 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6199,6 +7163,9 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -6220,10 +7187,18 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6263,6 +7238,11 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6283,6 +7263,9 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -6307,12 +7290,20 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6327,6 +7318,9 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -6348,10 +7342,18 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6391,6 +7393,11 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6438,7 +7445,12 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6476,6 +7488,11 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6515,6 +7532,11 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6562,7 +7584,12 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6600,6 +7627,11 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6639,6 +7671,11 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6686,7 +7723,12 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6724,6 +7766,11 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6763,6 +7810,11 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6808,7 +7860,12 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6844,6 +7901,11 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -6883,6 +7945,11 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -6928,7 +7995,12 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -6964,6 +8036,11 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7003,6 +8080,11 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7048,7 +8130,12 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7084,6 +8171,11 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7123,6 +8215,11 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7168,7 +8265,12 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7204,6 +8306,11 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7243,6 +8350,11 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7292,7 +8404,12 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7332,6 +8449,11 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7371,6 +8493,11 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7393,6 +8520,9 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -7419,12 +8549,20 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7441,6 +8579,9 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -7464,10 +8605,18 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7507,6 +8656,11 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7552,7 +8706,12 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7588,6 +8747,11 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7627,6 +8791,11 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7672,7 +8841,12 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7708,6 +8882,11 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7747,6 +8926,11 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7792,7 +8976,12 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7828,6 +9017,11 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7867,6 +9061,11 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -7916,7 +9115,12 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -7956,6 +9160,11 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -7995,6 +9204,11 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8017,6 +9231,9 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8043,12 +9260,20 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8065,6 +9290,9 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8088,10 +9316,18 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8131,6 +9367,11 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8176,7 +9417,12 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8212,6 +9458,11 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8251,6 +9502,11 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8296,7 +9552,12 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8332,6 +9593,11 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8371,6 +9637,11 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8416,7 +9687,12 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8452,6 +9728,11 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8491,6 +9772,11 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8540,7 +9826,12 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8580,6 +9871,11 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8619,6 +9915,11 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8641,6 +9942,9 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -8667,12 +9971,20 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8689,6 +10001,9 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -8712,10 +10027,18 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8755,6 +10078,11 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8794,7 +10122,12 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8824,6 +10157,11 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8863,6 +10201,11 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8898,7 +10241,12 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -8924,6 +10272,11 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -8963,6 +10316,11 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -8992,7 +10350,12 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9012,6 +10375,11 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9051,6 +10419,11 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9080,7 +10453,12 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9100,6 +10478,11 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Sub(arg2)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9139,6 +10522,11 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9161,6 +10549,9 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9187,12 +10578,20 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9209,6 +10608,9 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9232,10 +10634,18 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9275,6 +10685,11 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9291,6 +10706,9 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9311,12 +10729,20 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9327,6 +10753,9 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9344,10 +10773,18 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9387,6 +10824,11 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9407,6 +10849,9 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9431,12 +10876,20 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9451,6 +10904,9 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9472,10 +10928,18 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9515,6 +10979,11 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9535,6 +11004,9 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9559,12 +11031,20 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9579,6 +11059,9 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9600,10 +11083,18 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9643,6 +11134,11 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9663,6 +11159,9 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9687,12 +11186,20 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9707,6 +11214,9 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9728,10 +11238,18 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9771,6 +11289,11 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9791,6 +11314,9 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9815,12 +11341,20 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9835,6 +11369,9 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9856,10 +11393,18 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -9899,6 +11444,11 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -9919,6 +11469,9 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -9943,12 +11496,20 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -9963,6 +11524,9 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -9984,10 +11548,18 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10027,6 +11599,11 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10074,7 +11651,12 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10112,6 +11694,11 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10151,6 +11738,11 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10198,7 +11790,12 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10236,6 +11833,11 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10275,6 +11877,11 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10322,7 +11929,12 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10360,6 +11972,11 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10399,6 +12016,11 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10444,7 +12066,12 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10480,6 +12107,11 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10519,6 +12151,11 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10558,7 +12195,12 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10588,6 +12230,11 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg2.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10627,6 +12274,11 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10688,7 +12340,12 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10740,6 +12397,11 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10779,6 +12441,11 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10840,7 +12507,12 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -10892,6 +12564,11 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -10931,6 +12608,11 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -10992,7 +12674,12 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11044,6 +12731,11 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11083,6 +12775,11 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11132,7 +12829,12 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11172,6 +12874,11 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11211,6 +12918,11 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11240,7 +12952,12 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11260,6 +12977,11 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11299,6 +13021,11 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11360,7 +13087,12 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11412,6 +13144,11 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11451,6 +13188,11 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11512,7 +13254,12 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11564,6 +13311,11 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11603,6 +13355,11 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11664,7 +13421,12 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11716,6 +13478,11 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11755,6 +13522,11 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11804,7 +13576,12 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11844,6 +13621,11 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11883,6 +13665,11 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -11912,7 +13699,12 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -11932,6 +13724,11 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -11971,6 +13768,11 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12032,7 +13834,12 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12084,6 +13891,11 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12123,6 +13935,11 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12184,7 +14001,12 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12236,6 +14058,11 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12275,6 +14102,11 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12336,7 +14168,12 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12388,6 +14225,11 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12427,6 +14269,11 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12476,7 +14323,12 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12516,6 +14368,11 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12555,6 +14412,11 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12584,7 +14446,12 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12604,6 +14471,11 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12643,6 +14515,11 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12682,7 +14559,12 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12712,6 +14594,11 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12751,6 +14638,11 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12780,7 +14672,12 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12800,6 +14697,11 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg2.MulFloat(float64(arg1))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12839,6 +14741,11 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12868,7 +14775,12 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12888,6 +14800,11 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -12927,6 +14844,11 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -12956,7 +14878,12 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -12976,6 +14903,11 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13015,6 +14947,11 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13044,7 +14981,12 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13064,6 +15006,11 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13103,6 +15050,11 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13132,7 +15084,12 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13152,6 +15109,11 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.MulFloat(float64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13191,6 +15153,11 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13230,7 +15197,12 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13260,6 +15232,11 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.MulFloat(f)
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13299,6 +15276,11 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13354,7 +15336,12 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13400,6 +15387,11 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13439,6 +15431,11 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13494,7 +15491,12 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13540,6 +15542,11 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13579,6 +15586,11 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13634,7 +15646,12 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13680,6 +15697,11 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13719,6 +15741,11 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13772,7 +15799,12 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13816,6 +15848,11 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13855,6 +15892,11 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -13908,7 +15950,12 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -13952,6 +15999,11 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -13991,6 +16043,11 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14044,7 +16101,12 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14088,6 +16150,11 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14127,6 +16194,11 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14180,7 +16252,12 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14224,6 +16301,11 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14263,6 +16345,11 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14320,7 +16407,12 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14368,6 +16460,11 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14407,6 +16504,11 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14460,7 +16562,12 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14504,6 +16611,11 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14543,6 +16655,11 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14596,7 +16713,12 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14640,6 +16762,11 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14679,6 +16806,11 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14732,7 +16864,12 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14776,6 +16913,11 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14815,6 +16957,11 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -14872,7 +17019,12 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -14920,6 +17072,11 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -14959,6 +17116,11 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15012,7 +17174,12 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15056,6 +17223,11 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15095,6 +17267,11 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15148,7 +17325,12 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15192,6 +17374,11 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15231,6 +17418,11 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15284,7 +17476,12 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15328,6 +17525,11 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15367,6 +17569,11 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15424,7 +17631,12 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15472,6 +17684,11 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15511,6 +17728,11 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15558,7 +17780,12 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15596,6 +17823,11 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15635,6 +17867,11 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15672,7 +17909,12 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15700,6 +17942,11 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.Div(int64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15739,6 +17986,11 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15776,7 +18028,12 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15804,6 +18061,11 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				projCol[i] = arg1.DivFloat(float64(arg2))
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15843,6 +18105,11 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -15898,7 +18165,12 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -15944,6 +18216,11 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -15983,6 +18260,11 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16038,7 +18320,12 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16084,6 +18371,11 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16123,6 +18415,11 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16178,7 +18475,12 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16224,6 +18526,11 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16263,6 +18570,11 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16316,7 +18628,12 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16360,6 +18677,11 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16399,6 +18721,11 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16442,7 +18769,12 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16476,6 +18808,11 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16515,6 +18852,11 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16558,7 +18900,12 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16592,6 +18939,11 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16631,6 +18983,11 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16674,7 +19031,12 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16708,6 +19070,11 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16747,6 +19114,11 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16804,7 +19176,12 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16852,6 +19229,11 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -16891,6 +19273,11 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -16934,7 +19321,12 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -16968,6 +19360,11 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17007,6 +19404,11 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17050,7 +19452,12 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17084,6 +19491,11 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17123,6 +19535,11 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17166,7 +19583,12 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17200,6 +19622,11 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17239,6 +19666,11 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17296,7 +19728,12 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17344,6 +19781,11 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17383,6 +19825,11 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17426,7 +19873,12 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17460,6 +19912,11 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17499,6 +19956,11 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17542,7 +20004,12 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17576,6 +20043,11 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17615,6 +20087,11 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17658,7 +20135,12 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17692,6 +20174,11 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17731,6 +20218,11 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17788,7 +20280,12 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17836,6 +20333,11 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17875,6 +20377,11 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -17922,7 +20429,12 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -17960,6 +20472,11 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -17999,6 +20516,11 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18054,7 +20576,12 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18100,6 +20627,11 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18139,6 +20671,11 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18194,7 +20731,12 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18240,6 +20782,11 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18279,6 +20826,11 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18334,7 +20886,12 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18380,6 +20937,11 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18419,6 +20981,11 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18472,7 +21039,12 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18516,6 +21088,11 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18555,6 +21132,11 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18598,7 +21180,12 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18632,6 +21219,11 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18671,6 +21263,11 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18714,7 +21311,12 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18748,6 +21350,11 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18787,6 +21394,11 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18830,7 +21442,12 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -18864,6 +21481,11 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -18903,6 +21525,11 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -18960,7 +21587,12 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19008,6 +21640,11 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19047,6 +21684,11 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19090,7 +21732,12 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19124,6 +21771,11 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19163,6 +21815,11 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19206,7 +21863,12 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19240,6 +21902,11 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19279,6 +21946,11 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19322,7 +21994,12 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19356,6 +22033,11 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19395,6 +22077,11 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19452,7 +22139,12 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19500,6 +22192,11 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19539,6 +22236,11 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19582,7 +22284,12 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19616,6 +22323,11 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19655,6 +22367,11 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19698,7 +22415,12 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19732,6 +22454,11 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19771,6 +22498,11 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19814,7 +22546,12 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19848,6 +22585,11 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -19887,6 +22629,11 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -19944,7 +22691,12 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -19992,6 +22744,11 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20031,6 +22788,11 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20078,7 +22840,12 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20116,6 +22883,11 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20155,6 +22927,11 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20202,7 +22979,12 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20240,6 +23022,11 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20279,6 +23066,11 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20326,7 +23118,12 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20364,6 +23161,11 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20403,6 +23205,11 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20450,7 +23257,12 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20488,6 +23300,11 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20527,6 +23344,11 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20572,7 +23394,12 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20608,6 +23435,11 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20647,6 +23479,11 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20704,7 +23541,12 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20752,6 +23594,11 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20791,6 +23638,11 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20848,7 +23700,12 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -20896,6 +23753,11 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -20935,6 +23797,11 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -20992,7 +23859,12 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21040,6 +23912,11 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21079,6 +23956,11 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21128,7 +24010,12 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21168,6 +24055,11 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21207,6 +24099,11 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21264,7 +24161,12 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21312,6 +24214,11 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21351,6 +24258,11 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21408,7 +24320,12 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21456,6 +24373,11 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21495,6 +24417,11 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21552,7 +24479,12 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21600,6 +24532,11 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21639,6 +24576,11 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21688,7 +24630,12 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21728,6 +24675,11 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21767,6 +24719,11 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21824,7 +24781,12 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -21872,6 +24834,11 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -21911,6 +24878,11 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -21968,7 +24940,12 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22016,6 +24993,11 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22055,6 +25037,11 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22112,7 +25099,12 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22160,6 +25152,11 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22199,6 +25196,11 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22248,7 +25250,12 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22288,6 +25295,11 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22327,6 +25339,11 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22366,7 +25383,12 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22396,6 +25418,11 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22435,6 +25462,11 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22474,7 +25506,12 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22504,6 +25541,11 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22543,6 +25585,11 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22559,6 +25606,9 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -22579,12 +25629,20 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22595,6 +25653,9 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -22612,10 +25673,18 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22655,6 +25724,11 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22700,7 +25774,12 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22736,6 +25815,11 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22775,6 +25859,11 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22820,7 +25909,12 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22856,6 +25950,11 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -22895,6 +25994,11 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -22940,7 +26044,12 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -22976,6 +26085,11 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23015,6 +26129,11 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23060,7 +26179,12 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23096,6 +26220,11 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23135,6 +26264,11 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23180,7 +26314,12 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23216,6 +26355,11 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23255,6 +26399,11 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23300,7 +26449,12 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23336,6 +26490,11 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23375,6 +26534,11 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23420,7 +26584,12 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23456,6 +26625,11 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23495,6 +26669,11 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23540,7 +26719,12 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23576,6 +26760,11 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23615,6 +26804,11 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23660,7 +26854,12 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23696,6 +26895,11 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23735,6 +26939,11 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23755,6 +26964,9 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23779,12 +26991,20 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23799,6 +27019,9 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23820,10 +27043,18 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23863,6 +27094,11 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -23883,6 +27119,9 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -23907,12 +27146,20 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -23927,6 +27174,9 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -23948,10 +27198,18 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -23991,6 +27249,11 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24011,6 +27274,9 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -24035,12 +27301,20 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24055,6 +27329,9 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -24076,10 +27353,18 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24119,6 +27404,11 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24164,7 +27454,12 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24200,6 +27495,11 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24239,6 +27539,11 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24284,7 +27589,12 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24320,6 +27630,11 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24359,6 +27674,11 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24404,7 +27724,12 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24440,6 +27765,11 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24479,6 +27809,11 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24524,7 +27859,12 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24560,6 +27900,11 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24599,6 +27944,11 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24644,7 +27994,12 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24680,6 +28035,11 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24719,6 +28079,11 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24764,7 +28129,12 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24800,6 +28170,11 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24839,6 +28214,11 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -24884,7 +28264,12 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -24920,6 +28305,11 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -24959,6 +28349,11 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25004,7 +28399,12 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25040,6 +28440,11 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25079,6 +28484,11 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25124,7 +28534,12 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25160,6 +28575,11 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25199,6 +28619,11 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25219,6 +28644,9 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25243,12 +28671,20 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25263,6 +28699,9 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25284,10 +28723,18 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25327,6 +28774,11 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25347,6 +28799,9 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25371,12 +28826,20 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25391,6 +28854,9 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25412,10 +28878,18 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25455,6 +28929,11 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25475,6 +28954,9 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25499,12 +28981,20 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25519,6 +29009,9 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25540,10 +29033,18 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25583,6 +29084,11 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25603,6 +29109,9 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25627,12 +29136,20 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25647,6 +29164,9 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25668,10 +29188,18 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25711,6 +29239,11 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25731,6 +29264,9 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25755,12 +29291,20 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25775,6 +29319,9 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25796,10 +29343,18 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25839,6 +29394,11 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25859,6 +29419,9 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -25883,12 +29446,20 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -25903,6 +29474,9 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -25924,10 +29498,18 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -25967,6 +29549,11 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -25987,6 +29574,9 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
@@ -26011,12 +29601,20 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
 					projCol.Set(i, _res)
 
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26031,6 +29629,9 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, _nonDatumArgAsDatum)
 				if err != nil {
 					colexecerror.ExpectedError(err)
+				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
 				}
 				projCol.Set(i, _res)
 
@@ -26052,10 +29653,18 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}
+				if _res == tree.DNull {
+					_outNulls.SetNull(i)
+				}
 				projCol.Set(i, _res)
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26095,6 +29704,11 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26152,7 +29766,12 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26200,6 +29819,11 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26239,6 +29863,11 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26276,7 +29905,12 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26304,6 +29938,11 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26343,6 +29982,11 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26396,7 +30040,12 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26440,6 +30089,11 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26479,6 +30133,11 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26532,7 +30191,12 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26576,6 +30240,11 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26615,6 +30284,11 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26668,7 +30342,12 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26712,6 +30391,11 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26751,6 +30435,11 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26808,7 +30497,12 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26856,6 +30550,11 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -26895,6 +30594,11 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -26936,7 +30640,12 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -26968,6 +30677,11 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27007,6 +30721,11 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27070,7 +30789,12 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27124,6 +30848,11 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27163,6 +30892,11 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27226,7 +30960,12 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27280,6 +31019,11 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27319,6 +31063,11 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27382,7 +31131,12 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27436,6 +31190,11 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27475,6 +31234,11 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27554,7 +31318,12 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27624,6 +31393,11 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27663,6 +31437,11 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27716,7 +31495,12 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27760,6 +31544,11 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27799,6 +31588,11 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -27862,7 +31656,12 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -27916,6 +31715,11 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -27955,6 +31759,11 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28018,7 +31827,12 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28072,6 +31886,11 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28111,6 +31930,11 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28174,7 +31998,12 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28228,6 +32057,11 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28267,6 +32101,11 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28346,7 +32185,12 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28416,6 +32260,11 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28455,6 +32304,11 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28508,7 +32362,12 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28552,6 +32411,11 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28591,6 +32455,11 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28654,7 +32523,12 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28708,6 +32582,11 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28747,6 +32626,11 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28810,7 +32694,12 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -28864,6 +32753,11 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -28903,6 +32797,11 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -28966,7 +32865,12 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29020,6 +32924,11 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29059,6 +32968,11 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -29138,7 +33052,12 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29208,6 +33127,11 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29247,6 +33171,11 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -29300,7 +33229,12 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29344,6 +33278,11 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29383,6 +33322,11 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -29462,7 +33406,12 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29532,6 +33481,11 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29571,6 +33525,11 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -29650,7 +33609,12 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29720,6 +33684,11 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29759,6 +33728,11 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -29838,7 +33812,12 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -29908,6 +33887,11 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -29947,6 +33931,11 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30026,7 +34015,12 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30096,6 +34090,11 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30135,6 +34134,11 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30192,7 +34196,12 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30240,6 +34249,11 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30279,6 +34293,11 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30334,7 +34353,12 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30380,6 +34404,11 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30419,6 +34448,11 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30460,7 +34494,12 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30492,6 +34531,11 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30531,6 +34575,11 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30576,7 +34625,12 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30612,6 +34666,11 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30651,6 +34710,11 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30708,7 +34772,12 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30756,6 +34825,11 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30795,6 +34869,11 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30832,7 +34911,12 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30860,6 +34944,11 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -30899,6 +34988,11 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -30952,7 +35046,12 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -30996,6 +35095,11 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31035,6 +35139,11 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31088,7 +35197,12 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31132,6 +35246,11 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31171,6 +35290,11 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31224,7 +35348,12 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31268,6 +35397,11 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31307,6 +35441,11 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31364,7 +35503,12 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31412,6 +35556,11 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31451,6 +35600,11 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31492,7 +35646,12 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31524,6 +35683,11 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31563,6 +35727,11 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31626,7 +35795,12 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31680,6 +35854,11 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31719,6 +35898,11 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31782,7 +35966,12 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31836,6 +36025,11 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -31875,6 +36069,11 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -31938,7 +36137,12 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -31992,6 +36196,11 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32031,6 +36240,11 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32110,7 +36324,12 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32180,6 +36399,11 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32219,6 +36443,11 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32272,7 +36501,12 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32316,6 +36550,11 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32355,6 +36594,11 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32418,7 +36662,12 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32472,6 +36721,11 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32511,6 +36765,11 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32574,7 +36833,12 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32628,6 +36892,11 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32667,6 +36936,11 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32730,7 +37004,12 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32784,6 +37063,11 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -32823,6 +37107,11 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -32902,7 +37191,12 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -32972,6 +37266,11 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33011,6 +37310,11 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33064,7 +37368,12 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33108,6 +37417,11 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33147,6 +37461,11 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33210,7 +37529,12 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33264,6 +37588,11 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33303,6 +37632,11 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33366,7 +37700,12 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33420,6 +37759,11 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33459,6 +37803,11 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33522,7 +37871,12 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33576,6 +37930,11 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33615,6 +37974,11 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33694,7 +38058,12 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33764,6 +38133,11 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33803,6 +38177,11 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -33856,7 +38235,12 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -33900,6 +38284,11 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -33939,6 +38328,11 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34018,7 +38412,12 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34088,6 +38487,11 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34127,6 +38531,11 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34206,7 +38615,12 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34276,6 +38690,11 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34315,6 +38734,11 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34394,7 +38818,12 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34464,6 +38893,11 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34503,6 +38937,11 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34582,7 +39021,12 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34652,6 +39096,11 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34691,6 +39140,11 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34748,7 +39202,12 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34796,6 +39255,11 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34835,6 +39299,11 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -34890,7 +39359,12 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -34936,6 +39410,11 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -34975,6 +39454,11 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35016,7 +39500,12 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35048,6 +39537,11 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35087,6 +39581,11 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35132,7 +39631,12 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35168,6 +39672,11 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35207,6 +39716,11 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35264,7 +39778,12 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35312,6 +39831,11 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35351,6 +39875,11 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35388,7 +39917,12 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35416,6 +39950,11 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35455,6 +39994,11 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35508,7 +40052,12 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35552,6 +40101,11 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35591,6 +40145,11 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35644,7 +40203,12 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35688,6 +40252,11 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35727,6 +40296,11 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35780,7 +40354,12 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35824,6 +40403,11 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -35863,6 +40447,11 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -35920,7 +40509,12 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -35968,6 +40562,11 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36007,6 +40606,11 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36048,7 +40652,12 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36080,6 +40689,11 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36119,6 +40733,11 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36182,7 +40801,12 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36236,6 +40860,11 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36275,6 +40904,11 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36338,7 +40972,12 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36392,6 +41031,11 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36431,6 +41075,11 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36494,7 +41143,12 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36548,6 +41202,11 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36587,6 +41246,11 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36666,7 +41330,12 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36736,6 +41405,11 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36775,6 +41449,11 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36828,7 +41507,12 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -36872,6 +41556,11 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -36911,6 +41600,11 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -36974,7 +41668,12 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37028,6 +41727,11 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37067,6 +41771,11 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37130,7 +41839,12 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37184,6 +41898,11 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37223,6 +41942,11 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37286,7 +42010,12 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37340,6 +42069,11 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37379,6 +42113,11 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37458,7 +42197,12 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37528,6 +42272,11 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37567,6 +42316,11 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37620,7 +42374,12 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37664,6 +42423,11 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37703,6 +42467,11 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37766,7 +42535,12 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37820,6 +42594,11 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -37859,6 +42638,11 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -37922,7 +42706,12 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -37976,6 +42765,11 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38015,6 +42809,11 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38078,7 +42877,12 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38132,6 +42936,11 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38171,6 +42980,11 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38250,7 +43064,12 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38320,6 +43139,11 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38359,6 +43183,11 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38412,7 +43241,12 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38456,6 +43290,11 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38495,6 +43334,11 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38574,7 +43418,12 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38644,6 +43493,11 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38683,6 +43537,11 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38762,7 +43621,12 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -38832,6 +43696,11 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -38871,6 +43740,11 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -38950,7 +43824,12 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39020,6 +43899,11 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39059,6 +43943,11 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39138,7 +44027,12 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39208,6 +44102,11 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39247,6 +44146,11 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39304,7 +44208,12 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39352,6 +44261,11 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39391,6 +44305,11 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39446,7 +44365,12 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39492,6 +44416,11 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39531,6 +44460,11 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39572,7 +44506,12 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39604,6 +44543,11 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39643,6 +44587,11 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39688,7 +44637,12 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39724,6 +44678,11 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39763,6 +44722,11 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39820,7 +44784,12 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39868,6 +44837,11 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -39907,6 +44881,11 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -39944,7 +44923,12 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -39972,6 +44956,11 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40011,6 +45000,11 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40064,7 +45058,12 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40108,6 +45107,11 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40147,6 +45151,11 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40200,7 +45209,12 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40244,6 +45258,11 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40283,6 +45302,11 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40336,7 +45360,12 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40380,6 +45409,11 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40419,6 +45453,11 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40476,7 +45515,12 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40524,6 +45568,11 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40563,6 +45612,11 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40604,7 +45658,12 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40636,6 +45695,11 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40675,6 +45739,11 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40738,7 +45807,12 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40792,6 +45866,11 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40831,6 +45910,11 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -40894,7 +45978,12 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -40948,6 +46037,11 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -40987,6 +46081,11 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41050,7 +46149,12 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41104,6 +46208,11 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41143,6 +46252,11 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41222,7 +46336,12 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41292,6 +46411,11 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41331,6 +46455,11 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41384,7 +46513,12 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41428,6 +46562,11 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41467,6 +46606,11 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41530,7 +46674,12 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41584,6 +46733,11 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41623,6 +46777,11 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41686,7 +46845,12 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41740,6 +46904,11 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41779,6 +46948,11 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -41842,7 +47016,12 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -41896,6 +47075,11 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -41935,6 +47119,11 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42014,7 +47203,12 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42084,6 +47278,11 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42123,6 +47322,11 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42176,7 +47380,12 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42220,6 +47429,11 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42259,6 +47473,11 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42322,7 +47541,12 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42376,6 +47600,11 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42415,6 +47644,11 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42478,7 +47712,12 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42532,6 +47771,11 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42571,6 +47815,11 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42634,7 +47883,12 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42688,6 +47942,11 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42727,6 +47986,11 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42806,7 +48070,12 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -42876,6 +48145,11 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -42915,6 +48189,11 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -42968,7 +48247,12 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43012,6 +48296,11 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43051,6 +48340,11 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -43130,7 +48424,12 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43200,6 +48499,11 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43239,6 +48543,11 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -43318,7 +48627,12 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43388,6 +48702,11 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43427,6 +48746,11 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -43506,7 +48830,12 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43576,6 +48905,11 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43615,6 +48949,11 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -43694,7 +49033,12 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43764,6 +49108,11 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43803,6 +49152,11 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -43860,7 +49214,12 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -43908,6 +49267,11 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -43947,6 +49311,11 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44002,7 +49371,12 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44048,6 +49422,11 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44087,6 +49466,11 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44128,7 +49512,12 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44160,6 +49549,11 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44199,6 +49593,11 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44244,7 +49643,12 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44280,6 +49684,11 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44319,6 +49728,11 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44376,7 +49790,12 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44424,6 +49843,11 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44463,6 +49887,11 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44500,7 +49929,12 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44528,6 +49962,11 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44567,6 +50006,11 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44620,7 +50064,12 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44664,6 +50113,11 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44703,6 +50157,11 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44756,7 +50215,12 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44800,6 +50264,11 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44839,6 +50308,11 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -44892,7 +50366,12 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -44936,6 +50415,11 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -44975,6 +50459,11 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45032,7 +50521,12 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45080,6 +50574,11 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45119,6 +50618,11 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45160,7 +50664,12 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45192,6 +50701,11 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45231,6 +50745,11 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45294,7 +50813,12 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45348,6 +50872,11 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45387,6 +50916,11 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45450,7 +50984,12 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45504,6 +51043,11 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45543,6 +51087,11 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45606,7 +51155,12 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45660,6 +51214,11 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45699,6 +51258,11 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45778,7 +51342,12 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45848,6 +51417,11 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -45887,6 +51461,11 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -45940,7 +51519,12 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -45984,6 +51568,11 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46023,6 +51612,11 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46086,7 +51680,12 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46140,6 +51739,11 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46179,6 +51783,11 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46242,7 +51851,12 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46296,6 +51910,11 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46335,6 +51954,11 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46398,7 +52022,12 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46452,6 +52081,11 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46491,6 +52125,11 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46570,7 +52209,12 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46640,6 +52284,11 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46679,6 +52328,11 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46732,7 +52386,12 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46776,6 +52435,11 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46815,6 +52479,11 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -46878,7 +52547,12 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -46932,6 +52606,11 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -46971,6 +52650,11 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47034,7 +52718,12 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47088,6 +52777,11 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47127,6 +52821,11 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47190,7 +52889,12 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47244,6 +52948,11 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47283,6 +52992,11 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47362,7 +53076,12 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47432,6 +53151,11 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47471,6 +53195,11 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47524,7 +53253,12 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47568,6 +53302,11 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47607,6 +53346,11 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47686,7 +53430,12 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47756,6 +53505,11 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47795,6 +53549,11 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -47874,7 +53633,12 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -47944,6 +53708,11 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -47983,6 +53752,11 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48062,7 +53836,12 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48132,6 +53911,11 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48171,6 +53955,11 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48250,7 +54039,12 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48320,6 +54114,11 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48359,6 +54158,11 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48416,7 +54220,12 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48464,6 +54273,11 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48503,6 +54317,11 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48558,7 +54377,12 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48604,6 +54428,11 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48643,6 +54472,11 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48684,7 +54518,12 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48716,6 +54555,11 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48755,6 +54599,11 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48800,7 +54649,12 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48836,6 +54690,11 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -48875,6 +54734,11 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bool()
 	col2 := vec2.Bool()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -48932,7 +54796,12 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -48980,6 +54849,11 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49019,6 +54893,11 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Bytes()
 	col2 := vec2.Bytes()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49056,7 +54935,12 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49084,6 +54968,11 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49123,6 +55012,11 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49176,7 +55070,12 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49220,6 +55119,11 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49259,6 +55163,11 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49312,7 +55221,12 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49356,6 +55270,11 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49395,6 +55314,11 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49448,7 +55372,12 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49492,6 +55421,11 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49531,6 +55465,11 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49588,7 +55527,12 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49636,6 +55580,11 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49675,6 +55624,11 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Decimal()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49716,7 +55670,12 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49748,6 +55707,11 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49787,6 +55751,11 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -49850,7 +55819,12 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -49904,6 +55878,11 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -49943,6 +55922,11 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50006,7 +55990,12 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50060,6 +56049,11 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50099,6 +56093,11 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50162,7 +56161,12 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50216,6 +56220,11 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50255,6 +56264,11 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50334,7 +56348,12 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50404,6 +56423,11 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50443,6 +56467,11 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int16()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50496,7 +56525,12 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50540,6 +56574,11 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50579,6 +56618,11 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50642,7 +56686,12 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50696,6 +56745,11 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50735,6 +56789,11 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50798,7 +56857,12 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -50852,6 +56916,11 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -50891,6 +56960,11 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -50954,7 +57028,12 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51008,6 +57087,11 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51047,6 +57131,11 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51126,7 +57215,12 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51196,6 +57290,11 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51235,6 +57334,11 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int32()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51288,7 +57392,12 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51332,6 +57441,11 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51371,6 +57485,11 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51434,7 +57553,12 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51488,6 +57612,11 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51527,6 +57656,11 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51590,7 +57724,12 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51644,6 +57783,11 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51683,6 +57827,11 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51746,7 +57895,12 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51800,6 +57954,11 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -51839,6 +57998,11 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -51918,7 +58082,12 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -51988,6 +58157,11 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52027,6 +58201,11 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Int64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52080,7 +58259,12 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -52124,6 +58308,11 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52163,6 +58352,11 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int16()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52242,7 +58436,12 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -52312,6 +58511,11 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52351,6 +58555,11 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int32()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52430,7 +58639,12 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -52500,6 +58714,11 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52539,6 +58758,11 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Int64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52618,7 +58842,12 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -52688,6 +58917,11 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52727,6 +58961,11 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Float64()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52806,7 +59045,12 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -52876,6 +59120,11 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -52915,6 +59164,11 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Float64()
 	col2 := vec2.Decimal()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -52972,7 +59226,12 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -53020,6 +59279,11 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -53059,6 +59323,11 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Timestamp()
 	col2 := vec2.Timestamp()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -53114,7 +59383,12 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -53160,6 +59434,11 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -53199,6 +59478,11 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Interval()
 	col2 := vec2.Interval()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -53240,7 +59524,12 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -53272,6 +59561,11 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set
@@ -53311,6 +59605,11 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1.Datum()
 	col2 := vec2.Datum()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		col1Nulls := vec1.Nulls()
 		col2Nulls := vec2.Nulls()
@@ -53356,7 +59655,12 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		}
-		projVec.SetNulls(col1Nulls.Or(col2Nulls))
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	} else {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
@@ -53392,6 +59696,11 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 			}
 		}
+		// _outNulls has been updated from within the _ASSIGN function to include
+		// any NULLs that resulted from the projection.
+		// If $hasNulls is true, union _outNulls with the set of input Nulls.
+		// If $hasNulls is false, then there are no input Nulls. _outNulls is
+		// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	}
 
 	// Although we didn't change the length of the batch, it is necessary to set

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -109,6 +109,11 @@ func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1._L_TYP()
 	col2 := vec2._R_TYP()
+	// Some operators can result in NULL with non-NULL inputs, like the JSON
+	// fetch value operator, ->. Therefore, _outNulls is defined to allow
+	// updating the output Nulls from within _ASSIGN functions when the result
+	// of a projection is Null.
+	_outNulls := projVec.Nulls()
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		_SET_PROJECTION(true)
 	} else {
@@ -156,8 +161,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	}
+	// _outNulls has been updated from within the _ASSIGN function to include
+	// any NULLs that resulted from the projection.
+	// If _HAS_NULLS is true, union _outNulls with the set of input Nulls.
+	// If _HAS_NULLS is false, then there are no input Nulls. _outNulls is
+	// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	// {{if _HAS_NULLS}}
-	projVec.SetNulls(col1Nulls.Or(col2Nulls))
+	projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
 	// {{end}}
 	// {{end}}
 	// {{end}}

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -705,6 +705,31 @@ DROP TABLE table_with_nulls
 statement ok
 DROP TABLE c
 
+subtest json_fetch_val
+
+statement ok
+CREATE TABLE f (
+  k INT PRIMARY KEY,
+  j JSON,
+  INVERTED INDEX i (j)
+)
+
+statement ok
+INSERT INTO f VALUES
+  (0, '{"a": 1}'),
+  (1, '{"a": 10}'),
+  (2, '{"b": 2}'),
+  (3, '{"b": 2, "a": 1}'),
+  (4, '{"a": 1, "c": 3}'),
+  (5, '{"a": [1, 2]}')
+
+query T
+SELECT j FROM f@i WHERE j->'a' = '1' ORDER BY k
+----
+{"a": 1}
+{"a": 1, "b": 2}
+{"a": 1, "c": 3}
+
 subtest arrays
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -719,3 +719,50 @@ a  b
 
 statement ok
 DROP TABLE json_family
+
+# Regression tests for #49143. Correctly handle cases where the -> operator
+# results in NULL when both arguments are non-NULL.
+subtest regression_49143
+
+statement ok
+CREATE TABLE t49143 (k INT PRIMARY KEY, j JSON);
+INSERT INTO t49143 VALUES
+  (0, '[]'),
+  (1, '[1]'),
+  (2, '[2]'),
+  (3, '[[1, 2], [3, 4]]'),
+  (4, '[[5, 6], [7, 8]]'),
+  (5, '{}'),
+  (6, '{"a": 1}'),
+  (7, '{"b": 1}'),
+  (8, '{"b": 2}'),
+  (9, '{"b": [1, 2]}'),
+  (10, '{"b": [3, 4]}');
+
+query T
+SELECT j FROM t49143 WHERE NOT (j->0 = '2') ORDER BY k
+----
+[1]
+[[1, 2], [3, 4]]
+[[5, 6], [7, 8]]
+
+query T
+SELECT j FROM t49143 WHERE NOT (j->'b' = '1') ORDER BY k
+----
+{"b": 2}
+{"b": [1, 2]}
+{"b": [3, 4]}
+
+query T
+SELECT j FROM t49143 WHERE NOT (j -> 0 @> '[1]') ORDER BY k
+----
+[1]
+[2]
+[[5, 6], [7, 8]]
+
+query T
+SELECT j FROM t49143 WHERE NOT (j -> 'b' @> '[1]') ORDER BY k
+----
+{"b": 1}
+{"b": 2}
+{"b": [3, 4]}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -573,9 +573,30 @@ NULL
 NULL
 ["foo", {"b": 3}]
 
+# Regression tests for #49143. Correctly handle cases where the -> operator
+# results in NULL when both arguments are non-NULL.
+subtest regression_49143
+
+query B
+SELECT _json -> 5  = '1' FROM many_types
+----
+NULL
+NULL
+NULL
+NULL
+
+query B
+SELECT _json -> _int -> 'a' = '["foo", {"b": 3}]' FROM many_types
+----
+NULL
+NULL
+NULL
+true
 
 # Make sure we fall back to row engine when we have a mixed-type expression
 # with dates.
+subtest mixed_types_with_dates
+
 query T
 EXPLAIN (VEC) SELECT _time + _date FROM many_types
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -273,23 +273,25 @@ filter     ·                    ·                     (a, b)  ·
 ·          spans                FULL SCAN             ·       ·
 
 
-# TODO(mgartner): This query can scan the inverted index when the -> operator is
-# supported by the inverted index constraint builder.
+# TODO(mgartner): It should not be required to force the index scan. It is
+# required until the statistics builder treats b->'a' = '"b"' similarly to the
+# containment operator, @>.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
+EXPLAIN (VERBOSE) SELECT * from d@foo_inv where b->'a' = '"b"'
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               (b->'a') = '"b"'      ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                d@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+·           distribution         local                        ·       ·
+·           vectorized           true                         ·       ·
+index join  ·                    ·                            (a, b)  ·
+ │          estimated row count  333 (missing stats)          ·       ·
+ │          table                d@primary                    ·       ·
+ │          key columns          a                            ·       ·
+ └── scan   ·                    ·                            (a)     ·
+·           estimated row count  110 (missing stats)          ·       ·
+·           table                d@foo_inv                    ·       ·
+·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
-# TODO(mgartner): This query can scan the inverted index when the -> operator is
-# supported by the inverted index constraint builder.
+# TODO(mgartner): Add support for building inverted index constraints for chained JSON
+# fetch operators.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
@@ -310,20 +312,22 @@ EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
 ·       vectorized    true   ·       ·
 norows  ·             ·      (a, b)  ·
 
-# TODO(mgartner): This query can scan the inverted index when the -> operator is
-# supported by the inverted index constraint builder.
+# TODO(mgartner): It should not be required to force the index scan. It is
+# required until the statistics builder treats b->'a' = '"b"' similarly to the
+# containment operator, @>.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
+EXPLAIN (VERBOSE) SELECT * from d@foo_inv where '"b"' = b->'a'
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               (b->'a') = '"b"'      ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                d@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+·           distribution         local                        ·       ·
+·           vectorized           true                         ·       ·
+index join  ·                    ·                            (a, b)  ·
+ │          estimated row count  333 (missing stats)          ·       ·
+ │          table                d@primary                    ·       ·
+ │          key columns          a                            ·       ·
+ └── scan   ·                    ·                            (a)     ·
+·           estimated row count  110 (missing stats)          ·       ·
+·           table                d@foo_inv                    ·       ·
+·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 # Make sure that querying for NULL equality doesn't use the inverted index.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -273,33 +273,35 @@ filter     ·                    ·                     (a, b)  ·
 ·          spans                FULL SCAN             ·       ·
 
 
+# TODO(mgartner): This query can scan the inverted index when the -> operator is
+# supported by the inverted index constraint builder.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
-·           distribution         local                        ·       ·
-·           vectorized           true                         ·       ·
-index join  ·                    ·                            (a, b)  ·
- │          estimated row count  110 (missing stats)          ·       ·
- │          table                d@primary                    ·       ·
- │          key columns          a                            ·       ·
- └── scan   ·                    ·                            (a)     ·
-·           estimated row count  110 (missing stats)          ·       ·
-·           table                d@foo_inv                    ·       ·
-·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·          distribution         local                 ·       ·
+·          vectorized           true                  ·       ·
+filter     ·                    ·                     (a, b)  ·
+ │         estimated row count  333 (missing stats)   ·       ·
+ │         filter               (b->'a') = '"b"'      ·       ·
+ └── scan  ·                    ·                     (a, b)  ·
+·          estimated row count  1000 (missing stats)  ·       ·
+·          table                d@primary             ·       ·
+·          spans                FULL SCAN             ·       ·
 
+# TODO(mgartner): This query can scan the inverted index when the -> operator is
+# supported by the inverted index constraint builder.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
-·           distribution         local                                ·       ·
-·           vectorized           true                                 ·       ·
-index join  ·                    ·                                    (a, b)  ·
- │          estimated row count  110 (missing stats)                  ·       ·
- │          table                d@primary                            ·       ·
- │          key columns          a                                    ·       ·
- └── scan   ·                    ·                                    (a)     ·
-·           estimated row count  110 (missing stats)                  ·       ·
-·           table                d@foo_inv                            ·       ·
-·           spans                /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
+·          distribution         local                    ·       ·
+·          vectorized           true                     ·       ·
+filter     ·                    ·                        (a, b)  ·
+ │         estimated row count  333 (missing stats)      ·       ·
+ │         filter               ((b->'a')->'c') = '"b"'  ·       ·
+ └── scan  ·                    ·                        (a, b)  ·
+·          estimated row count  1000 (missing stats)     ·       ·
+·          table                d@primary                ·       ·
+·          spans                FULL SCAN                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
@@ -308,19 +310,20 @@ EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
 ·       vectorized    true   ·       ·
 norows  ·             ·      (a, b)  ·
 
+# TODO(mgartner): This query can scan the inverted index when the -> operator is
+# supported by the inverted index constraint builder.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
-·           distribution         local                        ·       ·
-·           vectorized           true                         ·       ·
-index join  ·                    ·                            (a, b)  ·
- │          estimated row count  110 (missing stats)          ·       ·
- │          table                d@primary                    ·       ·
- │          key columns          a                            ·       ·
- └── scan   ·                    ·                            (a)     ·
-·           estimated row count  110 (missing stats)          ·       ·
-·           table                d@foo_inv                    ·       ·
-·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·          distribution         local                 ·       ·
+·          vectorized           true                  ·       ·
+filter     ·                    ·                     (a, b)  ·
+ │         estimated row count  333 (missing stats)   ·       ·
+ │         filter               (b->'a') = '"b"'      ·       ·
+ └── scan  ·                    ·                     (a, b)  ·
+·          estimated row count  1000 (missing stats)  ·       ·
+·          table                d@primary             ·       ·
+·          spans                FULL SCAN             ·       ·
 
 # Make sure that querying for NULL equality doesn't use the inverted index.
 query TTTTT

--- a/pkg/sql/opt/idxconstraint/testdata/inverted
+++ b/pkg/sql/opt/idxconstraint/testdata/inverted
@@ -96,3 +96,80 @@ index-constraints vars=(int[]) inverted-index=@1
 ----
 [ - ]
 Remaining filter: NULL
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = 'true'
+----
+[/'{"a": true}' - /'{"a": true}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = 'false'
+----
+[/'{"a": false}' - /'{"a": false}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = 'null'
+----
+[/'{"a": null}' - /'{"a": null}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = '1'
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = '"b"'
+----
+[/'{"a": "b"}' - /'{"a": "b"}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'0' = 'true'
+----
+[/'{"0": true}' - /'{"0": true}']
+
+# Do not create a constraint when the var is not an indexed column.
+index-constraints vars=(jsonb,jsonb) inverted-index=@2
+@1->'a' = '1'
+----
+[ - ]
+Remaining filter: (@1->'a') = '1'
+
+# Do not create a constraint when the fetch key is not a constant.
+index-constraints vars=(jsonb,string) inverted-index=@1
+@1->@2 = '1'
+----
+[ - ]
+Remaining filter: (@1->@2) = '1'
+
+# Do not create a constraint when the fetch key is an integer.
+index-constraints vars=(jsonb) inverted-index=@1
+@1->0 = '1'
+----
+[ - ]
+Remaining filter: (@1->0) = '1'
+
+# Do not create a constraint when the RHS of the equality is not a constant.
+# Note: @2 is wrapped in a function to avoid normalizing @2 to the RHS of the
+# equality. This normalization would result in an expression that fails to match
+# the j->'key' = 'val' pattern that is required for building this type of
+# inverted index constraint. Therefore, the wrapping function ensures that the
+# code path of a non-const RHS is tested.
+index-constraints vars=(jsonb,string) inverted-index=@1
+@1->'a' = lower(@2)::JSONB
+----
+[ - ]
+Remaining filter: (@1->'a') = lower(@2)::JSONB
+
+# Do not create a constraint when the RHS of the equality is a JSON array.
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = '[1]'
+----
+[ - ]
+Remaining filter: (@1->'a') = '[1]'
+
+# Do not create a constraint when the RHS of the equality is a JSON object.
+index-constraints vars=(jsonb) inverted-index=@1
+@1->'a' = '{"x": 1}'
+----
+[ - ]
+Remaining filter: (@1->'a') = '{"x": 1}'

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -55,11 +55,6 @@ func (c *CustomFuncs) HasColType(scalar opt.ScalarExpr, dstTyp *types.T) bool {
 	return scalar.DataType().Identical(dstTyp)
 }
 
-// IsString returns true if the given scalar expression is of type String.
-func (c *CustomFuncs) IsString(scalar opt.ScalarExpr) bool {
-	return scalar.DataType().Family() == types.StringFamily
-}
-
 // IsTimestamp returns true if the given scalar expression is of type Timestamp.
 func (c *CustomFuncs) IsTimestamp(scalar opt.ScalarExpr) bool {
 	return scalar.DataType().Family() == types.TimestampFamily

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -167,51 +167,6 @@ $input
 =>
 (Exists $input $subqueryPrivate)
 
-# NormalizeJSONFieldAccess transforms field access into a containment with a
-# simpler LHS. This allows inverted index constraints to be generated in some
-# cases.
-# The FetchVal operator also has an overload with integers instead of strings,
-# but this transformation is not valid in that case.
-# This transforms
-#
-#   a->'b' = '"c"'
-#
-# to
-#
-#   a @> '{"b": "c"}'
-#
-# Note that we can't make this transformation in cases like
-#
-#   a->'b' = '["c"]',
-#
-# because containment is not equivalent to equality for non-scalar types.
-[NormalizeJSONFieldAccess, Normalize]
-(Eq
-    (FetchVal $val:* $key:(Const) & (IsString $key))
-    $right:(Const) & (IsJSONScalar $right)
-)
-=>
-(Contains $val (MakeSingleKeyJSONObject $key $right))
-
-# NormalizeJSONContains contains transforms a field access containment into one
-# with a simpler LHS.  This transformation is only valid if the RHS is not a
-# scalar, since a JSON array "contains" a scalar which is inside of it.
-# This transforms
-#
-#   a->'b' @> '{"x": "c"}'
-#
-# to
-#
-#   a @> '{"b": {"x": "c"}}'
-#
-[NormalizeJSONContains, Normalize]
-(Contains
-    (FetchVal $val:* $key:(Const) & (IsString $key))
-    $right:(Const) & ^(IsJSONScalar $right)
-)
-=>
-(Contains $val (MakeSingleKeyJSONObject $key $right))
-
 # SimplifyCaseWhenConstValue removes branches known to not match. Any
 # branch known to match is used as the ELSE and further WHEN conditions
 # are skipped. If all WHEN conditions have been removed, the ELSE

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -96,24 +95,6 @@ func (c *CustomFuncs) SimplifyCoalesce(args memo.ScalarListExpr) opt.ScalarExpr 
 	// All operands up to the last were null (or the last is the only operand),
 	// so return the last operand without the wrapping COALESCE function.
 	return args[len(args)-1]
-}
-
-// IsJSONScalar returns if the JSON value is a number, string, true, false, or null.
-func (c *CustomFuncs) IsJSONScalar(value opt.ScalarExpr) bool {
-	v := value.(*memo.ConstExpr).Value.(*tree.DJSON)
-	return v.JSON.Type() != json.ObjectJSONType && v.JSON.Type() != json.ArrayJSONType
-}
-
-// MakeSingleKeyJSONObject returns a JSON object with one entry, mapping key to value.
-func (c *CustomFuncs) MakeSingleKeyJSONObject(key, value opt.ScalarExpr) opt.ScalarExpr {
-	k := key.(*memo.ConstExpr).Value.(*tree.DString)
-	v := value.(*memo.ConstExpr).Value.(*tree.DJSON)
-
-	builder := json.NewObjectBuilder(1)
-	builder.Add(string(*k), v.JSON)
-	j := builder.Build()
-
-	return c.f.ConstructConst(&tree.DJSON{JSON: j}, types.Jsonb)
 }
 
 // IsConstValueEqual returns whether const1 and const2 are equal.

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, arr int[])
 ----
 
 exec-ddl
@@ -27,22 +27,22 @@ SELECT
 FROM a
 ----
 project
- ├── columns: r:8 s:9 t:10!null u:11!null v:12 w:13 x:14 y:15 z:16
+ ├── columns: r:7 s:8 t:9!null u:10!null v:11 w:12 x:13 y:14 z:15
  ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      ├── k:1 = (i:2 + 1) [as=r:8, outer=(1,2), immutable]
-      ├── i:2 != (2 - k:1) [as=s:9, outer=(1,2), immutable]
-      ├── k:1 IS NOT DISTINCT FROM (i:2 + 1) [as=t:10, outer=(1,2), immutable]
-      ├── k:1 IS DISTINCT FROM (i:2 - 1) [as=u:11, outer=(1,2), immutable]
-      ├── k:1 + (i:2 * 2) [as=v:12, outer=(1,2), immutable]
-      ├── k:1 * (i:2 + 2) [as=w:13, outer=(1,2), immutable]
-      ├── k:1 & (i:2 ^ 2) [as=x:14, outer=(1,2), immutable]
-      ├── k:1 | (i:2 ^ 2) [as=y:15, outer=(1,2), immutable]
-      └── k:1 # (i:2 * i:2) [as=z:16, outer=(1,2), immutable]
+      ├── k:1 = (i:2 + 1) [as=r:7, outer=(1,2), immutable]
+      ├── i:2 != (2 - k:1) [as=s:8, outer=(1,2), immutable]
+      ├── k:1 IS NOT DISTINCT FROM (i:2 + 1) [as=t:9, outer=(1,2), immutable]
+      ├── k:1 IS DISTINCT FROM (i:2 - 1) [as=u:10, outer=(1,2), immutable]
+      ├── k:1 + (i:2 * 2) [as=v:11, outer=(1,2), immutable]
+      ├── k:1 * (i:2 + 2) [as=w:12, outer=(1,2), immutable]
+      ├── k:1 & (i:2 ^ 2) [as=x:13, outer=(1,2), immutable]
+      ├── k:1 | (i:2 ^ 2) [as=y:14, outer=(1,2), immutable]
+      └── k:1 # (i:2 * i:2) [as=z:15, outer=(1,2), immutable]
 
 # --------------------------------------------------
 # CommuteConst
@@ -62,22 +62,22 @@ SELECT
 FROM a
 ----
 project
- ├── columns: r:8 s:9 t:10!null u:11!null v:12 w:13 x:14 y:15 z:16!null
+ ├── columns: r:7 s:8 t:9!null u:10!null v:11 w:12 x:13 y:14 z:15!null
  ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── projections
-      ├── (i:2 + k:1) = 4 [as=r:8, outer=(1,2), immutable]
-      ├── (i:2 * 2) != 3 [as=s:9, outer=(2), immutable]
-      ├── (1 - k:1) IS NOT DISTINCT FROM 5 [as=t:10, outer=(1), immutable]
-      ├── k:1 IS DISTINCT FROM 11 [as=u:11, outer=(1)]
-      ├── f:3 + 1.0 [as=v:12, outer=(3), immutable]
-      ├── (i:2 * i:2) * 15 [as=w:13, outer=(2), immutable]
-      ├── (i:2 + i:2) & 10000 [as=x:14, outer=(2), immutable]
-      ├── (i:2 + i:2) | 4 [as=y:15, outer=(2), immutable]
-      └── (k:1 ^ 2) # -2 [as=z:16, outer=(1), immutable]
+      ├── (i:2 + k:1) = 4 [as=r:7, outer=(1,2), immutable]
+      ├── (i:2 * 2) != 3 [as=s:8, outer=(2), immutable]
+      ├── (1 - k:1) IS NOT DISTINCT FROM 5 [as=t:9, outer=(1), immutable]
+      ├── k:1 IS DISTINCT FROM 11 [as=u:10, outer=(1)]
+      ├── f:3 + 1.0 [as=v:11, outer=(3), immutable]
+      ├── (i:2 * i:2) * 15 [as=w:12, outer=(2), immutable]
+      ├── (i:2 + i:2) & 10000 [as=x:13, outer=(2), immutable]
+      ├── (i:2 + i:2) | 4 [as=y:14, outer=(2), immutable]
+      └── (k:1 ^ 2) # -2 [as=z:15, outer=(1), immutable]
 
 # --------------------------------------------------
 # EliminateCoalesce
@@ -86,21 +86,21 @@ norm expect=EliminateCoalesce
 SELECT COALESCE(i) FROM a
 ----
 project
- ├── columns: coalesce:8
+ ├── columns: coalesce:7
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2 [as=coalesce:8, outer=(2)]
+      └── i:2 [as=coalesce:7, outer=(2)]
 
 norm expect=EliminateCoalesce
 SELECT COALESCE(NULL) FROM a
 ----
 project
- ├── columns: coalesce:8
- ├── fd: ()-->(8)
+ ├── columns: coalesce:7
+ ├── fd: ()-->(7)
  ├── scan a
  └── projections
-      └── NULL [as=coalesce:8]
+      └── NULL [as=coalesce:7]
 
 # --------------------------------------------------
 # SimplifyCoalesce
@@ -110,43 +110,43 @@ norm expect=SimplifyCoalesce
 SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
- ├── columns: coalesce:8!null
- ├── fd: ()-->(8)
+ ├── columns: coalesce:7!null
+ ├── fd: ()-->(7)
  ├── scan a
  └── projections
-      └── 'foo' [as=coalesce:8]
+      └── 'foo' [as=coalesce:7]
 
 norm expect=SimplifyCoalesce
 SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
- ├── columns: coalesce:8
+ ├── columns: coalesce:7
  ├── immutable
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── COALESCE(s:4, s:4 || 'foo') [as=coalesce:8, outer=(4), immutable]
+      └── COALESCE(s:4, s:4 || 'foo') [as=coalesce:7, outer=(4), immutable]
 
 # Trailing null can't be removed.
 norm
 SELECT COALESCE(i, NULL, NULL) FROM a
 ----
 project
- ├── columns: coalesce:8
+ ├── columns: coalesce:7
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── COALESCE(i:2, CAST(NULL AS INT8), CAST(NULL AS INT8)) [as=coalesce:8, outer=(2)]
+      └── COALESCE(i:2, CAST(NULL AS INT8), CAST(NULL AS INT8)) [as=coalesce:7, outer=(2)]
 
 norm expect=SimplifyCoalesce
 SELECT COALESCE((1, 2, 3), (2, 3, 4)) FROM a
 ----
 project
- ├── columns: coalesce:8!null
- ├── fd: ()-->(8)
+ ├── columns: coalesce:7!null
+ ├── fd: ()-->(7)
  ├── scan a
  └── projections
-      └── (1, 2, 3) [as=coalesce:8]
+      └── (1, 2, 3) [as=coalesce:7]
 
 
 # --------------------------------------------------
@@ -174,16 +174,16 @@ exprnorm expect=EliminateCast
 )
 ----
 project
- ├── columns: c1:8 c2:9 c3:10!null c4:11 c5:12
- ├── fd: ()-->(10,11)
+ ├── columns: c1:7 c2:8 c3:9!null c4:10 c5:11
+ ├── fd: ()-->(9,10)
  ├── scan a
- │    └── columns: i:2 s:4 arr:6
+ │    └── columns: i:2 s:4 arr:5
  └── projections
-      ├── i:2 [as=c1:8, outer=(2)]
-      ├── arr:6 [as=c2:9, outer=(6)]
-      ├── '[1, 2]' [as=c3:10]
-      ├── CAST(NULL AS BIT) [as=c4:11]
-      └── s:4 [as=c5:12, outer=(4)]
+      ├── i:2 [as=c1:7, outer=(2)]
+      ├── arr:5 [as=c2:8, outer=(5)]
+      ├── '[1, 2]' [as=c3:9]
+      ├── CAST(NULL AS BIT) [as=c4:10]
+      └── s:4 [as=c5:11, outer=(4)]
 
 # Shouldn't eliminate these casts.
 norm expect-not=EliminateCast
@@ -199,19 +199,19 @@ SELECT
 FROM a
 ----
 project
- ├── columns: i:8 arr:9 s:10 s:11 i:12 s:13 array:14 array:15
+ ├── columns: i:7 arr:8 s:9 s:10 i:11 s:12 array:13 array:14
  ├── stable
  ├── scan a
- │    └── columns: a.i:2 a.s:4 a.arr:6
+ │    └── columns: a.i:2 a.s:4 a.arr:5
  └── projections
-      ├── a.i:2::FLOAT8 [as=i:8, outer=(2), immutable]
-      ├── a.arr:6::DECIMAL[] [as=arr:9, outer=(6), immutable]
-      ├── a.s:4::JSONB [as=s:10, outer=(4), immutable]
-      ├── a.s:4::VARCHAR(2) [as=s:11, outer=(4), immutable]
-      ├── a.i:2::INT2::INT8 [as=i:12, outer=(2), immutable]
-      ├── a.s:4::CHAR::VARCHAR [as=s:13, outer=(4), immutable]
-      ├── ARRAY[a.i:2, 2]::OIDVECTOR [as=array:14, outer=(2), stable]
-      └── ARRAY[a.i:2, 2]::INT2VECTOR [as=array:15, outer=(2), immutable]
+      ├── a.i:2::FLOAT8 [as=i:7, outer=(2), immutable]
+      ├── a.arr:5::DECIMAL[] [as=arr:8, outer=(5), immutable]
+      ├── a.s:4::JSONB [as=s:9, outer=(4), immutable]
+      ├── a.s:4::VARCHAR(2) [as=s:10, outer=(4), immutable]
+      ├── a.i:2::INT2::INT8 [as=i:11, outer=(2), immutable]
+      ├── a.s:4::CHAR::VARCHAR [as=s:12, outer=(4), immutable]
+      ├── ARRAY[a.i:2, 2]::OIDVECTOR [as=array:13, outer=(2), stable]
+      └── ARRAY[a.i:2, 2]::INT2VECTOR [as=array:14, outer=(2), immutable]
 
 # --------------------------------------------------
 # NormalizeInConst
@@ -220,34 +220,34 @@ norm expect=NormalizeInConst
 SELECT i IN (2, 1, 1, null, 3, 4.00, 4.0, null, 3.0) AS r FROM a
 ----
 project
- ├── columns: r:8
+ ├── columns: r:7
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2 IN (NULL, 1, 2, 3, 4) [as=r:8, outer=(2)]
+      └── i:2 IN (NULL, 1, 2, 3, 4) [as=r:7, outer=(2)]
 
 # Single value.
 norm expect-not=NormalizeInConst
 SELECT s NOT IN ('foo') AS r FROM a
 ----
 project
- ├── columns: r:8
+ ├── columns: r:7
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── s:4 NOT IN ('foo',) [as=r:8, outer=(4)]
+      └── s:4 NOT IN ('foo',) [as=r:7, outer=(4)]
 
 # Don't sort, since the list is not constant.
 norm expect-not=NormalizeInConst
 SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) AS r FROM a
 ----
 project
- ├── columns: r:8
+ ├── columns: r:7
  ├── immutable
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── s:4 NOT IN ('foo', s:4 || 'foo', 'bar', length(s:4)::STRING, NULL) [as=r:8, outer=(4), immutable]
+      └── s:4 NOT IN ('foo', s:4 || 'foo', 'bar', length(s:4)::STRING, NULL) [as=r:7, outer=(4), immutable]
 
 # Regression test #36031.
 norm expect-not=NormalizeInConst
@@ -292,24 +292,24 @@ norm expect=EliminateExistsProject
 SELECT * FROM a WHERE EXISTS(SELECT i+1, i*k FROM a)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: k:8!null i:9
+                ├── columns: k:7!null i:8
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(8,9)
+                ├── fd: ()-->(7,8)
                 ├── scan a
-                │    ├── columns: k:8!null i:9
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(9)
+                │    ├── columns: k:7!null i:8
+                │    ├── key: (7)
+                │    ├── fd: (7)-->(8)
                 │    └── limit hint: 1.00
                 └── 1
 
@@ -322,49 +322,49 @@ norm expect-not=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── scalar-group-by
-                ├── columns: max:15
+                ├── columns: max:13
                 ├── cardinality: [1 - 1]
                 ├── key: ()
-                ├── fd: ()-->(15)
+                ├── fd: ()-->(13)
                 ├── values
-                │    ├── columns: s:11!null
+                │    ├── columns: s:10!null
                 │    ├── cardinality: [0 - 0]
                 │    ├── key: ()
-                │    └── fd: ()-->(11)
+                │    └── fd: ()-->(10)
                 └── aggregations
-                     └── max [as=max:15, outer=(11)]
-                          └── s:11
+                     └── max [as=max:13, outer=(10)]
+                          └── s:10
 
 norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: s:11
+                ├── columns: s:10
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(11)
+                ├── fd: ()-->(10)
                 ├── scan a
-                │    ├── columns: s:11
+                │    ├── columns: s:10
                 │    └── limit hint: 1.00
                 └── 1
 
@@ -372,22 +372,22 @@ norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: i:9 s:11
+                ├── columns: i:8 s:10
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(9,11)
+                ├── fd: ()-->(8,10)
                 ├── scan a
-                │    ├── columns: i:9 s:11
+                │    ├── columns: i:8 s:10
                 │    └── limit hint: 1.00
                 └── 1
 
@@ -396,40 +396,40 @@ norm expect-not=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT (SELECT y FROM xy WHERE y=k) FROM a)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: k:8!null xy.y:16
+                ├── columns: k:7!null xy.y:14
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(8,16)
+                ├── fd: ()-->(7,14)
                 ├── ensure-distinct-on
-                │    ├── columns: k:8!null xy.y:16
-                │    ├── grouping columns: k:8!null
+                │    ├── columns: k:7!null xy.y:14
+                │    ├── grouping columns: k:7!null
                 │    ├── error: "more than one row returned by a subquery used as an expression"
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(16)
+                │    ├── key: (7)
+                │    ├── fd: (7)-->(14)
                 │    ├── limit hint: 1.00
                 │    ├── left-join (hash)
-                │    │    ├── columns: k:8!null xy.y:16
+                │    │    ├── columns: k:7!null xy.y:14
                 │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
                 │    │    ├── scan a
-                │    │    │    ├── columns: k:8!null
-                │    │    │    └── key: (8)
+                │    │    │    ├── columns: k:7!null
+                │    │    │    └── key: (7)
                 │    │    ├── scan xy
-                │    │    │    └── columns: xy.y:16
+                │    │    │    └── columns: xy.y:14
                 │    │    └── filters
-                │    │         └── xy.y:16 = k:8 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+                │    │         └── xy.y:14 = k:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
                 │    └── aggregations
-                │         └── const-agg [as=xy.y:16, outer=(16)]
-                │              └── xy.y:16
+                │         └── const-agg [as=xy.y:14, outer=(14)]
+                │              └── xy.y:14
                 └── 1
 
 # --------------------------------------------------
@@ -439,22 +439,22 @@ norm expect=(EliminateExistsGroupBy,EliminateExistsProject)
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a GROUP BY i)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: i:9 s:11
+                ├── columns: i:8 s:10
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(9,11)
+                ├── fd: ()-->(8,10)
                 ├── scan a
-                │    ├── columns: i:9 s:11
+                │    ├── columns: i:8 s:10
                 │    └── limit hint: 1.00
                 └── 1
 
@@ -465,22 +465,22 @@ norm expect=IntroduceExistsLimit
 SELECT * FROM a WHERE EXISTS(SELECT i FROM a)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: i:9
+                ├── columns: i:8
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(9)
+                ├── fd: ()-->(8)
                 ├── scan a
-                │    ├── columns: i:9
+                │    ├── columns: i:8
                 │    └── limit hint: 1.00
                 └── 1
 
@@ -489,37 +489,37 @@ norm expect-not=IntroduceExistsLimit
 SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i)
 ----
 semi-join (hash)
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a1
- │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  ├── scan a2
- │    └── columns: a2.i:9
+ │    └── columns: a2.i:8
  └── filters
-      └── a1.i:2 = a2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
 # Don't introduce a limit when the subquery has one row.
 norm expect-not=IntroduceExistsLimit
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (1)))
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── values
-                ├── columns: column1:8!null
+                ├── columns: column1:7!null
                 ├── cardinality: [1 - 1]
                 ├── key: ()
-                ├── fd: ()-->(8)
+                ├── fd: ()-->(7)
                 └── (1,)
 
 # --------------------------------------------------
@@ -529,167 +529,69 @@ norm expect=EliminateExistsLimit
 SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 1)
 ----
 semi-join (hash)
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a1
- │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  ├── scan a2
- │    └── columns: a2.i:9
+ │    └── columns: a2.i:8
  └── filters
-      └── a1.i:2 = a2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
 norm expect=EliminateExistsLimit
 SELECT * FROM a a1 WHERE NOT EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 1)
 ----
 anti-join (hash)
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a1
- │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  ├── scan a2
- │    └── columns: a2.i:9
+ │    └── columns: a2.i:8
  └── filters
-      └── a1.i:2 = a2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
 # Don't eliminate a non-positive limit.
 norm expect-not=EliminateExistsLimit
 SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 0)
 ----
 values
- ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null arr:6!null
+ ├── columns: k:1!null i:2!null f:3!null s:4!null arr:5!null
  ├── cardinality: [0 - 0]
  ├── key: ()
- └── fd: ()-->(1-6)
+ └── fd: ()-->(1-5)
 
 # Don't eliminate a limit from a non-correlated subquery.
 norm expect-not=EliminateExistsLimit
 SELECT * FROM a WHERE EXISTS(SELECT * FROM a LIMIT 1)
 ----
 select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
  ├── key: (1)
- ├── fd: (1)-->(2-6)
+ ├── fd: (1)-->(2-5)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
+ │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [subquery]
            └── limit
-                ├── columns: k:8!null i:9 f:10 s:11 j:12 arr:13
+                ├── columns: k:7!null i:8 f:9 s:10 arr:11
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(8-13)
+                ├── fd: ()-->(7-11)
                 ├── scan a
-                │    ├── columns: k:8!null i:9 f:10 s:11 j:12 arr:13
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(9-13)
+                │    ├── columns: k:7!null i:8 f:9 s:10 arr:11
+                │    ├── key: (7)
+                │    ├── fd: (7)-->(8-11)
                 │    └── limit hint: 1.00
                 └── 1
-
-# --------------------------------------------------
-# NormalizeJSONFieldAccess
-# --------------------------------------------------
-norm expect=NormalizeJSONFieldAccess
-SELECT * FROM a WHERE j->'a' = '"b"'::JSON
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters
-      └── j:5 @> '{"a": "b"}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
-
-norm expect=NormalizeJSONFieldAccess
-SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
-
-# The transformation is not valid in this case.
-norm expect-not=NormalizeJSONFieldAccess
-SELECT * FROM a WHERE j->2 = '"b"'::JSON
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters
-      └── (j:5->2) = '"b"' [outer=(5), immutable]
-
-# The transformation is not valid in this case, since j->'a' could be an array.
-norm expect-not=NormalizeJSONFieldAccess
-SELECT * FROM a WHERE j->'a' @> '"b"'::JSON
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters
-      └── (j:5->'a') @> '"b"' [outer=(5), immutable]
-
-# The transformation is not valid in this case, since containment doesn't imply
-# equality for non-scalars.
-norm
-SELECT j->'a' = '["b"]'::JSON, j->'a' = '{"b": "c"}'::JSON FROM a
-----
-project
- ├── columns: "?column?":8 "?column?":9
- ├── immutable
- ├── scan a
- │    └── columns: j:5
- └── projections
-      ├── (j:5->'a') = '["b"]' [as="?column?":8, outer=(5), immutable]
-      └── (j:5->'a') = '{"b": "c"}' [as="?column?":9, outer=(5), immutable]
-
-# --------------------------------------------------
-# NormalizeJSONContains
-# --------------------------------------------------
-
-norm expect=NormalizeJSONContains
-SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 j:5!null arr:6
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # --------------------------------------------------
 # SimplifyCaseWhenConstValue
@@ -788,12 +690,12 @@ FROM
     a
 ----
 project
- ├── columns: case:8!null
+ ├── columns: case:7!null
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── CASE 1 WHEN k:1 THEN 'one' ELSE 'two' END [as=case:8, outer=(1)]
+      └── CASE 1 WHEN k:1 THEN 'one' ELSE 'two' END [as=case:7, outer=(1)]
 
 norm expect=SimplifyCaseWhenConstValue
 SELECT
@@ -802,12 +704,12 @@ FROM
     a
 ----
 project
- ├── columns: case:8!null
+ ├── columns: case:7!null
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── CASE WHEN k:1 = 1 THEN 'one' ELSE 'two' END [as=case:8, outer=(1)]
+      └── CASE WHEN k:1 = 1 THEN 'one' ELSE 'two' END [as=case:7, outer=(1)]
 
 norm expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 2 THEN 'one' ELSE 'three' END
@@ -831,12 +733,12 @@ FROM
     a
 ----
 project
- ├── columns: case:8!null
+ ├── columns: case:7!null
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── CASE 1 WHEN k:1 THEN 'two' ELSE 'three' END [as=case:8, outer=(1)]
+      └── CASE 1 WHEN k:1 THEN 'two' ELSE 'three' END [as=case:7, outer=(1)]
 
 norm expect=SimplifyCaseWhenConstValue
 SELECT
@@ -1199,21 +1101,21 @@ select
            └── tuple
                 ├── subquery
                 │    └── max1-row
-                │         ├── columns: "?column?":15
+                │         ├── columns: "?column?":13
                 │         ├── error: "more than one row returned by a subquery used as an expression"
                 │         ├── cardinality: [0 - 1]
                 │         ├── immutable
                 │         ├── key: ()
-                │         ├── fd: ()-->(15)
+                │         ├── fd: ()-->(13)
                 │         └── project
-                │              ├── columns: "?column?":15
+                │              ├── columns: "?column?":13
                 │              ├── immutable
                 │              ├── scan a
-                │              │    ├── columns: k:8!null i:9
-                │              │    ├── key: (8)
-                │              │    └── fd: (8)-->(9)
+                │              │    ├── columns: k:7!null i:8
+                │              │    ├── key: (7)
+                │              │    └── fd: (7)-->(8)
                 │              └── projections
-                │                   └── k:8 * i:9 [as="?column?":15, outer=(8,9), immutable]
+                │                   └── k:7 * i:8 [as="?column?":13, outer=(7,8), immutable]
                 ├── 2
                 └── 3
 
@@ -1249,33 +1151,33 @@ project
  ├── immutable
  ├── key: (1)
  └── semi-join (hash)
-      ├── columns: k:1!null column11:11
+      ├── columns: k:1!null column10:10
       ├── immutable
       ├── key: (1)
-      ├── fd: (1)-->(11)
+      ├── fd: (1)-->(10)
       ├── project
-      │    ├── columns: column11:11 k:1!null
+      │    ├── columns: column10:10 k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(11)
+      │    ├── fd: (1)-->(10)
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── (k:1, i:2) [as=column11:11, outer=(1,2)]
+      │         └── (k:1, i:2) [as=column10:10, outer=(1,2)]
       ├── project
-      │    ├── columns: column10:10!null
+      │    ├── columns: column9:9!null
       │    ├── cardinality: [3 - 3]
       │    ├── values
-      │    │    ├── columns: column1:8!null column2:9!null
+      │    │    ├── columns: column1:7!null column2:8!null
       │    │    ├── cardinality: [3 - 3]
       │    │    ├── (1, 1)
       │    │    ├── (2, 2)
       │    │    └── (3, 3)
       │    └── projections
-      │         └── (column2:9, column1:8) [as=column10:10, outer=(8,9)]
+      │         └── (column2:8, column1:7) [as=column9:9, outer=(7,8)]
       └── filters
-           └── column11:11 = column10:10 [outer=(10,11), immutable, constraints=(/10: (/NULL - ]; /11: (/NULL - ]), fd=(10)==(11), (11)==(10)]
+           └── column10:10 = column9:9 [outer=(9,10), immutable, constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
 
 # --------------------------------------------------
 # SimplifyEqualsAnyTuple
@@ -1426,11 +1328,11 @@ norm expect-not=FoldCollate
 SELECT s COLLATE en_u_ks_level1 FROM a
 ----
 project
- ├── columns: s:8
+ ├── columns: s:7
  ├── scan a
  │    └── columns: a.s:4
  └── projections
-      └── a.s:4 COLLATE en_u_ks_level1 [as=s:8, outer=(4)]
+      └── a.s:4 COLLATE en_u_ks_level1 [as=s:7, outer=(4)]
 
 # --------------------------------------------------
 # NormalizeArrayFlattenToAgg
@@ -1440,102 +1342,102 @@ norm expect=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT k FROM a WHERE a.k = b.k) FROM a AS b
 ----
 project
- ├── columns: array:16
+ ├── columns: array:14
  ├── group-by
- │    ├── columns: b.k:1!null a.k:8!null array_agg:17!null
+ │    ├── columns: b.k:1!null a.k:7!null array_agg:15!null
  │    ├── grouping columns: b.k:1!null
- │    ├── key: (8)
- │    ├── fd: (1)==(8), (8)==(1), (8)-->(17), (1)-->(8,17)
+ │    ├── key: (7)
+ │    ├── fd: (1)==(7), (7)==(1), (7)-->(15), (1)-->(7,15)
  │    ├── inner-join (hash)
- │    │    ├── columns: b.k:1!null a.k:8!null
+ │    │    ├── columns: b.k:1!null a.k:7!null
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- │    │    ├── key: (8)
- │    │    ├── fd: (1)==(8), (8)==(1)
+ │    │    ├── key: (7)
+ │    │    ├── fd: (1)==(7), (7)==(1)
  │    │    ├── scan b
  │    │    │    ├── columns: b.k:1!null
  │    │    │    └── key: (1)
  │    │    ├── scan a
- │    │    │    ├── columns: a.k:8!null
- │    │    │    └── key: (8)
+ │    │    │    ├── columns: a.k:7!null
+ │    │    │    └── key: (7)
  │    │    └── filters
- │    │         └── a.k:8 = b.k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    │         └── a.k:7 = b.k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    └── aggregations
- │         ├── array-agg [as=array_agg:17, outer=(8)]
- │         │    └── a.k:8
- │         └── any-not-null-agg [as=a.k:8, outer=(8)]
- │              └── a.k:8
+ │         ├── array-agg [as=array_agg:15, outer=(7)]
+ │         │    └── a.k:7
+ │         └── any-not-null-agg [as=a.k:7, outer=(7)]
+ │              └── a.k:7
  └── projections
-      └── COALESCE(CASE WHEN a.k:8 IS NOT NULL THEN array_agg:17 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:16, outer=(8,17)]
+      └── COALESCE(CASE WHEN a.k:7 IS NOT NULL THEN array_agg:15 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:14, outer=(7,15)]
 
 # Ensure ordering is maintained.
 norm expect=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT k FROM a WHERE a.i = b.i ORDER BY a.k) FROM a AS b
 ----
 project
- ├── columns: array:16
+ ├── columns: array:14
  ├── group-by
- │    ├── columns: b.k:1!null a.k:8 array_agg:17
+ │    ├── columns: b.k:1!null a.k:7 array_agg:15
  │    ├── grouping columns: b.k:1!null
- │    ├── internal-ordering: +8 opt(9)
+ │    ├── internal-ordering: +7 opt(8)
  │    ├── key: (1)
- │    ├── fd: (1)-->(8,17)
+ │    ├── fd: (1)-->(7,15)
  │    ├── sort
- │    │    ├── columns: b.k:1!null b.i:2 a.k:8 a.i:9
- │    │    ├── key: (1,8)
- │    │    ├── fd: (1)-->(2), (8)-->(9)
- │    │    ├── ordering: +8 opt(9) [actual: +8]
+ │    │    ├── columns: b.k:1!null b.i:2 a.k:7 a.i:8
+ │    │    ├── key: (1,7)
+ │    │    ├── fd: (1)-->(2), (7)-->(8)
+ │    │    ├── ordering: +7 opt(8) [actual: +7]
  │    │    └── left-join (hash)
- │    │         ├── columns: b.k:1!null b.i:2 a.k:8 a.i:9
- │    │         ├── key: (1,8)
- │    │         ├── fd: (1)-->(2), (8)-->(9)
+ │    │         ├── columns: b.k:1!null b.i:2 a.k:7 a.i:8
+ │    │         ├── key: (1,7)
+ │    │         ├── fd: (1)-->(2), (7)-->(8)
  │    │         ├── scan b
  │    │         │    ├── columns: b.k:1!null b.i:2
  │    │         │    ├── key: (1)
  │    │         │    └── fd: (1)-->(2)
  │    │         ├── scan a
- │    │         │    ├── columns: a.k:8!null a.i:9
- │    │         │    ├── key: (8)
- │    │         │    └── fd: (8)-->(9)
+ │    │         │    ├── columns: a.k:7!null a.i:8
+ │    │         │    ├── key: (7)
+ │    │         │    └── fd: (7)-->(8)
  │    │         └── filters
- │    │              └── a.i:9 = b.i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │              └── a.i:8 = b.i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
  │    └── aggregations
- │         ├── array-agg [as=array_agg:17, outer=(8)]
- │         │    └── a.k:8
- │         └── any-not-null-agg [as=a.k:8, outer=(8)]
- │              └── a.k:8
+ │         ├── array-agg [as=array_agg:15, outer=(7)]
+ │         │    └── a.k:7
+ │         └── any-not-null-agg [as=a.k:7, outer=(7)]
+ │              └── a.k:7
  └── projections
-      └── COALESCE(CASE WHEN a.k:8 IS NOT NULL THEN array_agg:17 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:16, outer=(8,17)]
+      └── COALESCE(CASE WHEN a.k:7 IS NOT NULL THEN array_agg:15 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:14, outer=(7,15)]
 
 norm expect=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT generate_series(1, a.k) ORDER BY 1 DESC) FROM a
 ----
 project
- ├── columns: array:10
+ ├── columns: array:9
  ├── immutable
  ├── group-by
- │    ├── columns: k:1!null canary:11 array_agg:12
+ │    ├── columns: k:1!null canary:10 array_agg:11
  │    ├── grouping columns: k:1!null
- │    ├── internal-ordering: -8
+ │    ├── internal-ordering: -7
  │    ├── immutable
  │    ├── key: (1)
- │    ├── fd: (1)-->(11,12)
+ │    ├── fd: (1)-->(10,11)
  │    ├── sort
- │    │    ├── columns: k:1!null generate_series:8 canary:11
+ │    │    ├── columns: k:1!null generate_series:7 canary:10
  │    │    ├── immutable
- │    │    ├── ordering: -8
+ │    │    ├── ordering: -7
  │    │    └── left-join-apply
- │    │         ├── columns: k:1!null generate_series:8 canary:11
+ │    │         ├── columns: k:1!null generate_series:7 canary:10
  │    │         ├── immutable
  │    │         ├── scan a
  │    │         │    ├── columns: k:1!null
  │    │         │    └── key: (1)
  │    │         ├── project
- │    │         │    ├── columns: canary:11!null generate_series:8
+ │    │         │    ├── columns: canary:10!null generate_series:7
  │    │         │    ├── outer: (1)
  │    │         │    ├── immutable
- │    │         │    ├── fd: ()-->(11)
+ │    │         │    ├── fd: ()-->(10)
  │    │         │    ├── project-set
- │    │         │    │    ├── columns: generate_series:8
+ │    │         │    │    ├── columns: generate_series:7
  │    │         │    │    ├── outer: (1)
  │    │         │    │    ├── immutable
  │    │         │    │    ├── values
@@ -1545,143 +1447,143 @@ project
  │    │         │    │    └── zip
  │    │         │    │         └── generate_series(1, k:1) [outer=(1), immutable]
  │    │         │    └── projections
- │    │         │         └── true [as=canary:11]
+ │    │         │         └── true [as=canary:10]
  │    │         └── filters (true)
  │    └── aggregations
- │         ├── array-agg [as=array_agg:12, outer=(8)]
- │         │    └── generate_series:8
- │         └── any-not-null-agg [as=canary:11, outer=(11)]
- │              └── canary:11
+ │         ├── array-agg [as=array_agg:11, outer=(7)]
+ │         │    └── generate_series:7
+ │         └── any-not-null-agg [as=canary:10, outer=(10)]
+ │              └── canary:10
  └── projections
-      └── COALESCE(CASE WHEN canary:11 IS NOT NULL THEN array_agg:12 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:10, outer=(11,12)]
+      └── COALESCE(CASE WHEN canary:10 IS NOT NULL THEN array_agg:11 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:9, outer=(10,11)]
 
 # Uncorrelated ArrayFlatten inside a correlated ArrayFlatten.
 norm expect=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT ARRAY(SELECT k FROM a)[1] FROM a as b WHERE b.k = c.k) FROM a AS c
 ----
 project
- ├── columns: array:24
+ ├── columns: array:21
  ├── group-by
- │    ├── columns: c.k:1!null canary:25!null array_agg:26
+ │    ├── columns: c.k:1!null canary:22!null array_agg:23
  │    ├── grouping columns: c.k:1!null
  │    ├── key: (1)
- │    ├── fd: ()-->(25), (1)-->(25,26)
+ │    ├── fd: ()-->(22), (1)-->(22,23)
  │    ├── inner-join (hash)
- │    │    ├── columns: c.k:1!null b.k:8!null array:22 canary:25!null
+ │    │    ├── columns: c.k:1!null b.k:7!null array:19 canary:22!null
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- │    │    ├── key: (8)
- │    │    ├── fd: ()-->(22,25), (1)==(8), (8)==(1)
+ │    │    ├── key: (7)
+ │    │    ├── fd: ()-->(19,22), (1)==(7), (7)==(1)
  │    │    ├── scan c
  │    │    │    ├── columns: c.k:1!null
  │    │    │    └── key: (1)
  │    │    ├── project
- │    │    │    ├── columns: canary:25!null array:22 b.k:8!null
- │    │    │    ├── key: (8)
- │    │    │    ├── fd: ()-->(22,25)
+ │    │    │    ├── columns: canary:22!null array:19 b.k:7!null
+ │    │    │    ├── key: (7)
+ │    │    │    ├── fd: ()-->(19,22)
  │    │    │    ├── scan b
- │    │    │    │    ├── columns: b.k:8!null
- │    │    │    │    └── key: (8)
+ │    │    │    │    ├── columns: b.k:7!null
+ │    │    │    │    └── key: (7)
  │    │    │    └── projections
- │    │    │         ├── true [as=canary:25]
- │    │    │         └── indirection [as=array:22, subquery]
+ │    │    │         ├── true [as=canary:22]
+ │    │    │         └── indirection [as=array:19, subquery]
  │    │    │              ├── array-flatten
  │    │    │              │    └── scan a
- │    │    │              │         ├── columns: k:15!null
- │    │    │              │         └── key: (15)
+ │    │    │              │         ├── columns: k:13!null
+ │    │    │              │         └── key: (13)
  │    │    │              └── 1
  │    │    └── filters
- │    │         └── b.k:8 = c.k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    │         └── b.k:7 = c.k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    └── aggregations
- │         ├── array-agg [as=array_agg:26, outer=(22)]
- │         │    └── array:22
- │         └── any-not-null-agg [as=canary:25, outer=(25)]
- │              └── canary:25
+ │         ├── array-agg [as=array_agg:23, outer=(19)]
+ │         │    └── array:19
+ │         └── any-not-null-agg [as=canary:22, outer=(22)]
+ │              └── canary:22
  └── projections
-      └── COALESCE(CASE WHEN canary:25 IS NOT NULL THEN array_agg:26 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:24, outer=(25,26)]
+      └── COALESCE(CASE WHEN canary:22 IS NOT NULL THEN array_agg:23 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:21, outer=(22,23)]
 
 # Correlated ArrayFlatten inside another correlated ArrayFlatten.
 norm expect=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT ARRAY(SELECT k FROM a WHERE a.k = b.k)[1] FROM a as b WHERE b.k = c.k) FROM a AS c
 ----
 project
- ├── columns: array:26
+ ├── columns: array:23
  ├── group-by
- │    ├── columns: c.k:1!null canary:27 array_agg:28
+ │    ├── columns: c.k:1!null canary:24 array_agg:25
  │    ├── grouping columns: c.k:1!null
  │    ├── key: (1)
- │    ├── fd: (1)-->(27,28)
+ │    ├── fd: (1)-->(24,25)
  │    ├── left-join-apply
- │    │    ├── columns: c.k:1!null array:23 canary:27
+ │    │    ├── columns: c.k:1!null array:20 canary:24
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(23,27)
+ │    │    ├── fd: (1)-->(20,24)
  │    │    ├── scan c
  │    │    │    ├── columns: c.k:1!null
  │    │    │    └── key: (1)
  │    │    ├── project
- │    │    │    ├── columns: canary:27!null array:23
+ │    │    │    ├── columns: canary:24!null array:20
  │    │    │    ├── outer: (1)
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(23,27)
+ │    │    │    ├── fd: ()-->(20,24)
  │    │    │    ├── group-by
- │    │    │    │    ├── columns: a.k:15!null array_agg:24!null
+ │    │    │    │    ├── columns: a.k:13!null array_agg:21!null
  │    │    │    │    ├── outer: (1)
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(15,24)
+ │    │    │    │    ├── fd: ()-->(13,21)
  │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │    ├── columns: b.k:8!null a.k:15!null
+ │    │    │    │    │    ├── columns: b.k:7!null a.k:13!null
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(8,15)
+ │    │    │    │    │    ├── fd: ()-->(7,13)
  │    │    │    │    │    ├── select
- │    │    │    │    │    │    ├── columns: b.k:8!null
+ │    │    │    │    │    │    ├── columns: b.k:7!null
  │    │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    ├── fd: ()-->(8)
+ │    │    │    │    │    │    ├── fd: ()-->(7)
  │    │    │    │    │    │    ├── scan b
- │    │    │    │    │    │    │    ├── columns: b.k:8!null
- │    │    │    │    │    │    │    └── key: (8)
+ │    │    │    │    │    │    │    ├── columns: b.k:7!null
+ │    │    │    │    │    │    │    └── key: (7)
  │    │    │    │    │    │    └── filters
- │    │    │    │    │    │         └── b.k:8 = c.k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    │    │    │    │    │         └── b.k:7 = c.k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    │    │    │    │    ├── scan a
- │    │    │    │    │    │    ├── columns: a.k:15!null
- │    │    │    │    │    │    └── key: (15)
+ │    │    │    │    │    │    ├── columns: a.k:13!null
+ │    │    │    │    │    │    └── key: (13)
  │    │    │    │    │    └── filters
- │    │    │    │    │         └── a.k:15 = b.k:8 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
+ │    │    │    │    │         └── a.k:13 = b.k:7 [outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ]), fd=(7)==(13), (13)==(7)]
  │    │    │    │    └── aggregations
- │    │    │    │         ├── array-agg [as=array_agg:24, outer=(15)]
- │    │    │    │         │    └── a.k:15
- │    │    │    │         └── any-not-null-agg [as=a.k:15, outer=(15)]
- │    │    │    │              └── a.k:15
+ │    │    │    │         ├── array-agg [as=array_agg:21, outer=(13)]
+ │    │    │    │         │    └── a.k:13
+ │    │    │    │         └── any-not-null-agg [as=a.k:13, outer=(13)]
+ │    │    │    │              └── a.k:13
  │    │    │    └── projections
- │    │    │         ├── true [as=canary:27]
- │    │    │         └── COALESCE(CASE WHEN a.k:15 IS NOT NULL THEN array_agg:24 ELSE CAST(NULL AS INT8[]) END, ARRAY[])[1] [as=array:23, outer=(15,24)]
+ │    │    │         ├── true [as=canary:24]
+ │    │    │         └── COALESCE(CASE WHEN a.k:13 IS NOT NULL THEN array_agg:21 ELSE CAST(NULL AS INT8[]) END, ARRAY[])[1] [as=array:20, outer=(13,21)]
  │    │    └── filters (true)
  │    └── aggregations
- │         ├── array-agg [as=array_agg:28, outer=(23)]
- │         │    └── array:23
- │         └── any-not-null-agg [as=canary:27, outer=(27)]
- │              └── canary:27
+ │         ├── array-agg [as=array_agg:25, outer=(20)]
+ │         │    └── array:20
+ │         └── any-not-null-agg [as=canary:24, outer=(24)]
+ │              └── canary:24
  └── projections
-      └── COALESCE(CASE WHEN canary:27 IS NOT NULL THEN array_agg:28 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:26, outer=(27,28)]
+      └── COALESCE(CASE WHEN canary:24 IS NOT NULL THEN array_agg:25 ELSE CAST(NULL AS INT8[]) END, ARRAY[]) [as=array:23, outer=(24,25)]
 
 # Shouldn't trigger if there's no correlation.
 norm expect-not=NormalizeArrayFlattenToAgg
 SELECT ARRAY(SELECT k FROM a) FROM a
 ----
 project
- ├── columns: array:15
- ├── fd: ()-->(15)
+ ├── columns: array:13
+ ├── fd: ()-->(13)
  ├── scan a
  └── projections
-      └── array-flatten [as=array:15, subquery]
+      └── array-flatten [as=array:13, subquery]
            └── scan a
-                ├── columns: k:8!null
-                └── key: (8)
+                ├── columns: k:7!null
+                └── key: (7)
 
 exec-ddl
 CREATE TABLE pg_class (
@@ -1870,12 +1772,12 @@ norm expect=SimplifySameVarEqualities
 SELECT k = k FROM a
 ----
 project
- ├── columns: "?column?":8
+ ├── columns: "?column?":7
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── (k:1 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL) [as="?column?":8, outer=(1)]
+      └── (k:1 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL) [as="?column?":7, outer=(1)]
 
 # --------------------------------------------------
 # SimplifySameVarInequalities
@@ -1948,9 +1850,9 @@ norm expect=SimplifySameVarInequalities
 SELECT k != k FROM a
 ----
 project
- ├── columns: "?column?":8
+ ├── columns: "?column?":7
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL) [as="?column?":8, outer=(1)]
+      └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL) [as="?column?":7, outer=(1)]


### PR DESCRIPTION
#### sql: fix JSON fetch value operator evaluation

This commit fixes incorrect evaluation of the JSON fetch value operator,
`->`. There were two bugs causing incorrect evaluation.

The first issue was a result of optimizer normalization rules that
produced unequivalent scalar expressions when converting `->` to `@>`.
The rules would convert expressions like `j -> '"a"' = 1` to
`j @> '{"a": 1}'`. This is invalid because `->` results in `NULL` when
the LHS does not contain the RHS key, but the resulting `@>` expression
is always either `true` or `false`, never `NULL`. These normalization
rules have been removed.

These two rules existed to provide inverted index-acceleration for
queries with `->`, because the optimizer can only index-accerlate `@>`
operators during exploration. As a result of their removal, queries with
`->` operators are no longer index-accelerated. This will be remedied in
a future commit.

The second issue was a bug in the vectorized overload of the `->`
operator. Previously, when the operator evaluated to `NULL` with two
non-`NULL` inputs, the resulting `NULL` would not be tracked by the
`Nulls` struct.

Fixes #49143

Release note (bug fix): Previously, the JSON fetch value operator, `->`,
would evaluate incorrectly in some cases. This has been fixed.

#### opt: index-accelerate equalities with JSON fetch expressions

This commit allows inverted indexes to be scanned to satisfy query
filters in the form: `j->'a' = '1'`. The optimizer had previously
supported this by normalizing these expressions into expressions with
JSON containment operators, `@>`, but it lost this support when these
normalization rules were found to produce inequivalent expressions.

Note that query filters of several forms, which were previously
accelerated via the incorrect normalization rules, are not accelerated
as part of this commit, such as:

    j->'a' @> '{"x": "y"}
    j->'a'->'b' = '"c"'

Release note: None
