### PR TITLE
cli: include doctor output to debug.zip

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -581,6 +581,7 @@ func init() {
 		statusNodeCmd,
 		lsNodesCmd,
 		debugZipCmd,
+		doctorClusterCmd,
 		// If you add something here, make sure the actual implementation
 		// of the command uses `cmdTimeoutContext(.)` or it will ignore
 		// the timeout.

--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -25,6 +25,8 @@ retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_inte
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
 retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
+doctor examining cluster...No problems found!
+writing: debug/reports/doctor.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -25,6 +25,8 @@ retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_inte
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
 retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
+doctor examining cluster...No problems found!
+writing: debug/reports/doctor.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -25,6 +25,8 @@ retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_inte
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
 retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
+doctor examining cluster...No problems found!
+writing: debug/reports/doctor.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 writing: debug/nodes/1/status.json

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -25,6 +25,8 @@ retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_inte
 retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
 retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
 retrieving SQL data for crdb_internal.invalid_objects... writing: debug/crdb_internal.invalid_objects.txt
+doctor examining cluster...No problems found!
+writing: debug/reports/doctor.txt
 requesting nodes... writing: debug/nodes.json
 requesting liveness... writing: debug/liveness.json
 requesting CPU profiles... ok

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -337,6 +338,17 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 		}
 		if err := dumpTableDataForZip(z, sqlConn, timeout, base, table, selectClause); err != nil {
 			return errors.Wrapf(err, "fetching %s", table)
+		}
+	}
+
+	{
+		var doctorData bytes.Buffer
+		fmt.Printf("doctor examining cluster...")
+		if err := runClusterDoctor(nil, nil, sqlConn, &doctorData, timeout); err != nil {
+			return err
+		}
+		if err := z.createRawOrError(reportsPrefix+"/doctor.txt", doctorData.Bytes(), err); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Instead of having to run `doctor debug zip ...` on a given
debug.zip unzipped directory we can include it directly in
the debug zip as a report as `reports/doctor.txt`.

Release note: none.