### PR TITLE
release-20.1: logictest: temporarily disable mutations max batch size randomization

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2501,6 +2501,9 @@ func RunLogicTest(t *testing.T, serverArgs TestServerArgs, globs ...string) {
 
 	rng, _ := randutil.NewPseudoRand()
 	randomizedMutationsMaxBatchSize := mutations.MaxBatchSize()
+	// Temporarily disable this randomization because of #54948.
+	// TODO(yuzefovich): re-enable it once the issue is figured out.
+	serverArgs.DisableMutationsMaxBatchSizeRandomization = true
 	if !serverArgs.DisableMutationsMaxBatchSizeRandomization {
 		randomizedMutationsMaxBatchSize = randomValue(rng, []int{1, 2 + rng.Intn(99)}, []float64{0.25, 0.25}, mutations.MaxBatchSize())
 		if randomizedMutationsMaxBatchSize != mutations.MaxBatchSize() {


### PR DESCRIPTION
Backport 1/1 commits from #55180.

/cc @cockroachdb/release

---

Pending investigation of 54948 we disable that randomization
temporarily.

Informs: #54948.

Release note: None
