### PR TITLE
release-20.2: docker: Add hostname to the docker image

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -6,7 +6,9 @@ FROM registry.access.redhat.com/ubi8/ubi
 # ca-certificates - to authenticate TLS connections for telemetry and
 #                   bulk-io with S3/GCS/Azure
 # tzdata - for time zone functions
-RUN yum update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos -y && rm -rf /var/cache/yum
+RUN yum update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos -y && \
+    yum install --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos hostname -y && \
+    rm -rf /var/cache/yum
 
 # Install GEOS libraries.
 RUN mkdir /usr/local/lib/cockroach


### PR DESCRIPTION
Backport 1/1 commits from #55383.

/cc @cockroachdb/release

---

Before: `hostname` was not installed on the image.

Why: The `hostname` command is used by our publicly available k8s
manifests.

Now: The `hostname` command is installed in the standard base image.

Release note (bug fix): Add the `hostname` command to the docker image so the
image can be used with our helm chart and cockroach-operator.
