### PR TITLE
release-20.1: colexec: account for some things during the aggregation

### DIFF
--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -166,6 +166,9 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec._TYPE(), vec.Nulls()
+	// {{if eq .LTyp.String "Bytes"}}
+	oldCurAggSize := len(a.curAgg)
+	// {{end}}
 	a.allocator.PerformOperation(
 		[]coldata.Vec{a.vec},
 		func() {
@@ -196,6 +199,9 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		},
 	)
+	// {{if eq .LTyp.String "Bytes"}}
+	a.allocator.AdjustMemoryUsage(int64(len(a.curAgg) - oldCurAggSize))
+	// {{end}}
 }
 
 func (a *_AGG_TYPEAgg) HandleEmptyInputScalar() {


### PR DESCRIPTION
Backport 1/4 commits from #55195.

/cc @cockroachdb/release

---

**colexec: account for some things during the aggregation**

Previously, we didn't account for several things during the aggregation
(which can be non-trivial in case of the hash aggregation)
- any_not_null and min/max aggregates can hold on to byte slices and
datums of arbitrary size for a long time (namely, until the input to the
aggregation has been fully consumed in case of the hash aggregation)
- any_not_null aggregate didn't call `PerformOperation` on the output
vector when setting the last value from each bucket.

These shortcomings are now fixed.

Fixes: #54360.

Release note (bug fix): CockroachDB previously didn't account for all
the memory used by the vectorized hash aggregation which could lead to
an OOM crash.