### PR TITLE
sql: use new explain format in explain bundles

### DIFF
--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -93,8 +93,8 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 	// Sort backward, since the first thing you add to a treeprinter will come last.
 	sort.Slice(sortedFlows, func(i, j int) bool { return sortedFlows[i].nodeID < sortedFlows[j].nodeID })
-	tp := treeprinter.NewWithIndent(false /* leftPad */, true /* rightPad */, 0 /* edgeLength */)
-	root := tp.Child("")
+	tp := treeprinter.NewWithStyle(treeprinter.CompactStyle)
+	root := tp.Child("│")
 	verbose := n.options.Flags[tree.ExplainFlagVerbose]
 	thisNodeID, _ := params.extendedEvalCtx.NodeID.OptionalNodeID()
 	for _, flow := range sortedFlows {

--- a/pkg/sql/opt/exec/explain/testdata/output
+++ b/pkg/sql/opt/exec/explain/testdata/output
@@ -1,0 +1,167 @@
+string
+----
+                     distributed  true
+meta
+ └── render
+      │              render 0     foo
+      │              render 1     bar
+      └── join
+           │         type         outer
+           ├── scan
+           │         table        foo
+           └── scan
+                     table        bar
+
+string verbose
+----
+                     distributed  true
+meta
+ └── render                              (a, b)  +a,-b
+      │              render 0     foo
+      │              render 1     bar
+      └── join                           (x)
+           │         type         outer
+           ├── scan                      (x)
+           │         table        foo
+           └── scan                      ()
+                     table        bar
+
+string types
+----
+                     distributed  true
+meta
+ └── render                              (a int, b string)  +a,-b
+      │              render 0     foo
+      │              render 1     bar
+      └── join                           (x int)
+           │         type         outer
+           ├── scan                      (x int)
+           │         table        foo
+           └── scan                      ()
+                     table        bar
+
+tree
+----
+name: meta
+attrs: []
+children:
+- name: render
+  attrs:
+  - key: render 0
+    value: foo
+  - key: render 1
+    value: bar
+  children:
+  - name: join
+    attrs:
+    - key: type
+      value: outer
+    children:
+    - name: scan
+      attrs:
+      - key: table
+        value: foo
+      children: []
+    - name: scan
+      attrs:
+      - key: table
+        value: bar
+      children: []
+
+tree verbose
+----
+name: meta
+attrs: []
+children:
+- name: render
+  attrs:
+  - key: render 0
+    value: foo
+  - key: render 1
+    value: bar
+  children:
+  - name: join
+    attrs:
+    - key: type
+      value: outer
+    children:
+    - name: scan
+      attrs:
+      - key: table
+        value: foo
+      children: []
+    - name: scan
+      attrs:
+      - key: table
+        value: bar
+      children: []
+
+tree types
+----
+name: meta
+attrs: []
+children:
+- name: render
+  attrs:
+  - key: render 0
+    value: foo
+  - key: render 1
+    value: bar
+  children:
+  - name: join
+    attrs:
+    - key: type
+      value: outer
+    children:
+    - name: scan
+      attrs:
+      - key: table
+        value: foo
+      children: []
+    - name: scan
+      attrs:
+      - key: table
+        value: bar
+      children: []
+
+datums
+----
+                     distributed  true
+meta
+ └── render
+      │              render 0     foo
+      │              render 1     bar
+      └── join
+           │         type         outer
+           ├── scan
+           │         table        foo
+           └── scan
+                     table        bar
+
+datums verbose
+----
+                     0          distributed  true
+meta                 0  meta
+ └── render          1  render                      (a, b)  +a,-b
+      │              1          render 0     foo
+      │              1          render 1     bar
+      └── join       2  join                        (x)
+           │         2          type         outer
+           ├── scan  3  scan                        (x)
+           │         3          table        foo
+           └── scan  3  scan                        ()
+                     3          table        bar
+
+datums types
+----
+                     0          distributed  true
+meta                 0  meta
+ └── render          1  render                      (a int, b string)  +a,-b
+      │              1          render 0     foo
+      │              1          render 1     bar
+      └── join       2  join                        (x int)
+           │         2          type         outer
+           ├── scan  3  scan                        (x int)
+           │         3          table        foo
+           └── scan  3  scan                        ()
+                     3          table        bar

--- a/pkg/sql/opt/exec/explain/testdata/output
+++ b/pkg/sql/opt/exec/explain/testdata/output
@@ -1,44 +1,78 @@
 string
 ----
-                     distributed  true
-meta
- └── render
-      │              render 0     foo
-      │              render 1     bar
-      └── join
-           │         type         outer
-           ├── scan
-           │         table        foo
-           └── scan
-                     table        bar
+----
+distributed: true
+
+• meta
+│
+└── • render
+    │ render 0: foo
+    │ render 1: bar
+    │
+    └── • join
+        │ type: outer
+        │
+        ├── • scan
+        │     table: foo
+        │
+        └── • scan
+              table: bar
+----
+----
 
 string verbose
 ----
-                     distributed  true
-meta
- └── render                              (a, b)  +a,-b
-      │              render 0     foo
-      │              render 1     bar
-      └── join                           (x)
-           │         type         outer
-           ├── scan                      (x)
-           │         table        foo
-           └── scan                      ()
-                     table        bar
+----
+distributed: true
+
+• meta
+│
+└── • render
+    │ columns: (a, b)
+    │ ordering: +a,-b
+    │ render 0: foo
+    │ render 1: bar
+    │
+    └── • join
+        │ columns: (x)
+        │ type: outer
+        │
+        ├── • scan
+        │     columns: (x)
+        │     table: foo
+        │
+        └── • scan
+              columns: ()
+              table: bar
+----
+----
 
 string types
 ----
-                     distributed  true
-meta
- └── render                              (a int, b string)  +a,-b
-      │              render 0     foo
-      │              render 1     bar
-      └── join                           (x int)
-           │         type         outer
-           ├── scan                      (x int)
-           │         table        foo
-           └── scan                      ()
-                     table        bar
+----
+distributed: true
+
+• meta
+│
+└── • render
+    │ columns: (a int, b string)
+    │ ordering: +a,-b
+    │ render 0: foo
+    │ render 1: bar
+    │
+    └── • join
+        │ columns: (x int)
+        │ type: outer
+        │
+        ├── • scan
+        │     columns: (x int)
+        │     table: foo
+        │
+        └── • scan
+              columns: ()
+              table: bar
+----
+----
 
 tree
 ----

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -6,12 +6,17 @@ CREATE TABLE t.orders (oid INT PRIMARY KEY, cid INT, value DECIMAL, date DATE)
 plan-string
 SELECT oid FROM t.orders WHERE oid = 123
 ----
-      distribution         local
-      vectorized           false
-scan                                          (oid int)
-      estimated row count  1 (missing stats)
-      table                orders@primary
-      spans                /123-/123/#
+----
+distribution: local
+vectorized: false
+
+• scan
+  columns: (oid int)
+  estimated row count: 1 (missing stats)
+  table: orders@primary
+  spans: /123-/123/#
+----
+----
 
 plan-tree
 SELECT oid FROM t.orders WHERE oid = 123
@@ -29,12 +34,17 @@ children: []
 plan-string
 SELECT cid, date, value FROM t.orders
 ----
-      distribution         local
-      vectorized           false
-scan                                             (cid int, date date, value decimal)
-      estimated row count  1000 (missing stats)
-      table                orders@primary
-      spans                FULL SCAN
+----
+distribution: local
+vectorized: false
+
+• scan
+  columns: (cid int, date date, value decimal)
+  estimated row count: 1000 (missing stats)
+  table: orders@primary
+  spans: FULL SCAN
+----
+----
 
 plan-tree
 SELECT cid, date, value FROM t.orders
@@ -52,29 +62,47 @@ children: []
 plan-string
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
 ----
-                                    distribution         local
-                                    vectorized           false
-project                                                                                               (cid int, sum decimal)
- └── sort                                                                                             (column8 decimal, cid int, sum decimal)  +column8
-      │                             estimated row count  98 (missing stats)
-      │                             order                +column8
-      └── render                                                                                      (column8 decimal, cid int, sum decimal)
-           │                        estimated row count  98 (missing stats)
-           │                        render 0             ((1)[decimal] - (sum)[decimal])[decimal]
-           │                        render 1             (cid)[int]
-           │                        render 2             (sum)[decimal]
-           └── group                                                                                  (cid int, sum decimal)
-                │                   estimated row count  98 (missing stats)
-                │                   aggregate 0          sum(value)
-                │                   group by             cid
-                └── project                                                                           (cid int, value decimal)
-                     └── filter                                                                       (cid int, value decimal, date date)
-                          │         estimated row count  333 (missing stats)
-                          │         filter               ((date)[date] > ('2015-01-01')[date])[bool]
-                          └── scan                                                                    (cid int, value decimal, date date)
-                                    estimated row count  1000 (missing stats)
-                                    table                orders@primary
-                                    spans                FULL SCAN
+----
+distribution: local
+vectorized: false
+
+• project
+│ columns: (cid int, sum decimal)
+│
+└── • sort
+    │ columns: (column8 decimal, cid int, sum decimal)
+    │ ordering: +column8
+    │ estimated row count: 98 (missing stats)
+    │ order: +column8
+    │
+    └── • render
+        │ columns: (column8 decimal, cid int, sum decimal)
+        │ estimated row count: 98 (missing stats)
+        │ render 0: ((1)[decimal] - (sum)[decimal])[decimal]
+        │ render 1: (cid)[int]
+        │ render 2: (sum)[decimal]
+        │
+        └── • group
+            │ columns: (cid int, sum decimal)
+            │ estimated row count: 98 (missing stats)
+            │ aggregate 0: sum(value)
+            │ group by: cid
+            │
+            └── • project
+                │ columns: (cid int, value decimal)
+                │
+                └── • filter
+                    │ columns: (cid int, value decimal, date date)
+                    │ estimated row count: 333 (missing stats)
+                    │ filter: ((date)[date] > ('2015-01-01')[date])[bool]
+                    │
+                    └── • scan
+                          columns: (cid int, value decimal, date date)
+                          estimated row count: 1000 (missing stats)
+                          table: orders@primary
+                          spans: FULL SCAN
+----
+----
 
 plan-tree
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
@@ -110,12 +138,17 @@ children:
 plan-string
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
 ----
-      distribution         local
-      vectorized           false
-scan                                             (value decimal)
-      estimated row count  1000 (missing stats)
-      table                orders@primary
-      spans                FULL SCAN
+----
+distribution: local
+vectorized: false
+
+• scan
+  columns: (value decimal)
+  estimated row count: 1000 (missing stats)
+  table: orders@primary
+  spans: FULL SCAN
+----
+----
 
 plan-tree
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
@@ -133,25 +166,38 @@ children: []
 plan-string
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
 ----
-                        distribution         local
-                        vectorized           false
-project                                                            (cid int, date date, value decimal)
- │                      estimated row count  1000 (missing stats)
- └── hash join (inner)                                             (cid int, value decimal, date date, date date)
-      │                 estimated row count  980 (missing stats)
-      │                 equality             (date) = (date)
-      │                 right cols are key
-      ├── scan                                                     (cid int, value decimal, date date)
-      │                 estimated row count  1000 (missing stats)
-      │                 table                orders@primary
-      │                 spans                FULL SCAN
-      └── distinct                                                 (date date)
-           │            estimated row count  100 (missing stats)
-           │            distinct on          date
-           └── scan                                                (date date)
-                        estimated row count  1000 (missing stats)
-                        table                orders@primary
-                        spans                FULL SCAN
+----
+distribution: local
+vectorized: false
+
+• project
+│ columns: (cid int, date date, value decimal)
+│ estimated row count: 1000 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (cid int, value decimal, date date, date date)
+    │ estimated row count: 980 (missing stats)
+    │ equality: (date) = (date)
+    │ right cols are key
+    │
+    ├── • scan
+    │     columns: (cid int, value decimal, date date)
+    │     estimated row count: 1000 (missing stats)
+    │     table: orders@primary
+    │     spans: FULL SCAN
+    │
+    └── • distinct
+        │ columns: (date date)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: date
+        │
+        └── • scan
+              columns: (date date)
+              estimated row count: 1000 (missing stats)
+              table: orders@primary
+              spans: FULL SCAN
+----
+----
 
 plan-tree
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
@@ -206,31 +252,47 @@ CREATE TABLE t.actors (
 plan-string
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
 ----
-                          distribution         local
-                          vectorized           false
-root                                                                                           (movie_id int, title string, name string)
- ├── render                                                                                    (movie_id int, title string, name string)
- │    │                   estimated row count  1000 (missing stats)
- │    │                   render 0             (@S1)[string]
- │    │                   render 1             (id)[int]
- │    │                   render 2             (title)[string]
- │    └── scan                                                                                 (id int, title string)
- │                        estimated row count  1000 (missing stats)
- │                        table                movies@primary
- │                        spans                FULL SCAN
- └── subquery
-      │                   id                   @S1
-      │                   original sql         (SELECT name FROM t.actors WHERE name = 'Foo')
-      │                   exec mode            one row
-      └── max1row                                                                              (name string)
-           │              estimated row count  1
-           └── filter                                                                          (name string)
-                │         estimated row count  10 (missing stats)
-                │         filter               ((name)[string] = ('Foo')[string])[bool]
-                └── scan                                                                       (name string)
-                          estimated row count  1000 (missing stats)
-                          table                actors@primary
-                          spans                FULL SCAN
+----
+distribution: local
+vectorized: false
+
+• root
+│ columns: (movie_id int, title string, name string)
+│
+├── • render
+│   │ columns: (movie_id int, title string, name string)
+│   │ estimated row count: 1000 (missing stats)
+│   │ render 0: (@S1)[string]
+│   │ render 1: (id)[int]
+│   │ render 2: (title)[string]
+│   │
+│   └── • scan
+│         columns: (id int, title string)
+│         estimated row count: 1000 (missing stats)
+│         table: movies@primary
+│         spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT name FROM t.actors WHERE name = 'Foo')
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (name string)
+        │ estimated row count: 1
+        │
+        └── • filter
+            │ columns: (name string)
+            │ estimated row count: 10 (missing stats)
+            │ filter: ((name)[string] = ('Foo')[string])[bool]
+            │
+            └── • scan
+                  columns: (name string)
+                  estimated row count: 1000 (missing stats)
+                  table: actors@primary
+                  spans: FULL SCAN
+----
+----
 
 plan-tree
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies

--- a/pkg/util/treeprinter/tree_printer.go
+++ b/pkg/util/treeprinter/tree_printer.go
@@ -20,6 +20,8 @@ var (
 	edgeLinkChr = rune('│')
 	edgeMidChr  = rune('├')
 	edgeLastChr = rune('└')
+	horLineChr  = rune('─')
+	bulletChr   = rune('•')
 )
 
 // Node is a handle associated with a specific depth in a tree. See below for
@@ -33,7 +35,7 @@ type Node struct {
 // should be used to add the root. Sample usage:
 //
 //   tp := New()
-//   root := n.Child("root")
+//   root := tp.Child("root")
 //   root.Child("child-1")
 //   root.Child("child-2").Child("grandchild\ngrandchild-more-info")
 //   root.Child("child-3")
@@ -52,54 +54,187 @@ type Node struct {
 // Note that the Child calls can't be rearranged arbitrarily; they have
 // to be in the order they need to be displayed (depth-first pre-order).
 func New() Node {
-	return NewWithIndent(true, true, 2)
+	return NewWithStyle(DefaultStyle)
 }
 
-// NewWithIndent creates a tree printer like New, permitting customization of
-// the width of the outputted tree.
-// leftPad controls whether the tree lines are padded from the first character
-// of their parent.
-// rightPad controls whether children are separated from their edges by a space.
-// edgeLength controls how many characters wide each edge is.
-func NewWithIndent(leftPad, rightPad bool, edgeLength int) Node {
-	var leftPadStr, rightPadStr string
-	var edgeBuilder strings.Builder
-	for i := 0; i < edgeLength; i++ {
-		edgeBuilder.WriteRune('─')
+// NewWithStyle creates a tree printer like New, permitting customization of
+// the style of the resulting tree.
+func NewWithStyle(style Style) Node {
+	t := &tree{style: style}
+
+	switch style {
+	case CompactStyle:
+		t.edgeLink = []rune{edgeLinkChr}
+		t.edgeMid = []rune{edgeMidChr, ' '}
+		t.edgeLast = []rune{edgeLastChr, ' '}
+
+	case BulletStyle:
+		t.edgeLink = []rune{edgeLinkChr}
+		t.edgeMid = []rune{edgeMidChr, horLineChr, horLineChr, ' '}
+		t.edgeLast = []rune{edgeLastChr, horLineChr, horLineChr, ' '}
+
+	default:
+		t.edgeLink = []rune{' ', edgeLinkChr}
+		t.edgeMid = []rune{' ', edgeMidChr, horLineChr, horLineChr, ' '}
+		t.edgeLast = []rune{' ', edgeLastChr, horLineChr, horLineChr, ' '}
 	}
-	edgeStr := edgeBuilder.String()
-	if leftPad {
-		leftPadStr = " "
-	}
-	if rightPad {
-		rightPadStr = " "
-	}
-	edgeLink := fmt.Sprintf("%s%c", leftPadStr, edgeLinkChr)
-	edgeMid := fmt.Sprintf("%s%c%s%s", leftPadStr, edgeMidChr, edgeStr, rightPadStr)
-	edgeLast := fmt.Sprintf("%s%c%s%s", leftPadStr, edgeLastChr, edgeStr, rightPadStr)
+
 	return Node{
-		tree: &tree{
-			edgeLink: []rune(edgeLink),
-			edgeMid:  []rune(edgeMid),
-			edgeLast: []rune(edgeLast),
-		},
+		tree:  t,
 		level: 0,
 	}
 }
 
-type tree struct {
-	// rows maintains the rows accumulated so far, as rune arrays.
+// Style is one of the predefined treeprinter styles.
+type Style int
+
+const (
+	// DefaultStyle is the default style. Example:
 	//
-	// When a new child is added (e.g. child2 above), we may have to
-	// go back up and fix edges.
+	//   foo
+	//    ├── bar1
+	//    │   bar2
+	//    │    └── baz
+	//    └── qux
+	//
+	DefaultStyle Style = iota
+
+	// CompactStyle is a compact style, for deeper trees. Example:
+	//
+	//   foo
+	//   ├ bar1
+	//   │ bar2
+	//   │ └ baz
+	//   └ qux
+	//
+	CompactStyle
+
+	// BulletStyle is a style that shows a bullet for each node, and groups any
+	// other lines under that bullet. Example:
+	//
+	//   • foo
+	//   │
+	//   ├── • bar1
+	//   │   │ bar2
+	//   │   │
+	//   │   └── • baz
+	//   │
+	//   └── • qux
+	//
+	BulletStyle
+)
+
+// tree implements the tree printing machinery.
+//
+// All Nodes hold a reference to the tree and Node calls result in modification
+// of the tree. At any point in time, tree.rows contains the formatted tree that
+// was described by the Node calls performed so far.
+//
+// When new nodes are added, some of the characters of the previous formatted
+// tree need to be updated. Here is an example stepping through the state:
+//
+//   API call                       Rows
+//
+//
+//   tp := New()                    <empty>
+//
+//
+//   root := tp.Child("root")       root
+//
+//
+//   root.Child("child-1")          root
+//                                   └── child-1
+//
+//
+//   c2 := root.Child("child-2")    root
+//                                   ├── child-1
+//                                   └── child-2
+//
+//     Note: here we had to go back up and change └─ into ├─ for child-1.
+//
+//
+//   c2.Child("grandchild")         root
+//                                   ├── child-1
+//                                   └── child-2
+//                                        └── grandchild
+//
+//
+//   root.Child("child-3"           root
+//                                   ├── child-1
+//                                   ├── child-2
+//                                   │    └── grandchild
+//                                   └── child-3
+//
+//     Note: here we had to go back up and change └─ into ├─ for child-2, and
+//     add a │ on the grandchild row. In general, we may need to add an
+//     arbitrary number of vertical bars.
+//
+// In order to perform these character changes, we maintain information about
+// the nodes on the bottom-most path.
+type tree struct {
+	style Style
+
+	// rows maintains the rows accumulated so far, as rune arrays.
 	rows [][]rune
 
-	// row index of the last row for a given level. Grows as needed.
-	lastNode []int
+	// stack contains information pertaining to the nodes on the bottom-most path
+	// of the tree.
+	stack []nodeInfo
 
 	edgeLink []rune
 	edgeMid  []rune
 	edgeLast []rune
+}
+
+type nodeInfo struct {
+	// firstChildConnectRow is the index (in tree.rows) of the row up to which we
+	// have to connect the first child of this node.
+	firstChildConnectRow int
+
+	// nextSiblingConnectRow is the index (in tree.rows) of the row up to which we
+	// have to connect the next sibling of this node. Typically this is the same
+	// with firstChildConnectRow, except when the node has multiple rows. For
+	// example:
+	//
+	//      foo
+	//       └── bar1               <---- nextSiblingConnectRow
+	//           bar2               <---- firstChildConnectRow
+	//
+	// firstChildConnectRow is used when adding "baz", nextSiblingConnectRow
+	// is used when adding "qux":
+	//      foo
+	//       ├── bar1
+	//       │   bar2
+	//       │    └── baz
+	//       └── qux
+	//
+	nextSiblingConnectRow int
+}
+
+// set copies the string of runes into a given row, at a specific position. The
+// row is extended with spaces if needed.
+func (t *tree) set(rowIdx int, colIdx int, what []rune) {
+	// Extend the line if necessary.
+	for len(t.rows[rowIdx]) < colIdx+len(what) {
+		t.rows[rowIdx] = append(t.rows[rowIdx], ' ')
+	}
+	copy(t.rows[rowIdx][colIdx:], what)
+}
+
+// addRow adds a row with a given text, with the proper indentation for the
+// given level.
+func (t *tree) addRow(level int, text string) (rowIdx int) {
+	runes := []rune(text)
+	// Each level indents by this much.
+	k := len(t.edgeLast)
+	indent := level * k
+	row := make([]rune, indent+len(runes))
+	for i := 0; i < indent; i++ {
+		row[i] = ' '
+	}
+	copy(row[indent:], runes)
+	t.rows = append(t.rows, row)
+	return len(t.rows) - 1
 }
 
 // Childf adds a node as a child of the given node.
@@ -114,79 +249,71 @@ func (n Node) Child(text string) Node {
 		splitLines := strings.Split(text, "\n")
 		node := n.childLine(splitLines[0])
 		for _, l := range splitLines[1:] {
-			n.AddLine(l)
+			node.AddLine(l)
 		}
 		return node
 	}
 	return n.childLine(text)
 }
 
-// AddLine adds a new line to a child node without an edge.
+// AddLine adds a new line to a node without an edge.
 func (n Node) AddLine(text string) {
-	runes := []rune(text)
-	// Each level indents by this much.
-	k := len(n.tree.edgeLast)
-	indent := n.level * k
-	row := make([]rune, indent+len(runes))
-	for i := 0; i < indent; i++ {
-		row[i] = ' '
+	t := n.tree
+	if t.style == BulletStyle {
+		text = "  " + text
 	}
-	for i, r := range runes {
-		row[indent+i] = r
+	rowIdx := t.addRow(n.level-1, text)
+	if t.style != BulletStyle {
+		t.stack[n.level-1].firstChildConnectRow = rowIdx
 	}
-	n.tree.rows = append(n.tree.rows, row)
 }
 
 // childLine adds a node as a child of the given node.
 func (n Node) childLine(text string) Node {
-	runes := []rune(text)
-
-	// Each level indents by this much.
-	k := len(n.tree.edgeLast)
-	indent := n.level * k
-	row := make([]rune, indent+len(runes))
-	for i := 0; i < indent-k; i++ {
-		row[i] = ' '
-	}
-	if indent >= k {
-		// Connect through any empty lines.
-		for i := len(n.tree.rows) - 1; i >= 0 && len(n.tree.rows[i]) == 0; i-- {
-			n.tree.rows[i] = make([]rune, indent-k+len(n.tree.edgeLink))
-			for j := 0; j < indent-k+len(n.tree.edgeLink); j++ {
-				n.tree.rows[i][j] = ' '
-			}
-			copy(n.tree.rows[i][indent-k:], n.tree.edgeLink)
+	t := n.tree
+	if t.style == BulletStyle {
+		text = fmt.Sprintf("%c %s", bulletChr, text)
+		if n.level > 0 {
+			n.AddEmptyLine()
 		}
-		copy(row[indent-k:], n.tree.edgeLast)
 	}
-	copy(row[indent:], runes)
-
-	for len(n.tree.lastNode) <= n.level+1 {
-		n.tree.lastNode = append(n.tree.lastNode, -1)
-	}
-	n.tree.lastNode[n.level+1] = -1
-
-	if last := n.tree.lastNode[n.level]; last != -1 {
-		if n.level == 0 {
+	rowIdx := t.addRow(n.level, text)
+	edgePos := (n.level - 1) * len(t.edgeLast)
+	if n.level == 0 {
+		// Case 1: root.
+		if len(t.stack) != 0 {
 			panic("multiple root nodes")
 		}
-		// Connect to the previous sibling.
-		copy(n.tree.rows[last][indent-k:], n.tree.edgeMid)
-		for i := last + 1; i < len(n.tree.rows); i++ {
-			// Add spaces if necessary.
-			for len(n.tree.rows[i]) < indent-k+len(n.tree.edgeLink) {
-				n.tree.rows[i] = append(n.tree.rows[i], ' ')
-			}
-			copy(n.tree.rows[i][indent-k:], n.tree.edgeLink)
+	} else if len(t.stack) <= n.level {
+		// Case 2: first child. Connect to parent.
+		if len(t.stack) != n.level {
+			panic("misuse of node")
 		}
+		parentRow := t.stack[n.level-1].firstChildConnectRow
+		for i := parentRow + 1; i < rowIdx; i++ {
+			t.set(i, edgePos, t.edgeLink)
+		}
+		t.set(rowIdx, edgePos, t.edgeLast)
+	} else {
+		// Case 3: non-first child. Connect to sibling.
+		siblingRow := t.stack[n.level].nextSiblingConnectRow
+		t.set(siblingRow, edgePos, t.edgeMid)
+		for i := siblingRow + 1; i < rowIdx; i++ {
+			t.set(i, edgePos, t.edgeLink)
+		}
+		t.set(rowIdx, edgePos, t.edgeLast)
+		// Update the nextSiblingConnectRow.
+		t.stack = t.stack[:n.level]
 	}
 
-	n.tree.lastNode[n.level] = len(n.tree.rows)
-	n.tree.rows = append(n.tree.rows, row)
+	t.stack = append(t.stack, nodeInfo{
+		firstChildConnectRow:  rowIdx,
+		nextSiblingConnectRow: rowIdx,
+	})
 
 	// Return a TreePrinter that can be used for children of this node.
 	return Node{
-		tree:  n.tree,
+		tree:  t,
 		level: n.level + 1,
 	}
 }

--- a/pkg/util/treeprinter/tree_printer_test.go
+++ b/pkg/util/treeprinter/tree_printer_test.go
@@ -16,26 +16,30 @@ import (
 )
 
 func TestTreePrinter(t *testing.T) {
-	n := New()
+	tree := func(n Node) {
+		r := n.Child("root")
+		r.AddEmptyLine()
+		n1 := r.Childf("%d", 1)
+		n1.Child("1.1")
+		n12 := n1.Child("1.2")
+		r.AddEmptyLine()
+		r.AddEmptyLine()
+		n12.Child("1.2.1")
+		r.AddEmptyLine()
+		n12.Child("1.2.2")
+		n13 := n1.Child("1.3")
+		n13.AddEmptyLine()
+		n131 := n13.Child("1.3.1")
+		n131.AddLine("1.3.1a")
+		n13.Child("1.3.2\n1.3.2a")
+		n13.AddEmptyLine()
+		n131.Child("1.3.1.1\n1.3.1.1a")
+		n1.Child("1.4")
+		r.Child("2")
+	}
 
-	r := n.Child("root")
-	r.AddEmptyLine()
-	n1 := r.Childf("%d", 1)
-	n1.Child("1.1")
-	n12 := n1.Child("1.2")
-	r.AddEmptyLine()
-	r.AddEmptyLine()
-	n12.Child("1.2.1")
-	r.AddEmptyLine()
-	n12.Child("1.2.2")
-	n13 := n1.Child("1.3")
-	n13.AddEmptyLine()
-	n131 := n13.Child("1.3.1\n1.3.1a")
-	n13.Child("1.3.2\n1.3.2a")
-	n13.AddEmptyLine()
-	n131.Child("1.3.1.1\n1.3.1.1a")
-	n1.Child("1.4")
-	r.Child("2")
+	n := New()
+	tree(n)
 
 	res := n.String()
 	exp := `
@@ -60,6 +64,79 @@ root
  │    │             1.3.1.1a
  │    └── 1.4
  └── 2
+`
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+
+	n = NewWithStyle(CompactStyle)
+	tree(n)
+	res = n.String()
+	exp = `
+root
+│
+├ 1
+│ ├ 1.1
+│ ├ 1.2
+│ │ │
+│ │ │
+│ │ ├ 1.2.1
+│ │ │
+│ │ └ 1.2.2
+│ ├ 1.3
+│ │ │
+│ │ ├ 1.3.1
+│ │ │ 1.3.1a
+│ │ └ 1.3.2
+│ │   1.3.2a
+│ │   │
+│ │   └ 1.3.1.1
+│ │     1.3.1.1a
+│ └ 1.4
+└ 2
+`
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+
+	n = NewWithStyle(BulletStyle)
+	tree(n)
+	res = n.String()
+	exp = `
+• root
+│
+│
+├── • 1
+│   │
+│   ├── • 1.1
+│   │
+│   ├── • 1.2
+│   │   │
+│   │   │
+│   │   │
+│   │   ├── • 1.2.1
+│   │   │
+│   │   │
+│   │   └── • 1.2.2
+│   │
+│   ├── • 1.3
+│   │   │
+│   │   │
+│   │   ├── • 1.3.1
+│   │   │     1.3.1a
+│   │   │
+│   │   └── • 1.3.2
+│   │       │ 1.3.2a
+│   │       │
+│   │       │
+│   │       └── • 1.3.1.1
+│   │             1.3.1.1a
+│   │
+│   └── • 1.4
+│
+└── • 2
 `
 	exp = strings.TrimLeft(exp, "\n")
 	if res != exp {


### PR DESCRIPTION
#### util: treeprinter improvements and new style

This change cleans up the treeprinter implementation and interface and
adds a "with bullets" style that looks like this:
```
  • foo
  │
  ├── • bar1
  │   │ bar2
  │   │
  │   └── • baz
  │
  └── • qux
```
This is a preliminary design from Anne for the new EXPLAIN output.

Release note: None

#### opt: rework explain output test

Changing the explain output test from an Example to a datadriven test
(which is much easier to update).

Release note: None

#### sql: use new explain format in explain bundles

This change switches the plan string in EXPLAIN ANALYZE (DEBUG)
bundles to use the new style with bullets. See the updated test for
some examples.

Release note: None