### PR TITLE
CI: limit GOMAXPROCS to 8 for testrace

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -48,6 +48,7 @@ for pkg in $pkgspec; do
   tc_start_block "Run ${pkg} under race detector"
   run_json_test build/builder.sh env \
     COCKROACH_LOGIC_TESTS_SKIP=true \
+    GOMAXPROCS=8 \
     stdbuf -oL -eL \
     make testrace \
     GOTESTFLAGS=-json \


### PR DESCRIPTION
Before: GOMAXPROCS was the default value

Why: testrace is consistently failing and the increased number of
concurrent go processes on the larger TeamCity agent VMs appears to be
the cause.

Now: Limit GOMAXPROCS to 8.

Release note: None