### PR TITLE
ui: load table details on expand on Databases page

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseSummary/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseSummary/index.tsx
@@ -24,6 +24,7 @@ import { TableInfo } from "src/views/databases/data/tableInfo";
 // on a DatabaseSummary component.
 export interface DatabaseSummaryExplicitData {
   name: string;
+  updateOnLoad?: boolean;
 }
 
 // DatabaseSummaryConnectedData describes properties which are applied to a
@@ -45,14 +46,26 @@ interface DatabaseSummaryActions {
   updateOnLoad: boolean;
 }
 
-type DatabaseSummaryProps = DatabaseSummaryExplicitData & DatabaseSummaryConnectedData & DatabaseSummaryActions;
+export type DatabaseSummaryProps = DatabaseSummaryExplicitData & DatabaseSummaryConnectedData & DatabaseSummaryActions;
+
+export interface DatabaseSummaryState {
+  isExpanded: boolean;
+}
 
 // DatabaseSummaryBase implements common lifecycle methods for DatabaseSummary
 // components, which differ primarily by their render() method.
 // TODO(mrtracy): We need to find a better abstraction for the common
 // "refresh-on-mount-or-receiveProps" we have in many of our connected
 // components; that would allow us to avoid this inheritance.
-export class DatabaseSummaryBase extends React.Component<DatabaseSummaryProps, {}> {
+export class DatabaseSummaryBase extends React.Component<DatabaseSummaryProps, DatabaseSummaryState> {
+  static defaultProps: Partial<DatabaseSummaryProps> = {
+    updateOnLoad: true,
+  };
+
+  state = {
+    isExpanded: false,
+  };
+
   // loadTableDetails loads data for each table which have no info in the store.
   // TODO(mrtracy): Should this be refreshing data always? Not sure if there
   // is a performance concern with invalidation periods.

--- a/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
+++ b/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
@@ -39,4 +39,10 @@
     margin-right 11px
   &:hover
     path
-      fill $colors--primary-blue-3  
+      fill $colors--primary-blue-3
+
+.database-summary-title
+  display flex
+
+.database-summary-load-button
+  margin-left 11px

--- a/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
+++ b/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
@@ -46,3 +46,20 @@
 
 .database-summary-load-button
   margin-left 11px
+
+.database-summary__title-anchor
+  display flex
+  flex-direction row
+  align-items center
+  color #000000d9!important
+  &--toggle-icon
+    margin-left 8px
+    margin-bottom 0.5em
+    font-size 16px
+  &:hover
+    color #1890ff!important
+  *
+    color inherit!important
+
+.database-summary__body--collapsed
+  display none

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -16,7 +16,13 @@ import { refreshDatabaseDetails, refreshTableDetails, refreshTableStats } from "
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import { Bytes } from "src/util/format";
-import { databaseDetails, DatabaseSummaryBase, DatabaseSummaryExplicitData, grants, tableInfos as selectTableInfos } from "src/views/databases/containers/databaseSummary";
+import {
+  databaseDetails,
+  DatabaseSummaryBase,
+  DatabaseSummaryExplicitData,
+  grants,
+  tableInfos as selectTableInfos,
+} from "src/views/databases/containers/databaseSummary";
 import { TableInfo } from "src/views/databases/data/tableInfo";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
@@ -27,7 +33,8 @@ import { SummaryCard } from "src/views/shared/components/summaryCard";
 import { SummaryHeadlineStat } from "src/views/shared/components/summaryBar";
 import TitleWithIcon from "../../components/titleWithIcon/titleWithIcon";
 import { ReplicatedSizeTooltip } from "src/views/databases/containers/databases/tooltips";
-import { Button } from "oss/src/components";
+import { Anchor } from "src/components";
+import { Icon } from "antd";
 
 const databaseTablesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "databases/sort_setting/tables", (s) => s.localSettings,
@@ -54,18 +61,36 @@ export class DatabaseSummaryTables extends DatabaseSummaryBase {
     </>
   )
 
+  handleOnTitleClick = () => {
+    const nextStateIsExpanded = !this.state.isExpanded;
+    this.setState({ isExpanded: nextStateIsExpanded });
+    if (nextStateIsExpanded) {
+      this.loadTableDetails(this.props);
+    }
+  }
+
   render() {
     const { tableInfos, dbResponse, sortSetting } = this.props;
+    const { isExpanded } = this.state;
     const dbID = this.props.name;
     const loading = dbResponse ? !!dbResponse.inFlight : true;
     const numTables = tableInfos && tableInfos.length || 0;
+    const isLoadingTableInfos = tableInfos?.some(ti => !ti.id);
     return (
-      <div className="database-summary">
+      <div className={`database-summary database-summary--${isExpanded ? "expanded" : "collapsed"}`}>
         <div className="database-summary-title">
-          <TitleWithIcon src={Stack} title={dbID}/>
-          <Button type="secondary" className="database-summary-load-button" onClick={() => this.loadTableDetails(this.props)}>Load stats for all tables</Button>
+          <Anchor
+            onClick={this.handleOnTitleClick}
+            className="database-summary__title-anchor"
+          >
+            <TitleWithIcon src={Stack} title={dbID}/>
+            <Icon
+              className="database-summary__title-anchor--toggle-icon"
+              type={isExpanded ? "caret-down" : "caret-right"}
+            />
+          </Anchor>
         </div>
-        <div className="l-columns">
+        <div className={`l-columns database-summary__body--${isExpanded ? "expanded" : "collapsed"}`} >
           <div className="l-columns__left">
             <DatabaseTableListSortedTable
               data={tableInfos}
@@ -106,7 +131,7 @@ export class DatabaseSummaryTables extends DatabaseSummaryBase {
                   sort: (tableInfo) => tableInfo.numIndices,
                 },
               ]}
-              loading={loading}
+              loading={loading || isLoadingTableInfos}
               renderNoResult={loading ? undefined : this.noDatabaseResults()}
           />
           </div>

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -27,6 +27,7 @@ import { SummaryCard } from "src/views/shared/components/summaryCard";
 import { SummaryHeadlineStat } from "src/views/shared/components/summaryBar";
 import TitleWithIcon from "../../components/titleWithIcon/titleWithIcon";
 import { ReplicatedSizeTooltip } from "src/views/databases/containers/databases/tooltips";
+import { Button } from "oss/src/components";
 
 const databaseTablesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "databases/sort_setting/tables", (s) => s.localSettings,
@@ -62,6 +63,7 @@ export class DatabaseSummaryTables extends DatabaseSummaryBase {
       <div className="database-summary">
         <div className="database-summary-title">
           <TitleWithIcon src={Stack} title={dbID}/>
+          <Button type="secondary" className="database-summary-load-button" onClick={() => this.loadTableDetails(this.props)}>Load stats for all tables</Button>
         </div>
         <div className="l-columns">
           <div className="l-columns__left">
@@ -85,7 +87,7 @@ export class DatabaseSummaryTables extends DatabaseSummaryBase {
                 },
                 {
                   title: <ReplicatedSizeTooltip tableName={dbID}>{"Replicated Size"}</ReplicatedSizeTooltip>,
-                  cell: (tableInfo) => Bytes(tableInfo.physicalSize),
+                  cell: (tableInfo) => _.isUndefined(tableInfo.physicalSize) ? "" : Bytes(tableInfo.physicalSize),
                   sort: (tableInfo) => tableInfo.physicalSize,
                 },
                 {

--- a/pkg/ui/src/views/databases/containers/databases/databases.styl
+++ b/pkg/ui/src/views/databases/containers/databases/databases.styl
@@ -11,6 +11,9 @@
 .database-summary
   margin-bottom 24px
 
+.database-summary--collapsed
+  margin-bottom 0
+
 hr
   border-left none
   border-right none

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -101,10 +101,10 @@ class DatabaseTablesList extends React.Component<DatabaseListProps> {
       <DatabaseListNav selected="tables" onChange={this.handleOnNavigationListChange}/>
       <div className="section databases">
         {
-          user.map(n => <DatabaseSummaryTables name={n} key={n} />)
+          user.map(n => <DatabaseSummaryTables name={n} key={n} updateOnLoad={false} />)
         }
         {
-          system.map(n => <DatabaseSummaryTables name={n} key={n} />)
+          system.map(n => <DatabaseSummaryTables name={n} key={n} updateOnLoad={false} />)
         }
         <NonTableSummary />
       </div>


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/pull/55559

This change initially renders all databases details in
collapsed mode and doesn't trigger table details requests.
When user expands particular table then table details requested and
user has to wait until all details is loaded.

Release note (admin-ui-change): show database details in collapsed mode
by default

![out](https://user-images.githubusercontent.com/3106437/96115426-97b31280-0eef-11eb-91dc-ad0e7cc96db6.gif)
