### PR TITLE
sql: write to the event log table when changing privileges

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -117,6 +117,13 @@ const (
 	// EventLogCreateStatistics is recorded when statistics are collected for a
 	// table.
 	EventLogCreateStatistics EventLogType = "create_statistics"
+
+	// EventLogGrantPrivilege is recorded when privileges are added to a user
+	// for a database object.
+	EventLogGrantPrivilege EventLogType = "grant_privilege"
+	// EventLogRevokePrivilege is recorded when privileges are removed from a
+	// user for a database object.
+	EventLogRevokePrivilege EventLogType = "revoke_privilege"
 )
 
 // EventLogSetClusterSettingDetail is the json details for a settings change.

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -65,7 +66,8 @@ func (p *planner) Grant(ctx context.Context, n *tree.Grant) (planNode, error) {
 		changePrivilege: func(privDesc *descpb.PrivilegeDescriptor, grantee string) {
 			privDesc.Grant(grantee, n.Privileges)
 		},
-		grantOn: grantOn,
+		grantOn:      grantOn,
+		eventLogType: EventLogGrantPrivilege,
 	}, nil
 }
 
@@ -106,7 +108,8 @@ func (p *planner) Revoke(ctx context.Context, n *tree.Revoke) (planNode, error) 
 		changePrivilege: func(privDesc *descpb.PrivilegeDescriptor, grantee string) {
 			privDesc.Revoke(grantee, n.Privileges, grantOn)
 		},
-		grantOn: grantOn,
+		grantOn:      grantOn,
+		eventLogType: EventLogRevokePrivilege,
 	}, nil
 }
 
@@ -116,6 +119,7 @@ type changePrivilegesNode struct {
 	desiredprivs    privilege.List
 	changePrivilege func(*descpb.PrivilegeDescriptor, string)
 	grantOn         privilege.ObjectType
+	eventLogType    EventLogType
 }
 
 // ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
@@ -239,7 +243,29 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 	}
 
 	// Now update the descriptors transactionally.
-	return p.txn.Run(ctx, b)
+	if err := p.txn.Run(ctx, b); err != nil {
+		return err
+	}
+
+	// Record this index alteration in the event log. This is an auditable log
+	// event and is recorded in the same transaction as the table descriptor
+	// update.
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	n.targets.Format(fmtCtx)
+	targets := fmtCtx.CloseAndGetString()
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		n.eventLogType,
+		0, /* no target */
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
+		struct {
+			Target     string
+			User       string
+			Grantees   string
+			Privileges string
+		}{targets, p.SessionData().User, strings.Join(n.grantees.ToStrings(), ","), n.desiredprivs.String()},
+	)
 }
 
 func (*changePrivilegesNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -490,3 +490,47 @@ SELECT "eventType", "reportingID", info::JSONB->>'ViewName'
 ----
 create_view  1  test.public.v
 drop_view    1  test.public.v
+
+
+# Change privileges
+##################
+
+statement ok
+CREATE TABLE a (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE b (id INT PRIMARY KEY)
+
+statement ok
+CREATE USER u
+
+statement ok
+CREATE USER v
+
+statement ok
+GRANT INSERT ON TABLE a,b TO u
+
+statement ok
+REVOKE UPDATE ON TABLE a FROM u,v
+
+query ITT
+SELECT "reportingID", "info", "eventType"
+FROM system.eventlog
+WHERE "eventType" = 'grant_privilege'
+OR "eventType" = 'revoke_privilege'
+ORDER BY "eventType"
+----
+1 {"Target":"TABLE a, b","User":"root","Grantees":"u","Privileges":"INSERT"} grant_privilege
+1 {"Target":"TABLE a","User":"root","Grantees":"u,v","Privileges":"UPDATE"} revoke_privilege
+
+statement ok
+DROP TABLE a
+
+statement ok
+DROP TABLE b
+
+statement ok
+DROP USER u
+
+statement ok
+DROP USER v

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -73,6 +73,10 @@ export const SET_ZONE_CONFIG = "set_zone_config";
 export const REMOVE_ZONE_CONFIG = "remove_zone_config";
 // Recorded when statistics are collected for a table.
 export const CREATE_STATISTICS = "create_statistics";
+// Recorded when privileges are added to a user(s).
+export const GRANT_PRIVILEGE = "grant_privilege";
+// Recorded when privileges are removed from a user(s).
+export const REVOKE_PRIVILEGE = "revoke_privilege";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONING, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -83,6 +83,10 @@ export function getEventDescription(e: Event$Properties): string {
       return `Zone Config Removed: User ${info.User} removed the zone config for ${info.Target}`;
     case eventTypes.CREATE_STATISTICS:
       return `Table statistics refreshed for ${info.TableName}`;
+    case eventTypes.GRANT_PRIVILEGE:
+      return `Privileges granted: User ${info.User} granted ${info.Privileges} to ${info.Grantees} on ${info.Target}`;
+    case eventTypes.REVOKE_PRIVILEGE:
+      return `Privileges revoked: User ${info.User} revoked ${info.Privileges} from ${info.Grantees} on ${info.Target}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }
@@ -105,6 +109,8 @@ export interface EventInfo {
   Target?: string;
   Config?: string;
   Statement?: string;
+  Grantees?: string;
+  Privileges?: string;
   // The following are three names for the same key (it was renamed twice).
   // All ar included for backwards compatibility.
   DroppedTables?: string[];


### PR DESCRIPTION
Helps towards https://github.com/cockroachdb/cockroach/issues/13492.

Release note (admin ui change): Changing privileges (i.e. grants or
revokes) now causes an avent to be logged and displayed in the admin ui

cc: @jordanlewis could you please review this or suggest someone who would be suitable?