### PR TITLE
sql: remove unused fields from groupNode and joinNode

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1342,7 +1342,7 @@ func (dsp *DistSQLPlanner) addAggregators(
 			return err
 		}
 		aggregations[i].Func = execinfrapb.AggregatorSpec_Func(funcIdx)
-		aggregations[i].Distinct = fholder.isDistinct()
+		aggregations[i].Distinct = fholder.isDistinct
 		for _, renderIdx := range fholder.argRenderIdxs {
 			aggregations[i].ColIdx = append(aggregations[i].ColIdx, uint32(p.PlanToStreamColMap[renderIdx]))
 		}
@@ -2393,7 +2393,7 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		leftPlanToStreamColMap:  leftMap,
 		rightPlanToStreamColMap: rightMap,
 	}
-	post, joinToStreamColMap := helper.joinOutColumns(n.joinType, n.columns)
+	post, joinToStreamColMap := helper.joinOutColumns(n.pred.joinType, n.columns)
 	onExpr, err := helper.remapOnExpr(planCtx, n.pred.onCond)
 	if err != nil {
 		return nil, err
@@ -2415,7 +2415,7 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 	return dsp.planJoiners(&joinPlanningInfo{
 		leftPlan:           leftPlan,
 		rightPlan:          rightPlan,
-		joinType:           n.joinType,
+		joinType:           n.pred.joinType,
 		joinResultTypes:    joinResultTypes,
 		onExpr:             onExpr,
 		post:               post,

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // A groupNode implements the planNode interface and handles the grouping logic.
@@ -38,7 +37,7 @@ type groupNode struct {
 	// even if there are no input rows, e.g. SELECT MIN(x) FROM t.
 	isScalar bool
 
-	// funcs are the aggregation functions that the renders use.
+	// funcs contains the information about all aggregate functions.
 	funcs []*aggregateFuncHolder
 
 	reqOrdering ReqOrdering
@@ -58,16 +57,11 @@ func (n *groupNode) Values() tree.Datums {
 
 func (n *groupNode) Close(ctx context.Context) {
 	n.plan.Close(ctx)
-	for _, f := range n.funcs {
-		f.close(ctx)
-	}
 }
 
 type aggregateFuncHolder struct {
-	// Name of the aggregate function. Empty if this column reproduces a bucket
-	// key unchanged.
+	// Name of the aggregate function.
 	funcName string
-
 	// The argument of the function is a single value produced by the renderNode
 	// underneath. If the function has no argument (COUNT_ROWS), it is empty.
 	argRenderIdxs []int
@@ -75,20 +69,11 @@ type aggregateFuncHolder struct {
 	// renderNode underneath. If there is no filter, it is set to
 	// tree.NoColumnIdx.
 	filterRenderIdx int
-
 	// arguments are constant expressions that can be optionally passed into an
 	// aggregator.
 	arguments tree.Datums
-
-	run aggregateFuncRun
-}
-
-// aggregateFuncRun contains the run-time state for one aggregation function
-// during local execution.
-type aggregateFuncRun struct {
-	buckets       map[string]tree.AggregateFunc
-	bucketsMemAcc mon.BoundAccount
-	seen          map[string]struct{}
+	// isDistinct indicates whether only distinct values are aggregated.
+	isDistinct bool
 }
 
 // newAggregateFuncHolder creates an aggregateFuncHolder.
@@ -98,44 +83,19 @@ type aggregateFuncRun struct {
 //
 // If the aggregation function takes no arguments (e.g. COUNT_ROWS),
 // argRenderIdx is noRenderIdx.
-func (n *groupNode) newAggregateFuncHolder(
-	funcName string, argRenderIdxs []int, arguments tree.Datums, acc mon.BoundAccount,
+func newAggregateFuncHolder(
+	funcName string, argRenderIdxs []int, arguments tree.Datums, isDistinct bool,
 ) *aggregateFuncHolder {
 	res := &aggregateFuncHolder{
 		funcName:        funcName,
 		argRenderIdxs:   argRenderIdxs,
 		filterRenderIdx: tree.NoColumnIdx,
 		arguments:       arguments,
-		run: aggregateFuncRun{
-			buckets:       make(map[string]tree.AggregateFunc),
-			bucketsMemAcc: acc,
-		},
+		isDistinct:      isDistinct,
 	}
 	return res
 }
 
 func (a *aggregateFuncHolder) hasFilter() bool {
 	return a.filterRenderIdx != tree.NoColumnIdx
-}
-
-// setDistinct causes a to ignore duplicate values of the argument.
-func (a *aggregateFuncHolder) setDistinct() {
-	a.run.seen = make(map[string]struct{})
-}
-
-// isDistinct returns true if only distinct values are aggregated,
-// e.g. SUM(DISTINCT x).
-func (a *aggregateFuncHolder) isDistinct() bool {
-	return a.run.seen != nil
-}
-
-func (a *aggregateFuncHolder) close(ctx context.Context) {
-	for _, aggFunc := range a.run.buckets {
-		aggFunc.Close(ctx)
-	}
-
-	a.run.buckets = nil
-	a.run.seen = nil
-
-	a.run.bucketsMemAcc.Close(ctx)
 }

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -14,15 +14,11 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// joinNode is a planNode whose rows are the result of an inner or
-// left/right outer join.
+// joinNode is a planNode whose rows are the result of a join operation.
 type joinNode struct {
-	joinType descpb.JoinType
-
 	// The data sources.
 	left  planDataSource
 	right planDataSource
@@ -46,11 +42,10 @@ func (p *planner) makeJoinNode(
 	left planDataSource, right planDataSource, pred *joinPredicate,
 ) *joinNode {
 	n := &joinNode{
-		left:     left,
-		right:    right,
-		joinType: pred.joinType,
-		pred:     pred,
-		columns:  pred.cols,
+		left:    left,
+		right:   right,
+		pred:    pred,
+		columns: pred.cols,
 	}
 	return n
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -439,11 +439,11 @@ func (ef *execFactory) ConstructGroupBy(
 	}
 	for _, col := range n.groupCols {
 		// TODO(radu): only generate the grouping columns we actually need.
-		f := n.newAggregateFuncHolder(
+		f := newAggregateFuncHolder(
 			builtins.AnyNotNull,
 			[]int{col},
-			nil, /* arguments */
-			ef.planner.EvalContext().Mon.MakeBoundAccount(),
+			nil,   /* arguments */
+			false, /* isDistinct */
 		)
 		n.funcs = append(n.funcs, f)
 	}
@@ -458,15 +458,12 @@ func (ef *execFactory) addAggregations(n *groupNode, aggregations []exec.AggInfo
 		agg := &aggregations[i]
 		renderIdxs := convertOrdinalsToInts(agg.ArgCols)
 
-		f := n.newAggregateFuncHolder(
+		f := newAggregateFuncHolder(
 			agg.FuncName,
 			renderIdxs,
 			agg.ConstArgs,
-			ef.planner.EvalContext().Mon.MakeBoundAccount(),
+			agg.Distinct,
 		)
-		if agg.Distinct {
-			f.setDistinct()
-		}
 		f.filterRenderIdx = int(agg.Filter)
 
 		n.funcs = append(n.funcs, f)


### PR DESCRIPTION
This commit removes some of the leftover no-longer-used stuff from
`groupNode` and a redundant field from `joinNode`.

Release note: None