### PR TITLE
[DO NOT MERGE] need help generating fixtures for roachtest

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1171,8 +1171,8 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"20.2": "20.1.6",
-		"20.1": "19.2.9",
+		"20.2": "20.1.7",
+		"20.1": "19.2.11",
 		"19.2": "19.1.11",
 		"19.1": "2.1.9",
 		"2.2":  "2.1.9",

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -90,11 +90,11 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, buildVersion ve
 	// the 20.2 release, this test will fail because it is missing a fixture for
 	// 20.1; run the test (on 20.1) with the bool flipped to create the fixture.
 	// Check it in (instructions will be logged below) and off we go.
-	if false {
+	if true {
 		// The version to create/update the fixture for. Must be released (i.e.
 		// can download it from the homepage); if that is not the case use the
 		// empty string which uses the local cockroach binary.
-		newV := "20.1.6"
+		newV := "20.1.7"
 		predV, err := PredecessorVersion(*version.MustParse("v" + newV))
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
For the latest `19.2.x` and `20.1.x` releases, I want to bump the versions in `roachtest` (See #55445).

However, I'm having trouble generating the associated fixtures, so I'm pushing up thisPR in hopes that someone can help troubleshoot. 

What I've done:
- flip the boolean in `runVersionUpgrade` (see this PR)
- run `make bin/roachtest`
- run `roachtest --local run acceptance/version-upgrade`

Expected:
I think all tests should pass (along with generated fixtures).

Actual:
I get a `cp {store-dir}/cluster-bootstrapped {store-dir}/checkpoint-v20.1` error (full trace below)

Thanks!

