### PR TITLE
changefeedccl: support specifying the sasl_mechanism

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2051,6 +2051,17 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `sasl_enabled must be enabled if a SASL password is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_password=a`,
 	)
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled if a SASL mechanism is provided`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_mechanism=a`,
+	)
+
+	// Invalid sasl_mechanism.
+	sqlDB.ExpectErr(
+		t, `invalid value for sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, or PLAIN`,
+		`CREATE CHANGEFEED FOR foo INTO $1`,
+		`kafka://nope/?sasl_enabled=true&sasl_user=foo&sasl_password=bar&sasl_mechanism=a`,
+	)
 
 	// The avro format doesn't support key_in_value yet.
 	sqlDB.ExpectErr(

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -90,6 +90,7 @@ const (
 	SinkParamSASLHandshake    = `sasl_handshake`
 	SinkParamSASLUser         = `sasl_user`
 	SinkParamSASLPassword     = `sasl_password`
+	SinkParamSASLMechanism    = `sasl_mechanism`
 )
 
 // ChangefeedOptionExpectValues is used to parse changefeed options using


### PR DESCRIPTION
This commit allows clients to specify the sasl_mechanism when connecting to
kafka clusters. It seems that in production the recommendation is to use
SCRAM256 but we only used to support PLAIN. It appears that there is no testing
of this SASL stuff whatsoever. We should probably add it.

Release note (enterprise change): Added support for `sasl_mechanism` to kafka
CHANGEFEED sink.