### PR TITLE
geo/geomfn: implement ST_Rotate({geometry, float8, float8, float8})

### DIFF
--- a/pkg/geo/geomfn/affine_transforms.go
+++ b/pkg/geo/geomfn/affine_transforms.go
@@ -264,7 +264,12 @@ func RotateWithPointOrigin(
 		return g, ErrPointOriginEmpty
 	}
 
-	x, y := t.FlatCoords()[0], t.FlatCoords()[1]
+	return RotateWithXY(g, rotRadians, t.FlatCoords()[0], t.FlatCoords()[1])
+}
+
+// RotateWithXY returns a modified Geometry whose coordinates are rotated
+// around the X and Y by a rotRadians.
+func RotateWithXY(g geo.Geometry, rotRadians, x, y float64) (geo.Geometry, error) {
 	cos, sin := math.Cos(rotRadians), math.Sin(rotRadians)
 	return Affine(
 		g,

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5289,6 +5289,27 @@ POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0.1 -0, -1 0, -
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((1 -0, 0 0, -0 -1, 1 -1, 1 -0))               POLYGON ((-0.707106781186548 -0.707106781186547, 0 0, -0.707106781186547 0.707106781186548, -1.414213562373095 0, -0.707106781186548 -0.707106781186547))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, -1 0, -1 -1, -0 -1, 0 0))               POLYGON ((0 0, 0.707106781186548 0.707106781186547, 0 1.414213562373095, -0.707106781186547 0.707106781186548, 0 0))
 
+query TT
+SELECT
+    ST_AsText(a.geom) d,
+    ST_AsText(ST_Rotate(a.geom, pi(),4,7))
+FROM geom_operators_test a
+ORDER BY d;
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (8 14)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (8.5 13.5, 7.5 13.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (8.5 13.5)
+POINT (0.5 0.5)                                        POINT (7.5 13.5)
+POINT (5 5)                                            POINT (2.999999999999999 9)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((8.1 14, 7 14, 7 13, 8.1 13, 8.1 14))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((9 14, 8 14, 8 13, 9 13, 9 14))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((8 14, 7 14, 7 13, 8 13, 8 14))
+
+
 query T
 SELECT
     ST_AsText(ST_Rotate(a.geom, pi(), 'POINT (6 3)'::geometry)) as t

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4132,7 +4132,15 @@ The matrix transformation will be applied as follows for each coordinate:
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				return nil, unimplemented.NewWithIssue(49019, "st_rotate")
+				g := tree.MustBeDGeometry(args[0])
+				rotRadians := float64(tree.MustBeDFloat(args[1]))
+				x := float64(tree.MustBeDFloat(args[2]))
+				y := float64(tree.MustBeDFloat(args[3]))
+				geometry, err := geomfn.RotateWithXY(g.Geometry, rotRadians, x, y)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geometry), nil
 			},
 			Info: infoBuilder{
 				info: `Returns a modified Geometry whose coordinates are rotated around the provided origin by a rotation angle.`,


### PR DESCRIPTION
Currently, CRDB builtin ST_Rotate doesn't support arguments geometry, angle_radians, X, and Y.

Fixes #49019.

Release note (sql change): Implemented the geometry based builtins
`ST_Rotate({geometry, float8, float8, float8})`.