### PR TITLE
opt: support multi-column inverted indexes in opt catalog

### DIFF
--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -62,11 +62,6 @@ type Index interface {
 	// the table.
 	ColumnCount() int
 
-	// Predicate returns the partial index predicate expression and true if the
-	// index is a partial index. If it is not a partial index, the empty string
-	// and false are returned.
-	Predicate() (string, bool)
-
 	// KeyColumnCount returns the number of columns in the index that are part
 	// of its unique key. No two rows in the index will have the same values for
 	// those columns (where NULL values are treated as equal). Every index has a
@@ -129,6 +124,15 @@ type Index interface {
 	// Column returns the ith IndexColumn within the index definition, where
 	// i < ColumnCount.
 	Column(i int) IndexColumn
+
+	// VirtualInvertedColumn returns the VirtualInverted IndexColumn of the
+	// index. Panics if the index is not an inverted index.
+	VirtualInvertedColumn() IndexColumn
+
+	// Predicate returns the partial index predicate expression and true if the
+	// index is a partial index. If it is not a partial index, the empty string
+	// and false are returned.
+	Predicate() (string, bool)
 
 	// Zone returns the zone which constrains placement of the index's range
 	// replicas. If the index was not explicitly assigned to a zone, then it

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -519,8 +519,8 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 		if !index.IsInverted() {
 			continue
 		}
-		// The first column of inverted indexes is always virtual.
-		col := index.Column(0)
+		// The inverted column of an inverted index is virtual.
+		col := index.VirtualInvertedColumn()
 		srcOrd := col.InvertedSourceColumnOrdinal()
 		invIndexVirtualCols[srcOrd] = append(invIndexVirtualCols[srcOrd], col.Ordinal())
 	}

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -534,3 +534,25 @@ project
       │              └── fd: (3)-->(5)
       └── filters
            └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ])]
+
+# Tests for multi-column inverted spatial indexes.
+
+exec-ddl
+CREATE TABLE m (
+  k INT PRIMARY KEY,
+  a INT,
+  g GEOMETRY,
+  INVERTED INDEX (a, g)
+)
+----
+
+# The stats builder should not panic during a SELECT on a table with a
+# multi-column inverted index.
+opt
+SELECT * FROM m
+----
+scan m
+ ├── columns: k:1(int!null) a:2(int) g:3(geometry)
+ ├── stats: [rows=1000]
+ ├── key: (1)
+ └── fd: (1)-->(2,3)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -762,6 +762,10 @@ type Index struct {
 	// predicate is the partial index predicate expression, if it exists.
 	predicate string
 
+	// invertedOrd is the ordinal of the VirtualInverted column, if the index is
+	// an inverted index.
+	invertedOrd int
+
 	// geoConfig is the geospatial index configuration, if this is a geospatial
 	// inverted index. Otherwise geoConfig is nil.
 	geoConfig *geoindex.Config
@@ -815,6 +819,14 @@ func (ti *Index) LaxKeyColumnCount() int {
 // Column is part of the cat.Index interface.
 func (ti *Index) Column(i int) cat.IndexColumn {
 	return ti.Columns[i]
+}
+
+// VirtualInvertedColumn is part of the cat.Index interface.
+func (ti *Index) VirtualInvertedColumn() cat.IndexColumn {
+	if !ti.IsInverted() {
+		panic("non-inverted indexes do not have inverted virtual columns")
+	}
+	return ti.Column(ti.invertedOrd)
 }
 
 // Zone is part of the cat.Index interface.

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -60,3 +60,37 @@ TABLE kv
       ├── k int not null
       └── WHERE
            └── v > 1
+
+exec-ddl
+CREATE TABLE g (
+    k INT PRIMARY KEY,
+    a INT,
+    b INT,
+    geog GEOGRAPHY,
+    INVERTED INDEX (a, geog),
+    INVERTED INDEX (a, b, geog)
+)
+----
+
+exec-ddl
+SHOW CREATE g
+----
+TABLE g
+ ├── k int not null
+ ├── a int
+ ├── b int
+ ├── geog geography
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ ├── INDEX primary
+ │    └── k int not null
+ ├── INVERTED INDEX secondary
+ │    ├── a int
+ │    ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ │    └── k int not null
+ └── INVERTED INDEX secondary
+      ├── a int
+      ├── b int
+      ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+      └── k int not null

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1164,13 +1164,6 @@ func (oi *optIndex) ColumnCount() int {
 	return oi.numCols
 }
 
-// Predicate is part of the cat.Index interface. It returns the predicate
-// expression and true if the index is a partial index. If the index is not
-// partial, the empty string and false is returned.
-func (oi *optIndex) Predicate() (string, bool) {
-	return oi.desc.Predicate, oi.desc.Predicate != ""
-}
-
 // KeyColumnCount is part of the cat.Index interface.
 func (oi *optIndex) KeyColumnCount() int {
 	return oi.numKeyCols
@@ -1207,6 +1200,22 @@ func (oi *optIndex) Column(i int) cat.IndexColumn {
 	i -= length
 	ord, _ := oi.tab.lookupColumnOrdinal(oi.storedCols[i])
 	return cat.IndexColumn{Column: oi.tab.Column(ord), Descending: false}
+}
+
+// VirtualInvertedColumn is part of the cat.Index interface.
+func (oi *optIndex) VirtualInvertedColumn() cat.IndexColumn {
+	if !oi.IsInverted() {
+		panic("non-inverted indexes do not have inverted virtual columns")
+	}
+	ord := len(oi.desc.ColumnIDs) - 1
+	return oi.Column(ord)
+}
+
+// Predicate is part of the cat.Index interface. It returns the predicate
+// expression and true if the index is a partial index. If the index is not
+// partial, the empty string and false is returned.
+func (oi *optIndex) Predicate() (string, bool) {
+	return oi.desc.Predicate, oi.desc.Predicate != ""
 }
 
 // Zone is part of the cat.Index interface.
@@ -1819,11 +1828,6 @@ func (oi *optVirtualIndex) ColumnCount() int {
 	return oi.numCols
 }
 
-// Predicate is part of the cat.Index interface.
-func (oi *optVirtualIndex) Predicate() (string, bool) {
-	return "", false
-}
-
 // KeyColumnCount is part of the cat.Index interface.
 func (oi *optVirtualIndex) KeyColumnCount() int {
 	// Virtual indexes for the time being always have exactly 2 key columns,
@@ -1874,6 +1878,16 @@ func (oi *optVirtualIndex) Column(i int) cat.IndexColumn {
 	i -= length + 1
 	ord, _ := oi.tab.lookupColumnOrdinal(oi.desc.StoreColumnIDs[i])
 	return cat.IndexColumn{Column: oi.tab.Column(ord)}
+}
+
+// VirtualInvertedColumn is part of the cat.Index interface.
+func (oi *optVirtualIndex) VirtualInvertedColumn() cat.IndexColumn {
+	panic("virtual indexes do not have inverted virtual columns")
+}
+
+// Predicate is part of the cat.Index interface.
+func (oi *optVirtualIndex) Predicate() (string, bool) {
+	return "", false
 }
 
 // Zone is part of the cat.Index interface.


### PR DESCRIPTION
This commit updates the opt catalog to support multi-column inverted
indexes. A multi-column inverted index's last indexed column must be a
inverted-indexable type, such as JSON, ARRAY, GEOMETRY, or GEOGRAPHY.
All other indexed columns must be scalars.

In order to determine the last indexed column, the `IndexedColumnCount`
function has been added to the `cat.Index` interface.

Release note: None