### PR TITLE
kvserver: stop pretending to deal with Raft leadership when draining 

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1577,22 +1577,22 @@ func (r *Replica) maybeWatchForMerge(ctx context.Context, freezeStart hlc.Timest
 	return err
 }
 
-func (r *Replica) maybeTransferRaftLeadership(ctx context.Context) {
+func (r *Replica) maybeTransferRaftLeadershipToLeaseholder(ctx context.Context) {
 	r.mu.Lock()
-	r.maybeTransferRaftLeadershipLocked(ctx)
+	r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx)
 	r.mu.Unlock()
 }
 
-// maybeTransferRaftLeadershipLocked attempts to transfer the leadership away
-// from this node to the leaseholder, if this node is the current raft leader
-// but not the leaseholder. We don't attempt to transfer leadership if the
-// leaseholder is behind on applying the log.
+// maybeTransferRaftLeadershipToLeaseholderLocked attempts to transfer the
+// leadership away from this node to the leaseholder, if this node is the
+// current raft leader but not the leaseholder. We don't attempt to transfer
+// leadership if the leaseholder is behind on applying the log.
 //
 // We like it when leases and raft leadership are collocated because that
 // facilitates quick command application (requests generally need to make it to
 // both the lease holder and the raft leader before being applied by other
 // replicas).
-func (r *Replica) maybeTransferRaftLeadershipLocked(ctx context.Context) {
+func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(ctx context.Context) {
 	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		return
 	}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -430,7 +430,7 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 	// If we're the current raft leader, may want to transfer the leadership to
 	// the new leaseholder. Note that this condition is also checked periodically
 	// when ticking the replica.
-	r.maybeTransferRaftLeadership(ctx)
+	r.maybeTransferRaftLeadershipToLeaseholder(ctx)
 
 	// Notify the store that a lease change occurred and it may need to
 	// gossip the updated store descriptor (with updated capacity).

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -905,7 +905,7 @@ func (r *Replica) tick(livenessMap IsLiveMap) (bool, error) {
 		return false, nil
 	}
 
-	r.maybeTransferRaftLeadershipLocked(ctx)
+	r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx)
 
 	// For followers, we update lastUpdateTimes when we step a message from them
 	// into the local Raft group. The leader won't hit that path, so we update


### PR DESCRIPTION
The draining code was pretending to deal with transferring Raft
leadership, besides leases, but it was all an illusion. This patch stops
the pretending, simplifying the code and preventing mis-interpretation
(which I've suffered from).
There are a few cases to discuss:
1) There is no lease. The code really looked like it will try to do
   something to the leadership, but ended up not doing anything because
   maybeTransferRaftLeadership() is a no-op when there's no lease.
2) The leases needs to be moved. In this case, the code was first trying
   to move the lease and then, if that *failed, was trying to move the
   leadership. This was a no-op since maybeTransferRaftLeadership() only
   moves to the leadership to the leaseholder; if the leaseholder hasn't
   moved, it's a no-op.
3) The lease doesn't need to be moved, but the leadership does. In this
   case the code could theoretically do the leadership transfer, but
   this case is very rare - the leadership moves as lease transfers
   apply, and if that fails, we'll continue attempting to move the
   leadership every Raft tick (every 200ms).

Release note: None