### PR TITLE
profilestore: recognize v20.2-beta timestamps

### DIFF
--- a/pkg/server/heapprofiler/profilestore.go
+++ b/pkg/server/heapprofiler/profilestore.go
@@ -156,6 +156,15 @@ func (s *profileStore) parseFileName(
 		// Not for us. Silently ignore.
 		return
 	}
+	if len(parts[2]) < 3 {
+		// At some point in the v20.2 cycle the timestamps were generated
+		// with format .999, which caused the trailing zeroes to be
+		// omitted. During parsing, they must be present, so re-add them
+		// here.
+		//
+		// TODO(knz): Remove this code in v21.1.
+		parts[2] += "000"[:3-len(parts[2])]
+	}
 	maybeTimestamp := parts[1] + "." + parts[2]
 	var err error
 	timestamp, err = time.Parse(timestampFormat, maybeTimestamp)

--- a/pkg/server/heapprofiler/profilestore_test.go
+++ b/pkg/server/heapprofiler/profilestore_test.go
@@ -58,6 +58,10 @@ func TestParseFileName(t *testing.T) {
 
 		// New format.
 		{"memprof.2020-06-15T13_19_19.543.123456", time.Date(2020, 6, 15, 13, 19, 19, 543000000, time.UTC), 123456, false},
+		// v20.2 transition formats.
+		// TODO(knz): Remove in v21.1.
+		{"memprof.2020-06-15T13_19_19.54.123456", time.Date(2020, 6, 15, 13, 19, 19, 540000000, time.UTC), 123456, false},
+		{"memprof.2020-06-15T13_19_19.5.123456", time.Date(2020, 6, 15, 13, 19, 19, 500000000, time.UTC), 123456, false},
 	}
 
 	s := profileStore{prefix: HeapFileNamePrefix}


### PR DESCRIPTION
The previous code was generating timestamps with format `.999` which
caused trailing zeroes to be truncated.

Since filenames with this format may still be present in data
directories, this patch makes the code tolerate them.

Release note: None