### PR TITLE
sql: disallow moving tables with user-defined types into a different DB

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -317,3 +317,58 @@ DROP DATABASE olddb CASCADE
 
 statement ok
 DROP DATABASE newdb CASCADE
+
+subtest rename_table_using_types_to_different_database_not_allowed_55709
+
+statement ok
+CREATE DATABASE olddb
+
+statement ok
+CREATE DATABASE newdb
+
+statement ok
+USE olddb
+
+statement ok
+CREATE TYPE typ AS ENUM ('foo')
+
+statement ok
+CREATE TABLE tbl(a typ)
+
+statement error pgcode 55000 cannot change database of table if any of its column types are user-defined
+ALTER TABLE tbl RENAME TO newdb.tbl
+
+# Try it in a transaction with non-public columns.
+
+statement ok
+CREATE TABLE tbl2()
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE tbl2 ADD COLUMN b typ
+
+statement error pgcode 55000 cannot change database of table if any of its column types are user-defined
+ALTER TABLE tbl2 RENAME TO newdb.tbl2
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE tbl DROP COLUMN a
+
+statement error pgcode 55000 cannot change database of table if any of its column types are user-defined
+ALTER TABLE tbl RENAME TO newdb.tbl
+
+statement ok
+ROLLBACK
+
+statement ok
+DROP DATABASE olddb CASCADE
+
+statement ok
+DROP DATABASE newdb CASCADE

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -144,13 +144,32 @@ func (n *renameTableNode) startExec(params runParams) error {
 		)
 	}
 
-	// Disable renaming objects between databases unless both the source and
-	// target schemas are the public schema. This preserves backward compatibility
-	// for the behavior prior to user-defined schemas.
-	if oldTn.Catalog() != newTn.Catalog() &&
-		(oldTn.Schema() != string(tree.PublicSchemaName) || newTn.Schema() != string(tree.PublicSchemaName)) {
-		return pgerror.Newf(pgcode.InvalidName,
-			"cannot change database of table unless both the old and new schemas are the public schema in each database")
+	// Special checks when attempting to move a table to a different database,
+	// which is usually not allowed.
+	if oldTn.Catalog() != newTn.Catalog() {
+		// Don't allow moving the table to a different database unless both the
+		// source and target schemas are the public schema. This preserves backward
+		// compatibility for the behavior prior to user-defined schemas.
+		if oldTn.Schema() != string(tree.PublicSchemaName) || newTn.Schema() != string(tree.PublicSchemaName) {
+			return pgerror.Newf(pgcode.InvalidName,
+				"cannot change database of table unless both the old and new schemas are the public schema in each database")
+		}
+		// Don't allow moving the table to a different database if the table
+		// references any user-defined types, to prevent cross-database type
+		// references.
+		columns := make([]descpb.ColumnDescriptor, 0, len(tableDesc.Columns)+len(tableDesc.Mutations))
+		columns = append(columns, tableDesc.Columns...)
+		for _, m := range tableDesc.Mutations {
+			if col := m.GetColumn(); col != nil {
+				columns = append(columns, *col)
+			}
+		}
+		for _, c := range columns {
+			if c.Type.UserDefined() {
+				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"cannot change database of table if any of its column types are user-defined")
+			}
+		}
 	}
 
 	// oldTn and newTn are already normalized, so we can compare directly here.


### PR DESCRIPTION
We disallow columns using user-defined types in a different database
from the table at creation time. However, we have a loophole where it's
possible to move the table to a different database using `RENAME` and
thus create a cross-database reference. This breaks backup/restore and
is generally unintended. This PR adds a check to disallow this.

Partially addresses #55709.
Related to #55772.

Release note (bug fix): Tables can no longer be moved to a different
database using `RENAME` if they have columns using user-defined types
(enums).