### PR TITLE
geo/geomfn: implement ST_PointInsideCircle

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1992,6 +1992,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_pointfromwkb"></a><code>st_pointfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation with an SRID. If the shape underneath is not Point, NULL is returned.</p>
 </span></td></tr>
+<tr><td><a name="st_pointinsidecircle"></a><code>st_pointinsidecircle(geometry: geometry, x_coord: <a href="float.html">float</a>, y_coord: <a href="float.html">float</a>, radius: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns the true if the geometry is a point and is inside the circle. Returns false otherwise.</p>
+</span></td></tr>
 <tr><td><a name="st_pointn"></a><code>st_pointn(geometry: geometry, n: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the n-th Point of a LineString (1-indexed). Returns NULL if out of bounds or not a LineString.</p>
 </span></td></tr>
 <tr><td><a name="st_pointonsurface"></a><code>st_pointonsurface(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a point that intersects with the given Geometry.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5435,3 +5435,36 @@ SELECT ST_MemSize(g) FROM ( VALUES
 173
 121
 119
+
+subtest  st_pointinsidecircle
+
+query B
+SELECT ST_PointInsideCircle(point, x, y, radius) FROM ( VALUES
+   ((ST_Point(1,2)),    (0.5::float), (2.0::float), (3.0::float)),
+   ((ST_Point(0,0)),    (3.0::float), (3.0::float), (2.0::float)),
+   ((ST_Point(1,-1)),    (1.5::float), (-2.0::float), (5.0::float)),
+   ((ST_Point(0,0)),    (1.0::float), (1.0::float), (1.0::float)),
+   ((ST_Point(0,0)),    (1.0::float), (1.0::float), (2.0::float)),
+   ((ST_Point(-1,-1)),  (1.0::float), (1.0::float), (1.0::float)),
+   ((ST_Point(-1,-1)),  (1.0::float), (1.0::float), (2.0::float)),
+   ((ST_Point(2.5,-2)), (2.5::float), (-1.5::float), (1.0::float)),
+   ((ST_Point(2.5,-2)), (2.5::float), (-1.0::float), (0.5::float)),
+   ((ST_Point(2.5,-2)), (2.5::float), (-1.5::float), (2.0::float))
+) points_inside_circle(point, x, y, radius)
+----
+true
+false
+true
+false
+true
+false
+false
+true
+false
+true
+
+statement error pq: st_pointinsidecircle\(\): radius of the circle has to be positive
+SELECT ST_PointInsideCircle(ST_Point(1,2), 0.5, 2, -3);
+
+statement error pq: st_pointinsidecircle\(\): first parameter has to be of type Point
+SELECT ST_PointInsideCircle(ST_GeomFromText('LINESTRING (-0.5 0.5, 0.5 0.5)'), 0.5, 2, -3);


### PR DESCRIPTION
This commits implements ST_PointInsideCircle builtin which returns
the true if the geometry is a point and is inside the circle false
otherwise. Issue #49007.

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note (sql change): implements ST_PointInsideCircle builtin
function to check whenever given point placed within the circle