### PR TITLE
release-20.2: ui: add transactions page to Admin UI

### DIFF
--- a/pkg/ui/src/app.tsx
+++ b/pkg/ui/src/app.tsx
@@ -61,6 +61,7 @@ import StatementDetails from "src/views/statements/statementDetails";
 import StatementsPage from "src/views/statements/statementsPage";
 import SessionsPage from "src/views/sessions/sessionsPage";
 import SessionDetails from "src/views/sessions/sessionDetails";
+import TransactionsPage from "src/views/transactions/transactionsPage";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import "styl/app.styl";
 
@@ -144,6 +145,8 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   { /* sessions */ }
                   <Route exact path="/sessions" component={ SessionsPage }/>
                   <Route exact path={ `/session/:${sessionAttr}`} component={ SessionDetails } />
+                  { /* transactions */ }
+                  <Route exact path="/transactions" component={ TransactionsPage }/>
 
                   { /* debug pages */ }
                   <Route exact path="/debug" component={Debug}/>

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -41,6 +41,7 @@ export class Sidebar extends React.Component<SidebarProps> {
     { path: "/databases", text: "Databases", activeFor: ["/database"] },
     { path: "/sessions", text: "Active Sessions", activeFor: ["/session"] },
     { path: "/statements", text: "Statements", activeFor: ["/statement"] },
+    { path: "/transactions", text: "Transactions", activeFor: ["/transactions"] },
     {
       path: "/reports/network",
       text: "Network Latency",

--- a/pkg/ui/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/src/views/transactions/transactionsPage.tsx
@@ -1,0 +1,60 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+import { withRouter } from "react-router-dom";
+import {
+  refreshStatements,
+} from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { AdminUIState } from "src/redux/state";
+import { StatementsResponseMessage } from "src/util/api";
+
+import { TimestampToMoment } from "src/util/convert";
+import { PrintTime } from "src/views/reports/containers/range/print";
+
+import { TransactionsPage } from "@cockroachlabs/admin-ui-components";
+
+// selectStatements returns the array of AggregateStatistics to show on the
+// TransactionsPage, based on if the appAttr route parameter is set.
+export const selectData = createSelector(
+  (state: AdminUIState) => state.cachedData.statements,
+  (state: CachedDataReducerState<StatementsResponseMessage>) => {
+    return state.data || null;
+  },
+);
+
+// selectLastReset returns a string displaying the last time the statement
+// statistics were reset.
+export const selectLastReset = createSelector(
+  (state: AdminUIState) => state.cachedData.statements,
+  (state: CachedDataReducerState<StatementsResponseMessage>) => {
+    if (!state.data) {
+      return "unknown";
+    }
+
+    return PrintTime(TimestampToMoment(state.data.last_reset));
+  },
+);
+
+// tslint:disable-next-line:variable-name
+const TransactionsPageConnected = withRouter(connect(
+  (state: AdminUIState) => ({
+    data: selectData(state),
+    statementsError: state.cachedData.statements.lastError,
+    lastReset: selectLastReset(state),
+  }),
+  {
+    refreshData: refreshStatements,
+  },
+)(TransactionsPage));
+
+export default TransactionsPageConnected;


### PR DESCRIPTION
Backport 1/1 commits from #54261.

/cc @cockroachdb/release

---

This commit adds the new Transactions Page to the Admin UI.

This page is much like the Statements Page but differs in that
it shows Transaction-level statistics in tabular and detail form.

Every Transaction is able to display its contained Statements
for more detailed analysis.

The page and its components are imported from the
`admin-ui-components` library.

Depends on: https://github.com/cockroachdb/yarn-vendored/pull/38

Release justification: low-risk high impact addition to Admin UI

Release note (admin ui change): add Transactions and Transactions
details pages. These pages allow for viewing stats at the
transaction level.
