### PR TITLE
release-20.2: opt: do not mutate GenerateConstrainedScans input filters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1280,3 +1280,21 @@ CREATE TABLE public.indexes_article (
 
 statement ok
 CREATE INDEX "recent_article_idx" ON "indexes_article" ("pub_date") WHERE "pub_date" IS NOT NULL
+
+# Regression test for #55387. The optimizer should not incorrectly remove
+# filters from an expression while proving partial index implication.
+subtest regression_55387
+
+statement ok
+CREATE TABLE t55387 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX (a) WHERE a > 1,
+  INDEX (b) WHERE b > 2
+);
+INSERT INTO t55387 VALUES (1, 1, 5);
+
+query I rowsort
+SELECT k FROM t55387 WHERE a > 1 AND b > 3
+----

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -233,8 +233,8 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~12KB, required=[presentation: i:1,f:2,s:3,b:4])
- ├── G1: (select G2 G3) (index-join G4 p,cols=(1-4)) (index-join G5 p,cols=(1-4)) (index-join G6 p,cols=(1-4))
+memo (optimized, ~13KB, required=[presentation: i:1,f:2,s:3,b:4])
+ ├── G1: (select G2 G3) (index-join G4 p,cols=(1-4)) (index-join G5 p,cols=(1-4)) (index-join G6 p,cols=(1-4)) (index-join G7 p,cols=(1-4))
  │    └── [presentation: i:1,f:2,s:3,b:4]
  │         ├── best: (index-join G4 p,cols=(1-4))
  │         └── cost: 30.05
@@ -242,35 +242,39 @@ memo (optimized, ~12KB, required=[presentation: i:1,f:2,s:3,b:4])
  │    └── []
  │         ├── best: (scan p,cols=(1-4))
  │         └── cost: 1094.02
- ├── G3: (filters G7 G8)
- ├── G4: (select G9 G10)
+ ├── G3: (filters G8 G9)
+ ├── G4: (select G10 G11)
  │    └── []
- │         ├── best: (select G9 G10)
+ │         ├── best: (select G10 G11)
  │         └── cost: 14.93
- ├── G5: (select G11 G12)
+ ├── G5: (select G12 G13)
  │    └── []
- │         ├── best: (select G11 G12)
+ │         ├── best: (select G12 G13)
  │         └── cost: 354.03
  ├── G6: (scan p@idx,partial,cols=(1-3,5),constrained)
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(1-3,5),constrained)
  │         └── cost: 14.09
- ├── G7: (gt G13 G14)
- ├── G8: (eq G15 G16)
- ├── G9: (scan p@idx,partial,cols=(1-3,5))
+ ├── G7: (scan p@idx2,partial,cols=(3,5),constrained)
+ │    └── []
+ │         ├── best: (scan p@idx2,partial,cols=(3,5),constrained)
+ │         └── cost: 13.72
+ ├── G8: (gt G14 G15)
+ ├── G9: (eq G16 G17)
+ ├── G10: (scan p@idx,partial,cols=(1-3,5))
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(1-3,5))
  │         └── cost: 14.81
- ├── G10: (filters G7)
- ├── G11: (scan p@idx2,partial,cols=(3,5))
+ ├── G11: (filters G8)
+ ├── G12: (scan p@idx2,partial,cols=(3,5))
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(3,5))
  │         └── cost: 350.68
- ├── G12: (filters G8)
- ├── G13: (variable i)
- ├── G14: (const 0)
- ├── G15: (variable s)
- └── G16: (const 'foo')
+ ├── G13: (filters G9)
+ ├── G14: (variable i)
+ ├── G15: (const 0)
+ ├── G16: (variable s)
+ └── G17: (const 'foo')
 
 # Do not generate a partial index scan when the predicate is not implied by the
 # filter.
@@ -1195,6 +1199,46 @@ memo (optimized, ~7KB, required=[presentation: i:1])
 exec-ddl
 DROP INDEX idx
 ----
+
+# Regression test for #55387. GenerateConstrainedScans should not reduce the
+# input filters when proving partial index implication.
+
+exec-ddl
+CREATE TABLE t55387 (
+    k INT PRIMARY KEY,
+    a INT,
+    b INT,
+    INDEX (a) WHERE a > 1,
+    INDEX (b) WHERE b > 2
+)
+----
+
+opt
+SELECT k FROM t55387 WHERE a > 1 AND b > 3
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── index-join t55387
+      │    ├── columns: k:1!null a:2 b:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── select
+      │         ├── columns: k:1!null b:3!null
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(3)
+      │         ├── scan t55387@secondary,partial
+      │         │    ├── columns: k:1!null b:3!null
+      │         │    ├── key: (1)
+      │         │    └── fd: (1)-->(3)
+      │         └── filters
+      │              └── b:3 > 3 [outer=(3), constraints=(/3: [/4 - ]; tight)]
+      └── filters
+           └── a:2 > 1 [outer=(2), constraints=(/2: [/2 - ]; tight)]
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans


### PR DESCRIPTION
Backport 1/1 commits from #55391.

/cc @cockroachdb/release

---

This commit fixes a bug in GenerateConstrainedScans which can cause
incorrect query results in tables with a partial index. Filters reduced
while proving implication of a partial index would mutate the input
filters. These filters would remain mutated for future iterations over
other indexes, causing constrained scans to be created without these
necessary filters.

Fixes #55387

Release justification: This fixes a critical correctness bug for a new
feature, partial indexes.

Release note (bug fix): A bug was fixed that caused incorrect query
results on tables with partial indexes. This bug did not affect any
queries involving tables without partial indexes.
