### PR TITLE
sql: properly handle cases where marking a job as canceled fails

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -110,6 +110,7 @@ type Registry struct {
 	settings *cluster.Settings
 	execCtx  jobExecCtxMaker
 	metrics  Metrics
+	knobs    TestingKnobs
 
 	// adoptionChan is used to nudge the registry to resume claimed jobs and
 	// potentially attempt to claim jobs.
@@ -201,6 +202,7 @@ func MakeRegistry(
 	histogramWindowInterval time.Duration,
 	execCtxFn jobExecCtxMaker,
 	preventAdoptionFile string,
+	knobs *TestingKnobs,
 ) *Registry {
 	r := &Registry{
 		ac:                  ac,
@@ -215,6 +217,9 @@ func MakeRegistry(
 		execCtx:             execCtxFn,
 		preventAdoptionFile: preventAdoptionFile,
 		adoptionCh:          make(chan adoptionNotice),
+	}
+	if knobs != nil {
+		r.knobs = *knobs
 	}
 	r.mu.deprecatedEpoch = 1
 	r.mu.deprecatedJobs = make(map[int64]context.CancelFunc)

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -107,6 +107,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 			ac, s.Stopper(), clock, optionalnodeliveness.MakeContainer(nodeLiveness), db,
 			s.InternalExecutor().(sqlutil.InternalExecutor), idContainer, sqlInstance,
 			s.ClusterSettings(), base.DefaultHistogramWindowInterval(), jobs.FakePHS, "",
+			nil, /* knobs */
 		)
 		if err := r.Start(ctx, s.Stopper(), cancelInterval, adoptInterval); err != nil {
 			t.Fatal(err)

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -82,6 +82,7 @@ func TestRegistryCancelation(t *testing.T) {
 		histogramWindowInterval,
 		FakePHS,
 		"",
+		nil, /* knobs */
 	)
 
 	const cancelInterval = time.Nanosecond

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -46,6 +46,11 @@ type TestingKnobs struct {
 	// OverrideAsOfClause is a function which has a chance of modifying
 	// tree.AsOfClause.
 	OverrideAsOfClause func(clause *tree.AsOfClause)
+
+	// BeforeUpdate is called in the update transaction after the update function
+	// has run. If an error is returned, it will be propagated and the update will
+	// not be committed.
+	BeforeUpdate func(orig, updated JobMetadata) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -155,7 +155,11 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 		if err := updateFn(txn, md, &ju); err != nil {
 			return err
 		}
-
+		if j.registry.knobs.BeforeUpdate != nil {
+			if err := j.registry.knobs.BeforeUpdate(md, ju.md); err != nil {
+				return err
+			}
+		}
 		if !ju.hasUpdates() {
 			return nil
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1492,26 +1492,34 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		// If this is a real mutation, it should be the first mutation. Assert that.
 		if sc.mutationID != descpb.InvalidMutationID {
 			if len(scTable.Mutations) == 0 {
-				return errors.AssertionFailedf("expected mutation %d to be the"+
-					" first mutation when reverted, found no mutations in descriptor %d",
-					sc.mutationID, scTable.ID)
+				alreadyReversed = true
 			} else if scTable.Mutations[0].MutationID != sc.mutationID {
-				return errors.AssertionFailedf("expected mutation %d to be the"+
-					" first mutation when reverted, found %d in descriptor %d",
-					sc.mutationID, scTable.Mutations[0].MutationID, scTable.ID)
+				var found bool
+				for i := range scTable.Mutations {
+					if found = scTable.Mutations[i].MutationID == sc.mutationID; found {
+						break
+					}
+				}
+				if alreadyReversed = !found; !alreadyReversed {
+					return errors.AssertionFailedf("expected mutation %d to be the"+
+						" first mutation when reverted, found %d in descriptor %d",
+						sc.mutationID, scTable.Mutations[0].MutationID, scTable.ID)
+				}
+			} else if scTable.Mutations[0].Rollback {
+				alreadyReversed = true
 			}
+		}
+
+		// Mutation is already reversed, so we don't need to do any more work.
+		// This can happen if the mutations were already reversed, but before
+		// the rollback completed the job was adopted.
+		if alreadyReversed {
+			return nil
 		}
 
 		for _, mutation := range scTable.Mutations {
 			if mutation.MutationID != sc.mutationID {
 				break
-			}
-			if mutation.Rollback {
-				// Mutation is already reversed, so we don't need to do any more work.
-				// This can happen if the mutations were already reversed, but before
-				// the rollback completed the job was adopted.
-				alreadyReversed = true
-				return nil
 			}
 			if constraint := mutation.GetConstraint(); constraint != nil &&
 				constraint.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY &&

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1469,6 +1469,10 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 			return err
 		}
 	}
+	// There's nothing to do if the mutation is InvalidMutationID.
+	if sc.mutationID == descpb.InvalidMutationID {
+		return nil
+	}
 
 	// Get the other tables whose foreign key backreferences need to be removed.
 	var fksByBackrefTable map[descpb.ID][]*descpb.ConstraintToUpdate
@@ -1489,25 +1493,23 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 			return err
 		}
 
-		// If this is a real mutation, it should be the first mutation. Assert that.
-		if sc.mutationID != descpb.InvalidMutationID {
-			if len(scTable.Mutations) == 0 {
-				alreadyReversed = true
-			} else if scTable.Mutations[0].MutationID != sc.mutationID {
-				var found bool
-				for i := range scTable.Mutations {
-					if found = scTable.Mutations[i].MutationID == sc.mutationID; found {
-						break
-					}
+		// If this mutation exists, it should be the first mutation. Assert that.
+		if len(scTable.Mutations) == 0 {
+			alreadyReversed = true
+		} else if scTable.Mutations[0].MutationID != sc.mutationID {
+			var found bool
+			for i := range scTable.Mutations {
+				if found = scTable.Mutations[i].MutationID == sc.mutationID; found {
+					break
 				}
-				if alreadyReversed = !found; !alreadyReversed {
-					return errors.AssertionFailedf("expected mutation %d to be the"+
-						" first mutation when reverted, found %d in descriptor %d",
-						sc.mutationID, scTable.Mutations[0].MutationID, scTable.ID)
-				}
-			} else if scTable.Mutations[0].Rollback {
-				alreadyReversed = true
 			}
+			if alreadyReversed = !found; !alreadyReversed {
+				return errors.AssertionFailedf("expected mutation %d to be the"+
+					" first mutation when reverted, found %d in descriptor %d",
+					sc.mutationID, scTable.Mutations[0].MutationID, scTable.ID)
+			}
+		} else if scTable.Mutations[0].Rollback {
+			alreadyReversed = true
 		}
 
 		// Mutation is already reversed, so we don't need to do any more work.
@@ -1543,11 +1545,6 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		b := txn.NewBatch()
 		for i, mutation := range scTable.Mutations {
 			if mutation.MutationID != sc.mutationID {
-				// Only reverse the first set of mutations if they have the
-				// mutation ID we're looking for.
-				if i == 0 {
-					return nil
-				}
 				break
 			}
 


### PR DESCRIPTION
In #55056 an assertion was added that was too strict. It is possible for a
revert to complete and then for the writing of the completed status to fail
and run again after the descriptor has had the mutation removed. This PR
allows that missing mutation to pass through just fine.

Release note (bug fix): Fix a bug which can lead to canceled schema change jobs
ending in the failed rather than canceled state.