### PR TITLE
util: fix metamorphic build tag

### DIFF
--- a/pkg/util/metamorphic_off.go
+++ b/pkg/util/metamorphic_off.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// -build metamorphic
+// +build !metamorphic
 
 package util
 


### PR DESCRIPTION
Prevously, the build tag for when metamorphic was set to on was
misconfigured.

Release note: None