### PR TITLE
sqlsmith: disable partial index mutator

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -70,8 +70,13 @@ func randTables(r *rand.Rand) string {
 	stmts := rowenc.RandCreateTables(r, "table", r.Intn(5)+1,
 		mutations.ForeignKeyMutator,
 		mutations.StatisticsMutator,
-		mutations.PartialIndexMutator,
+		// TODO(mgartner): Re-enable the partial index mutator once it is aware
+		// that it should not mutate unique indexes on foreign key references.
+		// mutations.PartialIndexMutator,
 	)
+	// Satisfy the linter's desire to have mutations.PartialIndexMutator be
+	// used.
+	var _ = mutations.PartialIndexMutator
 
 	for _, stmt := range stmts {
 		sb.WriteString(tree.SerializeForDisplay(stmt))


### PR DESCRIPTION
This is a temporary fix for #55718.

Release justification: This fixes a flaky sqlsmith test which is
blocking builds on the release branch.

Release note: None