### PR TITLE
Crash when deleting a row on a table with a unique index and similar PK #54629

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -233,7 +233,6 @@ func (p *planner) AlterPrimaryKey(
 	// * don't store or index all columns in the new primary key.
 	shouldRewriteIndex := func(idx *descpb.IndexDescriptor) bool {
 		shouldRewrite := false
-		
 		for _, exColID := range idx.ExtraColumnIDs {
 			if col, err := tableDesc.FindColumnByID(exColID); err != nil {
 				break
@@ -242,7 +241,6 @@ func (p *planner) AlterPrimaryKey(
 				break
 			}
 		}
-		
 		for _, colID := range newPrimaryIndexDesc.ColumnIDs {
 			if !idx.ContainsColumnID(colID) {
 				shouldRewrite = true

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -233,14 +233,16 @@ func (p *planner) AlterPrimaryKey(
 	// * don't store or index all columns in the new primary key.
 	shouldRewriteIndex := func(idx *descpb.IndexDescriptor) bool {
 		shouldRewrite := false
-		for _,exColID:=range idx.ExtraColumnIDs{
-			if col, err := tableDesc.FindColumnByID(exColID);err!=nil{
-				break;
-			}else if col.Hidden && tableDesc.PrimaryIndex.ContainsColumnID(col.ID){
-				shouldRewrite=true;
-				break;
+		
+		for _, exColID := range idx.ExtraColumnIDs {
+			if col, err := tableDesc.FindColumnByID(exColID); err != nil {
+				break
+			} else if col.Hidden && tableDesc.PrimaryIndex.ContainsColumnID(col.ID) {
+				shouldRewrite = true
+				break
 			}
 		}
+		
 		for _, colID := range newPrimaryIndexDesc.ColumnIDs {
 			if !idx.ContainsColumnID(colID) {
 				shouldRewrite = true

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -233,6 +233,14 @@ func (p *planner) AlterPrimaryKey(
 	// * don't store or index all columns in the new primary key.
 	shouldRewriteIndex := func(idx *descpb.IndexDescriptor) bool {
 		shouldRewrite := false
+		for _,exColID:=range idx.ExtraColumnIDs{
+			if col, err := tableDesc.FindColumnByID(exColID);err!=nil{
+				break;
+			}else if col.Hidden && tableDesc.PrimaryIndex.ContainsColumnID(col.ID){
+				shouldRewrite=true;
+				break;
+			}
+		}
 		for _, colID := range newPrimaryIndexDesc.ColumnIDs {
 			if !idx.ContainsColumnID(colID) {
 				shouldRewrite = true


### PR DESCRIPTION
#54629 

Release note (bug fix): try fix #54629 by rewrite unique-index when alter primary key;