### PR TITLE
logictest: add multiregion configuration

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -67,6 +67,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 // This file is home to TestLogic, a general-purpose engine for
@@ -452,6 +453,9 @@ type testClusterConfig struct {
 	// isCCLConfig should be true for any config that can only be run with a CCL
 	// binary.
 	isCCLConfig bool
+	// localities is set if nodes should be set to a particular locality.
+	// Nodes are 1-indexed.
+	localities map[int]roachpb.Locality
 }
 
 const threeNodeTenantConfigName = "3node-tenant"
@@ -633,6 +637,67 @@ var logicTestConfigs = []testClusterConfig{
 		overrideAutoStats: "false",
 		useTenant:         true,
 		isCCLConfig:       true,
+	},
+	{
+		name:              "multiregion-9node-3region-3azs",
+		numNodes:          9,
+		overrideAutoStats: "false",
+		localities: map[int]roachpb.Locality{
+			1: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test1"},
+					{Key: "availability-zone", Value: "test1-az1"},
+				},
+			},
+			2: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test1"},
+					{Key: "availability-zone", Value: "test1-az2"},
+				},
+			},
+			3: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test1"},
+					{Key: "availability-zone", Value: "test1-az3"},
+				},
+			},
+			4: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test2"},
+					{Key: "availability-zone", Value: "test2-az1"},
+				},
+			},
+			5: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test2"},
+					{Key: "availability-zone", Value: "test2-az2"},
+				},
+			},
+			6: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test2"},
+					{Key: "availability-zone", Value: "test2-az3"},
+				},
+			},
+			7: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test3"},
+					{Key: "availability-zone", Value: "test3-az1"},
+				},
+			},
+			8: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test3"},
+					{Key: "availability-zone", Value: "test3-az2"},
+				},
+			},
+			9: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test3"},
+					{Key: "availability-zone", Value: "test3-az3"},
+				},
+			},
+		},
 	},
 }
 
@@ -1300,22 +1365,38 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).DisableAutomaticVersionUpgrade = 1
 	}
 
-	if cfg.binaryVersion != (roachpb.Version{}) {
-		// If we want to run a specific server version, we assume that it
-		// supports at least the bootstrap version.
-		paramsPerNode := map[int]base.TestServerArgs{}
-		binaryMinSupportedVersion := cfg.binaryVersion
-		if cfg.bootstrapVersion != (roachpb.Version{}) {
-			binaryMinSupportedVersion = cfg.bootstrapVersion
+	paramsPerNode := map[int]base.TestServerArgs{}
+	require.Truef(
+		t.rootT,
+		len(cfg.localities) == 0 || len(cfg.localities) == cfg.numNodes,
+		"localities must be set for each node -- got %#v for %d nodes",
+		cfg.localities,
+		cfg.numNodes,
+	)
+	for i := 0; i < cfg.numNodes; i++ {
+		nodeParams := params.ServerArgs
+		if locality, ok := cfg.localities[i+1]; ok {
+			nodeParams.Locality = locality
+		} else {
+			require.Lenf(t.rootT, cfg.localities, 0, "node %d does not have a locality set", i+1)
 		}
-		for i := 0; i < cfg.numNodes; i++ {
-			nodeParams := params.ServerArgs
+
+		if cfg.binaryVersion != (roachpb.Version{}) {
+			binaryMinSupportedVersion := cfg.binaryVersion
+			if cfg.bootstrapVersion != (roachpb.Version{}) {
+				// If we want to run a specific server version, we assume that it
+				// supports at least the bootstrap version.
+				binaryMinSupportedVersion = cfg.bootstrapVersion
+			}
 			nodeParams.Settings = cluster.MakeTestingClusterSettingsWithVersions(
-				cfg.binaryVersion, binaryMinSupportedVersion, false /* initializeVersion */)
-			paramsPerNode[i] = nodeParams
+				cfg.binaryVersion,
+				binaryMinSupportedVersion,
+				false, /* initializeVersion */
+			)
 		}
-		params.ServerArgsPerNode = paramsPerNode
+		paramsPerNode[i] = nodeParams
 	}
+	params.ServerArgsPerNode = paramsPerNode
 
 	// Update the defaults for automatic statistics to avoid delays in testing.
 	// Avoid making the DefaultAsOfTime too small to avoid interacting with

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -1,3 +1,5 @@
+# LogicTest: multiregion-9node-3region-3azs
+
 statement error implementation pending
 CREATE DATABASE new_db REGION "us-west-1"
 


### PR DESCRIPTION
Add a logictest configuration that has three regions, with three
nodes in three different AZs.

Release note: None
