### PR TITLE
lint: force developers to think about the usage of evalCtx.Mon

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -112,7 +112,7 @@ func newChangeAggregatorProcessor(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changeagg-mem") //nolint:monitor
+	memMonitor := flowCtx.EvalCtx.NewMonitor(ctx, "changeagg-mem", 0 /* limit */)
 	ca := &changeAggregator{
 		flowCtx: flowCtx,
 		spec:    spec,
@@ -480,7 +480,7 @@ func newChangeFrontierProcessor(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem") //nolint:monitor
+	memMonitor := flowCtx.EvalCtx.NewMonitor(ctx, "changefntr-mem", 0 /* limit */)
 	cf := &changeFrontier{
 		flowCtx: flowCtx,
 		spec:    spec,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -112,7 +112,7 @@ func newChangeAggregatorProcessor(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changeagg-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changeagg-mem") //nolint:monitor
 	ca := &changeAggregator{
 		flowCtx: flowCtx,
 		spec:    spec,
@@ -480,7 +480,7 @@ func newChangeFrontierProcessor(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem") //nolint:monitor
 	cf := &changeFrontier{
 		flowCtx: flowCtx,
 		spec:    spec,

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -109,7 +109,10 @@ func (a *applyJoinNode) startExec(params runParams) error {
 	}
 	a.run.out = make(tree.Datums, len(a.columns))
 	ci := colinfo.ColTypeInfoFromResCols(a.rightCols)
-	acc := params.EvalContext().Mon.MakeBoundAccount()
+	// TODO(yuzefovich): at the moment, this memory account is only limited by
+	// the total SQL memory budget, we probably should change that and use a
+	// disk-backed container as well.
+	acc := params.EvalContext().Mon.MakeBoundAccount() //nolint:monitor
 	a.run.rightRows = rowcontainer.NewRowContainer(acc, ci)
 	return nil
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1906,8 +1906,8 @@ func columnBackfillInTxn(
 	}
 	var columnBackfillerMon *mon.BytesMonitor
 	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil {
-		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-column-backfill-mon")
+	if evalCtx.Mon != nil { //nolint:monitor
+		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-column-backfill-mon") //nolint:monitor
 	}
 
 	var backfiller backfill.ColumnBackfiller
@@ -1944,8 +1944,8 @@ func indexBackfillInTxn(
 ) error {
 	var indexBackfillerMon *mon.BytesMonitor
 	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil {
-		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-index-backfill-mon")
+	if evalCtx.Mon != nil { //nolint:monitor
+		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-index-backfill-mon") //nolint:monitor
 	}
 
 	var backfiller backfill.IndexBackfiller

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1906,8 +1905,8 @@ func columnBackfillInTxn(
 	}
 	var columnBackfillerMon *mon.BytesMonitor
 	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil { //nolint:monitor
-		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-column-backfill-mon") //nolint:monitor
+	if evalCtx.HasMonitor() {
+		columnBackfillerMon = evalCtx.NewMonitor(ctx, "local-column-backfill-mon", 0 /* limit */)
 	}
 
 	var backfiller backfill.ColumnBackfiller
@@ -1944,8 +1943,8 @@ func indexBackfillInTxn(
 ) error {
 	var indexBackfillerMon *mon.BytesMonitor
 	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil { //nolint:monitor
-		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-index-backfill-mon") //nolint:monitor
+	if evalCtx.HasMonitor() {
+		indexBackfillerMon = evalCtx.NewMonitor(ctx, "local-index-backfill-mon", 0 /* limit */)
 	}
 
 	var backfiller backfill.IndexBackfiller

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -36,7 +36,7 @@ type bufferNode struct {
 
 func (n *bufferNode) startExec(params runParams) error {
 	n.bufferedRows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(getPlanColumns(n.plan, false /* mut */)),
 	)
 	return nil

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -957,7 +957,7 @@ func benchmarkAggregateFunction(
 	ctx := context.Background()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	aggMemAcc := evalCtx.Mon.MakeBoundAccount()
+	aggMemAcc := evalCtx.mon.MakeBoundAccount()
 	defer aggMemAcc.Close(ctx)
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	const bytesFixedLength = 8

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1243,9 +1243,7 @@ func (r *postProcessResult) planPostProcessSpec(
 func (r opResult) createBufferingUnlimitedMemMonitor(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BytesMonitor {
-	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
-		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited", //nolint:monitor
-	)
+	bufferingOpUnlimitedMemMonitor := flowCtx.EvalCtx.NewMonitor(ctx, name+"-unlimited", 0 /* limit */)
 	r.OpMonitors = append(r.OpMonitors, bufferingOpUnlimitedMemMonitor)
 	return bufferingOpUnlimitedMemMonitor
 }
@@ -1257,9 +1255,7 @@ func (r opResult) createBufferingUnlimitedMemMonitor(
 func (r opResult) createMemAccountForSpillStrategy(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BoundAccount {
-	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
-		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name+"-limited", //nolint:monitor
-	)
+	bufferingOpMemMonitor := flowCtx.EvalCtx.NewMonitor(ctx, name+"-limited", execinfra.GetWorkMemLimit(flowCtx.Cfg))
 	r.OpMonitors = append(r.OpMonitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
 	r.OpAccounts = append(r.OpAccounts, &bufferingMemAccount)

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1244,7 +1244,7 @@ func (r opResult) createBufferingUnlimitedMemMonitor(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BytesMonitor {
 	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
-		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited", //nolint:monitor
 	)
 	r.OpMonitors = append(r.OpMonitors, bufferingOpUnlimitedMemMonitor)
 	return bufferingOpUnlimitedMemMonitor
@@ -1258,7 +1258,7 @@ func (r opResult) createMemAccountForSpillStrategy(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BoundAccount {
 	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
-		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name+"-limited",
+		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name+"-limited", //nolint:monitor
 	)
 	r.OpMonitors = append(r.OpMonitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -130,7 +130,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	aggMemAcc := evalCtx.Mon.MakeBoundAccount()
+	aggMemAcc := evalCtx.mon.MakeBoundAccount()
 	defer aggMemAcc.Close(context.Background())
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	semaCtx := tree.MakeSemaContext()

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -529,7 +529,7 @@ func (s *vectorizedFlowCreator) createBufferingUnlimitedMemMonitor(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BytesMonitor {
 	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
-		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited", //nolint:monitor
 	)
 	s.monitors = append(s.monitors, bufferingOpUnlimitedMemMonitor)
 	return bufferingOpUnlimitedMemMonitor
@@ -558,7 +558,7 @@ func (s *vectorizedFlowCreator) createDiskAccounts(
 func (s *vectorizedFlowCreator) newStreamingMemAccount(
 	flowCtx *execinfra.FlowCtx,
 ) *mon.BoundAccount {
-	streamingMemAccount := flowCtx.EvalCtx.Mon.MakeBoundAccount()
+	streamingMemAccount := flowCtx.EvalCtx.Mon.MakeBoundAccount() //nolint:monitor
 	s.streamingMemAccounts = append(s.streamingMemAccounts, &streamingMemAccount)
 	return &streamingMemAccount
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2168,7 +2168,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.IVarContainer = nil
 	evalCtx.Context = ex.Ctx()
 	evalCtx.Txn = txn
-	evalCtx.Mon = ex.state.mon
+	evalCtx.Mon = ex.state.mon //nolint:monitor
 	evalCtx.PrepareOnly = false
 	evalCtx.SkipNormalize = false
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2168,7 +2168,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.IVarContainer = nil
 	evalCtx.Context = ex.Ctx()
 	evalCtx.Txn = txn
-	evalCtx.Mon = ex.state.mon //nolint:monitor
+	evalCtx.SetMonitor(ex.state.mon)
 	evalCtx.PrepareOnly = false
 	evalCtx.SkipNormalize = false
 }

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -149,8 +149,8 @@ func newCopyMachine(
 			PGAttributeNum: cols[i].GetPGAttributeNum(),
 		}
 	}
-	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
-	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
+	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount() //nolint:monitor
+	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()  //nolint:monitor
 	c.processRows = c.insertRows
 	return c, nil
 }

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -152,8 +152,8 @@ func newFileUploadMachine(
 	c.resultColumns = make(colinfo.ResultColumns, 1)
 	c.resultColumns[0] = colinfo.ResultColumn{Typ: types.Bytes}
 	c.parsingEvalCtx = c.p.EvalContext()
-	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
-	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
+	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount() //nolint:monitor
+	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()  //nolint:monitor
 	c.processRows = f.writeFile
 	c.forceNotNull = true
 	return

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -152,8 +152,9 @@ func newFileUploadMachine(
 	c.resultColumns = make(colinfo.ResultColumns, 1)
 	c.resultColumns[0] = colinfo.ResultColumn{Typ: types.Bytes}
 	c.parsingEvalCtx = c.p.EvalContext()
-	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount() //nolint:monitor
-	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()  //nolint:monitor
+	c.memMonitor = c.p.extendedEvalCtx.NewMonitor(ctx, "copy-file-upload-mem", 0 /* limit */)
+	c.rowsMemAcc = c.memMonitor.MakeBoundAccount()
+	c.bufMemAcc = c.memMonitor.MakeBoundAccount()
 	c.processRows = f.writeFile
 	c.forceNotNull = true
 	return

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -582,14 +582,14 @@ CREATE TABLE crdb_internal.jobs (
 		}
 
 		// Attempt to account for the memory of the retrieved rows and the data
-		// we're going to unmarshal and keep bufferred in RAM.
+		// we're going to unmarshal and keep buffered in RAM.
 		//
 		// TODO(ajwerner): This is a pretty terrible hack. Instead the internal
 		// executor should be hooked into the memory monitor associated with this
 		// conn executor. If we did that we would still want to account for the
-		// unmarshaling. Additionally, it's probably a good idea to paginate this
+		// unmarshalling. Additionally, it's probably a good idea to paginate this
 		// and other virtual table queries but that's a bigger task.
-		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount()
+		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount() //nolint:monitor
 		defer ba.Close(ctx)
 		var totalMem int64
 		for _, r := range rows {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -589,7 +589,9 @@ CREATE TABLE crdb_internal.jobs (
 		// conn executor. If we did that we would still want to account for the
 		// unmarshalling. Additionally, it's probably a good idea to paginate this
 		// and other virtual table queries but that's a bigger task.
-		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount() //nolint:monitor
+		memMonitor := p.ExtendedEvalContext().NewMonitor(ctx, "crdb-internal-mem", 0 /* limit */)
+		defer memMonitor.Stop(ctx)
+		ba := memMonitor.MakeBoundAccount()
 		defer ba.Close(ctx)
 		var totalMem int64
 		for _, r := range rows {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -495,7 +495,7 @@ func (r *createStatsResumer) Resume(
 	evalCtx := p.ExtendedEvalContext()
 
 	ci := colinfo.ColTypeInfoFromColTypes([]*types.T{})
-	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci)
+	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci) //nolint:monitor
 	defer func() {
 		if rows != nil {
 			rows.Close(ctx)

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -69,7 +69,7 @@ func (d *deleteNode) startExec(params runParams) error {
 
 	if d.run.rowsNeeded {
 		d.run.td.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(),
+			params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 			colinfo.ColTypeInfoFromResCols(d.columns))
 	}
 	return d.run.td.init(params.ctx, params.p.txn, params.EvalContext())

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -68,8 +68,9 @@ func (d *deleteNode) startExec(params runParams) error {
 	d.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
 	if d.run.rowsNeeded {
+		d.run.td.memMonitor = params.EvalContext().NewMonitor(params.ctx, "delete-mem", 0 /* limit */)
 		d.run.td.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
+			d.run.td.memMonitor.MakeBoundAccount(),
 			colinfo.ColTypeInfoFromResCols(d.columns))
 	}
 	return d.run.td.init(params.ctx, params.p.txn, params.EvalContext())

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -122,7 +122,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		return errors.New("processor is unexpectedly not a RowSource")
 	}
 
-	acc := evalCtx.Mon.MakeBoundAccount()
+	acc := evalCtx.mon.MakeBoundAccount()
 	defer acc.Close(ctx)
 	testAllocator := colmem.NewAllocator(ctx, &acc, coldataext.NewExtendedColumnFactory(&evalCtx))
 	columnarizers := make([]colexecbase.Operator, len(args.inputs))

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -252,7 +252,7 @@ func (ds *ServerImpl) setupFlow(
 	var leafTxn *kv.Txn
 	if localState.EvalContext != nil {
 		evalCtx = localState.EvalContext
-		evalCtx.Mon = monitor
+		evalCtx.Mon = monitor //nolint:monitor
 	} else {
 		if localState.IsLocal {
 			return nil, nil, errors.AssertionFailedf(

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -262,7 +262,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	localReq := setupReq
 	localReq.Flow = *flows[thisNodeID]
 	defer physicalplan.ReleaseSetupFlowRequest(&localReq)
-	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState)
+	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState) //nolint:monitor
 	if err != nil {
 		return nil, nil, err
 	}
@@ -861,7 +861,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	subqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	subqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{}) //nolint:monitor
 	defer subqueryMonitor.Stop(ctx)
 
 	subqueryMemAccount := subqueryMonitor.MakeBoundAccount()
@@ -1153,7 +1153,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	postqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	postqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{}) //nolint:monitor
 	defer postqueryMonitor.Stop(ctx)
 
 	postqueryMemAccount := postqueryMonitor.MakeBoundAccount()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -262,7 +262,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	localReq := setupReq
 	localReq.Flow = *flows[thisNodeID]
 	defer physicalplan.ReleaseSetupFlowRequest(&localReq)
-	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState) //nolint:monitor
+	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, &localReq, recv, localState)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -861,7 +861,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	subqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{}) //nolint:monitor
+	evalCtx.StartChildMonitor(ctx, subqueryMonitor)
 	defer subqueryMonitor.Stop(ctx)
 
 	subqueryMemAccount := subqueryMonitor.MakeBoundAccount()
@@ -1153,7 +1153,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	postqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{}) //nolint:monitor
+	evalCtx.StartChildMonitor(ctx, postqueryMonitor)
 	defer postqueryMonitor.Stop(ctx)
 
 	postqueryMemAccount := postqueryMonitor.MakeBoundAccount()

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -918,15 +918,13 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon
 // overridden to 1 if config.TestingKnobs.ForceDiskSpill is set or
 // config.TestingKnobs.MemoryLimitBytes if not.
 func NewLimitedMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, config *ServerConfig, name string,
+	ctx context.Context, evalCtx *tree.EvalContext, config *ServerConfig, name string,
 ) *mon.BytesMonitor {
 	limit := GetWorkMemLimit(config)
 	if config.TestingKnobs.ForceDiskSpill {
 		limit = 1
 	}
-	limitedMon := mon.NewMonitorInheritWithLimit(name, limit, parent)
-	limitedMon.Start(ctx, parent, mon.BoundAccount{})
-	return limitedMon
+	return evalCtx.NewMonitor(ctx, name, limit)
 }
 
 // LocalProcessor is a RowSourcedProcessor that needs to be initialized with

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -87,8 +87,9 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 	if !r.rowsNeeded {
 		return
 	}
+	r.ti.memMonitor = params.EvalContext().NewMonitor(params.ctx, "insert-mem", 0 /* limit */)
 	r.ti.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
+		r.ti.memMonitor.MakeBoundAccount(),
 		colinfo.ColTypeInfoFromResCols(columns),
 	)
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -88,7 +88,7 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 		return
 	}
 	r.ti.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(columns),
 	)
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -374,22 +374,22 @@ func internalExtendedEvalCtx(
 	plannerMon *mon.BytesMonitor,
 ) extendedEvalContext {
 	evalContextTestingKnobs := execCfg.EvalContextTestingKnobs
-
+	evalCtx := tree.EvalContext{
+		Txn:              txn,
+		SessionData:      sd,
+		TxnReadOnly:      false,
+		TxnImplicit:      true,
+		Settings:         execCfg.Settings,
+		Codec:            execCfg.Codec,
+		Context:          ctx,
+		TestingKnobs:     evalContextTestingKnobs,
+		StmtTimestamp:    stmtTimestamp,
+		TxnTimestamp:     txnTimestamp,
+		InternalExecutor: execCfg.InternalExecutor,
+	}
+	evalCtx.SetMonitor(plannerMon)
 	return extendedEvalContext{
-		EvalContext: tree.EvalContext{
-			Txn:              txn,
-			SessionData:      sd,
-			TxnReadOnly:      false,
-			TxnImplicit:      true,
-			Settings:         execCfg.Settings,
-			Codec:            execCfg.Codec,
-			Context:          ctx,
-			Mon:              plannerMon,
-			TestingKnobs:     evalContextTestingKnobs,
-			StmtTimestamp:    stmtTimestamp,
-			TxnTimestamp:     txnTimestamp,
-			InternalExecutor: execCfg.InternalExecutor,
-		},
+		EvalContext:       evalCtx,
 		SessionMutator:    dataMutator,
 		VirtualSchemas:    execCfg.VirtualSchemas,
 		Tracing:           &SessionTracing{},

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -53,7 +53,7 @@ type recursiveCTERun struct {
 
 func (n *recursiveCTENode) startExec(params runParams) error {
 	n.workingRows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
 	)
 	n.nextRowIdx = 0
@@ -102,7 +102,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 	defer lastWorkingRows.Close(params.ctx)
 
 	n.workingRows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
 	)
 

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -189,7 +189,7 @@ func TestDiskRowContainer(t *testing.T) {
 				// Make another row container that stores all the rows then sort
 				// it to compare equality.
 				var sortedRows MemRowContainer
-				sortedRows.Init(ordering, types, &evalCtx)
+				sortedRows.Init(ordering, types, &evalCtx, evalCtx.Mon)
 				defer sortedRows.Close(ctx)
 				for _, row := range rows {
 					if err := sortedRows.AddRow(ctx, row); err != nil {

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -825,7 +825,7 @@ func (h *HashDiskBackedRowContainer) Init(
 	}
 	if h.mrc == nil {
 		h.mrc = &MemRowContainer{}
-		h.mrc.InitWithMon(ordering, types, h.evalCtx, h.memoryMonitor)
+		h.mrc.Init(ordering, types, h.evalCtx, h.memoryMonitor)
 	}
 	hmrc := MakeHashMemRowContainer(h.mrc, h.memoryMonitor)
 	h.hmrc = &hmrc

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -157,17 +157,8 @@ type MemRowContainer struct {
 var _ heap.Interface = &MemRowContainer{}
 var _ IndexedRowContainer = &MemRowContainer{}
 
-// Init initializes the MemRowContainer. The MemRowContainer uses evalCtx.Mon
-// to track memory usage.
+// Init initializes the MemRowContainer.
 func (mc *MemRowContainer) Init(
-	ordering colinfo.ColumnOrdering, types []*types.T, evalCtx *tree.EvalContext,
-) {
-	mc.InitWithMon(ordering, types, evalCtx, evalCtx.Mon)
-}
-
-// InitWithMon initializes the MemRowContainer with an explicit monitor. Only
-// use this if the default MemRowContainer.Init() function is insufficient.
-func (mc *MemRowContainer) InitWithMon(
 	ordering colinfo.ColumnOrdering,
 	types []*types.T,
 	evalCtx *tree.EvalContext,
@@ -413,7 +404,7 @@ func (f *DiskBackedRowContainer) Init(
 	diskMonitor *mon.BytesMonitor,
 ) {
 	mrc := MemRowContainer{}
-	mrc.InitWithMon(ordering, types, evalCtx, memoryMonitor)
+	mrc.Init(ordering, types, evalCtx, memoryMonitor)
 	f.mrc = &mrc
 	f.src = &mrc
 	f.engine = engine

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -100,7 +100,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	defer m.Stop(ctx)
 
 	var mc MemRowContainer
-	mc.InitWithMon(
+	mc.Init(
 		colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}},
 		[]*types.T{types.Int, types.String}, evalCtx, m,
 	)
@@ -142,11 +142,7 @@ func TestRowContainerIterators(t *testing.T) {
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
 	var mc MemRowContainer
-	mc.Init(
-		ordering,
-		rowenc.OneIntCol,
-		evalCtx,
-	)
+	mc.Init(ordering, rowenc.OneIntCol, evalCtx, evalCtx.Mon)
 	defer mc.Close(ctx)
 
 	for _, row := range rows {

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -731,7 +731,7 @@ func TestEncDatumFingerprintMemory(t *testing.T) {
 	ctx := context.Background()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	memAcc := evalCtx.Mon.MakeBoundAccount()
+	memAcc := evalCtx.mon.MakeBoundAccount()
 	defer memAcc.Close(ctx)
 	var da DatumAlloc
 	for _, c := range testCases {

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -95,7 +95,7 @@ func (ag *aggregatorBase) init(
 	trailingMetaCallback func(context.Context) []execinfrapb.ProducerMetadata,
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem") //nolint:monitor
+	memMonitor := flowCtx.EvalCtx.NewMonitor(ctx, "aggregator-mem", 0 /* limit */)
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		input = newInputStatCollector(input)
 		ag.FinishTrace = ag.outputStatsToTrace
@@ -160,7 +160,7 @@ func (ag *aggregatorBase) init(
 	// accounts to be bound to the correct monitor we override it here. Note
 	// that modifying the eval context is acceptable since we have created a
 	// copy in ProcessorBase.Init call above.
-	ag.EvalCtx.Mon = memMonitor //nolint:monitor
+	ag.EvalCtx.SetMonitor(memMonitor)
 	return nil
 }
 

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -99,7 +99,7 @@ func newDistinct(
 	}
 
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem") //nolint:monitor
+	memMonitor := flowCtx.EvalCtx.NewMonitor(ctx, "distinct-mem", 0 /* limit */)
 	d := &distinct{
 		input:            input,
 		memAcc:           memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -99,7 +99,7 @@ func newDistinct(
 	}
 
 	ctx := flowCtx.EvalCtx.Ctx()
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem") //nolint:monitor
 	d := &distinct{
 		input:            input,
 		memAcc:           memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -181,14 +181,14 @@ func newHashJoiner(
 		if h.FlowCtx.Cfg.TestingKnobs.ForceDiskSpill {
 			limit = 1
 		}
-		h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "hashjoiner-limited")
+		h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "hashjoiner-limited") //nolint:monitor
 		h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "hashjoiner-disk")
 		// Override initialBufferSize to be half of this processor's memory
 		// limit. We consume up to h.initialBufferSize bytes from each input
 		// stream.
 		h.initialBufferSize = limit / 2
 	} else {
-		h.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "hashjoiner-mem")
+		h.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "hashjoiner-mem") //nolint:monitor
 	}
 
 	// If the trace is recording, instrument the hashJoiner to collect stats.
@@ -198,10 +198,10 @@ func newHashJoiner(
 		h.FinishTrace = h.outputStatsToTrace
 	}
 
-	h.rows[leftSide].InitWithMon(
+	h.rows[leftSide].Init(
 		nil /* ordering */, h.leftSource.OutputTypes(), h.EvalCtx, h.MemMonitor,
 	)
-	h.rows[rightSide].InitWithMon(
+	h.rows[rightSide].Init(
 		nil /* ordering */, h.rightSource.OutputTypes(), h.EvalCtx, h.MemMonitor,
 	)
 

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -181,14 +181,14 @@ func newHashJoiner(
 		if h.FlowCtx.Cfg.TestingKnobs.ForceDiskSpill {
 			limit = 1
 		}
-		h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "hashjoiner-limited") //nolint:monitor
+		h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx, flowCtx.Cfg, "hashjoiner-limited")
 		h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "hashjoiner-disk")
 		// Override initialBufferSize to be half of this processor's memory
 		// limit. We consume up to h.initialBufferSize bytes from each input
 		// stream.
 		h.initialBufferSize = limit / 2
 	} else {
-		h.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "hashjoiner-mem") //nolint:monitor
+		h.MemMonitor = flowCtx.EvalCtx.NewMonitor(ctx, "hashjoiner-mem", 0 /* limit */)
 	}
 
 	// If the trace is recording, instrument the hashJoiner to collect stats.

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -115,7 +115,7 @@ func newInvertedFilterer(
 
 	ctx := flowCtx.EvalCtx.Ctx()
 	// Initialize memory monitor and row container for input rows.
-	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "inverter-filterer-limited") //nolint:monitor
+	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx, flowCtx.Cfg, "inverter-filterer-limited")
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "inverted-filterer-disk")
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -115,7 +115,7 @@ func newInvertedFilterer(
 
 	ctx := flowCtx.EvalCtx.Ctx()
 	// Initialize memory monitor and row container for input rows.
-	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "inverter-filterer-limited")
+	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "inverter-filterer-limited") //nolint:monitor
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "inverted-filterer-disk")
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -277,7 +277,7 @@ func newInvertedJoiner(
 	// and so do not need to see in-progress schema changes.
 	_, _, err = initRowFetcher(
 		flowCtx, &fetcher, &ij.desc, int(spec.IndexIdx), ij.colIdxMap, false, /* reverse */
-		allIndexCols, false /* isCheck */, flowCtx.EvalCtx.Mon, &ij.alloc, execinfra.ScanVisibilityPublic,
+		allIndexCols, false /* isCheck */, flowCtx.EvalCtx.Mon, &ij.alloc, execinfra.ScanVisibilityPublic, //nolint:monitor
 		descpb.ScanLockingStrength_FOR_NONE, descpb.ScanLockingWaitPolicy_BLOCK,
 		nil, /* systemColumns */
 	)
@@ -302,7 +302,7 @@ func newInvertedJoiner(
 
 	// Initialize memory monitors and row container for key rows.
 	ctx := flowCtx.EvalCtx.Ctx()
-	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "invertedjoiner-limited")
+	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "invertedjoiner-limited") //nolint:monitor
 	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "invertedjoiner-disk")
 	ij.keyRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -276,7 +276,7 @@ func newJoinReader(
 
 	_, _, err = initRowFetcher(
 		flowCtx, &fetcher, &jr.desc, int(spec.IndexIdx), jr.colIdxMap, false, /* reverse */
-		rightCols, false /* isCheck */, jr.EvalCtx.Mon, &jr.alloc, spec.Visibility, spec.LockingStrength,
+		rightCols, false /* isCheck */, jr.EvalCtx.Mon, &jr.alloc, spec.Visibility, spec.LockingStrength, //nolint:monitor
 		spec.LockingWaitPolicy, sysColDescs,
 	)
 
@@ -346,7 +346,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		limit = 1
 	}
 	// Initialize memory monitors and row container for looked up rows.
-	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joinreader-limited")
+	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joinreader-limited") //nolint:monitor
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "joinreader-disk")
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -95,7 +95,7 @@ func newMergeJoiner(
 		return nil, err
 	}
 
-	m.MemMonitor = execinfra.NewMonitor(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, "mergejoiner-mem")
+	m.MemMonitor = execinfra.NewMonitor(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, "mergejoiner-mem") //nolint:monitor
 
 	var err error
 	m.streamMerger, err = makeStreamMerger(

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -95,7 +95,7 @@ func newMergeJoiner(
 		return nil, err
 	}
 
-	m.MemMonitor = execinfra.NewMonitor(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, "mergejoiner-mem") //nolint:monitor
+	m.MemMonitor = flowCtx.EvalCtx.NewMonitor(flowCtx.EvalCtx.Ctx(), "mergejoiner-mem", 0 /* limit */)
 
 	var err error
 	m.streamMerger, err = makeStreamMerger(

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -109,7 +109,7 @@ func newSampleAggregator(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sample-aggregator-mem")
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sample-aggregator-mem") //nolint:monitor
 	rankCol := len(input.OutputTypes()) - 7
 	s := &sampleAggregator{
 		spec:         spec,

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -109,7 +109,7 @@ func newSampleAggregator(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sample-aggregator-mem") //nolint:monitor
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx, flowCtx.Cfg, "sample-aggregator-mem")
 	rankCol := len(input.OutputTypes()) - 7
 	s := &sampleAggregator{
 		spec:         spec,

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -116,7 +116,7 @@ func newSamplerProcessor(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sampler-mem") //nolint:monitor
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx, flowCtx.Cfg, "sampler-mem")
 	s := &samplerProcessor{
 		flowCtx:         flowCtx,
 		input:           input,

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -116,7 +116,7 @@ func newSamplerProcessor(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sampler-mem")
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "sampler-mem") //nolint:monitor
 	s := &samplerProcessor{
 		flowCtx:         flowCtx,
 		input:           input,

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -125,7 +125,7 @@ func newScrubTableReader(
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
 		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
-		spec.Reverse, neededColumns, true /* isCheck */, flowCtx.EvalCtx.Mon, &tr.alloc,
+		spec.Reverse, neededColumns, true /* isCheck */, flowCtx.EvalCtx.Mon, &tr.alloc, //nolint:monitor
 		execinfra.ScanVisibilityPublic, spec.LockingStrength, spec.LockingWaitPolicy,
 		nil, /* systemColumns */
 	); err != nil {

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -80,6 +80,7 @@ func newScrubTableReader(
 
 	tr.tableDesc = tabledesc.MakeImmutable(spec.Table)
 	tr.limitHint = execinfra.LimitHint(spec.LimitHint, post)
+	tr.fetcherMemMonitor = flowCtx.EvalCtx.NewMonitor(flowCtx.EvalCtx.Ctx(), "scrub-fetcher-mem", 0 /* limit */)
 
 	if err := tr.Init(
 		tr,
@@ -125,7 +126,7 @@ func newScrubTableReader(
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
 		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
-		spec.Reverse, neededColumns, true /* isCheck */, flowCtx.EvalCtx.Mon, &tr.alloc, //nolint:monitor
+		spec.Reverse, neededColumns, true /* isCheck */, tr.fetcherMemMonitor, &tr.alloc,
 		execinfra.ScanVisibilityPublic, spec.LockingStrength, spec.LockingWaitPolicy,
 		nil, /* systemColumns */
 	); err != nil {

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -62,7 +62,7 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, fmt.Sprintf("%s-limited", processorName))
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, fmt.Sprintf("%s-limited", processorName)) //nolint:monitor
 	if err := s.ProcessorBase.Init(
 		self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
 	); err != nil {

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -62,7 +62,7 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, fmt.Sprintf("%s-limited", processorName)) //nolint:monitor
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx, flowCtx.Cfg, fmt.Sprintf("%s-limited", processorName))
 	if err := s.ProcessorBase.Init(
 		self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
 	); err != nil {

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -140,7 +140,7 @@ func newTableReader(
 		spec.Reverse,
 		neededColumns,
 		spec.IsCheck,
-		flowCtx.EvalCtx.Mon,
+		flowCtx.EvalCtx.Mon, //nolint:monitor
 		&tr.alloc,
 		spec.Visibility,
 		spec.LockingStrength,

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -163,8 +163,7 @@ func newWindower(
 			limit = memRequiredByWindower
 		}
 	}
-	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon) //nolint:monitor
-	limitedMon.Start(ctx, evalCtx.Mon, mon.BoundAccount{})                               //nolint:monitor
+	limitedMon := evalCtx.NewMonitor(ctx, "windower-limited", limit)
 
 	if err := w.InitWithEvalCtx(
 		w,

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -163,8 +163,8 @@ func newWindower(
 			limit = memRequiredByWindower
 		}
 	}
-	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)
-	limitedMon.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon) //nolint:monitor
+	limitedMon.Start(ctx, evalCtx.Mon, mon.BoundAccount{})                               //nolint:monitor
 
 	if err := w.InitWithEvalCtx(
 		w,

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -464,8 +464,8 @@ func (z *zigzagJoiner) setupInfo(
 		info.table.ColumnIdxMap(),
 		false, /* reverse */
 		neededCols,
-		false, /* check */
-		flowCtx.EvalCtx.Mon,
+		false,               /* check */
+		flowCtx.EvalCtx.Mon, //nolint:monitor
 		info.alloc,
 		execinfra.ScanVisibilityPublic,
 		// NB: zigzag joins are disabled when a row-level locking clause is

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -248,7 +248,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 		// to take the mutex.
 		evalCtx := flowCtx.NewEvalCtx()
 		rb.outputs[i].memoryMonitor = execinfra.NewLimitedMonitor(
-			ctx, evalCtx.Mon, flowCtx.Cfg,
+			ctx, evalCtx.Mon, flowCtx.Cfg, //nolint:monitor
 			fmt.Sprintf("router-limited-%d", rb.outputs[i].streamID),
 		)
 		rb.outputs[i].diskMonitor = execinfra.NewMonitor(

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -248,7 +248,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 		// to take the mutex.
 		evalCtx := flowCtx.NewEvalCtx()
 		rb.outputs[i].memoryMonitor = execinfra.NewLimitedMonitor(
-			ctx, evalCtx.Mon, flowCtx.Cfg, //nolint:monitor
+			ctx, evalCtx, flowCtx.Cfg,
 			fmt.Sprintf("router-limited-%d", rb.outputs[i].streamID),
 		)
 		rb.outputs[i].diskMonitor = execinfra.NewMonitor(

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -470,7 +470,7 @@ func scrubRunDistSQL(
 	ctx context.Context, planCtx *PlanningCtx, p *planner, plan *PhysicalPlan, columnTypes []*types.T,
 ) (*rowcontainer.RowContainer, error) {
 	ci := colinfo.ColTypeInfoFromColTypes(columnTypes)
-	acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+	acc := p.extendedEvalCtx.Mon.MakeBoundAccount() //nolint:monitor
 	rows := rowcontainer.NewRowContainer(acc, ci)
 	rowResultWriter := NewRowResultWriter(rows)
 	recv := MakeDistSQLReceiver(

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -373,7 +373,7 @@ var aggregates = map[string]builtinDefinition{
 				params []*types.T, evalCtx *tree.EvalContext, arguments tree.Datums,
 			) tree.AggregateFunc {
 				return &stMakeLineAgg{
-					acc: evalCtx.Mon.MakeBoundAccount(),
+					acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 				}
 			},
 			infoBuilder{
@@ -630,7 +630,7 @@ func makeSTUnionBuiltin() builtinDefinition {
 				params []*types.T, evalCtx *tree.EvalContext, arguments tree.Datums,
 			) tree.AggregateFunc {
 				return &stUnionAgg{
-					acc: evalCtx.Mon.MakeBoundAccount(),
+					acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 				}
 			},
 			infoBuilder{
@@ -787,7 +787,7 @@ type stCollectAgg struct {
 
 func newSTCollectAgg(_ []*types.T, evalCtx *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
 	return &stCollectAgg{
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 	}
 }
 
@@ -1091,10 +1091,10 @@ const (
 
 // makeSingleDatumAggregateBase makes a new singleDatumAggregateBase. If
 // evalCtx has non-nil SingleDatumAggMemAccount field, then that memory account
-// will be used by the new struct which will operate in "shared" mode
+// will be used by the new struct which will operate in "shared" mode.
 func makeSingleDatumAggregateBase(evalCtx *tree.EvalContext) singleDatumAggregateBase {
 	if evalCtx.SingleDatumAggMemAccount == nil {
-		newAcc := evalCtx.Mon.MakeBoundAccount()
+		newAcc := evalCtx.Mon.MakeBoundAccount() //nolint:monitor
 		return singleDatumAggregateBase{
 			mode: nonSharedSingleDatumAggregateBaseMode,
 			acc:  &newAcc,
@@ -1223,7 +1223,7 @@ func newArrayAggregate(
 ) tree.AggregateFunc {
 	return &arrayAggregate{
 		arr: tree.NewDArray(params[0]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 	}
 }
 
@@ -3374,7 +3374,7 @@ func newPercentileDiscAggregate(
 ) tree.AggregateFunc {
 	return &percentileDiscAggregate{
 		arr: tree.NewDArray(params[1]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 	}
 }
 
@@ -3472,7 +3472,7 @@ func newPercentileContAggregate(
 ) tree.AggregateFunc {
 	return &percentileContAggregate{
 		arr: tree.NewDArray(params[1]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 	}
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2236,7 +2236,7 @@ may increase either contention or retry errors, or both.`,
 				ctxTime := ctx.GetRelativeParseTime()
 				// From postgres@a166d408eb0b35023c169e765f4664c3b114b52e src/backend/utils/adt/timestamp.c#L1637,
 				// we should support "%a %b %d %H:%M:%S.%%06d %Y %Z".
-				return tree.NewDString(ctxTime.Format("Mon Jan 2 15:04:05.000000 2006 -0700")), nil
+				return tree.NewDString(ctxTime.Format("mon Jan 2 15:04:05.000000 2006 -0700")), nil
 			},
 			Info:       "Returns the current system time on one of the cluster nodes as a string.",
 			Volatility: tree.VolatilityStable,

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -53,7 +53,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Right:    NewDString(d.right),
 		}
 		ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.mon.Stop(context.Background())
 		ctx.ReCache = NewRegexpCache(8)
 		typedExpr, err := TypeCheck(context.Background(), expr, nil, types.Any)
 		if err != nil {

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -40,7 +40,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 	}
 
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.mon.Stop(context.Background())
 	c := tree.MakeConstantEvalVisitor(ctx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3301,7 +3301,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 		NodeID:      base.TestingIDContainer,
 	}
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
-	ctx.Mon = monitor
+	ctx.Mon = monitor //nolint:monitor
 	ctx.Context = context.TODO()
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
@@ -3341,7 +3341,7 @@ func NewTestingEvalContext(st *cluster.Settings) *EvalContext {
 
 // Stop closes out the EvalContext and must be called once it is no longer in use.
 func (ctx *EvalContext) Stop(c context.Context) {
-	ctx.Mon.Stop(c)
+	ctx.Mon.Stop(c) //nolint:monitor
 }
 
 // GetStmtTimestamp retrieves the current statement timestamp as per

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -194,7 +194,7 @@ func TestTimeConversion(t *testing.T) {
 
 	for _, test := range tests {
 		ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.mon.Stop(context.Background())
 		exprStr := fmt.Sprintf("experimental_strptime('%s', '%s')", test.start, test.format)
 		expr, err := parser.ParseExpr(exprStr)
 		if err != nil {

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -141,7 +141,7 @@ func TestExprString(t *testing.T) {
 		}
 		// Compare the normalized expressions.
 		ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.mon.Stop(context.Background())
 		normalized, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)

--- a/pkg/sql/sem/tree/like_test.go
+++ b/pkg/sql/sem/tree/like_test.go
@@ -167,7 +167,7 @@ func benchmarkLike(b *testing.B, ctx *EvalContext, caseInsensitive bool) {
 func BenchmarkLikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.mon.Stop(context.Background())
 
 	benchmarkLike(b, ctx, false)
 }
@@ -182,7 +182,7 @@ func BenchmarkLikeWithoutCache(b *testing.B) {
 func BenchmarkILikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.mon.Stop(context.Background())
 
 	benchmarkLike(b, ctx, true)
 }

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -293,7 +293,7 @@ func TestNormalizeExpr(t *testing.T) {
 			}
 			rOrig := typedExpr.String()
 			ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer ctx.Mon.Stop(context.Background())
+			defer ctx.mon.Stop(context.Background())
 			r, err := ctx.NormalizeExpr(typedExpr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -42,7 +42,7 @@ func (s *spoolNode) startExec(params runParams) error {
 	}
 
 	s.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(planColumns(s.source)),
 	)
 

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -117,6 +117,8 @@ type tableWriterBase struct {
 	lastBatchSize int
 	// rows contains the accumulated result rows if rowsNeeded is set on the
 	// corresponding tableWriter.
+	// TODO(yuzefovich): should this be disk-backed container with an in-memory
+	// limit?
 	rows *rowcontainer.RowContainer
 }
 

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -105,8 +105,9 @@ func (tu *optTableUpserter) init(
 	// rows returned from the operation.
 	if tu.rowsNeeded {
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))
+		tu.memMonitor = evalCtx.NewMonitor(ctx, "upsert-mem", 0 /* limit */)
 		tu.rows = rowcontainer.NewRowContainer(
-			evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
+			tu.memMonitor.MakeBoundAccount(),
 			colinfo.ColTypeInfoFromColDescs(tu.returnCols),
 		)
 

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -106,7 +106,7 @@ func (tu *optTableUpserter) init(
 	if tu.rowsNeeded {
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))
 		tu.rows = rowcontainer.NewRowContainer(
-			evalCtx.Mon.MakeBoundAccount(),
+			evalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 			colinfo.ColTypeInfoFromColDescs(tu.returnCols),
 		)
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -125,7 +125,7 @@ func (u *updateNode) startExec(params runParams) error {
 
 	if u.run.rowsNeeded {
 		u.run.tu.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(),
+			params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 			colinfo.ColTypeInfoFromResCols(u.columns),
 		)
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -124,8 +124,9 @@ func (u *updateNode) startExec(params runParams) error {
 	u.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
 	if u.run.rowsNeeded {
+		u.run.tu.memMonitor = params.EvalContext().NewMonitor(params.ctx, "update-mem", 0 /* limit */)
 		u.run.tu.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
+			u.run.tu.memMonitor.MakeBoundAccount(),
 			colinfo.ColTypeInfoFromResCols(u.columns),
 		)
 	}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -117,7 +117,7 @@ func (p *planner) newContainerValuesNode(columns colinfo.ResultColumns, capacity
 		columns: columns,
 		valuesRun: valuesRun{
 			rows: rowcontainer.NewRowContainerWithCapacity(
-				p.EvalContext().Mon.MakeBoundAccount(),
+				p.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 				colinfo.ColTypeInfoFromResCols(columns),
 				capacity,
 			),
@@ -143,7 +143,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	// from other planNodes), so its expressions need evaluating.
 	// This may run subqueries.
 	n.rows = rowcontainer.NewRowContainerWithCapacity(
-		params.extendedEvalCtx.Mon.MakeBoundAccount(),
+		params.extendedEvalCtx.Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(n.columns),
 		len(n.tuples),
 	)

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -242,7 +242,7 @@ var _ rowPusher = &vTableLookupJoinNode{}
 func (v *vTableLookupJoinNode) startExec(params runParams) error {
 	v.run.keyCtx = constraint.KeyContext{EvalCtx: params.EvalContext()}
 	v.run.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.EvalContext().Mon.MakeBoundAccount(), //nolint:monitor
 		colinfo.ColTypeInfoFromResCols(v.columns),
 	)
 	v.run.indexKeyDatums = make(tree.Datums, len(v.columns))

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1672,48 +1672,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestEvalCtxMon", func(t *testing.T) {
-		// t.Parallel() // Disabled due to CI not parsing failure from parallel tests correctly. Can be re-enabled on Go 1.15 (see: https://github.com/golang/go/issues/38458).
-		cmd, stderr, filter, err := dirCmd(
-			pkgDir,
-			"git",
-			"grep",
-			"-nE",
-			// We want to encourage the developers to think through whether the
-			// usage of the memory monitor from the eval context is
-			// appropriate, so we try to guess the most common string patterns
-			// that would correspond to such usage.
-			fmt.Sprintf(`(ctx|Ctx|Ctx\(\)|Context\(\))\.Mon`),
-			"--",
-			"*",
-			":!*_test.go",
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stream.ForEach(filter, func(s string) {
-			if !strings.Contains(s, "//nolint:monitor") {
-				t.Errorf(
-					"\n%s <- make sure that you're using the appropriate monitor, "+
-						"and if so, add '//nolint:monitor' directive to the end of this line", s,
-				)
-			}
-		}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	t.Run("TestVectorizedTypeSchemaCopy", func(t *testing.T) {
 		// t.Parallel() // Disabled due to CI not parsing failure from parallel tests correctly. Can be re-enabled on Go 1.15 (see: https://github.com/golang/go/issues/38458).
 		cmd, stderr, filter, err := dirCmd(


### PR DESCRIPTION
We have recently discovered a case when the memory monitor from the eval
context was used incorrectly which resulted in a hash mem row container
possibly using too much memory although we have a disk-backed one to
fall back to. In order to prevent such cases from happening this commit
adds a linter rule that attempts to guess all string patterns that could
occur with the usage of such monitor and asks the developers think
through their use case more. If the usage is desired, `//nolint:monitor`
directive needs to be added to the end of the line.

Informs: #55204.

Release note: None