### PR TITLE
*: go 1.15 linter fixes

### DIFF
--- a/pkg/ccl/changefeedccl/name_test.go
+++ b/pkg/ccl/changefeedccl/name_test.go
@@ -37,8 +37,8 @@ func TestSQLNameToKafkaName(t *testing.T) {
 		{`/`, `_u002f_`},
 		{`☃`, `_u2603_`},
 		{"\x00", `_u0000_`},
-		{string(utf8.RuneSelf), `_u0080_`},
-		{string(utf8.MaxRune), `_u0010ffff_`},
+		{string(rune(utf8.RuneSelf)), `_u0080_`},
+		{string(rune(utf8.MaxRune)), `_u0010ffff_`},
 		// special case: exact match of . and .. are disallowed by kafka
 		{`.`, `_u002e_`},
 		{`..`, `_u002e__u002e_`},
@@ -77,8 +77,8 @@ func TestSQLNameToAvroName(t *testing.T) {
 		{`/`, `_u002f_`},
 		{`☃`, `_u2603_`},
 		{"\x00", `_u0000_`},
-		{string(utf8.RuneSelf), `_u0080_`},
-		{string(utf8.MaxRune), `_u0010ffff_`},
+		{string(rune(utf8.RuneSelf)), `_u0080_`},
+		{string(rune(utf8.MaxRune)), `_u0010ffff_`},
 	}
 	for i, test := range tests {
 		if a := SQLNameToAvroName(test.sql); a != test.avro {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -2933,11 +2933,11 @@ func TestCountRanges(t *testing.T) {
 	for i := range descriptors {
 		startKey := testMetaEndKey
 		if i > 0 {
-			startKey = roachpb.RKey(string(firstKeyBoundary + i - 1))
+			startKey = roachpb.RKey(string(rune(firstKeyBoundary + i - 1)))
 		}
 		endKey := roachpb.RKeyMax
 		if i < len(descriptors)-1 {
-			endKey = roachpb.RKey(string(firstKeyBoundary + i))
+			endKey = roachpb.RKey(string(rune(firstKeyBoundary + i)))
 		}
 
 		descriptors[i] = roachpb.RangeDescriptor{

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -887,7 +887,7 @@ func TestLockTableConcurrentSingleRequests(t *testing.T) {
 	}
 	var keys []roachpb.Key
 	for i := 0; i < 10; i++ {
-		keys = append(keys, roachpb.Key(string('a'+i)))
+		keys = append(keys, roachpb.Key(string(rune('a'+i))))
 	}
 	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
@@ -960,7 +960,7 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 	}
 	var keys []roachpb.Key
 	for i := 0; i < 10; i++ {
-		keys = append(keys, roachpb.Key(string('a'+i)))
+		keys = append(keys, roachpb.Key(string(rune('a'+i))))
 	}
 	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 	const numActiveTxns = 8

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -1170,8 +1171,8 @@ func extractRangeFromEntries(logEntries [][]byte) (string, error) {
 			return "", err
 		}
 
-		firstIndex = string(firstAndLastLogEntries[0].Index)
-		lastIndex = string(firstAndLastLogEntries[1].Index)
+		firstIndex = strconv.FormatUint(firstAndLastLogEntries[0].Index, 10)
+		lastIndex = strconv.FormatUint(firstAndLastLogEntries[1].Index, 10)
 	}
 	return fmt.Sprintf("[%s, %s]", firstIndex, lastIndex), nil
 }

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1502,7 +1502,7 @@ func BenchmarkPeekType(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		typ = PeekType(buf)
 	}
-	sink = string(typ)
+	sink = fmt.Sprint(typ)
 }
 
 type randData struct {


### PR DESCRIPTION
The 1st of the two commits is actually a bug fix, but I checked that it only affects crash reporting upon malformed snapshots, and the data was not even wrong. Unsure it deserves a test.