### PR TITLE
roachtest: bump estimated max warehouses of tpccbench/nodes=3/cpu=16

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -369,8 +369,8 @@ func registerTPCC(r *testRegistry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehouses: gceOrAws(cloud, 2000, 3000),
-		EstimatedMax:   gceOrAws(cloud, 1600, 2500),
+		LoadWarehouses: gceOrAws(cloud, 2500, 3000),
+		EstimatedMax:   gceOrAws(cloud, 2200, 2500),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,


### PR DESCRIPTION
Now that we're importing instead of restoring and picking up a number
of optimizations along the way, this estimated max warehouse count is
too low. This is why we have been flatlining on:
https://roachperf.crdb.dev/?filter=&view=tpccbench%2Fnodes%3D3%2Fcpu%3D16&tab=gce