### PR TITLE
build: fix builds using grep to match a string.

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -9,8 +9,10 @@ export BUILDER_HIDE_GOPATH_SRC=1
 
 build/builder.sh make .buildinfo/tag
 build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
-release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+")"
-is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-")"
+
+# On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
+release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
+is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET-cockroach-builds}"

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -8,7 +8,9 @@ source "$(dirname "${0}")/teamcity-support.sh"
 mark_build() {
   tc_start_block "Variable Setup"
   build_label=$1
-  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^v[0-9]+\.[0-9]+")"
+
+  # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
+  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 
   if [[ -z "${DRY_RUN}" ]] ; then
     google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS


### PR DESCRIPTION
Before: `grep -Eo` was used in a couple places in release scripts
where it might not find the string being searched for, the non-zero
return code wasn't handled and the script should have continued
executing.

Why: The release scripts were erroring out when they should have
continued executing.

Now: The non-zero return code is handled by adding a `|| echo""` to the
commands.

This was discovered by PR #54661 causing master to fail builds in Make
and Publish Build.

Release note: None