### PR TITLE
sql: create event log entry for schema events

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -32,8 +32,14 @@ const (
 	// EventLogRenameDatabase is recorded when a database is renamed.
 	EventLogRenameDatabase EventLogType = "rename_database"
 
+	// EventLogCreateSchema is recorded when a schema is created.
+	EventLogCreateSchema EventLogType = "create_schema"
 	// EventLogDropSchema is recorded when a schema is dropped.
 	EventLogDropSchema EventLogType = "drop_schema"
+	// EventLogRenameSchema is recorded when a schema is renamed.
+	EventLogRenameSchema EventLogType = "rename_schema"
+	// EventLogChangeSchemaOwner is recorded when a schema's owner is changed.
+	EventLogAlterSchemaOwner EventLogType = "alter_schema_owner"
 
 	// EventLogCreateTable is recorded when a table is created.
 	EventLogCreateTable EventLogType = "create_table"

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -534,3 +534,57 @@ DROP USER u
 
 statement ok
 DROP USER v
+
+
+# Schema events
+##################
+
+statement ok
+CREATE SCHEMA s
+
+statement ok
+CREATE USER u
+
+statement ok
+CREATE SCHEMA AUTHORIZATION u
+
+query ITT
+SELECT "reportingID", info::JSONB->>'SchemaName', info::JSONB->>'Owner'
+FROM system.eventlog
+WHERE "eventType" = 'create_schema'
+ORDER BY 2
+----
+1 s root
+1 u u
+
+statement ok
+ALTER SCHEMA u RENAME TO t
+
+query ITT
+SELECT "reportingID", info::JSONB->>'SchemaName', info::JSONB->>'NewSchemaName'
+FROM system.eventlog
+WHERE "eventType" = 'rename_schema'
+----
+1 u t
+
+statement ok
+ALTER SCHEMA t OWNER TO root
+
+query ITT
+SELECT "reportingID", info::JSONB->>'SchemaName', info::JSONB->>'Owner'
+FROM system.eventlog
+WHERE "eventType" = 'alter_schema_owner'
+----
+1 t root
+
+statement ok
+DROP SCHEMA s, t
+
+query IT
+SELECT "reportingID", info::JSONB->>'SchemaName'
+FROM system.eventlog
+WHERE "eventType" = 'drop_schema'
+ORDER BY 2
+----
+1 s
+1 t

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -77,6 +77,14 @@ export const CREATE_STATISTICS = "create_statistics";
 export const GRANT_PRIVILEGE = "grant_privilege";
 // Recorded when privileges are removed from a user(s).
 export const REVOKE_PRIVILEGE = "revoke_privilege";
+// Recorded when a schema is created.
+export const CREATE_SCHEMA = "create_schema";
+// Recorded when a schema is dropped.
+export const DROP_SCHEMA = "drop_schema";
+// Recorded when a schema is renamed.
+export const RENAME_SCHEMA = "rename_schema";
+// Recorded when a schema's owner is changed.
+export const ALTER_SCHEMA_OWNER = "alter_schema_owner";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONING, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -87,6 +87,14 @@ export function getEventDescription(e: Event$Properties): string {
       return `Privileges granted: User ${info.User} granted ${info.Privileges} to ${info.Grantees} on ${info.Target}`;
     case eventTypes.REVOKE_PRIVILEGE:
       return `Privileges revoked: User ${info.User} revoked ${info.Privileges} from ${info.Grantees} on ${info.Target}`;
+    case eventTypes.CREATE_SCHEMA:
+      return `Schema Created: User ${info.User} created schema ${info.SchemaName} with owner ${info.Owner}`;
+    case eventTypes.DROP_SCHEMA:
+      return `Schema Dropped: User ${info.User} dropped schema ${info.SchemaName}`;
+    case eventTypes.RENAME_SCHEMA:
+      return `Schema Renamed: User ${info.User} renamed schema ${info.SchemaName} to ${info.NewSchemaName}`;
+    case eventTypes.ALTER_SCHEMA_OWNER:
+      return `Schema Owner Altered: User ${info.User} altered the owner of schema ${info.SchemaName} to ${info.Owner}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }
@@ -111,6 +119,9 @@ export interface EventInfo {
   Statement?: string;
   Grantees?: string;
   Privileges?: string;
+  SchemaName?: string;
+  NewSchemaName?: string;
+  Owner?: string;
   // The following are three names for the same key (it was renamed twice).
   // All ar included for backwards compatibility.
   DroppedTables?: string[];


### PR DESCRIPTION
Previously, events were not created when schema objects were
created, dropped or modified.

Fixes #55744 

Release note (admin ui change): changing schema object
now causes an event to be logged and displayed in the admin ui