### PR TITLE
Revert "roachtest: remove --tolerate-errors from schema change"

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -87,6 +87,12 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps,
 
 	runCmd := []string{
 		"./workload run schemachange --verbose=1",
+		// The workload is still in development and occasionally discovers schema
+		// change errors so for now we don't fail on them but only on panics, server
+		// crashes, deadlocks, etc.
+		// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
+		// is closed.
+		"--tolerate-errors=true",
 		// Save the histograms so that they can be reported to https://roachperf.crdb.dev/.
 		" --histograms=" + perfArtifactsDir + "/stats.json",
 		fmt.Sprintf("--max-ops %d", maxOps),

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -103,12 +103,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, buildVersion ve
 	}
 
 	testFeaturesStep := versionUpgradeTestFeatures.step(c.All())
-	schemaChangeStep := runSchemaChangeWorkloadStep(
-		c.All().randNode()[0],
-		10, /* maxOps */
-		2,  /* concurrency */
-		predecessorVersion,
-	)
+	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().randNode()[0], 10 /* maxOps */, 2 /* concurrency */)
 	backupStep := func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		// This check was introduced for the system.tenants table and the associated
 		// changes to full-cluster backup to include tenants. It mostly wants to


### PR DESCRIPTION
This reverts commit f6290c1efe9c1d49fb7b978f10c03a75e2523712.

Resolves #55275
Refs #47430

Release note: None