### PR TITLE
roachprod: point to right certs when using --secure

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -240,7 +240,7 @@ func (Cockroach) CertsDir(c *SyncedCluster, index int) string {
 func (Cockroach) NodeURL(c *SyncedCluster, host string, port int) string {
 	url := fmt.Sprintf("'postgres://root@%s:%d", host, port)
 	if c.Secure {
-		url += "?sslcert=certs%2Fnode.crt&sslkey=certs%2Fnode.key&" +
+		url += "?sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&" +
 			"sslrootcert=certs%2Fca.crt&sslmode=verify-full"
 	} else {
 		url += "?sslmode=disable"


### PR DESCRIPTION
Fixes #54534.

When starting up a secure cluster (repro steps below), it like we were
pointing to node.crt, when `cockroach` expects to be pointed to
client.root.crt instead[1][2]. It isn't clear that this worked properly
before, doesn't look like it was changed as part of the roachprod
refactor[3].

To repro the original issue, try the following:

    roachprod destroy local; roachprod create local
    roachprod put local `which cockroach`
    roachprod start local:1 --secure

[1]: https://github.com/cockroachdb/cockroach/blob/d66b7de1bd4/pkg/cli/client_url.go#L305
[2]: https://github.com/cockroachdb/cockroach/blob/d66b7de1bd4/pkg/security/certificate_manager.go#L344-L345
[3]: https://github.com/cockroachdb/cockroach/commit/cd7e56502935160a3d41f59c9d114c82615f9342

Release note: None