### PR TITLE
clusterversion: bump binaryMinSupportedVersion for starting 21.1

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -451,14 +451,7 @@ var (
 	// this binary. If this binary is started using a store marked with an older
 	// version than binaryMinSupportedVersion, then the binary will exit with
 	// an error.
-	//
-	// We support everything after 19.1, including pre-release 19.2 versions.
-	// This is generally beneficial, but in particular it allows the
-	// version-upgrade roachtest to use a pre-release 19.2 binary before upgrading
-	// to HEAD; if we were to set binaryMinSupportedVersion to Version19_2,
-	// that wouldn't work since you'd have to go through the final 19.2 binary
-	// before going to HEAD.
-	binaryMinSupportedVersion = VersionByKey(Version20_1)
+	binaryMinSupportedVersion = VersionByKey(Version20_2)
 
 	// binaryVersion is the version of this binary.
 	//

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -52,10 +52,8 @@ go_test(
     embed = [":lease"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security",


### PR DESCRIPTION
sql/catalog: remove TestFinalizeVersionEnablesRangefeedUpdates

This mixed-version test isn't needed anymore.

Release note: None

----

clusterversion: bump binaryMinSupportedVersion for starting 21.1

Following up on introducing a new cluster version for development on
21.1, this patch bumps the `binaryMinSupportedVersion` to `Version20_2`.

Release note: None