### PR TITLE
release-20.1: backupccl: add system.role_options to cluster backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -62,6 +62,7 @@ var fullClusterSystemTables = []string{
 	// Rest of system tables.
 	sqlbase.LocationsTable.Name,
 	sqlbase.RoleMembersTable.Name,
+	sqlbase.RoleOptionsTable.Name,
 	sqlbase.UITable.Name,
 	sqlbase.CommentsTable.Name,
 	sqlbase.JobsTable.Name,

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -92,6 +92,7 @@ func TestFullClusterBackup(t *testing.T) {
 	// Populate system.users.
 	for i := 0; i < 1000; i++ {
 		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
+		sqlDB.Exec(t, fmt.Sprintf("ALTER USER maxroach%d CREATEROLE", i))
 	}
 	// Populate system.zones.
 	sqlDB.Exec(t, `ALTER TABLE data.bank CONFIGURE ZONE USING gc.ttlseconds = 3600`)
@@ -155,6 +156,7 @@ func TestFullClusterBackup(t *testing.T) {
 			sqlbase.CommentsTable.Name,
 			sqlbase.LocationsTable.Name,
 			sqlbase.RoleMembersTable.Name,
+			sqlbase.RoleOptionsTable.Name,
 			sqlbase.SettingsTable.Name,
 			sqlbase.TableStatisticsTable.Name,
 			sqlbase.UITable.Name,
@@ -235,8 +237,8 @@ func TestFullClusterBackup(t *testing.T) {
 		}
 		dbName, tableName := "new_db", "new_table"
 		// N.B. We skip the database ID that was allocated too the temporary
-		// system table and all of the temporary system tables (1 + 8).
-		numIDsToSkip := 9
+		// system table and all of the temporary system tables (1 + 9).
+		numIDsToSkip := 10
 		expectedDBID := maxID + numIDsToSkip + 1
 		expectedTableID := maxID + numIDsToSkip + 2
 		sqlDBRestore.Exec(t, fmt.Sprintf("CREATE DATABASE %s", dbName))


### PR DESCRIPTION
Backport 1/1 commits from #55189.

/cc @cockroachdb/release

---

Previously, the role_options system table was not included in cluster
backups. This commit adds this table.

Fixes #55188.

Release note (bug fix): Options set on users (e.g. ALTER USER u
CREATEDB) were not included in cluster backups and thus not restored.
Role options were introduced in 20.2.
