### PR TITLE
release-20.2: sql: bugfix to vtable lookup joins

### DIFF
--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -260,7 +260,8 @@ func (c *RowContainer) NumCols() int {
 	return c.numCols
 }
 
-// At accesses a row at a specific index.
+// At accesses a row at a specific index. Note that it does *not* copy the row:
+// callers must copy the row if they wish to mutate it.
 func (c *RowContainer) At(i int) tree.Datums {
 	// This is a hot-path: do not add additional checks here.
 	chunk, pos := c.getChunkAndPos(i)

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -271,7 +271,7 @@ func (v *vTableLookupJoinNode) Next(params runParams) (bool, error) {
 	for {
 		// Check if there are any rows left to emit from the last input row.
 		if v.run.rows.Len() > 0 {
-			v.run.row = v.run.rows.At(0)
+			copy(v.run.row, v.run.rows.At(0))
 			v.run.rows.PopFirst(params.ctx)
 			return true, nil
 		}


### PR DESCRIPTION
Backport 1/1 commits from #55212.

/cc @cockroachdb/release

---

Previously, vtable lookup joins had a memory aliasing bug that could
cause incorrect results in some circumstances. This bug is now fixed.

Fixes #55140

Release note (bug fix): prevent a crash in prerelease 20.2 binaries in
plans that use the new virtual table lookup join feature.
