### PR TITLE
sql/sem/tree: fix formatting of COPY to match grammar

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1413,6 +1413,7 @@ func TestParse(t *testing.T) {
 		{`COPY t (a, b, c) FROM STDIN`},
 		{`COPY crdb_internal.file_upload FROM STDIN WITH destination = 'filename'`},
 		{`COPY t (a, b, c) FROM STDIN WITH BINARY`},
+		{`COPY crdb_internal.file_upload FROM STDIN WITH BINARY destination = 'filename'`},
 
 		{`ALTER TABLE a SPLIT AT VALUES (1)`},
 		{`EXPLAIN ALTER TABLE a SPLIT AT VALUES (1)`},
@@ -2293,6 +2294,8 @@ $function$`,
 
 		{`COPY t (a, b, c) FROM STDIN BINARY`,
 			`COPY t (a, b, c) FROM STDIN WITH BINARY`},
+		{`COPY t (a, b, c) FROM STDIN destination = 'filename' BINARY`,
+			`COPY t (a, b, c) FROM STDIN WITH BINARY destination = 'filename'`},
 
 		// Identifier handling for zone configs.
 

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -52,24 +52,24 @@ func (o *CopyOptions) Format(ctx *FmtCtx) {
 	var addSep bool
 	maybeAddSep := func() {
 		if addSep {
-			ctx.WriteString(", ")
+			ctx.WriteString(" ")
 		}
 		addSep = true
 	}
+	if o.CopyFormat != CopyFormatText {
+		switch o.CopyFormat {
+		case CopyFormatBinary:
+			ctx.WriteString("BINARY")
+			addSep = true
+		}
+	}
 	if o.Destination != nil {
+		maybeAddSep()
 		// Lowercase because that's what has historically been produced
 		// by copy_file_upload.go, so this will provide backward
 		// compatibility with older servers.
 		ctx.WriteString("destination = ")
 		o.Destination.Format(ctx)
-		addSep = true
-	}
-	if o.CopyFormat != CopyFormatText {
-		maybeAddSep()
-		switch o.CopyFormat {
-		case CopyFormatBinary:
-			ctx.WriteString("BINARY")
-		}
 	}
 }
 


### PR DESCRIPTION
The Format function of CopyOptions was incorrectly adding commas to the
output. If you look at sql.y, you'll see that the copy options don't
allow any commas. Right now, we only support the older Postgres syntax
for BINARY format.

See the "Compatibility" section of
https://www.postgresql.org/docs/9.2/sql-copy.html

This bug is causing RandomSyntaxTests to fail.

Release note: None