### PR TITLE
sql: make SPLIT AT output be consistent with SHOW_RANGES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/split_at
+++ b/pkg/sql/logictest/testdata/logic_test/split_at
@@ -1,0 +1,30 @@
+# LogicTest: !3node-tenant
+
+# Test formatting of keys in output of SPLIT AT
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE t]
+----
+start_key  end_key  replicas  lease_holder
+NULL       NULL     {1}       1
+
+query TTT colnames
+ALTER TABLE t SPLIT AT VALUES (1), (10)
+----
+key            pretty    split_enforced_until
+[189 137 137]  /1        2262-04-11 23:47:16.854776 +0000 +0000
+[189 137 146]  /10       2262-04-11 23:47:16.854776 +0000 +0000
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE t]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1       {1}       1
+/1         /10      {1}       1
+/10        NULL     {1}       1
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -74,7 +75,7 @@ func (n *splitNode) Values() tree.Datums {
 	}
 	return tree.Datums{
 		tree.NewDBytes(tree.DBytes(n.run.lastSplitKey)),
-		tree.NewDString(keys.PrettyPrint(nil /* valDirs */, n.run.lastSplitKey)),
+		tree.NewDString(catalogkeys.PrettyKey(nil /* valDirs */, n.run.lastSplitKey, 2)),
 		splitEnforcedUntil,
 	}
 }


### PR DESCRIPTION
This fixes https://github.com/cockroachdb/cockroach/issues/24740

The output of the SPLIT AT command returns keys in the form
`/Table/52/1/1` whereas the output of SHOW RANGES omits the
prefix, of table id and index id, and displays keys as `/1`.
This is a little confusing and making them consistent would
make it easier to visually compare.

This patch strips the prefix from the keys in the output of
SPLIT AT.

Release note (sql change): pretty column of SPLIT AT output was changed
by stripping prefix. This makes it consistent with output from SHOW
RANGES.