### PR TITLE
delegate: change SHOW ENUMS to have array for values column

### DIFF
--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -22,7 +22,7 @@ func (d *delegator) delegateShowEnums() (tree.Statement, error) {
 WITH enums(enumtypid, values) AS (
 	SELECT
 		enums.enumtypid AS enumtypid,
-		string_agg(enums.enumlabel, '|') WITHIN GROUP (ORDER BY (enumsortorder)) AS values
+		array_agg(enums.enumlabel) WITHIN GROUP (ORDER BY (enumsortorder)) AS values
 	FROM pg_catalog.pg_enum AS enums
 	GROUP BY enumtypid
 )

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1124,18 +1124,18 @@ ROLLBACK
 query TTTT colnames
 SHOW ENUMS
 ----
-schema  name        values                            owner
-public  _collision  NULL                              root
-public  as_bytes    bytes                             root
-public  collision   NULL                              root
-public  dbs         postgres|mysql|spanner|cockroach  root
-public  empty       NULL                              root
-public  farewell    bye|seeya                         root
-public  greeting    hello|howdy|hi                    root
-public  greeting2   hello                             root
-public  int         Z|S of int                        root
-public  notbad      dup|DUP                           root
-public  t           NULL                              root
+schema  name        values                              owner
+public  _collision  NULL                                root
+public  as_bytes    {bytes}                             root
+public  collision   NULL                                root
+public  dbs         {postgres,mysql,spanner,cockroach}  root
+public  empty       NULL                                root
+public  farewell    {bye,seeya}                         root
+public  greeting    {hello,howdy,hi}                    root
+public  greeting2   {hello}                             root
+public  int         {Z,"S of int"}                      root
+public  notbad      {dup,DUP}                           root
+public  t           NULL                                root
 
 query TTT colnames
 SHOW TYPES
@@ -1160,19 +1160,19 @@ CREATE TYPE uds.typ AS ENUM ('schema')
 query TTTT colnames
 SHOW ENUMS
 ----
-schema  name        values                            owner
-public  _collision  NULL                              root
-public  as_bytes    bytes                             root
-public  collision   NULL                              root
-public  dbs         postgres|mysql|spanner|cockroach  root
-public  empty       NULL                              root
-public  farewell    bye|seeya                         root
-public  greeting    hello|howdy|hi                    root
-public  greeting2   hello                             root
-public  int         Z|S of int                        root
-public  notbad      dup|DUP                           root
-public  t           NULL                              root
-uds     typ         schema                            root
+schema  name        values                              owner
+public  _collision  NULL                                root
+public  as_bytes    {bytes}                             root
+public  collision   NULL                                root
+public  dbs         {postgres,mysql,spanner,cockroach}  root
+public  empty       NULL                                root
+public  farewell    {bye,seeya}                         root
+public  greeting    {hello,howdy,hi}                    root
+public  greeting2   {hello}                             root
+public  int         {Z,"S of int"}                      root
+public  notbad      {dup,DUP}                           root
+public  t           NULL                                root
+uds     typ         {schema}                            root
 
 statement error pq: cannot create "fakedb.typ" because the target database or schema does not exist
 CREATE TYPE fakedb.typ AS ENUM ('schema')


### PR DESCRIPTION
This displays better and does not conflict with having `|` characters in
ENUM names.

Release note (sql change): SHOW ENUMS now returns an array aggregation
of enum values instead of having them separated by the `|` character.