### PR TITLE
release-20.2: sql: alter svc lat calculation to play well with non exec engine queries

### DIFF
--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -28,3 +28,16 @@ send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "execution"
 eexpect "network"
 end_test
+
+start_test "Test non-negative PREPARE stmt timings #54888"
+send "create table t1 (a int, updated_at timestamptz);\r"
+send "prepare stmt (timestamptz) as insert into t1 values (1, \$1);\r"
+eexpect "execution \[0-9\]"
+eexpect "network \[0-9\]"
+end_test
+
+start_test "Test observer statements non neg timings #54750"
+send "SHOW SYNTAX 'CREATE TABLE t(a INT)';\r"
+eexpect "execution \[0-9\]"
+eexpect "network \[0-9\]"
+end_test

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -837,61 +837,81 @@ func TestShowLastQueryStatistics(t *testing.T) {
 	s, sqlConn, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
-	if _, err := sqlConn.Exec("CREATE TABLE t(a INT)"); err != nil {
-		t.Fatal(err)
+	testCases := []struct {
+		stmt           string
+		usesExecEngine bool
+	}{
+		{
+			stmt:           "CREATE TABLE t(a INT, b INT)",
+			usesExecEngine: true,
+		},
+		{
+			stmt:           "SHOW SYNTAX 'SELECT * FROM t'",
+			usesExecEngine: false,
+		},
+		{
+			stmt:           "PREPARE stmt(INT) AS INSERT INTO t VALUES(1, $1)",
+			usesExecEngine: false,
+		},
 	}
 
-	rows, err := sqlConn.Query("SHOW LAST QUERY STATISTICS")
-	if err != nil {
-		t.Fatalf("show last query statistics failed: %v", err)
-	}
-	defer rows.Close()
+	for _, tc := range testCases {
+		if _, err := sqlConn.Exec(tc.stmt); err != nil {
+			t.Fatalf("executing %s. failed: %v ", tc.stmt, err)
+		}
 
-	var parseLatency string
-	var planLatency string
-	var execLatency string
-	var serviceLatency string
+		rows, err := sqlConn.Query("SHOW LAST QUERY STATISTICS")
+		if err != nil {
+			t.Fatalf("show last query statistics failed: %v", err)
+		}
+		defer rows.Close()
 
-	rows.Next()
-	if err := rows.Scan(&parseLatency, &planLatency, &execLatency, &serviceLatency); err != nil {
-		t.Fatalf("unexpected error while reading last query statistics: %v", err)
-	}
+		var parseLatency string
+		var planLatency string
+		var execLatency string
+		var serviceLatency string
 
-	parseInterval, err := tree.ParseDInterval(parseLatency)
-	if err != nil {
-		t.Fatal(err)
-	}
-	planInterval, err := tree.ParseDInterval(planLatency)
-	if err != nil {
-		t.Fatal(err)
-	}
-	execInterval, err := tree.ParseDInterval(execLatency)
-	if err != nil {
-		t.Fatal(err)
-	}
-	serviceInterval, err := tree.ParseDInterval(serviceLatency)
-	if err != nil {
-		t.Fatal(err)
-	}
+		rows.Next()
+		if err := rows.Scan(&parseLatency, &planLatency, &execLatency, &serviceLatency); err != nil {
+			t.Fatalf("unexpected error while reading last query statistics: %v", err)
+		}
 
-	if parseInterval.AsFloat64() <= 0 || parseInterval.AsFloat64() > 1 {
-		t.Fatalf("unexpected parse latency: %v", parseInterval.AsFloat64())
-	}
+		parseInterval, err := tree.ParseDInterval(parseLatency)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planInterval, err := tree.ParseDInterval(planLatency)
+		if err != nil {
+			t.Fatal(err)
+		}
+		execInterval, err := tree.ParseDInterval(execLatency)
+		if err != nil {
+			t.Fatal(err)
+		}
+		serviceInterval, err := tree.ParseDInterval(serviceLatency)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if planInterval.AsFloat64() <= 0 || planInterval.AsFloat64() > 1 {
-		t.Fatalf("unexpected plan latency: %v", planInterval.AsFloat64())
-	}
+		if parseInterval.AsFloat64() <= 0 || parseInterval.AsFloat64() > 1 {
+			t.Fatalf("unexpected parse latency: %v", parseInterval.AsFloat64())
+		}
 
-	if serviceInterval.AsFloat64() <= 0 || serviceInterval.AsFloat64() > 1 {
-		t.Fatalf("unexpected service latency: %v", serviceInterval.AsFloat64())
-	}
+		if tc.usesExecEngine && (planInterval.AsFloat64() <= 0 || planInterval.AsFloat64() > 1) {
+			t.Fatalf("unexpected plan latency: %v", planInterval.AsFloat64())
+		}
 
-	if execInterval.AsFloat64() <= 0 || execInterval.AsFloat64() > 1 {
-		t.Fatalf("unexpected execution latency: %v", execInterval.AsFloat64())
-	}
+		if serviceInterval.AsFloat64() <= 0 || serviceInterval.AsFloat64() > 1 {
+			t.Fatalf("unexpected service latency: %v", serviceInterval.AsFloat64())
+		}
 
-	if rows.Next() {
-		t.Fatalf("unexpected number of rows returned by last query statistics: %v", err)
+		if tc.usesExecEngine && (execInterval.AsFloat64() <= 0 || execInterval.AsFloat64() > 1) {
+			t.Fatalf("unexpected execution latency: %v", execInterval.AsFloat64())
+		}
+
+		if rows.Next() {
+			t.Fatalf("unexpected number of rows returned by last query statistics: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #54991.

/cc @cockroachdb/release

---

Previously, we would only capture service latencies for queries that
hit the execution engine in effect. This was because service latency
was calculated as the time between when the query is received and when
it finishes executing. This meant that service latency was not defined for
things like prepare statement and observer statements, which don't go
through the execution engine. This wasn't a problem earlier, as service
latency was only used when recording statement statistics out of the exec
engine.

Unfortunately, this doesn't play well with the
`SHOW LAST QUERY STATISTICS` statement the CLI issues under the hood
to show statement timings. Currently, when an observer statement or a
prepare statement is executed by the client, the end of execution time
is left unset. This leads to weird/wrong numbers in such cases. This
patch fixes the issue by redefining how service latency is calculated.
In particular, a new phase `sessionQueryServiced` is added, whcih is
set by all statements. Service latency is now calculated using this
phase rather than `plannedEndExecStmt` as before. Unfortunately, we
may need to fallback to the old formula in some instances where the
service latency is requested before the query is actually serviced.
I've left a comment inline which explains why in more detail.
