### PR TITLE
sql: fix reg* cast escaping

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -347,3 +347,19 @@ FROM
       (d.adrelid = a.attrelid AND d.adnum = a.attnum)
   JOIN (SELECT 1 AS oid, 1 AS attnum) AS vals ON
       (c.oid = vals.oid AND a.attnum = vals.attnum);
+
+statement error relation ".*"regression_53686.*"" does not exist
+SELECT '\"regression_53686\"'::regclass
+
+statement ok
+CREATE TABLE "regression_53686""" (a int)
+
+query T
+SELECT 'regression_53686"'::regclass
+----
+"regression_53686"""
+
+query T
+SELECT 'public.regression_53686"'::regclass
+----
+"regression_53686"""

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -100,7 +100,7 @@ SELECT 'blah ()'::REGPROC
 query error unknown function: blah\(\)
 SELECT 'blah( )'::REGPROC
 
-query error unknown function: blah\(, \)\(\)
+query error invalid name: expected separator \.: blah\(, \)
 SELECT 'blah(, )'::REGPROC
 
 query error more than one function named 'sqrt'
@@ -363,3 +363,26 @@ query T
 SELECT 'public.regression_53686"'::regclass
 ----
 "regression_53686"""
+
+query T
+SELECT 'pg_catalog."radians"'::regproc
+----
+radians
+
+query T
+SELECT 'pg_catalog."radians"("float4")'::regproc
+----
+radians
+
+statement error unknown function: pg_catalog.radians"\(\)
+SELECT 'pg_catalog."radians"""'::regproc
+
+query TTTTT
+SELECT
+  '12345'::regclass::string,
+  '12345'::regtype::string,
+  '12345'::oid::string,
+  '12345'::regproc::string,
+  '12345'::regprocedure::string
+----
+12345  12345  12345  12345  12345

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1076,17 +1076,10 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			}
 		case *DString:
 			s := string(*v)
-			// Trim whitespace and unwrap outer quotes if necessary.
-			// This is required to mimic postgres.
-			s = strings.TrimSpace(s)
-			origS := s
-			if len(s) > 1 && s[0] == '"' && s[len(s)-1] == '"' {
-				s = s[1 : len(s)-1]
-			}
 
 			switch t.Oid() {
 			case oid.T_oid:
-				i, err := ParseDInt(s)
+				i, err := ParseDInt(strings.TrimSpace(s))
 				if err != nil {
 					return nil, err
 				}
@@ -1097,7 +1090,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				// going to always do it.
 				// We additionally do not yet implement disambiguation based on type
 				// parameters: we return the match iff there is exactly one.
-				s = pgSignatureRegexp.ReplaceAllString(s, "$1")
+				s = pgSignatureRegexp.ReplaceAllString(formatIdentifierForOidFamilyCast(s), "$1")
 				// Resolve function name.
 				substrs := strings.Split(s, ".")
 				if len(substrs) > 3 {
@@ -1118,6 +1111,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				}
 				return queryOid(ctx, t, NewDString(funcDef.Name))
 			case oid.T_regtype:
+				s = formatIdentifierForOidFamilyCast(s)
 				parsedTyp, err := ctx.Planner.ParseType(s)
 				if err == nil {
 					return &DOid{
@@ -1155,11 +1149,11 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				}, nil
 
 			case oid.T_regclass:
-				tn, err := ctx.Planner.ParseQualifiedTableName(origS)
+				tn, err := castStringToRegClassTableName(s)
 				if err != nil {
 					return nil, err
 				}
-				id, err := ctx.Planner.ResolveTableName(ctx.Ctx(), tn)
+				id, err := ctx.Planner.ResolveTableName(ctx.Ctx(), &tn)
 				if err != nil {
 					return nil, err
 				}
@@ -1176,4 +1170,131 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 
 	return nil, pgerror.Newf(
 		pgcode.CannotCoerce, "invalid cast: %s -> %s", d.ResolvedType(), t)
+}
+
+// castStringToRegClassTableName normalizes a TableName from a string.
+func castStringToRegClassTableName(s string) (TableName, error) {
+	components, err := splitIdentifierList(s)
+	if err != nil {
+		return TableName{}, err
+	}
+
+	if len(components) > 3 {
+		return TableName{}, pgerror.Newf(
+			pgcode.InvalidName,
+			"too many components: %s",
+			s,
+		)
+	}
+	var retComponents [3]string
+	for i := 0; i < len(components); i++ {
+		retComponents[len(components)-1-i] = components[i]
+	}
+	u, err := NewUnresolvedObjectName(
+		len(components),
+		retComponents,
+		0,
+	)
+	if err != nil {
+		return TableName{}, err
+	}
+	return u.ToTableName(), nil
+}
+
+// formatIdentifierForOidFamilyCast cleans the identifier by removing whitespace and removing
+// surrounding quotes.
+// TODO(#sql-features): this does not work for split types, e.g.
+// "asdf"."asdf" is incorrectly handled.
+func formatIdentifierForOidFamilyCast(s string) string {
+	s = strings.TrimSpace(s)
+	// Trim whitespace and unwrap outer quotes if necessary.
+	// This is required to mimic postgres.
+	if len(s) > 1 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+	return s
+}
+
+// splitIdentifierList splits identifiers to individual components, lower
+// casing non-quoted identifiers and escaping quoted identifiers as appropriate.
+// It is based on PostgreSQL's SplitIdentifier.
+func splitIdentifierList(in string) ([]string, error) {
+	var pos int
+	var ret []string
+	const separator = '.'
+
+	for pos < len(in) {
+		if isWhitespace(in[pos]) {
+			pos++
+			continue
+		}
+		if in[pos] == '"' {
+			var b strings.Builder
+			// Attempt to find the ending quote. If the quote is double "",
+			// fold it into a " character for the str (e.g. "a""" means a").
+			for {
+				pos++
+				endIdx := strings.IndexByte(in[pos:], '"')
+				if endIdx == -1 {
+					return nil, pgerror.Newf(
+						pgcode.InvalidName,
+						`invalid name: unclosed ": %s`,
+						in,
+					)
+				}
+				b.WriteString(in[pos : pos+endIdx])
+				pos += endIdx + 1
+				// If we reached the end, or the following character is not ",
+				// we can break and assume this is one identifier.
+				// There are checks below to ensure EOF or whitespace comes
+				// afterward.
+				if pos == len(in) || in[pos] != '"' {
+					break
+				}
+				b.WriteByte('"')
+			}
+			ret = append(ret, b.String())
+		} else {
+			var b strings.Builder
+			for pos < len(in) && in[pos] != separator && !isWhitespace(in[pos]) {
+				b.WriteByte(in[pos])
+				pos++
+			}
+			// Anything with no quotations should be lowered.
+			ret = append(ret, strings.ToLower(b.String()))
+		}
+
+		// Further ignore all white space.
+		for pos < len(in) && isWhitespace(in[pos]) {
+			pos++
+		}
+
+		// At this stage, we expect separator or end of string.
+		if pos == len(in) {
+			break
+		}
+
+		if in[pos] != separator {
+			return nil, pgerror.Newf(
+				pgcode.InvalidName,
+				"invalid name: expected separator %c: %s",
+				separator,
+				in,
+			)
+		}
+
+		pos++
+	}
+
+	return ret, nil
+}
+
+// isWhitespace returns true if the given character is a space.
+// This must match parser.SkipWhitespace above.
+func isWhitespace(ch byte) bool {
+	switch ch {
+	case ' ', '\t', '\r', '\f', '\n':
+		return true
+	}
+	return false
 }

--- a/pkg/sql/sem/tree/casts_test.go
+++ b/pkg/sql/sem/tree/casts_test.go
@@ -203,3 +203,77 @@ func TestTupleCastVolatility(t *testing.T) {
 		}
 	}
 }
+
+func TestCastStringToRegClassTableName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		in       string
+		expected TableName
+	}{
+		{"a", MakeUnqualifiedTableName("a")},
+		{`a"`, MakeUnqualifiedTableName(`a"`)},
+		{`"a""".bB."cD" `, MakeTableNameWithSchema(`a"`, "bb", "cD")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			out, err := castStringToRegClassTableName(tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, out)
+		})
+	}
+
+	errorTestCases := []struct {
+		in            string
+		expectedError string
+	}{
+		{"a.b.c.d", "too many components: a.b.c.d"},
+		{"", `invalid table name: `},
+	}
+
+	for _, tc := range errorTestCases {
+		t.Run(tc.in, func(t *testing.T) {
+			_, err := castStringToRegClassTableName(tc.in)
+			require.EqualError(t, err, tc.expectedError)
+		})
+	}
+
+}
+
+func TestSplitIdentifierList(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		in       string
+		expected []string
+	}{
+		{`abc`, []string{"abc"}},
+		{`abc.dEf  `, []string{"abc", "def"}},
+		{` "aBc"  . d  ."HeLLo"""`, []string{"aBc", "d", `HeLLo"`}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			out, err := splitIdentifierList(tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, out)
+		})
+	}
+
+	errorTestCases := []struct {
+		in            string
+		expectedError string
+	}{
+		{`"unclosed`, `invalid name: unclosed ": "unclosed`},
+		{`"unclosed""`, `invalid name: unclosed ": "unclosed""`},
+		{`hello !`, `invalid name: expected separator .: hello !`},
+	}
+
+	for _, tc := range errorTestCases {
+		t.Run(tc.in, func(t *testing.T) {
+			_, err := splitIdentifierList(tc.in)
+			require.EqualError(t, err, tc.expectedError)
+		})
+	}
+}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3616,7 +3616,7 @@ func (expr *CaseExpr) Eval(ctx *EvalContext) (Datum, error) {
 // pgSignatureRegexp matches a Postgres function type signature, capturing the
 // name of the function into group 1.
 // e.g. function(a, b, c) or function( a )
-var pgSignatureRegexp = regexp.MustCompile(`^\s*([\w\.]+)\s*\((?:(?:\s*\w+\s*,)*\s*\w+)?\s*\)\s*$`)
+var pgSignatureRegexp = regexp.MustCompile(`^\s*([\w\."]+)\s*\((?:(?:\s*[\w"]+\s*,)*\s*[\w"]+)?\s*\)\s*$`)
 
 // regTypeInfo contains details on a pg_catalog table that has a reg* type.
 type regTypeInfo struct {


### PR DESCRIPTION
Resolves #53686

----

tree: add more casting fixes for text to reg*

Release note (sql change): Added ability to cast a string containing all
integers to be cast into a given regtype, e.g. '1234'::regproc is now
valid.

Release note (bug fix): Fixed a bug where casts from string to regproc,
regtype or regprocedure would not work if they contained " characters at
the beginning or at the end.

sql: fix unescaped casts to regclass types

Release note (bug fix): Fix a bug where casts to
regclass were not escaped (i.e. when the
type or table name had " characters).

