### PR TITLE
row: fix crash during tracing given un-decodable datum

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -804,8 +804,10 @@ func (rf *Fetcher) prettyEncDatums(types []*types.T, vals []rowenc.EncDatum) str
 	var buf strings.Builder
 	for i, v := range vals {
 		if err := v.EnsureDecoded(types[i], rf.alloc); err != nil {
-			buf.WriteString("error decoding: ")
+			buf.WriteString("/{error decoding: ")
 			buf.WriteString(err.Error())
+			buf.WriteByte('}')
+			continue
 		}
 		buf.WriteByte('/')
 		buf.WriteString(v.Datum.String())


### PR DESCRIPTION
Previously, if tracing was enabled on a query that read bytes that
weren't decodable into datum, the database would crash.

Release note (bug fix): fix rare crash during tracing when reading
un-decodable data.