### PR TITLE
opt: fix normalization of st_distance when use_spheroid parameter used

### DIFF
--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -237,8 +237,18 @@ func (c *CustomFuncs) makeSTDWithin(
 		}
 	}
 
+	newArgs := make(memo.ScalarListExpr, len(args)+1)
+	const distanceIdx, useSpheroidIdx = 2, 3
+	copy(newArgs, args[:distanceIdx])
+
 	// The distance parameter must be type float.
-	newArgs := append(args, c.f.ConstructCast(bound, types.Float))
+	newArgs[distanceIdx] = c.f.ConstructCast(bound, types.Float)
+
+	// Add the use_spheroid parameter if it exists.
+	if len(newArgs) > useSpheroidIdx {
+		newArgs[useSpheroidIdx] = args[useSpheroidIdx-1]
+	}
+
 	props, overload, ok := memo.FindFunction(&newArgs, name)
 	if !ok {
 		panic(errors.AssertionFailedf("could not find overload for %s", name))

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -875,6 +875,18 @@ select
                 └── cast: INT8 [type=int]
                      └── variable: val:3 [type=float]
 
+# Regression test for #55675. Handle use_spheroid param.
+norm expect=FoldCmpSTDistanceLeft
+SELECT * FROM geom_geog WHERE st_distance(geog, 'point(0.0 0.0)', true) <= 5
+----
+select
+ ├── columns: geom:1 geog:2!null val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithin(geog:2, '0101000020E610000000000000000000000000000000000000', 5.0, true) [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+
 # --------------------------------------------------
 # FoldCmpSTDistanceRight
 # --------------------------------------------------
@@ -926,6 +938,18 @@ select
  │    └── columns: geom:1 geog:2 val:3
  └── filters
       └── st_dwithinexclusive(geom:1, '010100000000000000000000000000000000000000', val:3) [outer=(1,3), immutable, constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+
+# Regression test for #55675. Handle use_spheroid param.
+norm expect=FoldCmpSTDistanceRight
+SELECT * FROM geom_geog WHERE val > st_distance(geog, 'point(0.0 0.0)', false)
+----
+select
+ ├── columns: geom:1 geog:2!null val:3!null
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_dwithinexclusive(geog:2, '0101000020E610000000000000000000000000000000000000', val:3, false) [outer=(2,3), immutable, constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
 
 # --------------------------------------------------
 # FoldCmpSTMaxDistanceLeft


### PR DESCRIPTION
This commit fixes the normalization rule that converts `st_distance` to
`st_dwithin` or `st_dwithinexclusive`, which was broken in the case when
the `use_spheroid` parameter was used. Prior to this commit, the rule was
assigning the `use_spheroid` parameter as the 3rd parameter to `st_dwithin`
or `st_dwithinexclusive` and the `distance` parameter as the 4th, but that
order does not match the function signatures. This commit fixes the issue
by assigning `distance` as the 3rd parameter and `use_spheroid` as the 4th
if it exists.

Fixes #55675

Release note (bug fix): Fixed an internal error that could occur during
query planning when the use_spheroid parameter was used in the ST_Distance
function as part of a filter predicate. For example, `SELECT ... WHERE
ST_Distance(geog1, geog2, false) < 10` previously caused an error. This
has now been fixed.