### PR TITLE
geo/geomfn: implement ST_MinimumBoundingRadius

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1888,6 +1888,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_memsize"></a><code>st_memsize(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the amount of memory space (in bytes) the geometry takes.</p>
 </span></td></tr>
+<tr><td><a name="st_minimumboundingradius"></a><code>st_minimumboundingradius(geometry: geometry) &rarr; tuple{geometry AS center, float AS radius}</code></td><td><span class="funcdesc"><p>Returns a record containing the center point and radius of the smallest circle that can fully contains the given geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_minimumclearance"></a><code>st_minimumclearance(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the minimum distance a vertex can move before producing an invalid geometry. Returns Infinity if no minimum clearance can be found (e.g. for a single point).</p>
 </span></td></tr>
 <tr><td><a name="st_minimumclearanceline"></a><code>st_minimumclearanceline(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a LINESTRING spanning the minimum distance a vertex can move before producing an invalid geometry. If no minimum clearance can be found (e.g. for a single point), an empty LINESTRING is returned.</p>

--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -37,6 +37,26 @@ func Centroid(g geo.Geometry) (geo.Geometry, error) {
 	return geo.ParseGeometryFromEWKB(centroidEWKB)
 }
 
+// MinimumBoundingCircle returns minimum bounding circle of an EWKB
+func MinimumBoundingCircle(g geo.Geometry) (geo.Geometry, geo.Geometry, float64, error) {
+	polygonEWKB, centroidEWKB, radius, err := geos.MinimumBoundingCircle(g.EWKB())
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, 0, err
+	}
+
+	polygon, err := geo.ParseGeometryFromEWKB(polygonEWKB)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, 0, err
+	}
+
+	centroid, err := geo.ParseGeometryFromEWKB(centroidEWKB)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, 0, err
+	}
+
+	return polygon, centroid, radius, nil
+}
+
 // ClipByRect clips a given Geometry by the given BoundingBox.
 func ClipByRect(g geo.Geometry, b geo.CartesianBoundingBox) (geo.Geometry, error) {
 	if g.Empty() {

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -417,6 +417,23 @@ func Centroid(ewkb geopb.EWKB) (geopb.EWKB, error) {
 	return cStringToSafeGoBytes(cEWKB), nil
 }
 
+// MinimumBoundingCircle returns minimum bounding circle of an EWKB
+func MinimumBoundingCircle(ewkb geopb.EWKB) (geopb.EWKB, geopb.EWKB, float64, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	var centerEWKB C.CR_GEOS_String
+	var polygonEWKB C.CR_GEOS_String
+	var radius C.double
+
+	if err := statusToError(C.CR_GEOS_MinimumBoundingCircle(g, goToCSlice(ewkb), &radius, &centerEWKB, &polygonEWKB)); err != nil {
+		return nil, nil, 0, err
+	}
+	return cStringToSafeGoBytes(polygonEWKB), cStringToSafeGoBytes(centerEWKB), float64(radius), nil
+
+}
+
 // ConvexHull returns an EWKB which returns the convex hull of the given EWKB.
 func ConvexHull(ewkb geopb.EWKB) (geopb.EWKB, error) {
 	g, err := ensureInitInternal()

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -120,6 +120,8 @@ CR_GEOS_Status CR_GEOS_SymDifference(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slic
 CR_GEOS_Status CR_GEOS_SharedPaths(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
                                    CR_GEOS_String* ret);
 
+CR_GEOS_Status CR_GEOS_MinimumBoundingCircle(CR_GEOS* lib, CR_GEOS_Slice a, double* radius,
+                                              CR_GEOS_String* centerEWKB, CR_GEOS_String* polygonEWKB);
 //
 // Linear reference.
 //

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5518,3 +5518,26 @@ _p~iF~ps|U_ulLnnqC_mqNvxq`@
 
 statement error only SRID 4326 is supported
 SELECT ST_AsEncodedPolyline(GeomFromEWKT('SRID=4004;LINESTRING(9.00000001 -1.00009999, 0.00000007 0.00000091)'), 8);
+
+subtest st_minimumboundingradius
+
+query TR
+SELECT ST_AsText(center), round(radius, 2) FROM ST_MinimumBoundingRadius('POLYGON((26426 65078,26531 65242,26075 65136,26096 65427,26426 65078))')
+----
+POINT (26284.841802713268407 65267.114509082544828)  247.44
+
+query TR
+SELECT ST_AsText(center), round(radius, 2) FROM ST_MinimumBoundingRadius('GEOMETRYCOLLECTION (LINESTRING(0 0, 4 0), POINT(0 4))')
+----
+POINT (2 2)  2.83
+
+query TR
+SELECT ST_AsText(center), round(radius, 2) FROM ST_MinimumBoundingRadius('LINESTRING EMPTY')
+----
+POINT EMPTY  0
+
+query TR
+SELECT ST_AsText(center), round(radius, 2) FROM ST_MinimumBoundingRadius('POLYGON((0 2,-2 0,0 -2,2 0,0 2))')
+----
+POINT (0 0)  2
+


### PR DESCRIPTION
Signed-off-by: Artem Barger <bartem@il.ibm.com>

Resolves #48988

Release note (sql change): Returns a record containing the center point
and radius of the smallest circle that can fully contain a geometry.