### PR TITLE
ui: Transactions link between Sessions and Statements

### DIFF
--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -40,8 +40,8 @@ export class Sidebar extends React.Component<SidebarProps> {
     { path: "/metrics", text: "Metrics", activeFor: [] },
     { path: "/databases", text: "Databases", activeFor: ["/database"] },
     { path: "/sessions", text: "Sessions", activeFor: ["/session"] },
-    { path: "/statements", text: "Statements", activeFor: ["/statement"] },
     { path: "/transactions", text: "Transactions", activeFor: ["/transactions"] },
+    { path: "/statements", text: "Statements", activeFor: ["/statement"] },
     {
       path: "/reports/network",
       text: "Network Latency",


### PR DESCRIPTION
Resolves: #55131, #56244

Release note (admin ui change): Link to the Transactions page is now shown
between the Sessions and Statements links in the left hand navigation. This more
clearly reflects the hierarchy between the 3 concepts.