### PR TITLE
opt: add missing expect-not for join normalization regression test

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -102,7 +102,7 @@ left-join (cross)
 # contradictions. Doing so can split the filter expressions into two
 # FiltersItems such that they are no longer considered a contradiction, and
 # DetectJoinContradiction does not fire.
-norm expect=DetectJoinContradiction
+norm expect=DetectJoinContradiction expect-not=SimplifyJoinFilters
 SELECT * FROM a LEFT JOIN b ON k<1 AND k>2
 ----
 left-join (cross)


### PR DESCRIPTION
In #54813 I forgot to address @rytaft's comment to add an `expect-not`
to the new regression test. This commit adds the `expect-not` she
suggested.

Release note: None