### PR TITLE
opttester: change expect and expect-not behavior for exploration rules

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -643,13 +643,16 @@ inner-join-apply
       └── a = column1
 
 opt expect=ReorderJoins format=hide-all
-SELECT *
-FROM abc
-LEFT JOIN stu
-ON a = s
+SELECT * FROM abc
+LEFT JOIN stu ON a = s
+LEFT JOIN small ON a = m
 ----
 left-join (merge)
- ├── scan abc@ab
+ ├── left-join (merge)
+ │    ├── scan abc@ab
+ │    ├── sort
+ │    │    └── scan small
+ │    └── filters (true)
  ├── scan stu
  └── filters (true)
 
@@ -3214,7 +3217,7 @@ project
 
 # We should not generate a lookup semi-join when the index does not cover "s"
 # which is referenced in the remaining filter.
-opt expect=GenerateLookupJoinsWithFilter
+opt expect-not=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
 ----
 project
@@ -3253,7 +3256,7 @@ project
 
 # We should not generate a lookup anti-join when the index does not cover "s"
 # which is referenced in the remaining filter.
-opt expect=GenerateLookupJoinsWithFilter
+opt expect-not=GenerateLookupJoinsWithFilter
 SELECT m FROM small WHERE NOT EXISTS (SELECT 1 FROM partial_tab WHERE s = 'foo' AND n = i)
 ----
 project
@@ -3819,7 +3822,7 @@ project
 
 # It's not possible to generate an inverted join when there is an OR with a
 # non-geospatial function.
-opt expect=GenerateInvertedJoins
+opt expect-not=GenerateInvertedJoins
 SELECT
   n.name, c.boroname
 FROM nyc_census_blocks AS c


### PR DESCRIPTION
A number of exploration rules may pattern match expressions in the memo,
but never generate new expressions. For example,
`GenerateConstrainedScans` will match any `(Select (Scan))` expression
when the Scan is canonical, but will only generate new expressions when
there is a index that can be constrained by the Select filters.

The current behavior of the `expect` opttester flag does not allow tests
to assert that such an exploration rule actually generates a new
expression, only that it was matched. For rules like
`GenerateConstrainedScans` this level of assertion is not very useful.

Opt tests will now fail when an exploration rule specified in the
`expect` flag does not generate new expressions. Tests will also fail
when an exploration rule specified in the `expect-not` flag generates
new expressions.

Release note: None
