### PR TITLE
opt: prove partial index implication in scanIndexIter

### DIFF
--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -14,24 +14,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/partialidx"
 )
 
-// indexRejectFlags contains flags designating types of indexes to filter out
-// during iteration. For example, the iterator would skip over inverted and
-// partial indexes given these flags:
+// indexRejectFlags contains flags designating types of indexes to skip during
+// iteration. For example, the iterator would skip over inverted and partial
+// indexes given these flags:
 //
 //   flags := rejectInvertedIndexes|rejectPartialIndexes
 //
 type indexRejectFlags int8
 
 const (
-	// rejectNoIndexes is the default, which includes all indexes during
-	// iteration.
-	rejectNoIndexes indexRejectFlags = 0
-
 	// rejectPrimaryIndex excludes the primary index during iteration.
-	rejectPrimaryIndex indexRejectFlags = 1 << (iota - 1)
+	rejectPrimaryIndex indexRejectFlags = 1 << iota
 
 	// rejectInvertedIndexes excludes any inverted indexes during iteration.
 	rejectInvertedIndexes
@@ -48,154 +44,146 @@ const (
 	rejectNonPartialIndexes
 )
 
-// scanIndexIter is a helper struct that supports iteration over the indexes
-// of a Scan operator table. For example:
-//
-//   iter := makeScanIndexIter(mem, scanPrivate, rejectNoIndexes)
-//   for iter.Next() {
-//     index := iter.Index()
-//     cols := iter.IndexColumns()
-//     isCovering := iter.IsCovering()
-//   }
-//
+// scanIndexIter is a helper struct that facilitates iteration over the indexes
+// of a Scan operator table.
 type scanIndexIter struct {
-	mem         *memo.Memo
+	mem     *memo.Memo
+	im      *partialidx.Implicator
+	tabMeta *opt.TableMeta
+
+	// scanPrivate is the private of the scan operator to enumerate indexes for.
 	scanPrivate *memo.ScanPrivate
-	tabMeta     *opt.TableMeta
+
+	// originalFilters is filters that are applied after the original scan. If
+	// there are no filters applied after the original scan, originalFilters
+	// should be set to nil. It is used to determine if a partial index can be
+	// enumerated and to generate the filters passed to the enumerateIndexFunc
+	// (the originalFilters are passed as-is for non-partial indexes).
+	originalFilters memo.FiltersExpr
+
+	// rejectFlags is a set of flags that designate which types of indexes to
+	// skip during iteration.
 	rejectFlags indexRejectFlags
-	indexCount  int
-
-	// indexOrd is the ordinal of the current index in the list of the table's
-	// indexes.
-	indexOrd cat.IndexOrdinal
-
-	// currIndex is the current cat.Index that has been iterated to.
-	currIndex cat.Index
-
-	// indexColsCache caches the set of columns included in the index. See
-	// IndexColumns for more details.
-	indexColsCache opt.ColSet
 }
 
-// makeScanIndexIter returns an initialized scanIndexIter.
+// init initializes a new scanIndexIter.
+func (it *scanIndexIter) init(
+	mem *memo.Memo,
+	im *partialidx.Implicator,
+	scanPrivate *memo.ScanPrivate,
+	originalFilters memo.FiltersExpr,
+	rejectFlags indexRejectFlags,
+) {
+	it.mem = mem
+	it.im = im
+	it.tabMeta = mem.Metadata().TableMeta(scanPrivate.Table)
+	it.scanPrivate = scanPrivate
+	it.originalFilters = originalFilters
+	it.rejectFlags = rejectFlags
+}
+
+// enumerateIndexFunc defines the callback function for the ForEach and
+// ForEachStartingAfter functions. It is invoked for each index enumerated.
 //
-// The rejectFlags determine which types of indexes to skip when iterating.
-func makeScanIndexIter(
-	mem *memo.Memo, scanPrivate *memo.ScanPrivate, rejectFlags indexRejectFlags,
-) scanIndexIter {
-	tabMeta := mem.Metadata().TableMeta(scanPrivate.Table)
-	return scanIndexIter{
-		mem:         mem,
-		scanPrivate: scanPrivate,
-		tabMeta:     tabMeta,
-		indexCount:  tabMeta.Table.IndexCount(),
-		indexOrd:    -1,
-		rejectFlags: rejectFlags,
-	}
-}
+// The function is called with the enumerated index, the filters that must be
+// applied after a scan over the index, the index columns, and a boolean that is
+// true if the index covers the scanPrivate's columns. If the index is a partial
+// index, the filters are the remaining filters after proving partial index
+// implication (see partialidx.Implicator). Otherwise, the filters are the
+// originalFilters.
+type enumerateIndexFunc func(idx cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool)
 
-// StartAfter will cause the iterator to skip over indexes so that the first
-// call to Next will iterate to the index directly after the given index
-// ordinal, if there is one. StartAfter will panic if Next has already been
-// called on the iterator.
-func (it *scanIndexIter) StartAfter(i cat.IndexOrdinal) {
-	if it.indexOrd != -1 {
-		panic(errors.AssertionFailedf("cannot call StartAfter if iteration has started"))
-	}
-	it.indexOrd = i
-}
-
-// Next advances iteration to the next index of the Scan operator's table. This
-// is the primary index if it's the first time next is called, or a secondary
-// index thereafter. When there are no more indexes to enumerate, next returns
-// false. The current index is accessible via the iterator's "index" field.
+// ForEach calls the given callback function for every index of the Scan
+// operator's table in the order they appear in the catalog.
 //
-// The rejectFlags set in makeScanIndexIter determine which indexes to skip when
-// iterating, if any.
+// The rejectFlags determine types of indexes to skip, if any.
+//
+// Partial indexes are skipped if their predicate is not implied by the
+// originalFilters. If the originalFilters are nil, then only pseudo-partial
+// indexes (a partial index with an expression that always evaluates to true)
+// are enumerated. If the originalFilters are reduced during partial index
+// implication, the remaining filters are passed to the callback f.
 //
 // If the ForceIndex flag is set on the scanPrivate, then all indexes except the
-// forced index are skipped. Note that the index forced by the ForceIndex flag
-// is not guaranteed to be iterated on - it will be skipped if it is rejected by
-// the rejectFlags.
-func (it *scanIndexIter) Next() bool {
-	for {
-		it.indexOrd++
+// forced index are skipped. The index forced by the ForceIndex flag is not
+// guaranteed to be iterated on - it will be skipped if it is rejected by the
+// rejectFlags, or if it is a partial index with a predicate that is not implied
+// by the originalFilters.
+func (it *scanIndexIter) ForEach(f enumerateIndexFunc) {
+	it.ForEachStartingAfter(cat.PrimaryIndex-1, f)
+}
 
-		if it.indexOrd >= it.indexCount {
-			it.currIndex = nil
-			return false
-		}
-
-		it.currIndex = it.tabMeta.Table.Index(it.indexOrd)
-
+// ForEachStartingAfter calls the given callback function for every index of the
+// Scan operator's table with an ordinal greater than ord.
+func (it *scanIndexIter) ForEachStartingAfter(ord int, f enumerateIndexFunc) {
+	ord++
+	for ; ord < it.tabMeta.Table.IndexCount(); ord++ {
 		// Skip over the primary index if rejectPrimaryIndex is set.
-		if it.hasRejectFlag(rejectPrimaryIndex) && it.indexOrd == cat.PrimaryIndex {
+		if it.hasRejectFlag(rejectPrimaryIndex) && ord == cat.PrimaryIndex {
 			continue
 		}
 
+		// If we are forcing a specific index, ignore all other indexes.
+		if it.scanPrivate.Flags.ForceIndex && ord != it.scanPrivate.Flags.Index {
+			continue
+		}
+
+		index := it.tabMeta.Table.Index(ord)
+
 		// Skip over inverted indexes if rejectInvertedIndexes is set.
-		if it.hasRejectFlag(rejectInvertedIndexes) && it.currIndex.IsInverted() {
+		if it.hasRejectFlag(rejectInvertedIndexes) && index.IsInverted() {
 			continue
 		}
 
 		// Skip over non-inverted indexes if rejectNonInvertedIndexes is set.
-		if it.hasRejectFlag(rejectNonInvertedIndexes) && !it.currIndex.IsInverted() {
+		if it.hasRejectFlag(rejectNonInvertedIndexes) && !index.IsInverted() {
 			continue
 		}
 
-		if it.hasRejectFlag(rejectPartialIndexes | rejectNonPartialIndexes) {
-			_, isPartialIndex := it.currIndex.Predicate()
+		_, isPartialIndex := index.Predicate()
 
-			// Skip over partial indexes if rejectPartialIndexes is set.
-			if it.hasRejectFlag(rejectPartialIndexes) && isPartialIndex {
-				continue
-			}
-
-			// Skip over non-partial indexes if rejectNonPartialIndexes is set.
-			if it.hasRejectFlag(rejectNonPartialIndexes) && !isPartialIndex {
-				continue
-			}
-		}
-
-		// If we are forcing a specific index, ignore all other indexes.
-		if it.scanPrivate.Flags.ForceIndex && it.scanPrivate.Flags.Index != it.indexOrd {
+		// Skip over partial indexes if rejectPartialIndexes is set.
+		if it.hasRejectFlag(rejectPartialIndexes) && isPartialIndex {
 			continue
 		}
 
-		// Reset the cols so they can be recalculated.
-		it.indexColsCache = opt.ColSet{}
-		return true
+		// Skip over non-partial indexes if rejectNonPartialIndexes is set.
+		if it.hasRejectFlag(rejectNonPartialIndexes) && !isPartialIndex {
+			continue
+		}
+
+		filters := it.originalFilters
+
+		// If the index is a partial index, check whether or not the
+		// originalFilters imply the predicate.
+		if isPartialIndex {
+			pred := memo.PartialIndexPredicate(it.tabMeta, ord)
+
+			// If there are no originalFilters, then skip over any partial
+			// indexes that are not pseudo-partial indexes.
+			if filters == nil && !pred.IsTrue() {
+				continue
+			}
+
+			if filters != nil {
+				remainingFilters, ok := it.im.FiltersImplyPredicate(filters, pred)
+				if !ok {
+					// The originalFilters do not imply the predicate, so skip
+					// over the partial index.
+					continue
+				}
+
+				// Set the filters to the remaining filters which may have been
+				// reduced.
+				filters = remainingFilters
+			}
+		}
+
+		indexCols := it.tabMeta.IndexColumns(ord)
+		isCovering := it.scanPrivate.Cols.SubsetOf(indexCols)
+
+		f(index, filters, indexCols, isCovering)
 	}
-}
-
-// IndexOrdinal returns the ordinal of the current index that has been iterated
-// to.
-func (it *scanIndexIter) IndexOrdinal() int {
-	return it.indexOrd
-}
-
-// Index returns the current index that has been iterated to.
-func (it *scanIndexIter) Index() cat.Index {
-	return it.currIndex
-}
-
-// IndexColumns returns the set of columns contained in the current index. This
-// set includes the columns indexed and stored, as well as the primary key
-// columns.
-// TODO(mgartner): Caching here will no longer be necessary if we cache in
-// TableMeta. See the TODO at TableMeta.IndexColumns.
-func (it *scanIndexIter) IndexColumns() opt.ColSet {
-	if it.indexColsCache.Empty() {
-		it.indexColsCache = it.tabMeta.IndexColumns(it.indexOrd)
-	}
-	return it.indexColsCache
-}
-
-// IsCovering returns true if the current index "covers" all the columns projected
-// by the Scan operator. An index covers any columns that it indexes or stores,
-// as well as any primary key columns.
-func (it *scanIndexIter) IsCovering() bool {
-	return it.scanPrivate.Cols.SubsetOf(it.IndexColumns())
 }
 
 // hasRejectFlag returns true if the given flag is set in the rejectFlags.


### PR DESCRIPTION
This commit updates `scanIndexIter` in order to make it safer to reduce
filters during partial index implication. The goal is to help avoid the
common mistake of using filters for an enumerated index that were
reduced in a previous iteration. Another benefit of these changes is
that code for checking filter/predicate implication has been
de-duplicated and moved into `scanIndexIter`.

The `Next` and for-loop iteration pattern has been replaced with a
`ForEach` and callback pattern. Partial indexes are only enumerated if
their partial indexes are implied by the provided filters. Filters
reduced during partial index implication are passed to the callback
function.

`HasInvertedIndexes` and `canMaybeConstrainIndexWithCols` previously
used the `scanIndexIter` for simple iteration. They no longer do to
avoid over complicating the `scanIndexIter` with features to halt
iteration and ignore partial index implication.

Release note: None