### PR TITLE
release-20.2: partitionccl: disallow partitioning by user-defined types

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
@@ -1,0 +1,34 @@
+
+# Enums are not supported as the values for partitioning as of 20.2 because of
+# unfortunate interactions during validation. Assert that that is true.
+
+statement ok
+CREATE TYPE places AS ENUM ('us', 'eu');
+
+statement error partitioning by enum values is not supported
+CREATE TABLE partitioned_table (
+    place places, id INT8,
+    PRIMARY KEY (place, id)
+)
+    PARTITION BY LIST (place)
+        (
+            PARTITION us VALUES IN ('us'),
+            PARTITION eu VALUES IN ('eu')
+        );
+
+statement ok
+SELECT * FROM crdb_internal.tables
+
+statement ok
+CREATE TABLE partitioned_table (
+    place places, id INT8,
+    PRIMARY KEY (place, id)
+);
+
+statement error partitioning by enum values is not supported
+ALTER TABLE partitioned_table PARTITION BY LIST (place)
+        (
+            PARTITION us VALUES IN ('us'),
+            PARTITION eu VALUES IN ('eu')
+        );
+

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -97,6 +97,17 @@ func valueEncodePartitionTuple(
 		}
 
 		var semaCtx tree.SemaContext
+
+		// Disallow partitioning by user-defined types because it causes issues
+		// during table descriptor validation.
+		//
+		// TODO(ajwerner): Fix this limitation by reworking validation in the
+		// descs.Collection to operate on hydrated descriptors.
+		if cols[i].Type.UserDefined() {
+			return nil, errors.UnimplementedError(errors.IssueLink{
+				IssueURL: "https://github.com/cockroachdb/cockroach/issues/55342",
+			}, "partitioning by enum values is not supported")
+		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].Type, "partition",
 			&semaCtx,
 			tree.VolatilityImmutable,


### PR DESCRIPTION
Backport 1/1 commits from #55347.

/cc @cockroachdb/release

---

Fixes #55340

Release note (bug fix): Return an appropriate error when attempting to
partition by an enum column rather than crashing.
