### PR TITLE
release-20.2: colexec,colflow: catch expected errors from Init at the root

### DIFF
--- a/pkg/sql/colexecbase/operator.go
+++ b/pkg/sql/colexecbase/operator.go
@@ -25,6 +25,9 @@ type Operator interface {
 	// Init initializes this operator. Will be called once at operator setup
 	// time. If an operator has an input operator, it's responsible for calling
 	// Init on that input operator as well.
+	//
+	// It might panic with an expected error, so there must be a "root"
+	// component that will catch that panic.
 	// TODO(yuzefovich): we might need to clarify whether it is ok to call
 	// Init() multiple times before the first call to Next(). It is possible to
 	// hit the memory limit during Init(), and a disk-backed operator needs to
@@ -42,6 +45,9 @@ type Operator interface {
 	// Next.
 	// Canceling the provided context results in forceful termination of
 	// execution.
+	//
+	// It might panic with an expected error, so there must be a "root"
+	// component that will catch that panic.
 	Next(context.Context) coldata.Batch
 
 	execinfra.OpNode

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -225,52 +225,44 @@ func (o *Outbox) moveToDraining(ctx context.Context) {
 //    will be called in this case.
 func (o *Outbox) sendBatches(
 	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
-) (terminatedGracefully bool, _ error) {
-	nextBatch := func() {
-		if o.runnerCtx == nil {
-			o.runnerCtx = ctx
-		}
-		o.batch = o.Input().Next(o.runnerCtx)
+) (terminatedGracefully bool, errToSend error) {
+	if o.runnerCtx == nil {
+		o.runnerCtx = ctx
 	}
-	serializeBatch := func() {
-		o.scratch.buf.Reset()
-		d, err := o.converter.BatchToArrow(o.batch)
-		if err != nil {
-			colexecerror.InternalError(errors.Wrap(err, "Outbox BatchToArrow data serialization error"))
-		}
-		if _, _, err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
-			colexecerror.InternalError(errors.Wrap(err, "Outbox Serialize data error"))
-		}
-	}
-	for {
-		if atomic.LoadUint32(&o.draining) == 1 {
-			return true, nil
-		}
-
-		if err := colexecerror.CatchVectorizedRuntimeError(nextBatch); err != nil {
-			if log.V(1) {
-				log.Warningf(ctx, "Outbox Next error: %+v", err)
+	errToSend = colexecerror.CatchVectorizedRuntimeError(func() {
+		o.Input().Init()
+		for {
+			if atomic.LoadUint32(&o.draining) == 1 {
+				terminatedGracefully = true
+				return
 			}
-			return false, err
-		}
-		if o.batch.Length() == 0 {
-			return true, nil
-		}
 
-		if err := colexecerror.CatchVectorizedRuntimeError(serializeBatch); err != nil {
-			log.Errorf(ctx, "%+v", err)
-			return false, err
-		}
-		o.scratch.msg.Data.RawBytes = o.scratch.buf.Bytes()
+			o.batch = o.Input().Next(o.runnerCtx)
+			if o.batch.Length() == 0 {
+				terminatedGracefully = true
+				return
+			}
 
-		// o.scratch.msg can be reused as soon as Send returns since it returns as
-		// soon as the message is written to the control buffer. The message is
-		// marshaled (bytes are copied) before writing.
-		if err := stream.Send(o.scratch.msg); err != nil {
-			o.handleStreamErr(ctx, "Send (batches)", err, cancelFn)
-			return false, nil
+			o.scratch.buf.Reset()
+			d, err := o.converter.BatchToArrow(o.batch)
+			if err != nil {
+				colexecerror.InternalError(errors.Wrap(err, "Outbox BatchToArrow data serialization error"))
+			}
+			if _, _, err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
+				colexecerror.InternalError(errors.Wrap(err, "Outbox Serialize data error"))
+			}
+			o.scratch.msg.Data.RawBytes = o.scratch.buf.Bytes()
+
+			// o.scratch.msg can be reused as soon as Send returns since it returns as
+			// soon as the message is written to the control buffer. The message is
+			// marshaled (bytes are copied) before writing.
+			if err := stream.Send(o.scratch.msg); err != nil {
+				o.handleStreamErr(ctx, "Send (batches)", err, cancelFn)
+				return
+			}
 		}
-	}
+	})
+	return terminatedGracefully, errToSend
 }
 
 // sendMetadata drains the Outbox.metadataSources and sends the metadata over
@@ -299,8 +291,6 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 func (o *Outbox) runWithStream(
 	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
 ) {
-	o.Input().Init()
-
 	waitCh := make(chan struct{})
 	go func() {
 		for {


### PR DESCRIPTION
Backport 1/2 commits from #55087.

/cc @cockroachdb/release

---

**colexec,colflow: catch expected errors from Init at the root**

`Operator.Init` method might emit expected errors (e.g. when an operator
attempts to allocate a batch but hits the memory budget limit), and
previously we were not catching those - this would result in a crash.
This commit adds a catcher at components that can serve as the root of
the Operator tree (materializers and outboxes).

Fixes: #55077.

Release note (bug fix): CockroachDB could previously crash when
executing a query via the vectorized engine when most of the SQL memory
(determined via `--max-sql-memory` startup argument) has already been
reserved. This is now fixed.
