### PR TITLE
util/quotapool: add WithMinimumWait option to RateLimiter

### DIFF
--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -84,12 +84,24 @@ func WithCloser(closer <-chan struct{}) Option {
 	})
 }
 
+// WithMinimumWait is used with the RateLimiter to control the minimum duration
+// which a goroutine will sleep waiting for quota to accumulate. This
+// can help avoid expensive spinning when the workload consists of many
+// small acquisitions. If used with a regular (not rate limiting) quotapool,
+// this option has no effect.
+func WithMinimumWait(duration time.Duration) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.minimumWait = duration
+	})
+}
+
 type config struct {
 	onAcquisition            AcquisitionFunc
 	onSlowAcquisition        SlowAcquisitionFunc
 	slowAcquisitionThreshold time.Duration
 	timeSource               timeutil.TimeSource
 	closer                   <-chan struct{}
+	minimumWait              time.Duration
 }
 
 var defaultConfig = config{

--- a/pkg/util/quotapool/int_rate.go
+++ b/pkg/util/quotapool/int_rate.go
@@ -206,8 +206,6 @@ func (i *rateRequest) Acquire(
 }
 
 func (r *rateBucket) update(now time.Time) {
-	// TODO(ajwerner): Consider instituting a minimum update frequency to avoid
-	// spinning too fast on timers for tons of tiny allocations at a fast rate.
 	if since := now.Sub(r.lastUpdated); since > 0 {
 		r.cur += float64(r.rate) * since.Seconds()
 		if r.cur > float64(r.burst) {

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -259,6 +259,9 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 		if tryAgainAfter <= 0 {
 			return
 		}
+		if tryAgainAfter < qp.minimumWait {
+			tryAgainAfter = qp.minimumWait
+		}
 		if tryAgainTimer == nil {
 			tryAgainTimer = qp.timeSource.NewTimer()
 		}


### PR DESCRIPTION
This is handy to ensure that the rate limiter does not become a bottleneck
in the face of many small acquisitions.

Release note: None