### PR TITLE
sql: add constraint name to constraint error

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -271,10 +271,10 @@ func validateForeignKey(
 			return err
 		}
 		if values.Len() > 0 {
-			return pgerror.Newf(pgcode.ForeignKeyViolation,
+			return pgerror.WithConstraintName(pgerror.Newf(pgcode.ForeignKeyViolation,
 				"foreign key violation: MATCH FULL does not allow mixing of null and nonnull values %s for %s",
 				formatValues(colNames, values), fk.Name,
-			)
+			), fk.Name)
 		}
 	}
 	query, colNames, err := nonMatchingRowQuery(
@@ -296,9 +296,9 @@ func validateForeignKey(
 		return err
 	}
 	if values.Len() > 0 {
-		return pgerror.Newf(pgcode.ForeignKeyViolation,
+		return pgerror.WithConstraintName(pgerror.Newf(pgcode.ForeignKeyViolation,
 			"foreign key violation: %q row %s has no match in %q",
-			srcTable.Name, formatValues(colNames, values), targetTable.GetName())
+			srcTable.Name, formatValues(colNames, values), targetTable.GetName()), fk.Name)
 	}
 	return nil
 }
@@ -361,11 +361,11 @@ func checkMutationInput(
 			if err != nil {
 				// If we ran into an error trying to read the check constraint, wrap it
 				// and return.
-				return errors.Wrapf(err, "failed to satisfy CHECK constraint (%s)", checks[i].Expr)
+				return pgerror.WithConstraintName(errors.Wrapf(err, "failed to satisfy CHECK constraint (%s)", checks[i].Expr), checks[i].Name)
 			}
-			return pgerror.Newf(
+			return pgerror.WithConstraintName(pgerror.Newf(
 				pgcode.CheckViolation, "failed to satisfy CHECK constraint (%s)", expr,
-			)
+			), checks[i].Name)
 		}
 		colIdx++
 	}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -95,12 +95,12 @@ func NewUniquenessConstraintViolationError(
 			"duplicate key value: decoding err=%s", err)
 	}
 
-	return pgerror.Newf(pgcode.UniqueViolation,
+	return pgerror.WithConstraintName(pgerror.Newf(pgcode.UniqueViolation,
 		"duplicate key value (%s)=(%s) violates unique constraint %q",
 		strings.Join(names, ","),
 		strings.Join(values, ","),
 		index.Name,
-	)
+	), index.Name)
 }
 
 // NewLockNotAvailableError creates an error that represents an inability to


### PR DESCRIPTION
Add constraint name to error for unique constraint, check constraintand foreign key constraint violations. Those constraint names are then propagated over the PostgreSQL wire protocol and will show up for example in JDBC exceptions (org.postgresql.util.PSQLException#getServerErrorMessage().getConstraint()). This commit improves PostgreSQL compatibility.

Release note: Improve PosgreSQL wire protocol compatibility by adding constraint name to sql errors.