### PR TITLE
testcluster: avoid t.Fatal on goroutine

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -153,6 +153,8 @@ type TestClusterArgs struct {
 	// no entry in the map for a particular server, the default ServerArgs are
 	// used.
 	//
+	// These are indexes: the key 0 corresponds to the first node.
+	//
 	// A copy of an entry from this map will be copied to each individual server
 	// and potentially adjusted according to ReplicationMode.
 	ServerArgsPerNode map[int]TestServerArgs

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -106,7 +106,10 @@ func createTestCerts(certsDir string) (cleanup func() error) {
 	}
 
 	for _, a := range assets {
-		securitytest.RestrictedCopy(nil, a, certsDir, filepath.Base(a))
+		_, err := securitytest.RestrictedCopy(a, certsDir, filepath.Base(a))
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return func() error {

--- a/pkg/security/securitytest/securitytest.go
+++ b/pkg/security/securitytest/securitytest.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/errors"
@@ -33,16 +32,16 @@ import (
 // The file will have restrictive file permissions (0600), making it
 // appropriate for usage by libraries that require security assets to have such
 // restrictive permissions.
-func RestrictedCopy(t testing.TB, path, tempdir, name string) string {
+func RestrictedCopy(path, tempdir, name string) (string, error) {
 	contents, err := Asset(path)
 	if err != nil {
-		t.Fatal(err)
+		return "", err
 	}
 	tempPath := filepath.Join(tempdir, name)
 	if err := ioutil.WriteFile(tempPath, contents, 0600); err != nil {
-		t.Fatal(err)
+		return "", err
 	}
-	return tempPath
+	return tempPath, nil
 }
 
 // AssetReadDir mimics ioutil.ReadDir, returning a list of []os.FileInfo for

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -258,19 +258,23 @@ func NewServer(params base.TestServerArgs) TestServerInterface {
 	return srvFactoryImpl.New(params).(TestServerInterface)
 }
 
-// OpenDBConn sets up a gosql DB connection to the given server.
-func OpenDBConn(
-	t testing.TB, server TestServerInterface, params base.TestServerArgs, stopper *stop.Stopper,
-) *gosql.DB {
-	pgURL, cleanupGoDB := sqlutils.PGUrl(
-		t, server.ServingSQLAddr(), "StartServer" /* prefix */, url.User(security.RootUser))
+// OpenDBConnE is like OpenDBConn, but returns an error.
+func OpenDBConnE(
+	server TestServerInterface, params base.TestServerArgs, stopper *stop.Stopper,
+) (*gosql.DB, error) {
+	pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
+		server.ServingSQLAddr(), "StartServer" /* prefix */, url.User(security.RootUser))
+	if err != nil {
+		return nil, err
+	}
+
 	pgURL.Path = params.UseDatabase
 	if params.Insecure {
 		pgURL.RawQuery = "sslmode=disable"
 	}
 	goDB, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 
 	stopper.AddCloser(
@@ -278,7 +282,18 @@ func OpenDBConn(
 			_ = goDB.Close()
 			cleanupGoDB()
 		}))
-	return goDB
+	return goDB, nil
+}
+
+// OpenDBConn sets up a gosql DB connection to the given server.
+func OpenDBConn(
+	t testing.TB, server TestServerInterface, params base.TestServerArgs, stopper *stop.Stopper,
+) *gosql.DB {
+	conn, err := OpenDBConnE(server, params, stopper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
 }
 
 // StartServerRaw creates and starts a TestServer.


### PR DESCRIPTION
StartServer was using this odd pattern where it took both a `*testing.T`
and returned an `error`. This method was then also called on a goroutine
whenever `ParallelStart` was specified.

I wasted quite a bit on these errors (things just hang, really hard to
debug) so I cleaned this method up to always return an error.

Release note: None
