### PR TITLE
docker: Switch to using ubi8/ubi-minimal

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,14 +1,13 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-# For deployment, we need the following installed (they are installed
-# by default in RedHat UBI standard):
-# glibc - dynamically linked by cockroach binary
-# ca-certificates - to authenticate TLS connections for telemetry and
-#                   bulk-io with S3/GCS/Azure
-# tzdata - for time zone functions
-RUN yum update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos -y && \
-    yum install --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos hostname -y && \
-    rm -rf /var/cache/yum
+# For deployment, we need the following additionally installed:
+# tzdata - for time zone functions; reinstalled to replace the missing
+#          files in /usr/share/zoneinfo/
+# hostname - used in cockroach k8s manifests
+RUN microdnf update -y \
+    && rpm --erase --nodeps tzdata \
+    && microdnf install tzdata hostname -y \
+    && rm -rf /var/cache/yum
 
 # Install GEOS libraries.
 RUN mkdir /usr/local/lib/cockroach


### PR DESCRIPTION
Before: We were using ubi8/ubi because we hadn't figured out how to get
tzdata into the ubi8/ubi-minimal image.

Why: The ubi8/ubi-minimal image is smaller and now has everything we
need.

Now: The docker image is based on ubi8/ubi-minimal. The required tzdata
files are acquired by rpm erasing the tzdata package and then
reinstalling it (there is no `microdnf reinstall` command in the current
image).

Release note (backward-incompatible change): The docker image is now
based on RedHat's ubi8/ubi-minimal image (instead of ubi8/ubi). This
image is smaller.