### PR TITLE
roachprod: disable discard/TRIM commands for local SSDs

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1209,7 +1209,7 @@ the 'zfs rollback' command:
 			}
 			fsCmd = `sudo zpool create -f data1 -m /mnt/data1 /dev/sdb`
 		case "ext4":
-			fsCmd = `sudo mkfs.ext4 -F /dev/sdb && sudo mount -o discard,defaults /dev/sdb /mnt/data1`
+			fsCmd = `sudo mkfs.ext4 -F /dev/sdb && sudo mount -o defaults /dev/sdb /mnt/data1`
 		default:
 			return fmt.Errorf("unknown filesystem %q", fs)
 		}

--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -39,7 +39,7 @@ set -x
 sudo apt-get update
 sudo apt-get install -qy --no-install-recommends mdadm
 
-mount_opts="discard,defaults"
+mount_opts="defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
 use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
@@ -71,7 +71,7 @@ elif [ "${#disks[@]}" -eq "1" ] || [ -n "use_multiple_disks" ]; then
     disknum=$((disknum + 1 ))
     echo "Creating ${mountpoint}"
     mkdir -p ${mountpoint}
-    mkfs.ext4 -E nodiscard ${disk}
+    mkfs.ext4 -F ${disk}
     mount -o ${mount_opts} ${disk} ${mountpoint}
     chmod 777 ${mountpoint}
     echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
@@ -82,7 +82,7 @@ else
   mkdir -p ${mountpoint}
   raiddisk="/dev/md0"
   mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-  mkfs.ext4 -E nodiscard ${raiddisk}
+  mkfs.ext4 -F ${raiddisk}
   mount -o ${mount_opts} ${raiddisk} ${mountpoint}
   chmod 777 ${mountpoint}
   echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab

--- a/pkg/cmd/roachprod/vm/azure/azure.go
+++ b/pkg/cmd/roachprod/vm/azure/azure.go
@@ -459,7 +459,7 @@ final_message: "roachprod init completed"
 			fmt.Sprintf("chown -R %s /data1", remoteUser),
 		}
 		if opts.SSDOpts.NoExt4Barrier {
-			cmds = append(cmds, "mount -o remount,nobarrier,discard /mnt/data")
+			cmds = append(cmds, "mount -o remount,nobarrier /mnt/data")
 		}
 	} else {
 		// We define lun42 explicitly in the data disk request below.

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -421,6 +421,9 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 			"auto-delete=yes",
 		}
 		args = append(args, "--create-disk", strings.Join(pdProps, ","))
+		// Enable DISCARD commands for persistent disks, as is advised in:
+		// https://cloud.google.com/compute/docs/disks/optimizing-pd-performance#formatting_parameters.
+		extraMountOpts = "discard"
 	}
 
 	// Create GCE startup script file.

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -47,7 +47,7 @@ var Subdomain = func() string {
 const gceLocalSSDStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-mount_opts="discard,defaults"
+mount_opts="defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
 # ignore the boot disk: /dev/disk/by-id/google-persistent-disk-0.


### PR DESCRIPTION
This commit stops mounting local SSDs on AWS, Azure, and GCE with the `discard` mount option, which has been found to lead to a high degree of variance on certain AWS instances. It is still not clear exactly where the variance comes from or why some AWS instances perform better with TRIM commands than others. Avoiding `discard`, which is not recommended in AWS's docs, mitigates this issue. We do the same for GCE and Azure to avoid large differences between the three clouds and because neither of those clouds strongly recommend its use with local SSDs either.

The commit does not remove the option for GCE PDs, because those volumes specifically do recommend the use of the `discard` mount option: https://cloud.google.com/compute/docs/disks/optimizing-pd-performance.

While here, the commit stops passing the `nodiscard` mkfs option, which is not directly related to this issue but which does not seem to be necessary anymore. The flag was originally introduced in https://github.com/cockroachdb/roachprod/commit/7ad733daec0a7de92d1328a4b896c00f65694b71, I believe because of the sentence "For faster access to these volumes, you should skip the TRIM operation when you format them" in https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html#InstanceStoreTrimSupport. I do have some memory of this being important to speed up formatting, but that does not seem to be the case anymore.

See discussion in https://groups.google.com/a/cockroachlabs.com/g/eng/c/zwpSA0Vrs60.

Useful resources:
- https://cloud.google.com/compute/docs/disks/optimizing-local-ssd-performance
- https://cloud.google.com/compute/docs/disks/optimizing-pd-performance
- https://cloud.google.com/compute/docs/disks/local-ssd
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-using-volumes.html
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html
- https://linux.die.net/man/8/mkfs.ext4
- https://linux.die.net/man/8/mount