### PR TITLE
sql,roachtest: add pgcode to DROP INDEX error, turn --tolerate-errors off in schemachange/random-load

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -119,12 +119,7 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps,
 
 	runCmd := []string{
 		"./workload run schemachange --verbose=1",
-		// The workload is still in development and occasionally discovers schema
-		// change errors so for now we don't fail on them but only on panics, server
-		// crashes, deadlocks, etc.
-		// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
-		// is closed.
-		"--tolerate-errors=true",
+		"--tolerate-errors=false",
 		// Save the histograms so that they can be reported to https://roachperf.crdb.dev/.
 		" --histograms=" + perfArtifactsDir + "/stats.json",
 		fmt.Sprintf("--max-ops %d", maxOps),

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -245,7 +245,7 @@ func (p *planner) dropIndexByName(
 			return nil
 		}
 		// Index does not exist, but we want it to: error out.
-		return err
+		return pgerror.WithCandidateCode(err, pgcode.UndefinedObject)
 	}
 	if dropped {
 		return nil

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -22,13 +22,13 @@ DROP INDEX baw
 statement error index name "baw" is ambiguous
 DROP INDEX IF EXISTS baw
 
-statement error index "ark" does not exist
+statement error pgcode 42704 index "ark" does not exist
 DROP INDEX ark
 
 statement ok
 DROP INDEX IF EXISTS ark
 
-statement error index "ark" does not exist
+statement error pgcode 42704 index "ark" does not exist
 DROP INDEX users@ark
 
 statement ok


### PR DESCRIPTION
sql: add pgcode to DROP INDEX error

This patch adds a pgcode to an error and gets us a bit closer to
categorizing all expected errors in schema changes, which we need to do
to turn off `--tolerate-errors` in the schema change workload.

Closes #55275.

Release note (sql change): Added a pgcode (42704, undefined_object) to
the error returned when attempting to drop an index by table and index
name which doesn't exist.

----

roachtest: turn --tolerate-errors off in schemachange/random-load

This commit again sets `--tolerate-errors` to false for the random
`schemachange` workload in the roachtest and benchmarks. With the DROP
IDNEX error patch in this PR, I ran the roachtest with a much larger
`maxOps` for 12 hours and didn't get any failures, so I'm cautiously
optimistic.

Related to #47430.

Release note: None