### PR TITLE
rowexec: fix recent refactor of zigzag joiner

### DIFF
--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -927,11 +927,11 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 
 // Next is part of the RowSource interface.
 func (z *zigzagJoiner) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	if err := z.maybeFetchInitialRow(); err != nil {
-		z.MoveToDraining(err)
-	}
-
 	for z.State == execinfra.StateRunning {
+		if err := z.maybeFetchInitialRow(); err != nil {
+			z.MoveToDraining(err)
+			break
+		}
 		row, err := z.nextRow(z.Ctx, z.FlowCtx.Txn)
 		if err != nil {
 			z.MoveToDraining(err)


### PR DESCRIPTION
In a recent refactor of zigzag joiner I introduced a helper method that
could emit an error which would force the processor to move to draining.
The issue is that this could happen regardless of the current state of
the processor which breaks the contract (namely, we could try to move to
draining state twice). This is now fixed.

Fixes: #55573.

Release note: None (no release with the bug)