### PR TITLE
vendor: bump Pebble to b79d619f4761

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7
+	github.com/cockroachdb/pebble v0.0.0-20201007144542-b79d619f4761
 	github.com/cockroachdb/redact v1.0.7
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7 h1:iSWWcgAfvbEVlCWXx3NHvw4oPh3zshjqOwT9DHiuAXE=
-github.com/cockroachdb/pebble v0.0.0-20200924231108-71cdee7c3cc7/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20201007144542-b79d619f4761 h1:kzwW9T8+7A1/xuIZi2QCzzmnsS8Ws8zgl6lPXBod5EA=
+github.com/cockroachdb/pebble v0.0.0-20201007144542-b79d619f4761/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=


### PR DESCRIPTION
```
b79d619f sstable: skip readahead ramp-up for compactions
ab86f22f db: fix L0->LBase input expansion
879f3bfe db: changes to make iterators respect the bounds specified by the caller
91e8175b db: fix L0->LBase compaction picking bug with shared largest user keys
4e0eb739 db: fix WAL checksum error handling from previous versions
a69a94e1 db: optimize levelIter for repeated seeks with narrow and monotonic bounds
d670ff50 metamorphic: enhance iterSetBounds and position iter when setting bounds
b5c5df03 *: Add a simple test for forced compactions
```

Fix #55361.
Fix #54729.

Release note: None