### PR TITLE
colexec: adds support for JSONFetchTextPath binary operator [DO NOT MERGE][WIP]

### DIFF
--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -15,20 +15,21 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 // BinaryOpName is a mapping from all binary operators that are supported by
 // the vectorized engine to their names.
 var BinaryOpName = map[tree.BinaryOperator]string{
-	tree.Bitand:       "Bitand",
-	tree.Bitor:        "Bitor",
-	tree.Bitxor:       "Bitxor",
-	tree.Plus:         "Plus",
-	tree.Minus:        "Minus",
-	tree.Mult:         "Mult",
-	tree.Div:          "Div",
-	tree.FloorDiv:     "FloorDiv",
-	tree.Mod:          "Mod",
-	tree.Pow:          "Pow",
-	tree.Concat:       "Concat",
-	tree.LShift:       "LShift",
-	tree.RShift:       "RShift",
-	tree.JSONFetchVal: "JSONFetchVal",
+	tree.Bitand:            "Bitand",
+	tree.Bitor:             "Bitor",
+	tree.Bitxor:            "Bitxor",
+	tree.Plus:              "Plus",
+	tree.Minus:             "Minus",
+	tree.Mult:              "Mult",
+	tree.Div:               "Div",
+	tree.FloorDiv:          "FloorDiv",
+	tree.Mod:               "Mod",
+	tree.Pow:               "Pow",
+	tree.Concat:            "Concat",
+	tree.LShift:            "LShift",
+	tree.RShift:            "RShift",
+	tree.JSONFetchVal:      "JSONFetchVal",
+	tree.JSONFetchTextPath: "JSONFetchTextPath",
 }
 
 // ComparisonOpName is a mapping from all comparison operators that are

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -321,6 +321,13 @@ NULL
 [1, "hello", {"a": ["foo", {"b": 3}]}, 1, "hello", {"a": ["foo", {"b": 3}]}]
 
 query T
+SELECT _json #>> ["a", "foo", "b"] FROM many_types
+----
+NULL
+NULL
+3
+
+query T
 EXPLAIN (VEC) SELECT _varbit || _varbit FROM many_types
 ----
 │

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -446,8 +446,8 @@ func (o binOpOverload) lookupImpl(left, right *types.T) (*BinOp, bool) {
 	return nil, false
 }
 
-// getJSONPath is used for the #> and #>> operators.
-func getJSONPath(j DJSON, ary DArray) (Datum, error) {
+// GetJSONPath is used for the #> and #>> operators.
+func GetJSONPath(j DJSON, ary DArray) (Datum, error) {
 	// TODO(justin): this is slightly annoying because we have to allocate
 	// a new array since the JSON package isn't aware of DArray.
 	path := make([]string, len(ary.Array))
@@ -1833,7 +1833,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.MakeArray(types.String),
 			ReturnType: types.Jsonb,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				return getJSONPath(*left.(*DJSON), *MustBeDArray(right))
+				return GetJSONPath(*left.(*DJSON), *MustBeDArray(right))
 			},
 			Volatility: VolatilityImmutable,
 		},
@@ -1894,7 +1894,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.MakeArray(types.String),
 			ReturnType: types.String,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				res, err := getJSONPath(*left.(*DJSON), *MustBeDArray(right))
+				res, err := GetJSONPath(*left.(*DJSON), *MustBeDArray(right))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
This PR adds support for binary operator `JSONFetchTextPath` for vectorized engine. It resolves #49472 issue. 

This is first cut of the PR. Added following things:
1. Added operator in `execgen.BinaryOpName`
2. Registered the output `typepair` in `registerBinOpOutputTypes `. This Operator supports operations on `DatumVector` only and returns DatumVector. (Operand A: `Json`, Operand B: `[]string`, and return type `Json`). 
3. Modified `DatumCustomizer`'s `getBinOpAssignFunc()` for this operator to return template which calls `tree. GetJSONPath()`
4. Added a test case in `logic_test/vectorize_overloads`

Things Left: 
1. It is still not functionally tested. Test cases are failing. 
2. Code might have few mistakes and not 100% mergeable. 
3. Proper PR description. 

Reviews are very much needed and appreciated.
 