### PR TITLE
server: improve error message on drain timeout

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1220,7 +1220,8 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 	// until they're all gone, up to the configured timeout.
 	transferTimeout := raftLeadershipTransferWait.Get(&s.cfg.Settings.SV)
 
-	if err := contextutil.RunWithTimeout(ctx, "wait for raft leadership transfer", transferTimeout,
+	drainLeasesOp := "transfer range leases"
+	if err := contextutil.RunWithTimeout(ctx, drainLeasesOp, transferTimeout,
 		func(ctx context.Context) error {
 			opts := retry.Options{
 				InitialBackoff: 10 * time.Millisecond,
@@ -1251,9 +1252,16 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 			// err, take it into account here.
 			return errors.CombineErrors(err, ctx.Err())
 		}); err != nil {
-		// You expect this message when shutting down a server in an unhealthy
-		// cluster. If we see it on healthy ones, there's likely something to fix.
-		log.Warningf(ctx, "unable to drain cleanly within %s, service might briefly deteriorate: %+v", transferTimeout, err)
+		if tErr := (*contextutil.TimeoutError)(nil); errors.As(err, &tErr) && tErr.Operation() == drainLeasesOp {
+			// You expect this message when shutting down a server in an unhealthy
+			// cluster, or when draining all nodes with replicas for some range at the
+			// same time. If we see it on healthy ones, there's likely something to fix.
+			log.Warningf(ctx, "unable to drain cleanly within %s (cluster setting %s), "+
+				"service might briefly deteriorate if the node is terminated: %s",
+				transferTimeout, raftLeadershipTransferWaitKey, tErr.Cause())
+		} else {
+			log.Warningf(ctx, "drain error: %+v", err)
+		}
 	}
 }
 

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -96,6 +96,11 @@ var _ errors.Formatter = (*TimeoutError)(nil)
 // that people looking for net.Error attributes will still find them.
 var _ net.Error = (*TimeoutError)(nil)
 
+// Operation returns the name of the operation that timed out.
+func (t *TimeoutError) Operation() string {
+	return t.operation
+}
+
 func (t *TimeoutError) Error() string { return fmt.Sprintf("%v", t) }
 
 // Format implements fmt.Formatter.


### PR DESCRIPTION
When draining times out, we print out a warning. Commonly that warning
tells you that the leases could not be drained in time. In this case,
the patch improves the message:
- don't print a useless stack trace any more
- refer to the cluster setting controlling the timeout
- refer to leases, not "Raft leadership". Draining deals with both, but
  leases are the concept that's somewhat exposed to users.

Release note: None