### PR TITLE
CODEOWNERS: subscribe cli-prs to pkg/server/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 /pkg/sql/sem/builtins/       @cockroachdb/sql-api-prs
 
 /pkg/cli/                    @cockroachdb/cli-prs
+/pkg/server/                 @cockroachdb/cli-prs
 
 /pkg/ccl/backupccl/          @cockroachdb/bulk-prs
 /pkg/ccl/importccl/          @cockroachdb/bulk-prs


### PR DESCRIPTION
This way members of the new server/cli team can subscribe themselves to @cockroachdb/cli-prs to get notified of PRs in that area.

Release note: None