### PR TITLE
jobs,sqlliveness,server: start sqlliveness and pgserver after migrations

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -75,7 +75,7 @@ func (j *Job) Created(ctx context.Context) error {
 	if j.ID() != nil {
 		return errors.Errorf("job already created with ID %v", *j.ID())
 	}
-	return j.deprecatedInsert(ctx, j.registry.makeJobID(), nil /* lease */)
+	return j.deprecatedInsert(ctx, j.registry.makeJobID(), nil /* lease */, nil /* session */)
 }
 
 // Paused is a wrapper around the internal function that moves a job to the

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors"
 )
 
 var (
@@ -183,7 +182,6 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 	}()
 	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
-	sqlliveness.WaitForActive(ctx, l.settings)
 	t := timeutil.NewTimer()
 	t.Reset(0)
 	for {
@@ -261,7 +259,7 @@ func (l *Instance) Session(ctx context.Context) (sqlliveness.Session, error) {
 	l.mu.Lock()
 	if !l.mu.started {
 		l.mu.Unlock()
-		return nil, errors.New("the Instance has not been started yet")
+		return nil, sqlliveness.NotStartedError
 	}
 	l.mu.Unlock()
 


### PR DESCRIPTION
This commit reworks the SQL liveness subsystem to start on the local node
following the migrations that it relies upon. This is both safe and ensures
that jobs created on the new binary will have a session ID, thus avoiding
the issue that startable jobs created on the local node may not have had
a session ID and thus would not have had a proper claim to run the job
locally.

Fixes #55497.

Release note (bug fix): Fixes a bug which could cause IMPORT, BACKUP or
RESTORE to experience an error when they occur concurrently to when the
cluster sets its version to upgraded.