### PR TITLE
release-20.2: rowexec: fix metadata propagation in zigzag joiner

### DIFF
--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ import (
 // column on the right side. But the DatumsToInvertedExpr hook allows us to
 // convert any left side value into a SpanExpression for the join, so we
 // utilize that to simplify the test. The SpanExpressions are defined below.
-const numRows = 99
+const invertedJoinerNumRows = 99
 
 // For each integer d provided by the left side, this expression converter
 // constructs an intersection of d/10 and d%10. As mentioned earlier, the
@@ -217,7 +218,7 @@ func TestInvertedJoiner(t *testing.T) {
 	}
 	sqlutils.CreateTable(t, sqlDB, "t",
 		"a INT, b INT ARRAY, c JSONB, PRIMARY KEY (a), INVERTED INDEX bi (b), INVERTED INDEX ci(c)",
-		numRows,
+		invertedJoinerNumRows,
 		sqlutils.ToRowFn(aFn, bFn, cFn))
 	const biIndex = 1
 	const ciIndex = 2
@@ -516,6 +517,71 @@ func TestInvertedJoiner(t *testing.T) {
 
 		require.Equal(t, c.expected, result.String(c.outputTypes), c.description)
 	}
+}
+
+func TestInvertedJoinerDrain(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	aFn := func(row int) tree.Datum {
+		return tree.NewDInt(tree.DInt(row))
+	}
+	bFn := func(row int) tree.Datum {
+		arr := tree.NewDArray(types.Int)
+		arr.Array = tree.Datums{tree.NewDInt(tree.DInt(row / 10)), tree.NewDInt(tree.DInt(row % 10))}
+		return arr
+	}
+	sqlutils.CreateTable(t, sqlDB, "t",
+		"a INT, b INT ARRAY, INVERTED INDEX bi (b)",
+		invertedJoinerNumRows,
+		sqlutils.ToRowFn(aFn, bFn))
+	const biIndex = 1
+	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
+
+	tracer := tracing.NewTracer()
+	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	defer sp.Finish()
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, _, err := storage.NewTempEngine(ctx, storage.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(context.Background())
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
+	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
+	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), &leafInputState)
+	flowCtx := execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			TempStorage: tempEngine,
+			DiskMonitor: diskMonitor,
+		},
+		Txn: leafTxn,
+	}
+
+	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+		return newInvertedJoiner(
+			&flowCtx,
+			0, /* processorID */
+			&execinfrapb.InvertedJoinerSpec{
+				Table:        *td.TableDesc(),
+				IndexIdx:     biIndex,
+				InvertedExpr: execinfrapb.Expression{},
+				Type:         descpb.InnerJoin,
+			},
+			arrayIntersectionExpr{t: t},
+			distsqlutils.NewRowBuffer(rowenc.TwoIntCols, nil /* rows */, distsqlutils.RowBufferArgs{}),
+			&execinfrapb.PostProcessSpec{},
+			out,
+		)
+	})
 }
 
 // TODO(sumeer):

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -647,16 +647,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
-	diskMonitor := mon.NewMonitor(
-		"test-disk",
-		mon.DiskResource,
-		nil, /* curCount */
-		nil, /* maxHist */
-		-1,  /* increment: use default block size */
-		math.MaxInt64,
-		st,
-	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
@@ -676,22 +667,16 @@ func TestJoinReaderDrain(t *testing.T) {
 	encRow := make(rowenc.EncDatumRow, 1)
 	encRow[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1))
 
-	// ConsumerClosed verifies that when a joinReader's consumer is closed, the
-	// joinReader finishes gracefully.
-	t.Run("ConsumerClosed", func(t *testing.T) {
-		in := distsqlutils.NewRowBuffer(rowenc.OneIntCol, rowenc.EncDatumRows{encRow}, distsqlutils.RowBufferArgs{})
-
-		out := &distsqlutils.RowBuffer{}
-		out.ConsumerClosed()
-		jr, err := newJoinReader(
-			&flowCtx, 0 /* processorID */, &execinfrapb.JoinReaderSpec{
-				Table: *td.TableDesc(),
-			}, in, &execinfrapb.PostProcessSpec{},
-			out, lookupJoinReaderType)
-		if err != nil {
-			t.Fatal(err)
-		}
-		jr.Run(ctx)
+	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+		return newJoinReader(
+			&flowCtx,
+			0, /* processorID */
+			&execinfrapb.JoinReaderSpec{Table: *td.TableDesc()},
+			distsqlutils.NewRowBuffer(rowenc.OneIntCol, nil /* rows */, distsqlutils.RowBufferArgs{}),
+			&execinfrapb.PostProcessSpec{},
+			out,
+			lookupJoinReaderType,
+		)
 	})
 
 	// ConsumerDone verifies that the producer drains properly by checking that

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -968,3 +968,61 @@ func TestFlowConcurrentTxnUse(t *testing.T) {
 		require.True(t, flow.ConcurrentTxnUse(), "expected concurrent txn use given that there are two tableReaders each in a separate goroutine")
 	})
 }
+
+// testReaderProcessorDrain tests various scenarios in which a processor's
+// consumer is closed. It makes sure that that the trace metadata and the leaf
+// txn final state metadata are propagated, and it is the caller's
+// responsibility to set up all the necessary infrastructure. This method is
+// intended to be used by "reader" processors - those that read data from disk.
+func testReaderProcessorDrain(
+	ctx context.Context,
+	t *testing.T,
+	processorConstructor func(out execinfra.RowReceiver) (execinfra.Processor, error),
+) {
+	// ConsumerClosed verifies that when a processor's consumer is closed, the
+	// processor finishes gracefully.
+	t.Run("ConsumerClosed", func(t *testing.T) {
+		out := &distsqlutils.RowBuffer{}
+		out.ConsumerClosed()
+		p, err := processorConstructor(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p.Run(ctx)
+	})
+
+	// ConsumerDone verifies that the producer drains properly by checking that
+	// metadata coming from the producer is still read when ConsumerDone is
+	// called on the consumer.
+	t.Run("ConsumerDone", func(t *testing.T) {
+		out := &distsqlutils.RowBuffer{}
+		out.ConsumerDone()
+		p, err := processorConstructor(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p.Run(ctx)
+		var traceSeen, txnFinalStateSeen bool
+		for {
+			row, meta := out.Next()
+			if row != nil {
+				t.Fatalf("row was pushed unexpectedly")
+			}
+			if meta == nil {
+				break
+			}
+			if meta.TraceData != nil {
+				traceSeen = true
+			}
+			if meta.LeafTxnFinalState != nil {
+				txnFinalStateSeen = true
+			}
+		}
+		if !traceSeen {
+			t.Fatal("missing tracing trailing metadata")
+		}
+		if !txnFinalStateSeen {
+			t.Fatal("missing txn final state")
+		}
+	})
+}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -919,11 +919,11 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 
 // Next is part of the RowSource interface.
 func (z *zigzagJoiner) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	if err := z.maybeFetchInitialRow(); err != nil {
-		z.MoveToDraining(err)
-	}
-
 	for z.State == execinfra.StateRunning {
+		if err := z.maybeFetchInitialRow(); err != nil {
+			z.MoveToDraining(err)
+			break
+		}
 		row, err := z.nextRow(z.Ctx, z.FlowCtx.Txn)
 		if err != nil {
 			z.MoveToDraining(err)

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -138,7 +138,7 @@ import (
 //
 // When Should a Zigzag Join Be Planned:
 //
-// The intuition behind when a zigzag join should be used is when the carnality
+// The intuition behind when a zigzag join should be used is when the cardinality
 // of the output is much smaller than the size of either side of the join. If
 // this is not the case, it may end up being slower than other joins because it
 // is constantly alternating between sides of the join. Alternatively, the
@@ -227,10 +227,9 @@ import (
 type zigzagJoiner struct {
 	joinerBase
 
-	evalCtx       *tree.EvalContext
 	cancelChecker *cancelchecker.CancelChecker
 
-	// numTables stored the number of tables involved in the join.
+	// numTables stores the number of tables involved in the join.
 	numTables int
 	// side keeps track of which side is being processed.
 	side int
@@ -240,24 +239,18 @@ type zigzagJoiner struct {
 	// more information.
 	infos []*zigzagJoinerInfo
 
-	// Base row stores the that the algorithm is compared against and is updated
-	// with every change of side.
+	// baseRow stores the row that the algorithm is compared against and is
+	// updated with every change of side.
 	baseRow rowenc.EncDatumRow
 
-	rowAlloc rowenc.EncDatumRowAlloc
-
-	// TODO(andrei): get rid of this field and move the actions it gates into the
-	// Start() method.
-	started bool
-
-	// returnedMeta contains all the metadata that zigzag joiner has emitted.
-	returnedMeta []execinfrapb.ProducerMetadata
+	rowAlloc           rowenc.EncDatumRowAlloc
+	fetchedInititalRow bool
 }
 
-// Batch size is a parameter which determines how many rows should be fetched
-// at a time. Increasing this will improve performance for when matched rows
-// are grouped together, but increasing this too much will result in fetching
-// too many rows and therefore skipping less rows.
+// zigzagJoinerBatchSize is a parameter which determines how many rows should
+// be fetched at a time. Increasing this will improve performance for when
+// matched rows are grouped together, but increasing this too much will result
+// in fetching too many rows and therefore skipping less rows.
 const zigzagJoinerBatchSize = 5
 
 var _ execinfra.Processor = &zigzagJoiner{}
@@ -303,12 +296,10 @@ func newZigzagJoiner(
 		output,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
-				// producerMeta appends any extra metadata to the z.returnedMeta
-				// field, so we can just return that afterwards.
-				z.producerMeta(nil /* err */)
-				return z.returnedMeta
+				z.close()
+				return z.generateMeta(ctx)
 			},
-		}, // zigzagJoiner doesn't have any inputs to drain.
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -316,8 +307,6 @@ func newZigzagJoiner(
 
 	z.numTables = len(spec.Tables)
 	z.infos = make([]*zigzagJoinerInfo, z.numTables)
-	z.returnedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
-
 	for i := range z.infos {
 		z.infos[i] = &zigzagJoinerInfo{}
 	}
@@ -364,7 +353,6 @@ func valuesSpecToEncDatum(
 // Start is part of the RowSource interface.
 func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
 	ctx = z.StartInternal(ctx, zigzagJoinerProcName)
-	z.evalCtx = z.FlowCtx.NewEvalCtx()
 	z.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	log.VEventf(ctx, 2, "starting zigzag joiner run")
 	return ctx
@@ -494,35 +482,12 @@ func (z *zigzagJoiner) setupInfo(
 }
 
 func (z *zigzagJoiner) close() {
-	for i := range z.infos {
-		z.infos[i].fetcher.Close(z.Ctx)
-	}
-	log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
-}
-
-// producerMeta constructs the ProducerMetadata after consumption of rows has
-// terminated, either due to being indicated by the consumer, or because the
-// processor ran out of rows or encountered an error. It is ok for err to be
-// nil indicating that we're done producing rows even though no error occurred.
-func (z *zigzagJoiner) producerMeta(err error) *execinfrapb.ProducerMetadata {
-	var meta *execinfrapb.ProducerMetadata
 	if z.InternalClose() {
-		if err != nil {
-			meta = &execinfrapb.ProducerMetadata{Err: err}
-		} else if trace := execinfra.GetTraceData(z.Ctx); trace != nil {
-			meta = &execinfrapb.ProducerMetadata{TraceData: trace}
+		for i := range z.infos {
+			z.infos[i].fetcher.Close(z.Ctx)
 		}
-		if tfs := execinfra.GetLeafTxnFinalState(z.Ctx, z.FlowCtx.Txn); tfs != nil {
-			z.returnedMeta = append(z.returnedMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
-		}
-		// We need to close as soon as we send producer metadata as we're done
-		// sending rows. The consumer is allowed to not call ConsumerDone().
-		z.close()
+		log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
 	}
-	if meta != nil {
-		z.returnedMeta = append(z.returnedMeta, *meta)
-	}
-	return meta
 }
 
 func findColumnID(s []descpb.ColumnID, t descpb.ColumnID) int {
@@ -754,18 +719,16 @@ func (z *zigzagJoiner) emitFromContainers() (rowenc.EncDatumRow, error) {
 // nextRow fetches the nextRow to emit from the join. It iterates through all
 // sides until a match is found then emits the results of the match one result
 // at a time.
-func (z *zigzagJoiner) nextRow(
-	ctx context.Context, txn *kv.Txn,
-) (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+func (z *zigzagJoiner) nextRow(ctx context.Context, txn *kv.Txn) (rowenc.EncDatumRow, error) {
 	for {
 		if err := z.cancelChecker.Check(); err != nil {
-			return nil, &execinfrapb.ProducerMetadata{Err: err}
+			return nil, err
 		}
 
 		// Check if there are any rows built up in the containers that need to be
 		// emitted.
 		if rowToEmit, err := z.emitFromContainers(); err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		} else if rowToEmit != nil {
 			return rowToEmit, nil
 		}
@@ -783,7 +746,7 @@ func (z *zigzagJoiner) nextRow(
 		// use it to jump to the next possible match on the current side.
 		span, err := z.produceSpanFromBaseRow()
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		curInfo.key = span.Key
 
@@ -796,12 +759,12 @@ func (z *zigzagJoiner) nextRow(
 			z.FlowCtx.TraceKV,
 		)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 
 		fetchedRow, err := z.fetchRow(ctx)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		// If the next possible match on the current side that matches the previous
 		// row is `nil`, that means that there are no more matches in the join so
@@ -812,7 +775,7 @@ func (z *zigzagJoiner) nextRow(
 
 		matched, err := z.matchBase(fetchedRow, z.side)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		if matched {
 			// We've detected a match! Now, we collect all subsequent matches on both
@@ -834,11 +797,11 @@ func (z *zigzagJoiner) nextRow(
 			// of the two rows.
 			prevNext, err := z.collectAllMatches(ctx, prevSide)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			curNext, err := z.collectAllMatches(ctx, z.side)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 
 			// No more matches, so set the baseRow to nil to indicate that we should
@@ -853,12 +816,12 @@ func (z *zigzagJoiner) nextRow(
 			eqColTypes := curInfo.eqColTypes()
 			ordering, err := curInfo.eqOrdering()
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			da := &rowenc.DatumAlloc{}
 			cmp, err := prevEqCols.Compare(eqColTypes, da, ordering, z.FlowCtx.EvalCtx, currentEqCols)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			// We want the new current side to be the one that has the latest key
 			// since we know that this key will not be able to match any previous
@@ -924,18 +887,16 @@ func (z *zigzagJoiner) collectAllMatches(
 	return row, nil
 }
 
-// Next is part of the RowSource interface.
-func (z *zigzagJoiner) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	txn := z.FlowCtx.Txn
-
-	if !z.started {
-		z.started = true
+// maybeFetchInitialRow checks whether we have already fetched an initial row
+// from one of the inputs and does so if we haven't.
+func (z *zigzagJoiner) maybeFetchInitialRow() error {
+	if !z.fetchedInititalRow {
+		z.fetchedInititalRow = true
 
 		curInfo := z.infos[z.side]
-		// Fetch initial batch.
 		err := curInfo.fetcher.StartScan(
 			z.Ctx,
-			txn,
+			z.FlowCtx.Txn,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			true, /* batch limit */
 			zigzagJoinerBatchSize,
@@ -943,59 +904,59 @@ func (z *zigzagJoiner) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 		)
 		if err != nil {
 			log.Errorf(z.Ctx, "scan error: %s", err)
-			return nil, z.producerMeta(err)
+			return err
 		}
 		fetchedRow, err := z.fetchRow(z.Ctx)
 		if err != nil {
-			err = scrub.UnwrapScrubError(err)
-			return nil, z.producerMeta(err)
+			return scrub.UnwrapScrubError(err)
 		}
 		z.baseRow = z.rowAlloc.AllocRow(len(fetchedRow))
 		copy(z.baseRow, fetchedRow)
 		z.side = z.nextSide()
 	}
+	return nil
+}
 
-	if z.Closed {
-		return nil, z.producerMeta(nil /* err */)
+// Next is part of the RowSource interface.
+func (z *zigzagJoiner) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if err := z.maybeFetchInitialRow(); err != nil {
+		z.MoveToDraining(err)
 	}
 
-	for {
-		row, meta := z.nextRow(z.Ctx, txn)
-		if z.Closed || meta != nil {
-			if meta != nil {
-				z.returnedMeta = append(z.returnedMeta, *meta)
-			}
-			return nil, meta
+	for z.State == execinfra.StateRunning {
+		row, err := z.nextRow(z.Ctx, z.FlowCtx.Txn)
+		if err != nil {
+			z.MoveToDraining(err)
+			break
 		}
 		if row == nil {
 			z.MoveToDraining(nil /* err */)
 			break
 		}
 
-		outRow := z.ProcessRowHelper(row)
-		if outRow == nil {
-			continue
+		if outRow := z.ProcessRowHelper(row); outRow != nil {
+			return outRow, nil
 		}
-		return outRow, nil
 	}
-	meta := z.DrainHelper()
-	if meta != nil {
-		z.returnedMeta = append(z.returnedMeta, *meta)
-	}
-	return nil, meta
+
+	return nil, z.DrainHelper()
 }
 
 // ConsumerClosed is part of the RowSource interface.
 func (z *zigzagJoiner) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	if z.InternalClose() {
-		z.close()
+	z.close()
+}
+
+func (z *zigzagJoiner) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	if tfs := execinfra.GetLeafTxnFinalState(ctx, z.FlowCtx.Txn); tfs != nil {
+		return []execinfrapb.ProducerMetadata{{LeafTxnFinalState: tfs}}
 	}
+	return nil
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (z *zigzagJoiner) DrainMeta(_ context.Context) []execinfrapb.ProducerMetadata {
-	return z.returnedMeta
+func (z *zigzagJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	return z.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -570,23 +571,24 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	)
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t").TableDesc()
 
+	// Run the flow in a snowball trace so that we can test for tracing info.
+	tracer := tracing.NewTracer()
+	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	defer sp.Finish()
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
+
+	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
+	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), &leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
-		Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
+		Txn:     leafTxn,
 	}
 
-	encRow := make(rowenc.EncDatumRow, 1)
-	encRow[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1))
-
-	// ConsumerClosed verifies that when a joinReader's consumer is closed, the
-	// joinReader finishes gracefully.
-	t.Run("ConsumerClosed", func(t *testing.T) {
-		out := &distsqlutils.RowBuffer{}
-		out.ConsumerClosed()
-		zz, err := newZigzagJoiner(
+	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+		return newZigzagJoiner(
 			&flowCtx,
 			0, /* processorID */
 			&execinfrapb.ZigzagJoinerSpec{
@@ -599,12 +601,5 @@ func TestZigzagJoinerDrain(t *testing.T) {
 			&execinfrapb.PostProcessSpec{Projection: true, OutputColumns: []uint32{0, 1}},
 			out,
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		zz.Run(ctx)
 	})
-
-	//TODO(pbardea): When RowSource inputs are added, ensure that meta is
-	// propagated.
 }

--- a/pkg/util/cancelchecker/cancel_checker.go
+++ b/pkg/util/cancelchecker/cancel_checker.go
@@ -31,6 +31,8 @@ type CancelChecker struct {
 }
 
 // NewCancelChecker returns a new CancelChecker.
+// TODO(yuzefovich): audit all processors to make sure that the ones that
+// should use the cancel checker actually do so.
 func NewCancelChecker(ctx context.Context) *CancelChecker {
 	return &CancelChecker{
 		ctx: ctx,


### PR DESCRIPTION
Backport 1/3 commits from #54377.
Backport 1/1 commits from #55610.

/cc @cockroachdb/release

---

**rowexec: fix metadata propagation in zigzag joiner**

This commit refactors the zigzag joiner slightly to be more similar to
other processors. Most notable change is the removal of `producerMeta`
method and switching to returning an error and moving to draining
instead. In fact, previous behavior of metadata propagation was
incorrect in some cases when two or more metadata records needed to be
returned, and this is now fixed.

This commit also fixes an issue of zigzag joiner not propagating a leaf
txn final state metadata which could lead to a write skew. Additionally,
this commit adds low-level tests that verify that all reader-processors
output the leaf txn final state meta as well as trace meta.

Release note (bug fix): Fixed possible write skew in distributed queries
that have both zigzag joins and table readers with the zigzag joins
reading keys not read by the table readers. Note that although this
sounds scary, the bug itself is very rare.

**rowexec: fix recent refactor of zigzag joiner**

In a recent refactor of zigzag joiner I introduced a helper method that
could emit an error which would force the processor to move to draining.
The issue is that this could happen regardless of the current state of
the processor which breaks the contract (namely, we could try to move to
draining state twice). This is now fixed.

Release note: None (no release with the bug)