### PR TITLE
release-20.2: backupccl: fix bug due to transaction restart while publishing tables

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -999,7 +999,7 @@ func (r *restoreResumer) Resume(
 		return errors.Wrap(err, "inserting table statistics")
 	}
 
-	if err := r.publishTables(ctx); err != nil {
+	if err := r.publishTables(ctx, details); err != nil {
 		return err
 	}
 
@@ -1068,8 +1068,7 @@ func (r *restoreResumer) insertStats(ctx context.Context) error {
 }
 
 // publishTables updates the RESTORED tables status from OFFLINE to PUBLIC.
-func (r *restoreResumer) publishTables(ctx context.Context) error {
-	details := r.job.Details().(jobspb.RestoreDetails)
+func (r *restoreResumer) publishTables(ctx context.Context, details jobspb.RestoreDetails) error {
 	if details.TablesPublished {
 		return nil
 	}


### PR DESCRIPTION
Before this patch, if a restart occurred while trying to publish
descriptors, we would short-circuit publishing the descriptors on the
subsequent attempt.

The approach was validated by stressing TestBackupRestoreResume with the
patch in #54695 which previously reproduced the failure immediately.

Release note (bug fix): Fixed a bug whereby a transaction restart at the
wrong moment during a restore could leave descriptors offline after the
restore completed successfully.