### PR TITLE
backupccl: change CPUT semantics when publishing restored tables

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -536,3 +536,29 @@ func ConditionalGetTableDescFromTxn(
 	}
 	return existingKV.Value, nil
 }
+
+// GetTableDescFromTxn returns the TableDescriptor and the corresponding
+// roachpb.Value written to kv, for the supplied findTable.
+func GetTableDescFromTxn(
+	ctx context.Context, txn *kv.Txn, findTable ID,
+) (*TableDescriptor, *roachpb.Value, error) {
+	key := MakeDescMetadataKey(findTable)
+	existingKV, err := txn.Get(ctx, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var existing *Descriptor
+	if existingKV.Value != nil {
+		existing = &Descriptor{}
+		if err := existingKV.Value.GetProto(existing); err != nil {
+			return nil, nil, errors.Wrapf(err,
+				"decoding current table descriptor value for id: %d", findTable)
+		}
+	}
+
+	if existing == nil {
+		return nil, nil, errors.Newf("failed to find table desc for id: %d", findTable)
+	}
+	return existing.Table(existingKV.Value.Timestamp), existingKV.Value, nil
+}


### PR DESCRIPTION
Previously we asserted that the descriptors that we're publishing PUBLIC
have not changed since they were added in the OFFLINE state. There are
cases where this assertion is failing. This is not ideal since we
perform this check at the end of what could be a potentially lengthy
restore. This assertion is enforced via a CPut and so to prevent these
last stage failures we now resort to first reading the KV stored table
desc, mutating its state and then writing it back to KV.

To further collect information on what is changing the desc while it is
in an offline state, logging has been added.

Informs: #55690

Release note: None