### PR TITLE
geo/geomfn: implement ST_LineLocatePoint

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1849,6 +1849,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 <p>Note If the result has zero or one points, it will be returned as a POINT. If it has two or more points, it will be returned as a MULTIPOINT.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
+<tr><td><a name="st_linelocatepoint"></a><code>st_linelocatepoint(line: geometry, point: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a float between 0 and 1 representing the location of the closest point on LineString to the given Point, as a fraction of total 2d line length.</p>
+</span></td></tr>
 <tr><td><a name="st_linemerge"></a><code>st_linemerge(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a LineString or MultiLineString by joining together constituents of a MultiLineString with matching endpoints. If the input is not a MultiLineString or LineString, an empty GeometryCollection is returned.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5469,6 +5469,34 @@ SELECT ST_PointInsideCircle(ST_Point(1,2), 0.5, 2, -3);
 statement error pq: st_pointinsidecircle\(\): first parameter has to be of type Point
 SELECT ST_PointInsideCircle(ST_GeomFromText('LINESTRING (-0.5 0.5, 0.5 0.5)'), 0.5, 2, -3);
 
+subtest st_linelocatepoint
+
+query R
+SELECT round(ST_LineLocatePoint(line, point)::float, 2) FROM ( VALUES
+  ((ST_GeomFromText('LINESTRING (0 2, 2 0)')), (ST_Point(0, 0))),
+  ((ST_GeomFromText('LINESTRING (0 0, 0 2)')), (ST_Point(1, 1))),
+  ((ST_GeomFromText('LINESTRING (-1 -1, 3 3)')), (ST_Point(1, 0))),
+  ((ST_GeomFromText('LINESTRING (0 1, 2 0)')), (ST_Point(0, 0))),
+  ((ST_GeomFromText('LINESTRING (-1 0, 0 1)')), (ST_Point(1, 0))),
+  ((ST_GeomFromText('LINESTRING (0 0, 0 1)')), (ST_Point(1, 0))),
+  ((ST_GeomFromText('LINESTRING (-3 5, 4 -2)')), (ST_Point(-1, -1))),
+  ((ST_GeomFromText('LINESTRING (0 0, 10 10)')), (ST_Point(0, 3))),
+  ((ST_GeomFromText('LINESTRING (-5 7, 1 4)')), (ST_Point(-3, 3)))
+) line_locate_point(line, point)
+----
+0.5
+0.5
+0.37
+0.2
+1
+0
+0.57
+0.15
+0.53
+
+statement error pq: st_linelocatepoint\(\): first parameter has to be of type LineString
+SELECT ST_LineLocatePoint(ST_GeomFromText('GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))'), ST_Point(0, 0));
+
 
 query TT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -5401,6 +5401,36 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 			Info:       "Returns the amount of memory space (in bytes) the geometry takes.",
 			Volatility: tree.VolatilityImmutable,
 		}),
+
+	"st_linelocatepoint": makeBuiltin(defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{
+					Name: "line",
+					Typ:  types.Geometry,
+				},
+				{
+					Name: "point",
+					Typ:  types.Geometry,
+				},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				line := tree.MustBeDGeometry(args[0])
+				p := tree.MustBeDGeometry(args[1])
+
+				// compute fraction of new line segment compared to total line length
+				fraction, err := geomfn.LineLocatePoint(line.Geometry, p.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(fraction)), nil
+			},
+			Info: "Returns a float between 0 and 1 representing the location of the closest point " +
+				"on LineString to the given Point, as a fraction of total 2d line length.",
+			Volatility: tree.VolatilityImmutable,
+		}),
+
 	//
 	// Unimplemented.
 	//
@@ -5430,7 +5460,6 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 	"st_length2dspheroid":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48967}),
 	"st_lengthspheroid":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48968}),
 	"st_linecrossingdirection": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48969}),
-	"st_linelocatepoint":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48973}),
 	"st_linesubstring":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48975}),
 	"st_minimumboundingcircle": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48987}),
 	"st_minimumboundingradius": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48988}),


### PR DESCRIPTION
This commit adds an implementation of ST_LineLocatePoint builtin, which
returns a float between 0 and 1 representing the location of the closest
point on LineString to the given Point, as a fraction of total 2d line
length.


Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note (sql change): implement ST_LineLocatePoint to compute
the fraction of the line segment that represents the location of the given
point to the closest point on the original line.