### PR TITLE
sql: allow string concat with any non-array type

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -481,52 +481,90 @@
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
+<tr><td><a href="bool.html">bool</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td>box2d <code>||</code> box2d</td><td>box2d</td></tr>
+<tr><td>box2d <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date</a></td><td><a href="date.html">date[]</a></td></tr>
 <tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
 <tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float</a></td><td><a href="float.html">float[]</a></td></tr>
 <tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
 <tr><td>geography <code>||</code> geography</td><td>geography</td></tr>
+<tr><td>geography <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>geometry <code>||</code> geometry</td><td>geometry</td></tr>
+<tr><td>geometry <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="inet.html">inet</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet</a></td><td><a href="inet.html">inet[]</a></td></tr>
 <tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int</a></td><td><a href="int.html">int[]</a></td></tr>
 <tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
+<tr><td>jsonb <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td>oid <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> box2d</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="date.html">date</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="decimal.html">decimal</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="float.html">float</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> geography</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> geometry</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="inet.html">inet</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="int.html">int</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> jsonb</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> oid</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="time.html">time</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="timestamp.html">timestamp</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="timestamp.html">timestamptz</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> timetz</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> tuple</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="uuid.html">uuid</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> varbit</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="time.html">time</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="time.html">time</a> <code>||</code> <a href="time.html">time[]</a></td><td><a href="time.html">time[]</a></td></tr>
 <tr><td><a href="time.html">time[]</a> <code>||</code> <a href="time.html">time</a></td><td><a href="time.html">time[]</a></td></tr>
 <tr><td><a href="time.html">time[]</a> <code>||</code> <a href="time.html">time[]</a></td><td><a href="time.html">time[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> timestamptz</td><td>timestamptz</td></tr>
 <tr><td>timestamptz <code>||</code> <a href="timestamp.html">timestamptz</a></td><td>timestamptz</td></tr>
 <tr><td>timestamptz <code>||</code> timestamptz</td><td>timestamptz</td></tr>
+<tr><td>timetz <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>timetz <code>||</code> timetz</td><td>timetz</td></tr>
+<tr><td>tuple <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="uuid.html">uuid</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
+<tr><td>varbit <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>varbit <code>||</code> varbit</td><td>varbit</td></tr>
 </tbody></table>
 <table><thead>

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -268,7 +268,7 @@ project
 
 # Array Element Concat
 build
-SELECT x || arr AS r, arr || x AS s, x || NULL AS t, NULL || x AS u FROM unusual
+SELECT x || arr AS r, arr || x AS s, x || NULL::int[] AS t, NULL::int[] || x AS u FROM unusual
 ----
 project
  ├── columns: r:4(int[]) s:5(int[]) t:6(int[]) u:7(int[])

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -54,15 +54,17 @@ SELECT
     -- These shouldn't be folded because AllowNullArgs is true for concat with arrays.
     arr::decimal[] || null AS va, null || arr::string[] AS vb,
 
-    -- Scalars concatenated with nulls match array overloads, and shouldn't be folded.
-    -- In other words, the only overload for decimal concatenation is an array overload.
-    i::decimal || null AS wa, null || i::float AS wb
+    -- Concatenation with null arrays should not be folded.
+    i::decimal || null::decimal[] AS wa, null::float[] || i::float AS wb,
+    -- Scalars concatenated with nulls match string concatenation, and are folded.
+    i::decimal || null AS xa,
+    null || i::float AS xb
 FROM a
 ----
 project
- ├── columns: ra:8 rb:9 sa:10 sb:11 ta:12 tb:13 ua:14 ub:15 va:16 vb:17 wa:18 wb:19
+ ├── columns: ra:8 rb:9 sa:10 sb:11 ta:12 tb:13 ua:14 ub:15 va:16 vb:17 wa:18 wb:19 xa:20 xb:20
  ├── immutable
- ├── fd: ()-->(8-15)
+ ├── fd: ()-->(8-15,20)
  ├── scan a
  │    └── columns: i:2 arr:6
  └── projections
@@ -77,7 +79,8 @@ project
       ├── arr:6::DECIMAL[] || CAST(NULL AS DECIMAL[]) [as=va:16, outer=(6), immutable]
       ├── CAST(NULL AS STRING[]) || arr:6::STRING[] [as=vb:17, outer=(6), immutable]
       ├── i:2::DECIMAL || CAST(NULL AS DECIMAL[]) [as=wa:18, outer=(2), immutable]
-      └── CAST(NULL AS FLOAT8[]) || i:2::FLOAT8 [as=wb:19, outer=(2), immutable]
+      ├── CAST(NULL AS FLOAT8[]) || i:2::FLOAT8 [as=wb:19, outer=(2), immutable]
+      └── NULL [as=xa:20]
 
 norm
 SELECT

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -861,14 +861,14 @@ concat [type=int[]]
            └── null [type=unknown]
 
 build-scalar
-NULL::oid || ARRAY[1, 2]
+NULL::bigint || ARRAY[1, 2]
 ----
-concat [type=oid[]]
- ├── cast: OID [type=oid]
+concat [type=int[]]
+ ├── cast: INT8 [type=int]
  │    └── null [type=unknown]
- └── array: [type=oid[]]
-      ├── const: 1 [type=oid]
-      └── const: 2 [type=oid]
+ └── array: [type=int[]]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
 
 build-scalar
 ARRAY['"foo"'::jsonb]

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -201,6 +201,7 @@ go_test(
         "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/xform",
         "//pkg/sql/parser",
+        "//pkg/sql/rowenc",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -345,6 +345,10 @@ func LookupCastVolatility(from, to *types.T) (_ Volatility, ok bool) {
 	if fromFamily == types.TupleFamily && toFamily == types.TupleFamily {
 		fromTypes := from.TupleContents()
 		toTypes := to.TupleContents()
+		// Handle case where an overload makes a tuple get casted to tuple{}.
+		if len(toTypes) == 1 && toTypes[0].Family() == types.AnyFamily {
+			return VolatilityStable, true
+		}
 		if len(fromTypes) != len(toTypes) {
 			return 0, false
 		}

--- a/pkg/sql/sem/tree/casts_test.go
+++ b/pkg/sql/sem/tree/casts_test.go
@@ -177,6 +177,11 @@ func TestTupleCastVolatility(t *testing.T) {
 			exp:  "immutable",
 		},
 		{
+			from: []*types.T{types.Int, types.Int},
+			to:   []*types.T{types.Any},
+			exp:  "stable",
+		},
+		{
 			from: []*types.T{types.TimestampTZ},
 			to:   []*types.T{types.Date},
 			exp:  "stable",

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,6 +68,33 @@ func TestCastFromNull(t *testing.T) {
 		res, err := castExpr.Eval(nil)
 		require.NoError(t, err)
 		require.Equal(t, tree.DNull, res)
+	}
+}
+
+// TestStringConcat checks every tuple and scalar type can be concatenated with
+// a string.
+func TestStringConcat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
+	for _, typ := range append([]*types.T{types.AnyTuple}, types.Scalar...) {
+		// Strings and Bytes are handled specially.
+		if typ == types.String || typ == types.Bytes {
+			continue
+		}
+		d := rowenc.RandDatum(rng, typ, false /* nullOk */)
+		expected := tree.NewDString(tree.AsStringWithFlags(d, tree.FmtPgwireText))
+		concatExprLeft := tree.NewTypedBinaryExpr(tree.Concat, tree.NewDString(""), d, types.String)
+		resLeft, err := concatExprLeft.Eval(&evalCtx)
+		require.NoError(t, err)
+		require.Equal(t, expected, resLeft)
+		concatExprRight := tree.NewTypedBinaryExpr(tree.Concat, d, tree.NewDString(""), types.String)
+		resRight, err := concatExprRight.Eval(&evalCtx)
+		require.NoError(t, err)
+		require.Equal(t, expected, resRight)
 	}
 }
 

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -978,10 +978,11 @@ func init() {
 	DecimalOne.SetInt64(1)
 }
 
-// ReType ensures that the given numeric expression evaluates
+// ReType ensures that the given expression evaluates
 // to the requested type, inserting a cast if necessary.
 func ReType(expr TypedExpr, wantedType *types.T) TypedExpr {
-	if wantedType.Family() == types.AnyFamily || expr.ResolvedType().Identical(wantedType) {
+	resolvedType := expr.ResolvedType()
+	if wantedType.Family() == types.AnyFamily || resolvedType.Identical(wantedType) {
 		return expr
 	}
 	res := &CastExpr{Expr: expr, Type: wantedType}

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -11,11 +11,118 @@ eval
 'a3'
 
 eval
+e'\\x1a&v\\x16.q6' || ''
+----
+e'\\x1a&v\\x16.q6'
+
+eval
+'\x1a&v\x16.q6' || ''
+----
+e'\\x1a&v\\x16.q6'
+
+eval
 b'hello' || 'world'
 ----
 '\x68656c6c6f776f726c64'
+
+# String || any; any || String
+eval
+'b' || (5)::char || (8)::char || 'c'
+----
+'b58c'
+
+eval
+3 || 'a' || 3
+----
+'3a3'
+
+eval
+3::oid || 'a' || 3::oid
+----
+'3a3'
+
+eval
+3.33 || 'a' || 3.33
+----
+'3.33a3.33'
+
+eval
+(1,2) || 'a' || (3,4)
+----
+'(1,2)a(3,4)'
+
+eval
+(1,2,(3,4)) || 'a'
+----
+'(1,2,"(3,4)")a'
+
+eval
+'2011-01-01 22:30:00-05'::timestamptz || ' a ' || '2011-01-01 22:30:00'::timestamp
+----
+'2011-01-01 22:30:00-05:00 a 2011-01-01 22:30:00'
+
+eval
+'3 days 2 hours'::interval || ' a ' || '127.0.0.1'::inet
+----
+'3 days 02:00:00 a 127.0.0.1'
+
+eval
+'22:30:00'::time || ' a ' || '22:30:00-05'::timetz
+----
+'22:30:00 a 22:30:00-05:00:00'
+
+# Array concatenation.
 
 eval
 array['foo'] || '{a,b}'
 ----
 ARRAY['foo','a','b']
+
+# This should be treated as NULL::int[] || ARRAY[1, 2]
+eval
+NULL || ARRAY[1, 2]
+----
+ARRAY[1,2]
+
+# This should be treated as ARRAY['foo]' || NULL::text[]
+eval
+ARRAY['foo'] || NULL
+----
+ARRAY['foo']
+
+eval
+NULL::TEXT || ARRAY['foo']
+----
+ARRAY[NULL,'foo']
+
+eval
+ARRAY[1, 2] || NULL::INT
+----
+ARRAY[1,2,NULL]
+
+eval
+NULL::INT2 || ARRAY[1, 2]
+----
+ARRAY[NULL,1,2]
+
+# Match Postgres: choose INT || NULL::STRING
+eval
+1 || NULL
+----
+NULL
+
+# Match Postgres: choose NULL::STRING || INT
+eval
+NULL || 2
+----
+NULL
+
+eval
+1 || NULL::int[]
+----
+ARRAY[1]
+
+eval
+NULL::int[] || 2
+----
+ARRAY[2]


### PR DESCRIPTION
Many tools and ORMs that work with Postgres expect this behavior.

this is retrying the idea from #43190
fixes #41872
fixes #34404

Release note (sql change): the concatenation operator || is now usable
between strings and any other non-array type.

Release note (backward-incompatible change): Concatenation between a
non-null argument and a null argument is now typed as string
concatenation. (It previously used to be typed as array concatentation.)
This means that the result of `NULL || 1` will now be `NULL`.
Previously, the result would be `{1}`. To preserve the old behavior, the NULL
argument can be casted to an explicit type.