### PR TITLE
sql: clarify help text for `show range`

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4988,8 +4988,8 @@ show_zone_stmt:
 // %Help: SHOW RANGE - show range information for a row
 // %Category: Misc
 // %Text:
-// SHOW RANGE FROM TABLE <tablename> FOR ROW (row, value, ...)
-// SHOW RANGE FROM INDEX [ <tablename> @ ] <indexname> FOR ROW (row, value, ...)
+// SHOW RANGE FROM TABLE <tablename> FOR ROW (value1, value2, ...)
+// SHOW RANGE FROM INDEX [ <tablename> @ ] <indexname> FOR ROW (value1, value2, ...)
 show_range_for_row_stmt:
   SHOW RANGE FROM TABLE table_name FOR ROW '(' expr_list ')'
   {


### PR DESCRIPTION
The SHOW RANGE FOR ROW statement now accepts the indexed values
of the row as a tuple. The help text representation of this was
previous (row, value, ...). The help text representation is
now (value1, value2, ...), which I believe is clearer.

Counterpart to this docs PR: https://github.com/cockroachdb/docs/pull/8634

Release note: None