### PR TITLE
auth: add telemetry to OIDC feature

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",


### PR DESCRIPTION
This change adds 4 new counters to measure usage
of the OIDC-based login feature:

1. `auth.oidc.begin_auth` is incremented every time
a call is made to the OIDC auth endpoint and OIDC
is enabled. This is incremented prior to generating
a session cooke and state to redirect to the auth
provider.

2. `auth.oidc.begin_callback` is incremented every
time the OIDC callback URL is called and OIDC is
enabled. This is incremented prior to any processing
of the request.

3. `auth.oidc.login_success` is incremented every
time the OIDC callback successfully generates a
session for a DB user

4. `auth.oidc.enable` is incremented every time
 the `server.oidc_authentication.enabled` setting
is flipped from false to true.

Release note: none