### PR TITLE
release-20.1: colexec,colflow: catch expected errors from Init at the root

### DIFF
--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -25,6 +25,9 @@ type Operator interface {
 	// Init initializes this operator. Will be called once at operator setup
 	// time. If an operator has an input operator, it's responsible for calling
 	// Init on that input operator as well.
+	//
+	// It might panic with an expected error, so there must be a "root"
+	// component that will catch that panic.
 	// TODO(yuzefovich): we might need to clarify whether it is ok to call
 	// Init() multiple times before the first call to Next(). It is possible to
 	// hit the memory limit during Init(), and a disk-backed operator needs to
@@ -42,6 +45,9 @@ type Operator interface {
 	// Next.
 	// Canceling the provided context results in forceful termination of
 	// execution.
+	//
+	// It might panic with an expected error, so there must be a "root"
+	// component that will catch that panic.
 	Next(context.Context) coldata.Batch
 
 	execinfra.OpNode


### PR DESCRIPTION
Backport 1/2 commits from #55087.

/cc @cockroachdb/release

---

**colexec,colflow: catch expected errors from Init at the root**

`Operator.Init` method might emit expected errors (e.g. when an operator
attempts to allocate a batch but hits the memory budget limit), and
previously we were not catching those - this would result in a crash.
This commit adds a catcher at components that can serve as the root of
the Operator tree (materializers and outboxes).

Fixes: #55077.

Release note (bug fix): CockroachDB could previously crash when
executing a query via the vectorized engine when most of the SQL memory
(determined via `--max-sql-memory` startup argument) has already been
reserved. This is now fixed.
