### PR TITLE
sql: fix crdb_internal.{leases,node_runtime_info} when accessed by a tenant

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -176,10 +176,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
 
 		node := p.ExecCfg().NodeInfo
 
-		dNodeID := tree.DNull
-		if nodeID, ok := node.NodeID.OptionalNodeID(); ok {
-			dNodeID = tree.NewDInt(tree.DInt(nodeID))
-		}
+		nodeID, _ := node.NodeID.OptionalNodeID() // zero if not available
 		dbURL, err := node.PGURL(url.User(security.RootUser))
 		if err != nil {
 			return err
@@ -209,7 +206,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
 			} {
 				k, v := kv[0], kv[1]
 				if err := addRow(
-					dNodeID,
+					tree.NewDInt(tree.DInt(nodeID)),
 					tree.NewDString(item.component),
 					tree.NewDString(k),
 					tree.NewDString(v),
@@ -504,10 +501,7 @@ CREATE TABLE crdb_internal.leases (
 	populate: func(
 		ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error,
 	) (err error) {
-		dNodeID := tree.DNull
-		if nodeID, ok := p.execCfg.NodeID.OptionalNodeID(); ok {
-			dNodeID = tree.NewDInt(tree.DInt(nodeID))
-		}
+		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, dropped bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
 			if p.CheckAnyPrivilege(ctx, desc) != nil {
 				// TODO(ajwerner): inspect what type of error got returned.
@@ -515,7 +509,7 @@ CREATE TABLE crdb_internal.leases (
 			}
 
 			err = addRow(
-				dNodeID,
+				tree.NewDInt(tree.DInt(nodeID)),
 				tree.NewDInt(tree.DInt(int64(desc.GetID()))),
 				tree.NewDString(desc.GetName()),
 				tree.NewDInt(tree.DInt(int64(desc.GetParentID()))),

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,4 +1,7 @@
-# LogicTest: !3node-tenant(47895)
+# 3node-tenant is blocked from running this file due to heavy reliance on
+# unavailable node IDs in this test.
+# LogicTest: !3node-tenant
+
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -1,0 +1,12 @@
+# LogicTest: 3node-tenant
+
+query II
+SELECT count(distinct(node_id)), count(*)  FROM crdb_internal.node_runtime_info
+----
+1 12
+
+query IT
+SELECT node_id, name FROM crdb_internal.leases ORDER BY name
+----
+0  role_members
+0  test


### PR DESCRIPTION
Previously, accessing either of theses tables would lead to an internal error.
This was caused by defaulting to using a null node ID if the node ID was
unavailable, causing a null violation during validation.

The rest of internal tables simply use the zero node ID, so this commit fixes
crdb_internal.{leases,node_runtime_info} to use this behavior as well.

Release note: None

Fixes #55701 