### PR TITLE
colexec: add JSONFetchValPath operator for vectorized engine

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -203,6 +203,10 @@ func registerBinOpOutputTypes() {
 	for _, intWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
 		binOpOutputTypes[tree.JSONFetchVal][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, types.IntFamily, intWidth}] = types.Any
 	}
+
+	binOpOutputTypes[tree.JSONFetchValPath] = map[typePair]*types.T{
+		{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}: types.Any,
+	}
 }
 
 func newBinaryOverloadBase(op tree.BinaryOperator) *overloadBase {

--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -15,20 +15,21 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 // BinaryOpName is a mapping from all binary operators that are supported by
 // the vectorized engine to their names.
 var BinaryOpName = map[tree.BinaryOperator]string{
-	tree.Bitand:       "Bitand",
-	tree.Bitor:        "Bitor",
-	tree.Bitxor:       "Bitxor",
-	tree.Plus:         "Plus",
-	tree.Minus:        "Minus",
-	tree.Mult:         "Mult",
-	tree.Div:          "Div",
-	tree.FloorDiv:     "FloorDiv",
-	tree.Mod:          "Mod",
-	tree.Pow:          "Pow",
-	tree.Concat:       "Concat",
-	tree.LShift:       "LShift",
-	tree.RShift:       "RShift",
-	tree.JSONFetchVal: "JSONFetchVal",
+	tree.Bitand:           "Bitand",
+	tree.Bitor:            "Bitor",
+	tree.Bitxor:           "Bitxor",
+	tree.Plus:             "Plus",
+	tree.Minus:            "Minus",
+	tree.Mult:             "Mult",
+	tree.Div:              "Div",
+	tree.FloorDiv:         "FloorDiv",
+	tree.Mod:              "Mod",
+	tree.Pow:              "Pow",
+	tree.Concat:           "Concat",
+	tree.LShift:           "LShift",
+	tree.RShift:           "RShift",
+	tree.JSONFetchVal:     "JSONFetchVal",
+	tree.JSONFetchValPath: "JSONFetchValPath",
 }
 
 // ComparisonOpName is a mapping from all comparison operators that are

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -27518,6 +27518,135 @@ func (p projJSONFetchValDatumInt64ConstOp) Init() {
 	p.input.Init()
 }
 
+type projJSONFetchValPathDatumDatumConstOp struct {
+	projConstOpBase
+	constArg interface{}
+}
+
+func (p projJSONFetchValPathDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.DatumVec
+	col = vec.Datum()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		if projVec.MaybeHasNulls() {
+			// We need to make sure that there are no left over null values in the
+			// output vector.
+			projVec.Nulls().UnsetNulls()
+		}
+		projCol := projVec.Datum()
+		// Some operators can result in NULL with non-NULL inputs, like the JSON
+		// fetch value operator, ->. Therefore, _outNulls is defined to allow
+		// updating the output Nulls from within _ASSIGN functions when the result
+		// of a projection is Null.
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
+						if _res == tree.DNull {
+							_outNulls.SetNull(i)
+						}
+						projCol.Set(i, _res)
+
+					}
+				}
+			} else {
+				col = col.Slice(0, n)
+				_ = projCol.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
+						if _res == tree.DNull {
+							_outNulls.SetNull(i)
+						}
+						projCol.Set(i, _res)
+
+					}
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+			projVec.SetNulls(_outNulls.Or(colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
+					if err != nil {
+						colexecerror.ExpectedError(err)
+					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
+					projCol.Set(i, _res)
+
+				}
+			} else {
+				col = col.Slice(0, n)
+				_ = projCol.Get(n - 1)
+				for i := 0; i < n; i++ {
+					arg := col.Get(i)
+
+					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, p.constArg)
+					if err != nil {
+						colexecerror.ExpectedError(err)
+					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
+					projCol.Set(i, _res)
+
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		}
+		// Although we didn't change the length of the batch, it is necessary to set
+		// the length anyway (this helps maintaining the invariant of flat bytes).
+		batch.SetLength(n)
+	})
+	return batch
+}
+
+func (p projJSONFetchValPathDatumDatumConstOp) Init() {
+	p.input.Init()
+}
+
 type projEQBoolBoolConstOp struct {
 	projConstOpBase
 	constArg bool
@@ -57801,6 +57930,25 @@ func GetProjectionRConstOperator(
 							return &projJSONFetchValDatumInt64ConstOp{
 								projConstOpBase: projConstOpBase,
 								constArg:        c.(int64),
+							}, nil
+						}
+					}
+				}
+			}
+		case tree.JSONFetchValPath:
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
+			case typeconv.DatumVecCanonicalTypeFamily:
+				switch leftType.Width() {
+				case -1:
+				default:
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
+					case typeconv.DatumVecCanonicalTypeFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							return &projJSONFetchValPathDatumDatumConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(interface{}),
 							}, nil
 						}
 					}

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -29892,6 +29892,146 @@ func (p projJSONFetchValDatumInt64Op) Init() {
 	p.input.Init()
 }
 
+type projJSONFetchValPathDatumDatumOp struct {
+	projOpBase
+}
+
+func (p projJSONFetchValPathDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		if projVec.MaybeHasNulls() {
+			// We need to make sure that there are no left over null values in the
+			// output vector.
+			projVec.Nulls().UnsetNulls()
+		}
+		projCol := projVec.Datum()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Datum()
+		col2 := vec2.Datum()
+		// Some operators can result in NULL with non-NULL inputs, like the JSON
+		// fetch value operator, ->. Therefore, _outNulls is defined to allow
+		// updating the output Nulls from within _ASSIGN functions when the result
+		// of a projection is Null.
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
+						if _res == tree.DNull {
+							_outNulls.SetNull(i)
+						}
+						projCol.Set(i, _res)
+
+					}
+				}
+			} else {
+				col1 = col1.Slice(0, n)
+				colLen := col1.Len()
+				_ = projCol.Get(colLen - 1)
+				_ = col2.Get(colLen - 1)
+				for i := 0; i < n; i++ {
+					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
+						if _res == tree.DNull {
+							_outNulls.SetNull(i)
+						}
+						projCol.Set(i, _res)
+
+					}
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+			projVec.SetNulls(_outNulls.Or(col1Nulls).Or(col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
+					if err != nil {
+						colexecerror.ExpectedError(err)
+					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
+					projCol.Set(i, _res)
+
+				}
+			} else {
+				col1 = col1.Slice(0, n)
+				colLen := col1.Len()
+				_ = projCol.Get(colLen - 1)
+				_ = col2.Get(colLen - 1)
+				for i := 0; i < n; i++ {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.binFn, _overloadHelper.evalCtx, arg2)
+					if err != nil {
+						colexecerror.ExpectedError(err)
+					}
+					if _res == tree.DNull {
+						_outNulls.SetNull(i)
+					}
+					projCol.Set(i, _res)
+
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		}
+		// Although we didn't change the length of the batch, it is necessary to set
+		// the length anyway (this helps maintaining the invariant of flat bytes).
+		batch.SetLength(n)
+	})
+	return batch
+}
+
+func (p projJSONFetchValPathDatumDatumOp) Init() {
+	p.input.Init()
+}
+
 type projEQBoolBoolOp struct {
 	projOpBase
 }
@@ -61439,6 +61579,22 @@ func GetProjectionOperator(
 						case -1:
 						default:
 							return &projJSONFetchValDatumInt64Op{projOpBase: projOpBase}, nil
+						}
+					}
+				}
+			}
+		case tree.JSONFetchValPath:
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
+			case typeconv.DatumVecCanonicalTypeFamily:
+				switch leftType.Width() {
+				case -1:
+				default:
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
+					case typeconv.DatumVecCanonicalTypeFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							return &projJSONFetchValPathDatumDatumOp{projOpBase: projOpBase}, nil
 						}
 					}
 				}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -573,6 +573,55 @@ NULL
 NULL
 ["foo", {"b": 3}]
 
+query T
+EXPLAIN (VEC) SELECT _json #> '{a,b}' FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projJSONFetchValPathDatumDatumConstOp
+      └ *colfetcher.ColBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _json #> '{a,b}' #> '{c}' FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projJSONFetchValPathDatumDatumConstOp
+    └ *colexec.projJSONFetchValPathDatumDatumConstOp
+      └ *colfetcher.ColBatchScan
+
+query T
+SELECT _json #> '{2,a}' FROM many_types
+----
+NULL
+["foo", {"b": 3}]
+NULL
+["foo", {"b": 3}]
+
+query T
+SELECT _json #> '{2,a}' #> '{1,b}' FROM many_types
+----
+NULL
+3
+NULL
+3
+
+query T
+SELECT _json #> '{}' FROM many_types
+----
+NULL
+[1, "hello", {"a": ["foo", {"b": 3}]}]
+[2, "hi", {"b": ["bar", {"c": 4}]}]
+[1, "hello", {"a": ["foo", {"b": 3}]}]
+
+query T
+SELECT _json #> '{c}' #> '{d}' FROM many_types
+----
+NULL
+NULL
+NULL
+NULL
+
 # Regression tests for #49143. Correctly handle cases where the -> operator
 # results in NULL when both arguments are non-NULL.
 subtest regression_49143


### PR DESCRIPTION
Earlier JSONFetchValPath binary operator was not supported in vectorized engine. 
This PR adds support for `JSONFetchValPath (#>)`binary operator and tests it. 

Fixes: #49471 

Release note (sql change): Vectorized engine now supports JSONFetchValPath (#>) operator.
