### PR TITLE
opt: delete cascade fast path

### DIFF
--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -221,7 +221,9 @@ func (d *deleteRangeNode) processResults(
 
 // Next implements the planNode interface.
 func (*deleteRangeNode) Next(params runParams) (bool, error) {
-	panic("invalid")
+	// TODO(radu): this shouldn't be used, but it gets called when a cascade uses
+	// delete-range. Investigate this.
+	return false, nil
 }
 
 // Values implements the planNode interface.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1005,11 +1005,10 @@ var allowedKVOpTypes = []string{
 	"Put",
 	"InitPut",
 	"Del",
+	"DelRange",
 	"ClearRange",
 	"Get",
 	"Scan",
-	"FKScan",
-	"CascadeScan",
 }
 
 func isAllowedKVOp(op string) bool {

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -4245,3 +4245,80 @@ INSERT INTO parent VALUES (100, 1) ON CONFLICT(p) DO UPDATE SET p = 50
 
 statement ok
 DROP TABLE child, parent
+
+# Test that cascades don't incorrectly remove child rows with NULLs.
+subtest DeleteCascadeNulls
+
+statement ok
+CREATE TABLE parent (p INT, q INT, PRIMARY KEY(p,q));
+CREATE TABLE child (
+  p INT, q INT,
+  FOREIGN KEY (p,q) REFERENCES parent(p,q) ON DELETE CASCADE
+);
+INSERT INTO parent VALUES (1,1), (1,2), (2,2), (3,3);
+INSERT INTO child VALUES
+  (NULL, NULL),
+  (NULL, 1),
+  (NULL, 2),
+  (NULL, 3),
+  (1,    NULL),
+  (2,    NULL),
+  (3,    NULL),
+  (1,    1),
+  (1,    1),
+  (1,    2),
+  (2,    2),
+  (2,    2),
+  (3,    3),
+  (3,    3);
+
+statement ok
+DELETE FROM parent WHERE p = 1
+
+query II rowsort
+SELECT * FROM child
+----
+NULL  NULL
+NULL  1
+NULL  2
+NULL  3
+1     NULL
+2     NULL
+3     NULL
+2     2
+2     2
+3     3
+3     3
+
+statement ok
+DELETE FROM parent WHERE q = 2
+
+query II rowsort
+SELECT * FROM child
+----
+NULL  NULL
+NULL  1
+NULL  2
+NULL  3
+1     NULL
+2     NULL
+3     NULL
+3     3
+3     3
+
+statement ok
+DELETE FROM parent WHERE true
+
+query II rowsort
+SELECT * FROM child
+----
+NULL  NULL
+NULL  1
+NULL  2
+NULL  3
+1     NULL
+2     NULL
+3     NULL
+
+statement ok
+DROP TABLE child, parent

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -125,15 +125,19 @@ type cascadeBuilder struct {
 const cascadeInputWithID opt.WithID = 1000000
 
 func makeCascadeBuilder(b *Builder, mutationWithID opt.WithID) (*cascadeBuilder, error) {
+	cb := &cascadeBuilder{b: b}
+	if mutationWithID == 0 {
+		// Cascade does not require the buffered input.
+		return cb, nil
+	}
+
 	withExpr := b.findBuiltWithExpr(mutationWithID)
 	if withExpr == nil {
 		return nil, errors.AssertionFailedf("cannot find mutation input withExpr")
 	}
-	cb := &cascadeBuilder{
-		b:                  b,
-		mutationBuffer:     withExpr.bufferNode,
-		mutationBufferCols: withExpr.outputCols,
-	}
+
+	cb.mutationBuffer = withExpr.bufferNode
+	cb.mutationBufferCols = withExpr.outputCols
 
 	// Remember the column metadata, as we will need to recreate it in the new
 	// memo.
@@ -190,62 +194,82 @@ func (cb *cascadeBuilder) planCascade(
 	factory := o.Factory()
 	md := factory.Metadata()
 
-	// Set up metadata for the buffer columns.
-
-	// withColRemap is the mapping between the With column IDs in the original
-	// memo and the corresponding column IDs in the new memo.
-	var withColRemap opt.ColMap
+	// 2. Invoke the memo.CascadeBuilder to build the cascade.
+	var relExpr memo.RelExpr
 	// bufferColMap is the mapping between the column IDs in the new memo and
 	// the column ordinal in the buffer node.
 	var bufferColMap opt.ColMap
-	var withCols opt.ColSet
-	for i := range cb.colMeta {
-		id := md.AddColumn(cb.colMeta[i].Alias, cb.colMeta[i].Type)
-		withCols.Add(id)
-		ordinal, _ := cb.mutationBufferCols.Get(int(cb.colMeta[i].MetaID))
-		bufferColMap.Set(int(id), ordinal)
-		withColRemap.Set(int(cb.colMeta[i].MetaID), int(id))
-	}
+	if bufferRef == nil {
+		// No input buffering.
+		var err error
+		relExpr, err = cascade.Builder.Build(
+			ctx,
+			semaCtx,
+			evalCtx,
+			cb.b.catalog,
+			factory,
+			0,   /* binding */
+			nil, /* bindingProps */
+			nil, /* oldValues */
+			nil, /* newValues */
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "while building cascade expression")
+		}
+	} else {
+		// Set up metadata for the buffer columns.
 
-	// Create relational properties for the special WithID input.
-	// TODO(radu): save some more information from the original binding props
-	// (like not-null columns, FDs) and remap them to the new columns.
-	var bindingProps props.Relational
-	bindingProps.Populated = true
-	bindingProps.OutputCols = withCols
-	bindingProps.Cardinality = props.Cardinality{
-		Min: uint32(numBufferedRows),
-		Max: uint32(numBufferedRows),
-	}
-	bindingProps.Stats = props.Statistics{
-		Available: true,
-		RowCount:  float64(numBufferedRows),
-	}
+		// withColRemap is the mapping between the With column IDs in the original
+		// memo and the corresponding column IDs in the new memo.
+		var withColRemap opt.ColMap
+		var withCols opt.ColSet
+		for i := range cb.colMeta {
+			id := md.AddColumn(cb.colMeta[i].Alias, cb.colMeta[i].Type)
+			withCols.Add(id)
+			ordinal, _ := cb.mutationBufferCols.Get(int(cb.colMeta[i].MetaID))
+			bufferColMap.Set(int(id), ordinal)
+			withColRemap.Set(int(cb.colMeta[i].MetaID), int(id))
+		}
 
-	// Remap the cascade columns.
-	oldVals, err := remapColumns(cascade.OldValues, withColRemap)
-	if err != nil {
-		return nil, err
-	}
-	newVals, err := remapColumns(cascade.NewValues, withColRemap)
-	if err != nil {
-		return nil, err
-	}
+		// Create relational properties for the special WithID input.
+		// TODO(radu): save some more information from the original binding props
+		// (like not-null columns, FDs) and remap them to the new columns.
+		var bindingProps props.Relational
+		bindingProps.Populated = true
+		bindingProps.OutputCols = withCols
+		bindingProps.Cardinality = props.Cardinality{
+			Min: uint32(numBufferedRows),
+			Max: uint32(numBufferedRows),
+		}
+		bindingProps.Stats = props.Statistics{
+			Available: true,
+			RowCount:  float64(numBufferedRows),
+		}
 
-	// 2. Invoke the memo.CascadeBuilder to build the cascade.
-	relExpr, err := cascade.Builder.Build(
-		ctx,
-		semaCtx,
-		evalCtx,
-		cb.b.catalog,
-		factory,
-		cascadeInputWithID,
-		&bindingProps,
-		oldVals,
-		newVals,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "while building cascade expression")
+		// Remap the cascade columns.
+		oldVals, err := remapColumns(cascade.OldValues, withColRemap)
+		if err != nil {
+			return nil, err
+		}
+		newVals, err := remapColumns(cascade.NewValues, withColRemap)
+		if err != nil {
+			return nil, err
+		}
+
+		relExpr, err = cascade.Builder.Build(
+			ctx,
+			semaCtx,
+			evalCtx,
+			cb.b.catalog,
+			factory,
+			cascadeInputWithID,
+			&bindingProps,
+			oldVals,
+			newVals,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "while building cascade expression")
+		}
 	}
 
 	o.Memo().SetRoot(relExpr, &physical.Required{})
@@ -258,8 +282,10 @@ func (cb *cascadeBuilder) planCascade(
 
 	// 4. Execbuild the optimized expression.
 	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
-	// Set up the With binding.
-	eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
+	if bufferRef != nil {
+		// Set up the With binding.
+		eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
+	}
 	plan, err := eb.Build()
 	if err != nil {
 		return nil, errors.Wrap(err, "while building cascade plan")

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -719,8 +719,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r35: sending batch 1 Scan to (n1,s1):1
-dist sender send  r35: sending batch 1 Del to (n1,s1):1
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 1 Del, 1 EndTxn to (n1,s1):1
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -71,7 +71,7 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/53/1/"a-pk1"/0
+DelRange /Table/53/1/"a-pk1" - /Table/53/1/"a-pk1"/#
 executing cascade for constraint fk_delete_cascade_ref_a
 Del /Table/54/1/"b1-pk1"/0
 Del /Table/54/1/"b1-pk2"/0
@@ -315,7 +315,7 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/70/1/"a-pk1"/0
+DelRange /Table/70/1/"a-pk1" - /Table/70/1/"a-pk1"/#
 executing cascade for constraint fk_delete_cascade_ref_a
 Del /Table/71/1/"b1-pk1"/0
 Del /Table/71/1/"b1-pk2"/0
@@ -603,7 +603,7 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/92/1/"a-pk1"/0
+DelRange /Table/92/1/"a-pk1" - /Table/92/1/"a-pk1"/#
 executing cascade for constraint fk_delete_cascade_ref_a
 Del /Table/93/1/"b1-pk1"/0
 Del /Table/93/1/"b1-pk2"/0
@@ -782,11 +782,73 @@ INSERT INTO child1 VALUES (1, 1), (2, 1);
 INSERT INTO child2 VALUES (1, 1), (2, 1)
 
 # Here we ensure that after the cascaded deletes we don't need
-# to perform additional and unneeded FKScan operations after
+# to perform additional and unneeded Scan operations after
 # cascade deleting or setting null to referencing rows.
-query T kvtrace(Del,FKScan)
+query T kvtrace(Del)
 DELETE FROM parent WHERE x = 1
 ----
 Del /Table/109/1/1/0
 Del /Table/110/1/1/0
 Del /Table/110/1/2/0
+
+subtest DelRange
+
+# Verify use of del-range for cascades, with schema similar to what an
+# interleaved hierarchy would look like.
+statement ok
+CREATE TABLE delrng1 (
+  p INT PRIMARY KEY,
+  data INT
+);
+CREATE TABLE delrng2 (
+  p INT,
+  q INT,
+  data INT,
+  PRIMARY KEY (p,q),
+  FOREIGN KEY (p) REFERENCES delrng1(p) ON DELETE CASCADE
+);
+CREATE TABLE delrng2a (
+  p INT,
+  q INT,
+  data INT,
+  PRIMARY KEY (p,q),
+  FOREIGN KEY (p) REFERENCES delrng1(p) ON DELETE CASCADE
+);
+CREATE TABLE delrng3 (
+  p INT,
+  q INT,
+  r INT,
+  data INT,
+  PRIMARY KEY (p,q,r),
+  FOREIGN KEY (p,q) REFERENCES delrng2(p,q) ON DELETE CASCADE
+);
+
+query TTT
+EXPLAIN DELETE FROM delrng1 WHERE p = 1
+----
+·                  distribution  local
+·                  vectorized    false
+root               ·             ·
+ ├── delete range  ·             ·
+ │                 from          delrng1
+ │                 spans         [/1 - /1]
+ ├── fk-cascade    ·             ·
+ │                 fk            fk_p_ref_delrng1
+ └── fk-cascade    ·             ·
+·                  fk            fk_p_ref_delrng1
+
+query T kvtrace(DelRange)
+DELETE FROM delrng1 WHERE p = 1
+----
+DelRange /Table/112/1/1 - /Table/112/1/1/#
+DelRange /Table/113/1/1 - /Table/113/1/2
+DelRange /Table/114/1/1 - /Table/114/1/2
+DelRange /Table/115/1/1 - /Table/115/1/2
+
+query T kvtrace(DelRange)
+DELETE FROM delrng1 WHERE p >= 10 AND p <= 20
+----
+DelRange /Table/112/1/10 - /Table/112/1/20/#
+DelRange /Table/113/1/10 - /Table/113/1/21
+DelRange /Table/114/1/10 - /Table/114/1/21
+DelRange /Table/115/1/10 - /Table/115/1/21

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -328,23 +328,19 @@ CREATE TABLE external_ref (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                    distribution   local
-·                    vectorized     false
-root                 ·              ·
- ├── delete          ·              ·
- │    │              from           parent
- │    └── buffer     ·              ·
- │         │         label          buffer 1
- │         └── scan  ·              ·
- │                   missing stats  ·
- │                   table          parent@primary
- │                   spans          [/11 - ]
- ├── fk-cascade      ·              ·
- │                   fk             fk_pid_ref_parent
- │                   input          buffer 1
- └── fk-cascade      ·              ·
-·                    fk             fk_pid_ref_parent
-·                    input          buffer 1
+·                distribution   local
+·                vectorized     false
+root             ·              ·
+ ├── delete      ·              ·
+ │    │          from           parent
+ │    └── scan   ·              ·
+ │               missing stats  ·
+ │               table          parent@primary
+ │               spans          [/11 - ]
+ ├── fk-cascade  ·              ·
+ │               fk             fk_pid_ref_parent
+ └── fk-cascade  ·              ·
+·                fk             fk_pid_ref_parent
 
 statement ok
 DROP TABLE external_ref
@@ -458,23 +454,19 @@ CREATE TABLE child_without_fk (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                    distribution   local
-·                    vectorized     false
-root                 ·              ·
- ├── delete          ·              ·
- │    │              from           parent
- │    └── buffer     ·              ·
- │         │         label          buffer 1
- │         └── scan  ·              ·
- │                   missing stats  ·
- │                   table          parent@primary
- │                   spans          [/11 - ]
- ├── fk-cascade      ·              ·
- │                   fk             fk_pid_ref_parent
- │                   input          buffer 1
- └── fk-cascade      ·              ·
-·                    fk             fk_pid_ref_parent
-·                    input          buffer 1
+·                distribution   local
+·                vectorized     false
+root             ·              ·
+ ├── delete      ·              ·
+ │    │          from           parent
+ │    └── scan   ·              ·
+ │               missing stats  ·
+ │               table          parent@primary
+ │               spans          [/11 - ]
+ ├── fk-cascade  ·              ·
+ │               fk             fk_pid_ref_parent
+ └── fk-cascade  ·              ·
+·                fk             fk_pid_ref_parent
 
 statement ok
 DROP TABLE child_without_fk
@@ -496,17 +488,14 @@ CREATE TABLE abc (
 query TTT
 EXPLAIN DELETE FROM ab WHERE a = 1
 ----
-·                    distribution   local
-·                    vectorized     false
-root                 ·              ·
- ├── delete          ·              ·
- │    │              from           ab
- │    └── buffer     ·              ·
- │         │         label          buffer 1
- │         └── scan  ·              ·
- │                   missing stats  ·
- │                   table          ab@primary
- │                   spans          [/1 - /1]
- └── fk-cascade      ·              ·
-·                    fk             fk_b_ref_ab
-·                    input          buffer 1
+·                distribution   local
+·                vectorized     false
+root             ·              ·
+ ├── delete      ·              ·
+ │    │          from           ab
+ │    └── scan   ·              ·
+ │               missing stats  ·
+ │               table          ab@primary
+ │               spans          [/1 - /1]
+ └── fk-cascade  ·              ·
+·                fk             fk_b_ref_ab

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -804,7 +804,7 @@ UPSERT INTO t46397_child(c) VALUES (2)
 
 # Verify that cascade information shows up in EXPLAIN.
 statement ok
-CREATE TABLE cascadeparent (p INT PRIMARY KEY);
+CREATE TABLE cascadeparent (p INT PRIMARY KEY, data INT);
 CREATE TABLE cascadechild (
   c INT PRIMARY KEY,
   p INT NOT NULL REFERENCES cascadeparent(p) ON DELETE CASCADE
@@ -813,21 +813,37 @@ CREATE TABLE cascadechild (
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
 ----
-·                    distribution         local                   ·    ·
-·                    vectorized           false                   ·    ·
-root                 ·                    ·                       ()   ·
- ├── delete          ·                    ·                       ()   ·
- │    │              estimated row count  0 (missing stats)       ·    ·
- │    │              from                 cascadeparent           ·    ·
- │    └── buffer     ·                    ·                       (p)  ·
- │         │         label                buffer 1                ·    ·
- │         └── scan  ·                    ·                       (p)  ·
- │                   estimated row count  333 (missing stats)     ·    ·
- │                   table                cascadeparent@primary   ·    ·
- │                   spans                /2-                     ·    ·
- └── fk-cascade      ·                    ·                       ·    ·
-·                    fk                   fk_p_ref_cascadeparent  ·    ·
-·                    input                buffer 1                ·    ·
+·                  distribution         local                   ·   ·
+·                  vectorized           false                   ·   ·
+root               ·                    ·                       ()  ·
+ ├── delete range  ·                    ·                       ()  ·
+ │                 estimated row count  0 (missing stats)       ·   ·
+ │                 from                 cascadeparent           ·   ·
+ │                 spans                /2-                     ·   ·
+ └── fk-cascade    ·                    ·                       ·   ·
+·                  fk                   fk_p_ref_cascadeparent  ·   ·
+
+query TTTTT
+EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1 AND data > 0
+----
+·                         distribution         local                   ·          ·
+·                         vectorized           false                   ·          ·
+root                      ·                    ·                       ()         ·
+ ├── delete               ·                    ·                       ()         ·
+ │    │                   estimated row count  0 (missing stats)       ·          ·
+ │    │                   from                 cascadeparent           ·          ·
+ │    └── buffer          ·                    ·                       (p, data)  ·
+ │         │              label                buffer 1                ·          ·
+ │         └── filter     ·                    ·                       (p, data)  ·
+ │              │         estimated row count  311 (missing stats)     ·          ·
+ │              │         filter               data > 0                ·          ·
+ │              └── scan  ·                    ·                       (p, data)  ·
+ │                        estimated row count  333 (missing stats)     ·          ·
+ │                        table                cascadeparent@primary   ·          ·
+ │                        spans                /2-                     ·          ·
+ └── fk-cascade           ·                    ·                       ·          ·
+·                         fk                   fk_p_ref_cascadeparent  ·          ·
+·                         input                buffer 1                ·          ·
 
 statement ok
 CREATE TABLE a (

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -98,7 +98,9 @@ func Emit(plan *Plan, ob *OutputBuilder, spanFormatFn SpanFormatFn) error {
 	for i := range plan.Cascades {
 		ob.EnterMetaNode("fk-cascade")
 		ob.Attr("fk", plan.Cascades[i].FKName)
-		ob.Attr("input", plan.Cascades[i].Buffer.(*Node).args.(*bufferArgs).Label)
+		if buffer := plan.Cascades[i].Buffer; buffer != nil {
+			ob.Attr("input", buffer.(*Node).args.(*bufferArgs).Label)
+		}
 		ob.LeaveNode()
 	}
 	for _, n := range plan.Checks {

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -141,7 +141,9 @@ func (f *Factory) ConstructPlan(
 	}
 	wrappedCascades := append([]exec.Cascade(nil), cascades...)
 	for i := range wrappedCascades {
-		wrappedCascades[i].Buffer = wrappedCascades[i].Buffer.(*Node).WrappedNode()
+		if wrappedCascades[i].Buffer != nil {
+			wrappedCascades[i].Buffer = wrappedCascades[i].Buffer.(*Node).WrappedNode()
+		}
 	}
 	wrappedChecks := make([]exec.Node, len(checks))
 	for i := range wrappedChecks {

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -204,7 +204,7 @@ type Cascade struct {
 	FKName string
 
 	// Buffer is the Node returned by ConstructBuffer which stores the input to
-	// the mutation.
+	// the mutation. It is nil if the cascade does not require a buffer.
 	Buffer Node
 
 	// PlanFn builds the cascade query and creates the plan for it.
@@ -216,6 +216,9 @@ type Cascade struct {
 	// however, we allow the execution engine to provide a different copy or
 	// implementation of the node (e.g. to facilitate early cleanup of the
 	// original plan).
+	//
+	// If the cascade does not require input buffering (Buffer is nil), then
+	// bufferRef should be nil and numBufferedRows should be 0.
 	//
 	// This method does not mutate any captured state; it is ok to call PlanFn
 	// methods concurrently (provided that they don't use a single non-thread-safe

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
@@ -97,6 +98,235 @@ func (cb *onDeleteCascadeBuilder) Build(
 		mb.outScope = b.buildDeleteCascadeMutationInput(
 			cb.childTable, &mb.alias, fk, binding, bindingProps, oldValues,
 		)
+
+		// Set list of columns that will be fetched by the input expression.
+		mb.setFetchColIDs(mb.outScope.cols)
+		mb.buildDelete(nil /* returning */)
+		return mb.outScope.expr
+	})
+}
+
+// onDeleteCascadeBuilder is a memo.CascadeBuilder implementation for certain
+// cases of ON DELETE CASCADE where we are deleting the entire table or where we
+// can transfer a filter from the original statement instead of buffering the
+// deleted rows.
+//
+// It provides a method to build the cascading delete in the child table,
+// equivalent to a query like:
+//
+//   DELETE FROM child WHERE <condition on fk column> AND fk IS NOT NULL
+//
+// The input to the mutation is a Select on top of a Scan. For example:
+//
+//── delete child
+//    ├── columns: <none>
+//    ├── fetch columns: c:8 child.p:9
+//    └── select
+//         ├── columns: c:8!null child.p:9!null
+//         ├── scan child
+//         │    └── columns: c:8!null child.p:9!null
+//         └── filters
+//              ├── child.p:9 > 1
+//              └── child.p:9 IS DISTINCT FROM CAST(NULL AS INT8)
+//
+// See testdata/fk-on-delete-cascades for more examples.
+//
+type onDeleteFastCascadeBuilder struct {
+	mutatedTable cat.Table
+	// fkInboundOrdinal is the ordinal of the inbound foreign key constraint on
+	// the mutated table (can be passed to mutatedTable.InboundForeignKey).
+	fkInboundOrdinal int
+	childTable       cat.Table
+
+	origFilters memo.FiltersExpr
+	origFKCols  opt.ColList
+}
+
+var _ memo.CascadeBuilder = &onDeleteFastCascadeBuilder{}
+
+// tryNewOnDeleteFastCascadeBuilder checks if the fast path cascade is
+// applicable to the given mutation, and if yes it returns an instance of
+// onDeleteFastCascadeBuilder.
+func tryNewOnDeleteFastCascadeBuilder(
+	ctx context.Context,
+	md *opt.Metadata,
+	catalog cat.Catalog,
+	fk cat.ForeignKeyConstraint,
+	fkInboundOrdinal int,
+	parentTab, childTab cat.Table,
+	mutationInputScope *scope,
+) (_ *onDeleteFastCascadeBuilder, ok bool) {
+	fkCols := make(opt.ColList, fk.ColumnCount())
+	for i := range fkCols {
+		tabOrd := fk.ReferencedColumnOrdinal(parentTab, i)
+		fkCols[i] = mutationInputScope.getColumnForTableOrdinal(tabOrd).id
+	}
+	// Check that the input expression is a full table Scan or a Select on top of
+	// a Scan where the filter references only FK columns and can be transferred
+	// over to the child table.
+	var scan *memo.ScanExpr
+	var filters memo.FiltersExpr
+	switch mutationInputScope.expr.Op() {
+	case opt.SelectOp:
+		sel := mutationInputScope.expr.(*memo.SelectExpr)
+		if sel.Input.Op() != opt.ScanOp {
+			return nil, false
+		}
+		var p props.Shared
+		memo.BuildSharedProps(&sel.Filters, &p)
+		if p.VolatilitySet.HasVolatile() {
+			return nil, false
+		}
+		scan = sel.Input.(*memo.ScanExpr)
+		if !p.OuterCols.SubsetOf(fkCols.ToSet()) {
+			return nil, false
+		}
+		if memo.CanBeCompositeSensitive(md, &sel.Filters) {
+			return nil, false
+		}
+		filters = sel.Filters
+
+	case opt.ScanOp:
+		scan = mutationInputScope.expr.(*memo.ScanExpr)
+
+	default:
+		return nil, false
+	}
+	// Check that the scan retrieves all table data (currently, this should always
+	// be the case in a normalized expression).
+	if !scan.IsUnfiltered(md) {
+		return nil, false
+	}
+
+	var visited util.FastIntSet
+	parentTabID := parentTab.ID()
+	childTabID := childTab.ID()
+
+	// Check that inbound FK references form a simple tree.
+	//
+	// TODO(radu): we could allow multiple cascade paths to the same table if
+	// there are no cycles. We could also analyze cycles more deeply to see if
+	// they would in fact lead to a cascade loop. It's questionable if improving
+	// these cases would be useful in practice.
+	//
+	// checkPaths returns false if any tables are reachable from tabID through
+	// multiple inbound FK paths (or if there are cycles). It uses a recursive
+	// depth-first search.
+	var checkPaths func(tabID cat.StableID) bool
+	checkPaths = func(tabID cat.StableID) bool {
+		if visited.Contains(int(tabID)) {
+			return false
+		}
+		visited.Add(int(tabID))
+
+		var tab cat.Table
+		// Avoid calling resolveTable for tables we already resolved.
+		switch tabID {
+		case parentTabID:
+			tab = parentTab
+		case childTabID:
+			tab = childTab
+		default:
+			tab = resolveTable(ctx, catalog, tabID)
+		}
+		for i, n := 0, tab.InboundForeignKeyCount(); i < n; i++ {
+			if !checkPaths(tab.InboundForeignKey(i).OriginTableID()) {
+				return false
+			}
+		}
+		return true
+	}
+	if !checkPaths(parentTabID) {
+		return nil, false
+	}
+
+	return &onDeleteFastCascadeBuilder{
+		mutatedTable:     parentTab,
+		fkInboundOrdinal: fkInboundOrdinal,
+		childTable:       childTab,
+		origFilters:      filters,
+		origFKCols:       fkCols,
+	}, true
+}
+
+// Build is part of the memo.CascadeBuilder interface.
+func (cb *onDeleteFastCascadeBuilder) Build(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	catalog cat.Catalog,
+	factoryI interface{},
+	_ opt.WithID,
+	_ *props.Relational,
+	_, _ opt.ColList,
+) (_ memo.RelExpr, err error) {
+	return buildCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, func(b *Builder) memo.RelExpr {
+		fk := cb.mutatedTable.InboundForeignKey(cb.fkInboundOrdinal)
+
+		dep := opt.DepByID(fk.OriginTableID())
+		b.checkPrivilege(dep, cb.childTable, privilege.DELETE)
+		b.checkPrivilege(dep, cb.childTable, privilege.SELECT)
+
+		var mb mutationBuilder
+		mb.init(b, "delete", cb.childTable, tree.MakeUnqualifiedTableName(cb.childTable.Name()))
+
+		// Build the input to the delete mutation, which is simply a Scan with a
+		// Select on top.
+		mb.outScope = b.buildScan(
+			b.addTable(cb.childTable, &mb.alias),
+			tableOrdinals(cb.childTable, columnKinds{
+				includeMutations:       false,
+				includeSystem:          false,
+				includeVirtualInverted: false,
+				includeVirtualComputed: false,
+			}),
+			nil, /* indexFlags */
+			noRowLocking,
+			b.allocScope(),
+		)
+
+		var filters memo.FiltersExpr
+
+		// Build the filters by copying the original filters and replacing all
+		// variable references.
+		if len(cb.origFilters) > 0 {
+			var replaceFn norm.ReplaceFunc
+			replaceFn = func(e opt.Expr) opt.Expr {
+				if v, ok := e.(*memo.VariableExpr); ok {
+					idx, found := cb.origFKCols.Find(v.Col)
+					if !found {
+						panic(errors.AssertionFailedf("non-FK variable in filter"))
+					}
+					tabOrd := fk.OriginColumnOrdinal(cb.childTable, idx)
+					col := mb.outScope.getColumnForTableOrdinal(tabOrd)
+					return b.factory.ConstructVariable(col.id)
+				}
+				return b.factory.CopyAndReplaceDefault(e, replaceFn)
+			}
+			filters = *replaceFn(&cb.origFilters).(*memo.FiltersExpr)
+		}
+
+		// We have to filter out rows that have NULL values; add an IS NOT NULL
+		// filter for each FK column, unless the column is not-nullable (this is
+		// a minor optimization, as normalization rules would have removed the
+		// filter anyway).
+		notNullCols := mb.outScope.expr.Relational().NotNullCols
+		for i := range cb.origFKCols {
+			tabOrd := fk.OriginColumnOrdinal(cb.childTable, i)
+			col := mb.outScope.getColumnForTableOrdinal(tabOrd)
+			if !notNullCols.Contains(col.id) {
+				filters = append(filters, b.factory.ConstructFiltersItem(
+					b.factory.ConstructIsNot(
+						b.factory.ConstructVariable(col.id),
+						b.factory.ConstructNull(col.typ),
+					),
+				))
+			}
+		}
+
+		if len(filters) > 0 {
+			mb.outScope.expr = b.factory.ConstructSelect(mb.outScope.expr, filters)
+		}
 
 		// Set list of columns that will be fetched by the input expression.
 		mb.setFetchColIDs(mb.outScope.cols)

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -6,9 +6,36 @@ exec-ddl
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
 ----
 
-# Simple cascade.
+# Simple cascade; fast path (the filter gets transferred over to the cascade).
 build-cascades
 DELETE FROM parent WHERE p > 1
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 > 1
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:8 child.p:9
+           └── select
+                ├── columns: c:8!null child.p:9!null
+                ├── scan child
+                │    └── columns: c:8!null child.p:9!null
+                └── filters
+                     └── child.p:9 > 1
+
+# Simple cascade; no fast path.
+build-cascades
+DELETE FROM parent WHERE p > 1 AND random() < 0.5
 ----
 root
  ├── delete parent
@@ -22,7 +49,7 @@ root
  │         ├── scan parent
  │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
  │         └── filters
- │              └── p:3 > 1
+ │              └── (p:3 > 1) AND (random() < 0.5)
  └── cascade
       └── delete child
            ├── columns: <none>
@@ -38,13 +65,76 @@ root
                 └── filters
                      └── child.p:9 = p:11
 
+# Delete everything.
+build-cascades
+DELETE FROM parent
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── scan parent
+ │         └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:8 child.p:9
+           └── scan child
+                └── columns: c:8!null child.p:9!null
+
 exec-ddl
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT REFERENCES child(c) ON DELETE CASCADE)
 ----
 
-# Two-level cascade.
+# Two-level cascade; fast path for the first cascade.
 build-cascades
 DELETE FROM parent WHERE p > 1
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 > 1
+ └── cascade
+      ├── delete child
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:8 child.p:9
+      │    ├── input binding: &1
+      │    ├── cascades
+      │    │    └── fk_c_ref_child
+      │    └── select
+      │         ├── columns: c:8!null child.p:9!null
+      │         ├── scan child
+      │         │    └── columns: c:8!null child.p:9!null
+      │         └── filters
+      │              └── child.p:9 > 1
+      └── cascade
+           └── delete grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:14 grandchild.c:15
+                └── semi-join (hash)
+                     ├── columns: g:14!null grandchild.c:15
+                     ├── scan grandchild
+                     │    └── columns: g:14!null grandchild.c:15
+                     ├── with-scan &1
+                     │    ├── columns: c:17!null
+                     │    └── mapping:
+                     │         └──  child.c:8 => c:17
+                     └── filters
+                          └── grandchild.c:15 = c:17
+
+# Two-level cascade; no fast path.
+build-cascades
+DELETE FROM parent WHERE p > 1 AND random() < 0.5
 ----
 root
  ├── delete parent
@@ -58,7 +148,7 @@ root
  │         ├── scan parent
  │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
  │         └── filters
- │              └── p:3 > 1
+ │              └── (p:3 > 1) AND (random() < 0.5)
  └── cascade
       ├── delete child
       │    ├── columns: <none>
@@ -91,6 +181,37 @@ root
                      └── filters
                           └── grandchild.c:16 = c:18
 
+# Delete everything.
+build-cascades
+DELETE FROM parent
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── scan parent
+ │         └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ └── cascade
+      ├── delete child
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:8 child.p:9
+      │    ├── cascades
+      │    │    └── fk_c_ref_child
+      │    └── scan child
+      │         └── columns: c:8!null child.p:9!null
+      └── cascade
+           └── delete grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:14 grandchild.c:15
+                └── select
+                     ├── columns: g:14!null grandchild.c:15!null
+                     ├── scan grandchild
+                     │    └── columns: g:14!null grandchild.c:15
+                     └── filters
+                          └── grandchild.c:15 IS DISTINCT FROM CAST(NULL AS INT8)
+
 # Cascade with check query.
 exec-ddl
 DROP TABLE grandchild
@@ -107,7 +228,6 @@ root
  ├── delete parent
  │    ├── columns: <none>
  │    ├── fetch columns: p:3
- │    ├── input binding: &1
  │    ├── cascades
  │    │    └── fk_p_ref_parent
  │    └── select
@@ -116,6 +236,46 @@ root
  │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
  │         └── filters
  │              └── p:3 > 1
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: child.c:8 child.p:9
+           ├── input binding: &1
+           ├── select
+           │    ├── columns: child.c:8!null child.p:9!null
+           │    ├── scan child
+           │    │    └── columns: child.c:8!null child.p:9!null
+           │    └── filters
+           │         └── child.p:9 > 1
+           └── f-k-checks
+                └── f-k-checks-item: grandchild(c) -> child(c)
+                     └── semi-join (hash)
+                          ├── columns: c:11!null
+                          ├── with-scan &1
+                          │    ├── columns: c:11!null
+                          │    └── mapping:
+                          │         └──  child.c:8 => c:11
+                          ├── scan grandchild
+                          │    └── columns: grandchild.c:13
+                          └── filters
+                               └── c:11 = grandchild.c:13
+
+build-cascades
+DELETE FROM parent WHERE p > 1 AND random() < 0.5
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── (p:3 > 1) AND (random() < 0.5)
  └── cascade
       └── delete child
            ├── columns: <none>
@@ -242,6 +402,7 @@ exec-ddl
 ALTER TABLE ef ADD CONSTRAINT ef_ab FOREIGN KEY (f) REFERENCES ab(a) ON DELETE CASCADE
 ----
 
+# Fast path should not be used when there are cycles.
 build-cascades cascade-levels=3
 DELETE FROM ab WHERE a = 1
 ----
@@ -309,3 +470,361 @@ root
                           │         └──  cd.c:17 => c:27
                           └── filters
                                └── b:25 = c:27
+
+# Test a multi-level fast path.
+exec-ddl
+CREATE TABLE f1 (
+  a INT, data INT,
+  PRIMARY KEY (a)
+)
+----
+
+exec-ddl
+CREATE TABLE f2 (
+  a INT, b INT, data INT,
+  PRIMARY KEY (a,b),
+  CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES f1(a) ON DELETE CASCADE
+)
+----
+
+exec-ddl
+CREATE TABLE f3 (
+  a INT, b INT, c INT, data INT,
+  PRIMARY KEY (a,b,c),
+  CONSTRAINT fk3 FOREIGN KEY (a,b) REFERENCES f2(a,b) ON DELETE CASCADE
+)
+----
+
+build-cascades
+DELETE FROM f1 WHERE a >= 1 AND a <= 4
+----
+root
+ ├── delete f1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:4 data:5
+ │    ├── cascades
+ │    │    └── fk2
+ │    └── select
+ │         ├── columns: a:4!null data:5 crdb_internal_mvcc_timestamp:6
+ │         ├── scan f1
+ │         │    └── columns: a:4!null data:5 crdb_internal_mvcc_timestamp:6
+ │         └── filters
+ │              └── (a:4 >= 1) AND (a:4 <= 4)
+ └── cascade
+      ├── delete f2
+      │    ├── columns: <none>
+      │    ├── fetch columns: f2.a:11 b:12 f2.data:13
+      │    ├── cascades
+      │    │    └── fk3
+      │    └── select
+      │         ├── columns: f2.a:11!null b:12!null f2.data:13
+      │         ├── scan f2
+      │         │    └── columns: f2.a:11!null b:12!null f2.data:13
+      │         └── filters
+      │              └── (f2.a:11 >= 1) AND (f2.a:11 <= 4)
+      └── cascade
+           └── delete f3
+                ├── columns: <none>
+                ├── fetch columns: f3.a:20 f3.b:21 c:22 f3.data:23
+                └── select
+                     ├── columns: f3.a:20!null f3.b:21!null c:22!null f3.data:23
+                     ├── scan f3
+                     │    └── columns: f3.a:20!null f3.b:21!null c:22!null f3.data:23
+                     └── filters
+                          └── (f3.a:20 >= 1) AND (f3.a:20 <= 4)
+
+# No fast path possible (filter references other columns).
+build-cascades
+DELETE FROM f1 WHERE a = 1 AND data = 1
+----
+root
+ ├── delete f1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:4 data:5
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk2
+ │    └── select
+ │         ├── columns: a:4!null data:5!null crdb_internal_mvcc_timestamp:6
+ │         ├── scan f1
+ │         │    └── columns: a:4!null data:5 crdb_internal_mvcc_timestamp:6
+ │         └── filters
+ │              └── (a:4 = 1) AND (data:5 = 1)
+ └── cascade
+      ├── delete f2
+      │    ├── columns: <none>
+      │    ├── fetch columns: f2.a:11 b:12 f2.data:13
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk3
+      │    └── semi-join (hash)
+      │         ├── columns: f2.a:11!null b:12!null f2.data:13
+      │         ├── scan f2
+      │         │    └── columns: f2.a:11!null b:12!null f2.data:13
+      │         ├── with-scan &1
+      │         │    ├── columns: a:15!null
+      │         │    └── mapping:
+      │         │         └──  f1.a:4 => a:15
+      │         └── filters
+      │              └── f2.a:11 = a:15
+      └── cascade
+           └── delete f3
+                ├── columns: <none>
+                ├── fetch columns: f3.a:21 f3.b:22 c:23 f3.data:24
+                └── semi-join (hash)
+                     ├── columns: f3.a:21!null f3.b:22!null c:23!null f3.data:24
+                     ├── scan f3
+                     │    └── columns: f3.a:21!null f3.b:22!null c:23!null f3.data:24
+                     ├── with-scan &2
+                     │    ├── columns: a:26!null b:27!null
+                     │    └── mapping:
+                     │         ├──  f2.a:11 => a:26
+                     │         └──  f2.b:12 => b:27
+                     └── filters
+                          ├── f3.a:21 = a:26
+                          └── f3.b:22 = b:27
+
+# Test with a fast path cascade and a non-fast path cascade.
+exec-ddl
+CREATE TABLE g1 (a INT UNIQUE, b INT UNIQUE)
+----
+
+exec-ddl
+CREATE TABLE g2a (a INT REFERENCES g1(a) ON DELETE CASCADE, data INT)
+----
+
+exec-ddl
+CREATE TABLE g2b (b INT REFERENCES g1(b) ON DELETE CASCADE, data INT)
+----
+
+build-cascades
+DELETE FROM g1 WHERE a = 1
+----
+root
+ ├── delete g1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:5 b:6 rowid:7
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    ├── fk_a_ref_g1
+ │    │    └── fk_b_ref_g1
+ │    └── select
+ │         ├── columns: a:5!null b:6 rowid:7!null crdb_internal_mvcc_timestamp:8
+ │         ├── scan g1
+ │         │    └── columns: a:5 b:6 rowid:7!null crdb_internal_mvcc_timestamp:8
+ │         └── filters
+ │              └── a:5 = 1
+ ├── cascade
+ │    └── delete g2a
+ │         ├── columns: <none>
+ │         ├── fetch columns: g2a.a:13 data:14 g2a.rowid:15
+ │         └── select
+ │              ├── columns: g2a.a:13!null data:14 g2a.rowid:15!null
+ │              ├── scan g2a
+ │              │    └── columns: g2a.a:13 data:14 g2a.rowid:15!null
+ │              └── filters
+ │                   ├── g2a.a:13 = 1
+ │                   └── g2a.a:13 IS DISTINCT FROM CAST(NULL AS INT8)
+ └── cascade
+      └── delete g2b
+           ├── columns: <none>
+           ├── fetch columns: g2b.b:21 g2b.data:22 g2b.rowid:23
+           └── semi-join (hash)
+                ├── columns: g2b.b:21 g2b.data:22 g2b.rowid:23!null
+                ├── scan g2b
+                │    └── columns: g2b.b:21 g2b.data:22 g2b.rowid:23!null
+                ├── with-scan &1
+                │    ├── columns: b:25
+                │    └── mapping:
+                │         └──  g1.b:6 => b:25
+                └── filters
+                     └── g2b.b:21 = b:25
+
+build-cascades
+DELETE FROM g1 WHERE b = 1
+----
+root
+ ├── delete g1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:5 b:6 rowid:7
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    ├── fk_a_ref_g1
+ │    │    └── fk_b_ref_g1
+ │    └── select
+ │         ├── columns: a:5 b:6!null rowid:7!null crdb_internal_mvcc_timestamp:8
+ │         ├── scan g1
+ │         │    └── columns: a:5 b:6 rowid:7!null crdb_internal_mvcc_timestamp:8
+ │         └── filters
+ │              └── b:6 = 1
+ ├── cascade
+ │    └── delete g2a
+ │         ├── columns: <none>
+ │         ├── fetch columns: g2a.a:13 data:14 g2a.rowid:15
+ │         └── semi-join (hash)
+ │              ├── columns: g2a.a:13 data:14 g2a.rowid:15!null
+ │              ├── scan g2a
+ │              │    └── columns: g2a.a:13 data:14 g2a.rowid:15!null
+ │              ├── with-scan &1
+ │              │    ├── columns: a:17
+ │              │    └── mapping:
+ │              │         └──  g1.a:5 => a:17
+ │              └── filters
+ │                   └── g2a.a:13 = a:17
+ └── cascade
+      └── delete g2b
+           ├── columns: <none>
+           ├── fetch columns: g2b.b:22 g2b.data:23 g2b.rowid:24
+           └── select
+                ├── columns: g2b.b:22!null g2b.data:23 g2b.rowid:24!null
+                ├── scan g2b
+                │    └── columns: g2b.b:22 g2b.data:23 g2b.rowid:24!null
+                └── filters
+                     ├── g2b.b:22 = 1
+                     └── g2b.b:22 IS DISTINCT FROM CAST(NULL AS INT8)
+
+# Verify composite types handling.
+exec-ddl
+CREATE TABLE h1 (p DECIMAL PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE h2 (c INT PRIMARY KEY, p DECIMAL REFERENCES h1(p) ON DELETE CASCADE)
+----
+
+# Fast path cannot be used: it would be incorrect to transfer this
+# condition to the child column.
+build-cascades
+DELETE FROM h1 WHERE p::STRING = '1.0'
+----
+root
+ ├── delete h1
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_h1
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan h1
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3::STRING = '1.0'
+ └── cascade
+      └── delete h2
+           ├── columns: <none>
+           ├── fetch columns: c:8 h2.p:9
+           └── semi-join (hash)
+                ├── columns: c:8!null h2.p:9
+                ├── scan h2
+                │    └── columns: c:8!null h2.p:9
+                ├── with-scan &1
+                │    ├── columns: p:11!null
+                │    └── mapping:
+                │         └──  h1.p:3 => p:11
+                └── filters
+                     └── h2.p:9 = p:11
+
+# It is ok to use the fast path if the expression is not composite-sensitive.
+build-cascades
+DELETE FROM h1 WHERE p = 1
+----
+root
+ ├── delete h1
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_h1
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan h1
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 = 1
+ └── cascade
+      └── delete h2
+           ├── columns: <none>
+           ├── fetch columns: c:8 h2.p:9
+           └── select
+                ├── columns: c:8!null h2.p:9!null
+                ├── scan h2
+                │    └── columns: c:8!null h2.p:9
+                └── filters
+                     ├── h2.p:9 = 1
+                     └── h2.p:9 IS DISTINCT FROM CAST(NULL AS DECIMAL)
+
+# Test null column handling for fast path cascades.
+exec-ddl
+CREATE TABLE m1 (
+  a INT,
+  b INT,
+  c INT,
+  UNIQUE(a,b,c)
+)
+----
+
+exec-ddl
+CREATE TABLE m2 (
+  a INT,
+  b INT NOT NULL,
+  c INT,
+  FOREIGN KEY (a,b,c) REFERENCES m1(a,b,c) ON DELETE CASCADE
+)
+----
+
+build-cascades
+DELETE FROM m1 WHERE a+b+c=1
+----
+root
+ ├── delete m1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:6 b:7 c:8 rowid:9
+ │    ├── cascades
+ │    │    └── fk_a_ref_m1
+ │    └── select
+ │         ├── columns: a:6 b:7 c:8 rowid:9!null crdb_internal_mvcc_timestamp:10
+ │         ├── scan m1
+ │         │    └── columns: a:6 b:7 c:8 rowid:9!null crdb_internal_mvcc_timestamp:10
+ │         └── filters
+ │              └── ((a:6 + b:7) + c:8) = 1
+ └── cascade
+      └── delete m2
+           ├── columns: <none>
+           ├── fetch columns: m2.a:16 m2.b:17 m2.c:18 m2.rowid:19
+           └── select
+                ├── columns: m2.a:16!null m2.b:17!null m2.c:18!null m2.rowid:19!null
+                ├── scan m2
+                │    └── columns: m2.a:16 m2.b:17!null m2.c:18 m2.rowid:19!null
+                └── filters
+                     ├── ((m2.a:16 + m2.b:17) + m2.c:18) = 1
+                     ├── m2.a:16 IS DISTINCT FROM CAST(NULL AS INT8)
+                     └── m2.c:18 IS DISTINCT FROM CAST(NULL AS INT8)
+
+# The filter will end up being a contradiction, so the cascade is a no-op.
+build-cascades
+DELETE FROM m1 WHERE a IS NULL
+----
+root
+ ├── delete m1
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:6 b:7 c:8 rowid:9
+ │    ├── cascades
+ │    │    └── fk_a_ref_m1
+ │    └── select
+ │         ├── columns: a:6 b:7 c:8 rowid:9!null crdb_internal_mvcc_timestamp:10
+ │         ├── scan m1
+ │         │    └── columns: a:6 b:7 c:8 rowid:9!null crdb_internal_mvcc_timestamp:10
+ │         └── filters
+ │              └── a:6 IS NULL
+ └── cascade
+      └── delete m2
+           ├── columns: <none>
+           ├── fetch columns: m2.a:16 m2.b:17 m2.c:18 m2.rowid:19
+           └── select
+                ├── columns: m2.a:16!null m2.b:17!null m2.c:18!null m2.rowid:19!null
+                ├── scan m2
+                │    └── columns: m2.a:16 m2.b:17!null m2.c:18 m2.rowid:19!null
+                └── filters
+                     ├── m2.a:16 IS NULL
+                     ├── m2.a:16 IS DISTINCT FROM CAST(NULL AS INT8)
+                     └── m2.c:18 IS DISTINCT FROM CAST(NULL AS INT8)

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -391,8 +391,17 @@ func (g *factoryGen) genCopyAndReplaceDefault() {
 		g.w.unnest("\n")
 	}
 
-	g.w.writeIndent("}\n")
+	for _, define := range g.compiled.Defines.WithTag("List") {
+		opTyp := g.md.typeOf(define)
+		g.w.nestIndent("case *%s:\n", opTyp.name)
+		g.w.writeIndent("newVal := f.copyAndReplaceDefault%s(*t, replace)\n", opTyp.friendlyName)
+		g.w.writeIndent("return &newVal\n")
+		g.w.unnest("\n")
+	}
+
+	g.w.nestIndent("default:\n")
 	g.w.writeIndent("panic(errors.AssertionFailedf(\"unhandled op %%s\", errors.Safe(src.Op())))\n")
+	g.w.unnest("}\n")
 	g.w.unnest("}\n\n")
 
 	for _, define := range g.compiled.Defines.WithTag("List") {

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -264,8 +264,13 @@ func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst 
 			f.copyAndReplaceDefaultFiltersExpr(t.On, replace),
 		)
 
+	case *memo.FiltersExpr:
+		newVal := f.copyAndReplaceDefaultFiltersExpr(*t, replace)
+		return &newVal
+
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 	}
-	panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 }
 
 func (f *Factory) copyAndReplaceDefaultFiltersExpr(src memo.FiltersExpr, replace ReplaceFunc) (dst memo.FiltersExpr) {
@@ -528,8 +533,9 @@ func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst 
 			f.invokeReplace(t.Input, replace).(opt.ScalarExpr),
 		)
 
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 	}
-	panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 }
 
 // invokeReplace wraps the user-provided replace function. See comments for
@@ -649,8 +655,9 @@ func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst 
 			f.invokeReplace(t.Main, replace).(memo.RelExpr),
 		)
 
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 	}
-	panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 }
 
 // invokeReplace wraps the user-provided replace function. See comments for
@@ -882,8 +889,17 @@ func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst 
 			f.copyAndReplaceDefaultScalarListExpr(t.Rows, replace),
 		)
 
+	case *memo.ProjectionsExpr:
+		newVal := f.copyAndReplaceDefaultProjectionsExpr(*t, replace)
+		return &newVal
+
+	case *memo.ScalarListExpr:
+		newVal := f.copyAndReplaceDefaultScalarListExpr(*t, replace)
+		return &newVal
+
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 	}
-	panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 }
 
 func (f *Factory) copyAndReplaceDefaultProjectionsExpr(src memo.ProjectionsExpr, replace ReplaceFunc) (dst memo.ProjectionsExpr) {
@@ -1055,8 +1071,9 @@ func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst 
 			f.invokeReplace(t.And, replace).(opt.ScalarExpr),
 		)
 
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 	}
-	panic(errors.AssertionFailedf("unhandled op %s", errors.Safe(src.Op())))
 }
 
 // invokeReplace wraps the user-provided replace function. See comments for

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -164,8 +164,6 @@ var kvMsgRegexp = regexp.MustCompile(
 		"^Del ",
 		"^Get ",
 		"^Scan ",
-		"^FKScan ",
-		"^CascadeScan ",
 		"^querying next range at ",
 		"^output row: ",
 		"^rows affected: ",


### PR DESCRIPTION
🚨 If we backport this, we also need to backport the fast-path related fixes in #57100 🚨

#### opt: minor cleanup in optbuilder cascade code

Factoring out a few blocks of duplicated code.

Release note: None

#### opt: delete cascade fast path

Currently, a delete cascade is executed by buffering the input to the
parent deletion and joining that with the child table to find the
child rows to be deleted.

In cases where the DELETE WHERE clause only references FK columns,
instead of buffering the parent rows, we can transfer the filter to
the child table. For example:
```
  CREATE TABLE parent (p INT PRIMARY KEY)
  CREATE TABLE child (p INT REFERENCES parent(p))
  DELETE FROM parent WHERE p=1
```
We can execute the cascade as (effectively):
```
  DELETE FROM child WHERE p=1
```

There are a few subtleties:
 - we must not cascade to rows that have a NULL value on a FK column,
   even if they do satisfy the filter.
 - in special cases, some expressions might evaluate differently for
   corresponding FK values: for example expression `d::string=1.0`
   with the decimal 1.0 in the parent and 1.00 in the child.

The main advantage of this fast path is that it opens up the
possibility of using the much faster delete-range, both in the parent
(because we no longer need the actual rows) and in the child. In
particular, this closes the gap to interleaved tables which allow use
of delete-range across the entire hierarchy.

Release note: None