### PR TITLE
release-20.1: kvserver: sync cluster version setting to store

### DIFF
--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -136,11 +136,13 @@ DBStatus DBImpl::AssertPreClose() {
 
 DBStatus DBImpl::Put(DBKey key, DBSlice value) {
   rocksdb::WriteOptions options;
+  options.sync = true;
   return ToDBStatus(rep->Put(options, EncodeKey(key), ToSlice(value)));
 }
 
 DBStatus DBImpl::Merge(DBKey key, DBSlice value) {
   rocksdb::WriteOptions options;
+  options.sync = true;
   return ToDBStatus(rep->Merge(options, EncodeKey(key), ToSlice(value)));
 }
 
@@ -152,16 +154,19 @@ DBStatus DBImpl::Get(DBKey key, DBString* value) {
 
 DBStatus DBImpl::Delete(DBKey key) {
   rocksdb::WriteOptions options;
+  options.sync = true;
   return ToDBStatus(rep->Delete(options, EncodeKey(key)));
 }
 
 DBStatus DBImpl::SingleDelete(DBKey key) {
   rocksdb::WriteOptions options;
+  options.sync = true;
   return ToDBStatus(rep->SingleDelete(options, EncodeKey(key)));
 }
 
 DBStatus DBImpl::DeleteRange(DBKey start, DBKey end) {
   rocksdb::WriteOptions options;
+  options.sync = true;
   return ToDBStatus(
       rep->DeleteRange(options, rep->DefaultColumnFamily(), EncodeKey(start), EncodeKey(end)));
 }


### PR DESCRIPTION
Backport 1/1 commits from #55240.

/cc @cockroachdb/release

---

Writes to a `storage.Engine` are not sync'ed by default, meaning that
they can get lost due to an ill-timed crash.

Fixes #54906.

(The backport will take care of #54908).

Release note (bug fix): a rare scenario in which a node would refuse
to start after updating the binary was fixed. The log message would
indicate: "store [...], last used with cockroach version [...], is too
old for running version [...] (which requires data from [...] or
later)".
