### PR TITLE
release-20.1: sql/pgwire: min/max use correct type in planning

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -798,7 +798,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="generate_subscripts"></a><code>generate_subscripts(array: anyelement[], dim: <a href="int.html">int</a>, reverse: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a series comprising the given array’s subscripts.</p>
 <p>When reverse is true, the series is returned in reverse order.</p>
 </span></td></tr>
-<tr><td><a name="information_schema._pg_expandarray"></a><code>information_schema._pg_expandarray(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows with an index</p>
+<tr><td><a name="information_schema._pg_expandarray"></a><code>information_schema._pg_expandarray(input: anyelement[]) &rarr; tuple{anyelement AS x, int AS n}</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows with an index</p>
 </span></td></tr>
 <tr><td><a name="json_array_elements"></a><code>json_array_elements(input: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
@@ -822,7 +822,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="pg_get_keywords"></a><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
 </span></td></tr>
-<tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
+<tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple{anyelement AS unnest, anyelement AS unnest, anyelement AS unnest}</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
 </span></td></tr>
 <tr><td><a name="unnest"></a><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
 </span></td></tr></tbody>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -196,7 +196,7 @@ func generateFunctions(from []string, categorize bool) []byte {
 			}
 			args := fn.Types.String()
 
-			retType := fn.FixedReturnType()
+			retType := fn.InferReturnTypeFromInputArgTypes(fn.Types.Types())
 			ret := retType.String()
 
 			cat := props.Category

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -66,8 +66,7 @@ func GetAggregateInfo(
 			constructAgg := func(evalCtx *tree.EvalContext, arguments tree.Datums) tree.AggregateFunc {
 				return b.AggregateFunc(datumTypes, evalCtx, arguments)
 			}
-
-			colTyp := b.FixedReturnType()
+			colTyp := b.InferReturnTypeFromInputArgTypes(datumTypes)
 			return constructAgg, colTyp, nil
 		}
 	}
@@ -174,7 +173,8 @@ func GetWindowFunctionInfo(
 			constructAgg := func(evalCtx *tree.EvalContext) tree.WindowFunc {
 				return b.WindowFunc(datumTypes, evalCtx)
 			}
-			return constructAgg, b.FixedReturnType(), nil
+			colTyp := b.InferReturnTypeFromInputArgTypes(datumTypes)
+			return constructAgg, colTyp, nil
 		}
 	}
 	return nil, nil, errors.Errorf(

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -202,14 +202,21 @@ func TestTypingAggregateAssumptions(t *testing.T) {
 
 			// Check for fixed return types.
 			retType := overload.ReturnType(nil)
-			if retType == tree.UnknownReturnType {
-				t.Errorf("return type is not fixed for %s: %+v", name, overload.Types.Types())
-			}
 
+			// As per rule 3, max and min have slightly different rules. We allow
+			// max and min to have non-fixed return types to allow defining aggregate
+			// overloads that have container types as arguments.
 			if name == "min" || name == "max" {
-				if retType != overload.Types.Types()[0] {
+				// Evaluate the return typer.
+				types := overload.Types.Types()
+				retType = overload.InferReturnTypeFromInputArgTypes(types)
+				if retType != types[0] {
 					t.Errorf("return type differs from arg type for %s: %+v", name, overload.Types.Types())
 				}
+				continue
+			}
+			if retType == tree.UnknownReturnType {
+				t.Errorf("return type is not fixed for %s: %+v", name, overload.Types.Types())
 			}
 		}
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/data_type_size
+++ b/pkg/sql/pgwire/testdata/pgtest/data_type_size
@@ -1,0 +1,85 @@
+# This test verifies that the DataTypeSize field in the RowDescription and
+# DataRow messages both agree when using the MAX aggregate on an INT4 column.
+
+# Prepare the environment.
+send
+Query {"String": "DROP TABLE IF EXISTS minmax_test"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE minmax_test (id INT8 PRIMARY KEY, b INT4, c FLOAT4)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send
+Query {"String": "INSERT INTO minmax_test (id, b, c) VALUES (1, 1000, 11.1), (2, 250, 55.5)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT max(b), min(c) FROM minmax_test"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1000"},{"text":"11.1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+send
+Parse {"Name": "s1", "Query": "SELECT max(b), min(c) FROM minmax_test"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1"}
+Describe {"ObjectType": 80, "Name": "p1"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1000"},{"text":"11.1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+# ResultFormatCodes [1] = FormatBinary
+send
+Parse {"Name": "s2", "Query": "SELECT max(b), min(c) FROM minmax_test"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2", "ResultFormatCodes": [1,1]}
+Describe {"ObjectType": 80, "Name": "p2"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"max","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":1},{"Name":"min","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":700,"DataTypeSize":4,"TypeModifier":-1,"Format":1}]}
+{"Type":"DataRow","Values":[{"binary":"000003e8"},{"text":"A1\ufffd\ufffd"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/int_size
+++ b/pkg/sql/pgwire/testdata/pgtest/int_size
@@ -33,7 +33,7 @@ Query {"String": "SELECT * FROM t1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":52,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":52,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":53,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":53,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":53,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 0"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -80,7 +80,7 @@ Query {"String": "SELECT * FROM t2"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":53,"TableAttributeNumber":1,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":53,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":53,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":54,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":54,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 0"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -92,6 +92,6 @@ Query {"String": "SELECT * FROM t1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":52,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":52,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":53,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":53,"TableAttributeNumber":2,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":53,"TableAttributeNumber":3,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 0"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -59,7 +59,7 @@ Query {"String": "SELECT a FROM tab1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":59,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":60,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -71,7 +71,7 @@ Query {"String": "SELECT tab1.a, tab2.c FROM tab1 JOIN tab2 ON tab1.a = tab2.tab
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":59,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":60,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":60,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":61,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"4"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -83,7 +83,7 @@ Query {"String": "SELECT * FROM v WHERE v1 = 1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"v1","TableOID":59,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"v2","TableOID":60,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"v1","TableOID":60,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"v2","TableOID":61,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -115,7 +115,7 @@ Query {"String": "SELECT b FROM tab3"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":62,"TableAttributeNumber":2,"DataTypeOID":1042,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":63,"TableAttributeNumber":2,"DataTypeOID":1042,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hello"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -199,14 +199,18 @@ var aggregates = map[string]builtinDefinition{
 
 	"max": collectOverloads(aggProps(), types.Scalar,
 		func(t *types.T) tree.Overload {
-			return makeAggOverload([]*types.T{t}, t, newMaxAggregate,
-				"Identifies the maximum selected value.")
+			info := "Identifies the maximum selected value."
+			return makeAggOverloadWithReturnType(
+				[]*types.T{t}, tree.IdentityReturnType(0), newMaxAggregate, info,
+			)
 		}),
 
 	"min": collectOverloads(aggProps(), types.Scalar,
 		func(t *types.T) tree.Overload {
-			return makeAggOverload([]*types.T{t}, t, newMinAggregate,
-				"Identifies the minimum selected value.")
+			info := "Identifies the minimum selected value."
+			return makeAggOverloadWithReturnType(
+				[]*types.T{t}, tree.IdentityReturnType(0), newMinAggregate, info,
+			)
 		}),
 
 	"string_agg": makeBuiltin(aggPropsNullableArgs(),

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -174,6 +174,8 @@ var generators = map[string]builtinDefinition{
 				FixedTypes: []*types.T{types.AnyArray, types.AnyArray},
 				VarType:    types.AnyArray,
 			},
+			// TODO(rafiss): update this or docgen so that functions.md shows the
+			// return type as variadic.
 			func(args []tree.TypedExpr) *types.T {
 				returnTypes := make([]types.T, len(args))
 				labels := make([]string, len(args))

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -91,7 +91,32 @@ func (b Overload) FixedReturnType() *types.T {
 	if b.ReturnType == nil {
 		return nil
 	}
-	return returnTypeToFixedType(b.ReturnType)
+	return returnTypeToFixedType(b.ReturnType, nil)
+}
+
+// InferReturnTypeFromInputArgTypes returns the type that the function returns,
+// inferring the type based on the function's inputTypes if necessary.
+func (b Overload) InferReturnTypeFromInputArgTypes(inputTypes []*types.T) *types.T {
+	retTyp := b.FixedReturnType()
+	// If the output type of the function depends on its inputs, then
+	// the output of FixedReturnType will be ambiguous. In the ambiguous
+	// cases, use the information about the input types to construct the
+	// appropriate output type. The tree.ReturnTyper interface is
+	// []tree.TypedExpr -> *types.T, so construct the []tree.TypedExpr
+	// from the types that we know are the inputs. Note that we don't
+	// try to create datums of each input type, and instead use this
+	// "TypedDummy" construct. This is because some types don't have resident
+	// members (like an ENUM with no values), and we shouldn't error out
+	// trying to infer the return type in those cases.
+	if retTyp.IsAmbiguous() {
+		args := make([]TypedExpr, len(inputTypes))
+		for i, t := range inputTypes {
+			args[i] = &TypedDummy{Typ: t}
+		}
+		// Evaluate ReturnType with the fake input set of arguments.
+		retTyp = returnTypeToFixedType(b.ReturnType, args)
+	}
+	return retTyp
 }
 
 // Signature returns a human-readable signature.
@@ -382,8 +407,8 @@ func FirstNonNullReturnType() ReturnTyper {
 	}
 }
 
-func returnTypeToFixedType(s ReturnTyper) *types.T {
-	if t := s(nil); t != UnknownReturnType {
+func returnTypeToFixedType(s ReturnTyper, inputTyps []TypedExpr) *types.T {
+	if t := s(inputTyps); t != UnknownReturnType {
 		return t
 	}
 	return types.Any
@@ -838,15 +863,17 @@ func formatCandidates(prefix string, candidates []overloadImpl) string {
 		buf.WriteByte('(')
 		params := candidate.params()
 		tLen := params.Length()
+		inputTyps := make([]TypedExpr, tLen)
 		for i := 0; i < tLen; i++ {
 			t := params.GetAt(i)
+			inputTyps[i] = &TypedDummy{Typ: t}
 			if i > 0 {
 				buf.WriteString(", ")
 			}
 			buf.WriteString(t.String())
 		}
 		buf.WriteString(") -> ")
-		buf.WriteString(returnTypeToFixedType(candidate.returnType()).String())
+		buf.WriteString(returnTypeToFixedType(candidate.returnType(), inputTyps).String())
 		if candidate.preferred() {
 			buf.WriteString(" [preferred]")
 		}


### PR DESCRIPTION
Backport 1/2 commits from #54080

/cc @cockroachdb/release

---

When using a prepared statement, the optimizer is used in order to
determine the type OIDs of the resulting row. Since the min/max
aggregates had an overload that used a fix return type, min/max over
INT4 columns were reported as INT8. However, when it came to execution
time, they would in fact be INT4. This confuses drivers, and in the case
of pgx, caused a runtime exception because the wrong number of bytes was
returned (it tried to read 4 bytes for something we reported was an INT8
column).

Now, the min/max overloads return the same type as the argument type.
This allows us to remove special-case logic in the vectorized engine for
int64s. It also requires an update to how the engine calculates the
return type of window functions.

Also, there is a pgwire test for checking the data type size in the
RowDescription now.

Release note (bug fix): Using the min/max aggregates in a prepared
statement will now report the correct data type size.