### PR TITLE
sqlproxyccl: add a healthcheck and metrics

### DIFF
--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics contains pointers to the metrics for monitoring proxy
+// operations.
+type Metrics struct {
+	BackendDisconnectCount *metric.Counter
+	BackendDownCount       *metric.Counter
+	ClientDisconnectCount  *metric.Counter
+	CurConnCount           *metric.Gauge
+	RoutingErrCount        *metric.Counter
+}
+
+// MetricStruct implements the metrics.Struct interface.
+func (Metrics) MetricStruct() {}
+
+var _ metric.Struct = Metrics{}
+
+var (
+	metaCurConnCount = metric.Metadata{
+		Name:        "proxy.sql.conns",
+		Help:        "Number of connections being proxied",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRoutingErrCount = metric.Metadata{
+		Name:        "proxy.err.routing",
+		Help:        "Number of errors encountered when attempting to route clients",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaBackendDownCount = metric.Metadata{
+		Name:        "proxy.err.backend_down",
+		Help:        "Number of errors encountered when connecting to backend servers",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaBackendDisconnectCount = metric.Metadata{
+		Name:        "proxy.err.backend_disconnect",
+		Help:        "Number of disconnects initiated by proxied backends",
+		Measurement: "Disconnects",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaClientDisconnectCount = metric.Metadata{
+		Name:        "proxy.err.client_disconnect",
+		Help:        "Number of disconnects initiated by clients",
+		Measurement: "Disconnects",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// MakeProxyMetrics instantiates the metrics holder for proxy monitoring.
+func MakeProxyMetrics() Metrics {
+	return Metrics{
+		BackendDisconnectCount: metric.NewCounter(metaBackendDisconnectCount),
+		BackendDownCount:       metric.NewCounter(metaBackendDownCount),
+		ClientDisconnectCount:  metric.NewCounter(metaClientDisconnectCount),
+		CurConnCount:           metric.NewGauge(metaCurConnCount),
+		RoutingErrCount:        metric.NewCounter(metaRoutingErrCount),
+	}
+}

--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -55,9 +55,11 @@ openssl req -new -x509 -sha256 -key testserver.key -out testserver.crt -days 365
 		wg.Wait()
 	}
 
+	server := NewServer(*opts)
+
 	go func() {
 		defer wg.Done()
-		_ = Serve(ln, *opts)
+		_ = server.Serve(ln)
 	}()
 
 	return ln.Addr().String(), done

--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -11,25 +11,142 @@ package sqlproxyccl
 import (
 	"context"
 	"net"
+	"net/http"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
-// Serve serves a listener according to the given Options. Incoming client
-// connections are taken through the Postgres handshake and relayed to the
-// configured backend server.
-func Serve(ln net.Listener, opts Options) error {
+// Server is a TCP server that proxies SQL connections to a
+// configurable backend. It may also run an HTTP server to expose a
+// health check and prometheus metrics.
+type Server struct {
+	opts            *Options
+	mux             *http.ServeMux
+	metrics         *Metrics
+	metricsRegistry *metric.Registry
+
+	promMu             syncutil.Mutex
+	prometheusExporter metric.PrometheusExporter
+}
+
+// NewServer constructs a new proxy server and provisions metrics and health
+// checks as well.
+func NewServer(opts Options) *Server {
+	mux := http.NewServeMux()
+
+	registry := metric.NewRegistry()
+
+	proxyMetrics := MakeProxyMetrics()
+
+	registry.AddMetricStruct(proxyMetrics)
+
+	s := &Server{
+		opts:               &opts,
+		mux:                mux,
+		metrics:            &proxyMetrics,
+		metricsRegistry:    registry,
+		prometheusExporter: metric.MakePrometheusExporter(),
+	}
+
+	// /_status/{healthz,vars} matches CRDB's healthcheck and metrics
+	// endpoints.
+	mux.HandleFunc("/_status/vars/", s.handleVars)
+	mux.HandleFunc("/_status/healthz/", s.handleHealth)
+
+	return s
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	// TODO(chrisseto): Ideally, this health check should actually check the
+	// proxy's health in some fashion. How to actually check the health of a
+	// proxy remains to be seen.
+	// It has been noted that an overloaded CRDB server may fail to respond to
+	// a simple HTTP request, such as this one, within a short time frame
+	// (~5 seconds). Therefore, this health check provides a non-zero amount of
+	// value as it indicates if the service is _massively_ overloaded or not.
+	// In Kubernetes, a failed liveness check will result in the container
+	// being terminated and replaced.
+	// Its reasonable to assume that many, if not most, of the connections
+	// being served by this proxy are unusable, if this check can not be
+	// handled.  An operator may adjust this window by changing the timeout on
+	// the check.
+	w.WriteHeader(http.StatusOK)
+	// Explicitly ignore any errors from writing our body as there's
+	// nothing to be done if the write fails.
+	_, _ = w.Write([]byte("OK"))
+}
+
+func (s *Server) handleVars(w http.ResponseWriter, r *http.Request) {
+	s.promMu.Lock()
+	defer s.promMu.Unlock()
+
+	w.Header().Set(httputil.ContentTypeHeader, httputil.PlaintextContentType)
+	s.prometheusExporter.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/)
+	if err := s.prometheusExporter.PrintAsText(w); err != nil {
+		log.Errorf(r.Context(), "%v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// ServeHTTP starts the proxy's HTTP server on the given listener.
+// The server provides Prometheus metrics at /_status/vars
+// and a health check endpoint at /_status/healthz.
+func (s *Server) ServeHTTP(ctx context.Context, ln net.Listener) error {
+	srv := http.Server{
+		Handler: s.mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		// Wait up to 15 seconds for the HTTP server to shut itself
+		// down. The HTTP service is an auxiliary service for health
+		// checking and metrics, which does not need a completely
+		// graceful shutdown.
+		_ = contextutil.RunWithTimeout(
+			context.Background(),
+			"http server shutdown",
+			15*time.Second,
+			func(shutdownCtx context.Context) error {
+				// Ignore any errors as this routine will only be called
+				// when the server is shutting down.
+				_ = srv.Shutdown(shutdownCtx)
+
+				return nil
+			},
+		)
+	}()
+
+	if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	return nil
+}
+
+// Serve serves a listener according to the Options given in NewServer().
+// Incoming client connections are taken through the Postgres handshake and
+// relayed to the configured backend server.
+func (s *Server) Serve(ln net.Listener) error {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			return err
 		}
 		go func() {
+			s.metrics.CurConnCount.Inc(1)
 			defer conn.Close()
+			defer s.metrics.CurConnCount.Dec(1)
 			tBegin := timeutil.Now()
 			log.Infof(context.Background(), "handling client %s", conn.RemoteAddr())
-			err := Proxy(conn, opts)
+			err := s.Proxy(conn)
 			log.Infof(context.Background(), "client %s disconnected after %.2fs: %v",
 				conn.RemoteAddr(), timeutil.Since(tBegin).Seconds(), err)
 		}()

--- a/pkg/ccl/sqlproxyccl/server_test.go
+++ b/pkg/ccl/sqlproxyccl/server_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleHealth(t *testing.T) {
+	proxyServer := NewServer(Options{})
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/_status/healthz/", nil)
+
+	proxyServer.mux.ServeHTTP(rw, r)
+
+	require.Equal(t, http.StatusOK, rw.Code)
+	out, err := ioutil.ReadAll(rw.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, []byte("OK"), out)
+}
+
+func TestHandleVars(t *testing.T) {
+	proxyServer := NewServer(Options{})
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/_status/vars/", nil)
+
+	proxyServer.mux.ServeHTTP(rw, r)
+
+	require.Equal(t, http.StatusOK, rw.Code)
+	out, err := ioutil.ReadAll(rw.Body)
+	require.NoError(t, err)
+
+	require.Contains(t, string(out), "# HELP proxy_sql_conns")
+}


### PR DESCRIPTION
Previous the SQL Proxy exposed no metrics nor any healthcheck.

For the SQL Proxy to function optimally when deployed in a Kubernetes
cluster, a liveness probe needs to be available to automatically detect
any issues.
For SREs to manage the SQL Proxy in a production environment, it must
provide some amount of visibility into its operations, namely health
checks and metrics.
This commits adds a rudimentary heathcheck endpoint at /_status/healthz/
and minimal metrics at /_status/vars/. More importantly, it adds the
plumbing required to easily add more metrics and more intelligent
health checks in the future.

Release note: None

As a side note, I'm not entirely certain of the vision for the proxy. It may make sense to instead build this functionality else where and just provide hooks in the proxy itself?
I _think_ it makes sense for metrics to live in the proxy itself as most systems that deploy it will want to monitor its health in some fashion.