### PR TITLE
kvserver: implement Liveness.String() on value receiver

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/liveness.go
+++ b/pkg/kv/kvserver/kvserverpb/liveness.go
@@ -62,7 +62,7 @@ func (l *Liveness) Compare(o Liveness) int {
 	return 0
 }
 
-func (l *Liveness) String() string {
+func (l Liveness) String() string {
 	var extra string
 	if l.Draining || l.Membership.Decommissioning() || l.Membership.Decommissioned() {
 		extra = fmt.Sprintf(" drain:%t membership:%s", l.Draining, l.Membership.String())


### PR DESCRIPTION
The usual problem with only the pointer implementing Stringer.
Particularly important since NodeLiveness.GetLivenes() returns a value
Liveness.
It used to be implemented on values, but that changed in #50329 for some
reason.

Release note: None