### PR TITLE
release-20.2: rowexec: account for some allocations due to hashing of datums

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -11,6 +11,7 @@
 package coldataext
 
 import (
+	"context"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -82,7 +83,9 @@ func (d *Datum) Cast(dVec interface{}, toType *types.T) (tree.Datum, error) {
 // Hash returns the hash of the datum as a byte slice.
 func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	ed := rowenc.EncDatum{Datum: maybeUnwrapDatum(d)}
-	b, err := ed.Fingerprint(d.ResolvedType(), da, nil /* appendTo */)
+	// We know that we have tree.Datum, so there will definitely be no need to
+	// decode ed for fingerprinting, so we pass in nil memory account.
+	b, err := ed.Fingerprint(context.TODO(), d.ResolvedType(), da, nil /* appendTo */, nil /* acc */)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -358,8 +358,11 @@ func (b *distinctAggregatorHelperBase) selectDistinctTuples(
 			// encoding and return it without updating the EncDatum; therefore,
 			// simply setting Datum field to the argument is sufficient.
 			b.scratch.ed.Datum = b.aggColsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
+			// We know that we have tree.Datum, so there will definitely be no
+			// need to decode b.scratch.ed for fingerprinting, so we pass in
+			// nil memory account.
 			b.scratch.encoded, err = b.scratch.ed.Fingerprint(
-				b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded,
+				ctx, b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded, nil, /* acc */
 			)
 			if err != nil {
 				colexecerror.InternalError(err)

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -828,6 +828,26 @@ func (ag *aggregatorBase) accumulateRowIntoBucket(
 	return nil
 }
 
+// encode returns the encoding for the grouping columns, this is then used as
+// our group key to determine which bucket to add to.
+func (ag *hashAggregator) encode(
+	appendTo []byte, row rowenc.EncDatumRow,
+) (encoding []byte, err error) {
+	for _, colIdx := range ag.groupCols {
+		// We might allocate tree.Datums when hashing the row, so we'll ask the
+		// fingerprint to account for them. Note that if the datums are later
+		// used by the aggregate functions (and accounted for accordingly),
+		// this can lead to over-accounting which is acceptable.
+		appendTo, err = row[colIdx].Fingerprint(
+			ag.Ctx, ag.inputTypes[colIdx], &ag.datumAlloc, appendTo, &ag.bucketsAcc,
+		)
+		if err != nil {
+			return appendTo, err
+		}
+	}
+	return appendTo, nil
+}
+
 // accumulateRow accumulates a single row, returning an error if accumulation
 // failed for any reason.
 func (ag *hashAggregator) accumulateRow(row rowenc.EncDatumRow) error {
@@ -925,14 +945,16 @@ func (a *aggregateFuncHolder) isDistinct(
 ) (bool, error) {
 	// Allocate one EncDatum that will be reused when encoding every argument.
 	ed := rowenc.EncDatum{Datum: firstArg}
-	encoded, err := ed.Fingerprint(firstArg.ResolvedType(), alloc, prefix)
+	// We know that we have tree.Datum, so there will definitely be no need to
+	// decode ed for fingerprinting, so we pass in nil memory account.
+	encoded, err := ed.Fingerprint(ctx, firstArg.ResolvedType(), alloc, prefix, nil /* acc */)
 	if err != nil {
 		return false, err
 	}
 	if otherArgs != nil {
 		for _, arg := range otherArgs {
 			ed.Datum = arg
-			encoded, err = ed.Fingerprint(arg.ResolvedType(), alloc, encoded)
+			encoded, err = ed.Fingerprint(ctx, arg.ResolvedType(), alloc, encoded, nil /* acc */)
 			if err != nil {
 				return false, err
 			}
@@ -950,21 +972,6 @@ func (a *aggregateFuncHolder) isDistinct(
 	}
 	a.seen[s] = struct{}{}
 	return true, nil
-}
-
-// encode returns the encoding for the grouping columns, this is then used as
-// our group key to determine which bucket to add to.
-func (ag *aggregatorBase) encode(
-	appendTo []byte, row rowenc.EncDatumRow,
-) (encoding []byte, err error) {
-	for _, colIdx := range ag.groupCols {
-		appendTo, err = row[colIdx].Fingerprint(
-			ag.inputTypes[colIdx], &ag.datumAlloc, appendTo)
-		if err != nil {
-			return appendTo, err
-		}
-	}
-	return appendTo, nil
 }
 
 func (ag *aggregatorBase) createAggregateFuncs() (aggregateFuncs, error) {

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -204,7 +204,12 @@ func (d *distinct) encode(appendTo []byte, row rowenc.EncDatumRow) ([]byte, erro
 			continue
 		}
 
-		appendTo, err = datum.Fingerprint(d.types[i], &d.datumAlloc, appendTo)
+		// We might allocate tree.Datums when hashing the row, so we'll ask the
+		// fingerprint to account for them. Note that even though we're losing
+		// the references to the row (and to the newly allocated datums)
+		// shortly, it'll likely take some time before GC reclaims that memory,
+		// so we choose the over-accounting route to be safe.
+		appendTo, err = datum.Fingerprint(d.Ctx, d.types[i], &d.datumAlloc, appendTo, &d.memAcc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -617,7 +617,9 @@ func (hr *hashRouter) computeDestination(row rowenc.EncDatumRow) (int, error) {
 			return -1, err
 		}
 		var err error
-		hr.buffer, err = row[col].Fingerprint(hr.types[col], &hr.alloc, hr.buffer)
+		// We choose to not perform the memory accounting for possibly decoded
+		// tree.Datum because we will lose the references to row very soon.
+		hr.buffer, err = row[col].Fingerprint(context.TODO(), hr.types[col], &hr.alloc, hr.buffer, nil /* acc */)
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "rowexec: account for some allocations due to hashing of datums" (#54770)
  * 1/1 commits from "rowexec: remove recently added memory accounting in sampler" (#55199)

Please see individual PRs for details.

/cc @cockroachdb/release

Addresses: #54360.