### PR TITLE
log: fix `VInfof`

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -87,7 +87,7 @@ func Infof(ctx context.Context, format string, args ...interface{}) {
 // message. Arguments are handled in the manner of fmt.Printf; a newline is
 // appended.
 func VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
-	if V(level) {
+	if VDepth(level, 1) {
 		logDepth(ctx, 1, Severity_INFO, format, args)
 	}
 }


### PR DESCRIPTION
The function is meant to respect the vmodule setting at the point it
is called. This was incorrectly done with a call to `V()`, this patch
fixes it.

Release note: None