### PR TITLE
sql: fix ancestor interleave references on table drop

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -408,15 +408,8 @@ func (p *planner) dropIndexByName(
 	}
 	tableDesc.InboundFKs = tableDesc.InboundFKs[:sliceIdx]
 
-	if len(idx.Interleave.Ancestors) > 0 {
-		if err := p.removeInterleaveBackReference(ctx, tableDesc, idx); err != nil {
-			return err
-		}
-	}
-	for _, ref := range idx.InterleavedBy {
-		if err := p.removeInterleave(ctx, ref); err != nil {
-			return err
-		}
+	if err := p.removeInterleaveReferences(ctx, tableDesc, idx); err != nil {
+		return err
 	}
 
 	var droppedViews []string

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -241,22 +241,99 @@ func (p *planner) canRemoveInterleave(
 	return p.CheckPrivilege(ctx, table, privilege.CREATE)
 }
 
-func (p *planner) removeInterleave(ctx context.Context, ref descpb.ForeignKeyReference) error {
-	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
-	if err != nil {
-		return err
-	}
-	if table.Dropped() {
+// removeAncestorReferences removes any references to `idx` from `descendentIdx`
+// list of ancestors. `descendentIdx` should be an interleaved descendent of
+// `idx`. `idx` should belong to `tableDesc` and `descendentIdx` should belong
+// to `descendentTable`.
+func (p *planner) removeAncestorReferences(
+	ctx context.Context,
+	tableDesc *tabledesc.Mutable,
+	idx *descpb.IndexDescriptor,
+	descendentTable *tabledesc.Mutable,
+	descendentIdx *descpb.IndexDescriptor,
+) error {
+
+	if descendentTable.Dropped() {
 		// The referenced table is being dropped. No need to modify it further.
 		return nil
 	}
-	idx, err := table.FindIndexByID(ref.Index)
-	if err != nil {
-		return err
+
+	foundAncestor := false
+	for k, ancestor := range descendentIdx.Interleave.Ancestors {
+		if ancestor.TableID == tableDesc.ID && ancestor.IndexID == idx.ID {
+			if foundAncestor {
+				return errors.AssertionFailedf(
+					"ancestor entry in %s for %s@%s found more than once",
+					tableDesc.Name, tableDesc.Name, idx.Name)
+			}
+			// Since Ancestors are ordered far-to-near, if we are dropping and index
+			// that is at position k, then we need to remove the prefix up to and
+			// including position k.
+			descendentIdx.Interleave.Ancestors = descendentIdx.Interleave.Ancestors[k+1:]
+			foundAncestor = true
+		}
 	}
-	idx.Interleave.Ancestors = nil
+
 	// No job description, since this is presumably part of some larger schema change.
-	return p.writeSchemaChange(ctx, table, descpb.InvalidMutationID, "")
+	return p.writeSchemaChange(ctx, descendentTable, descpb.InvalidMutationID, "")
+}
+
+// removeInterleaveReferences removes interleaved relationships from both the
+// given index's parents and descendents.
+func (p *planner) removeInterleaveReferences(
+	ctx context.Context, tableDesc *tabledesc.Mutable, idx *descpb.IndexDescriptor,
+) error {
+	refToID := func(ref descpb.ForeignKeyReference) string {
+		return fmt.Sprintf("%d-%d", ref.Table, ref.Index)
+	}
+
+	// First remove references from the parents to this index.
+	if len(idx.Interleave.Ancestors) > 0 {
+		if err := p.removeInterleaveBackReference(ctx, tableDesc, idx); err != nil {
+			return err
+		}
+	}
+
+	// Then remove references from all descendents to this index.
+
+	// InterleavedBy only stores the IDs of the tables which are direct children
+	// this interleaved index. We need to remove references to (tableDesc, idx)
+	// from all descendants of this table.
+	descendentsToVisit := idx.InterleavedBy
+	seen := make(map[string]struct{})
+	for len(descendentsToVisit) > 0 {
+		descendent := descendentsToVisit[0]
+		descendentsToVisit = descendentsToVisit[1:]
+
+		// Let's detect cycles as a safeguard, but we expect these relationships to
+		// describe a tree since they describe the interleaving of data, and so
+		// should be acyclic.
+		descendentID := refToID(descendent)
+		if _, ok := seen[descendentID]; ok {
+			return errors.AssertionFailedf(
+				"found cycle in InterleavedBy relationships starting from %s@%s (%s already in %v)",
+				tableDesc.Name, idx.Name, descendentID, seen)
+		}
+		seen[descendentID] = struct{}{}
+
+		descendentTable, err := p.Descriptors().GetMutableTableVersionByID(ctx, descendent.Table, p.txn)
+		if err != nil {
+			return err
+		}
+		descendentIdx, err := descendentTable.FindIndexByID(descendent.Index)
+		if err != nil {
+			return err
+		}
+
+		if err := p.removeAncestorReferences(ctx, tableDesc, idx, descendentTable, descendentIdx); err != nil {
+			return err
+		}
+
+		// Add all of this table's children to the queue of descendents to visit.
+		descendentsToVisit = append(descendentsToVisit, descendentIdx.InterleavedBy...)
+	}
+
+	return nil
 }
 
 // dropTableImpl does the work of dropping a table (and everything that depends
@@ -290,15 +367,8 @@ func (p *planner) dropTableImpl(
 
 	// Remove interleave relationships.
 	for _, idx := range tableDesc.AllNonDropIndexes() {
-		if len(idx.Interleave.Ancestors) > 0 {
-			if err := p.removeInterleaveBackReference(ctx, tableDesc, idx); err != nil {
-				return droppedViews, err
-			}
-		}
-		for _, ref := range idx.InterleavedBy {
-			if err := p.removeInterleave(ctx, ref); err != nil {
-				return droppedViews, err
-			}
+		if err := p.removeInterleaveReferences(ctx, tableDesc, idx); err != nil {
+			return droppedViews, err
 		}
 	}
 
@@ -563,12 +633,18 @@ func removeFKBackReferenceFromTable(
 	return nil
 }
 
+// removeInterleaveBackReference removes references to the given (tableDesc, idx)
+// from the InterleavedBy list of this index's parents.
 func (p *planner) removeInterleaveBackReference(
 	ctx context.Context, tableDesc *tabledesc.Mutable, idx *descpb.IndexDescriptor,
 ) error {
 	if len(idx.Interleave.Ancestors) == 0 {
 		return nil
 	}
+	// Since InterleavedBy only references direct interleaved children, we only
+	// need to remove the reference from the parent table. And since Ancestors is
+	// sorted by far-to-near order, the last Ancestor in the list will be the
+	// direct parent.
 	ancestor := idx.Interleave.Ancestors[len(idx.Interleave.Ancestors)-1]
 	var t *tabledesc.Mutable
 	if ancestor.TableID == tableDesc.ID {

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":520,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":513,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
This commit fixes a bug where the Ancestor reference of descendants that
were not direct children of a dropped interleaved table would not be
updated. This meant that grand-children of dropped interleaved tables
would maintain a reference to a dropped table.

This prevented backups that included these grand-children tables.

Fixes #55510.

Release note (bug fix): A backup of a database might have not been
possible after dropping an interleaved table if it's children had other
interleaved tables as their children. This is now fixed.