### PR TITLE
colbuilder: disable wrapping of changefeed processors

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -236,6 +236,11 @@ func sinklessTest(testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory)) f
 		// TODO(dan): This is still needed to speed up table_history, that should be
 		// moved to RangeFeed as well.
 		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+		// Change a couple of settings related to the vectorized engine in
+		// order to ensure that changefeeds work as expected with them (note
+		// that we'll still use the row-by-row engine, see #55605).
+		sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.vectorize=on`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.vectorize_row_count_threshold=0`)
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 
 		sink, cleanup := sqlutils.PGUrl(t, s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -576,6 +576,19 @@ func NewColOperator(
 		if core.MetadataTestReceiver != nil {
 			return r, errors.Newf("core.MetadataTestReceiver is not supported")
 		}
+		// We do not wrap Change{Aggregator,Frontier} because these processors
+		// are very row-oriented and the Columnarizer might block indefinitely
+		// while buffering coldata.BatchSize() tuples to emit as a single
+		// batch.
+		if core.ChangeAggregator != nil {
+			return r, errors.Newf("core.ChangeAggregator is not supported")
+		}
+		if core.ChangeFrontier != nil {
+			return r, errors.Newf("core.ChangeFrontier is not supported")
+		}
+		// We do not wrap InvertedFilterer because that processor just happen
+		// to work due to the inverted data not being decoded which the
+		// ColBatchScan will attempt to do and will fail. See #50695.
 		if core.InvertedFilterer != nil {
 			// colfetcher.cfetcher currently tries to decode the inverted
 			// column needed for inverted filtering, but that inverted column is


### PR DESCRIPTION
The root of the problem is that `Columnarizer` has buffering behavior -
in 20.1 it will be hanging until `coldata.BatchSize()` (1024 by default)
rows are emitted by the changefeed. On 20.2 and master due to dynamic
batch size behavior it will still be hanging but in a slightly
different manner.

This is less of a problem on 20.2 and the current master because the
vectorized engine will not be used for the changefeed DistSQL flow since
the vectorized row count threshold is never met for it (the estimated
row count for the plan is 0, so unless a user does
`SET vectorize_row_count_threshold=0;` or
`SET vectorize=experimental_always;`, we will always use row-by-row
engine). In 20.1 the meaning of `vectorize=on` was different - we never
looked at the threshold and used the vectorized engine if it was
supported.

In order to fix this issue we simply refuse to wrap the changefeed
processors, so the row-by-row engine will be always used for changefeed
flows.

Fixes: #55605.

Release note (bug fix): The current implementation of changefeeds is
incompatible with the vectorized engine, so whenever the latter is being
used to run the former, it could hang indefinitely. This is now fixed.
Namely, on 20.2 releases this could happen if the user runs
`SET vectorize_row_count_threshold=0;`, and on 20.1 releases - if the
user runs `SET vectorize=on`.