### PR TITLE
backupccl: optimize spans selected for backup and ts protection

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -14,6 +14,7 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -146,20 +147,176 @@ func (e *encryptedDataKeyMap) rangeOverMap(fn func(masterKeyID hashedMasterKeyID
 	}
 }
 
+type sortedIndexIDs []descpb.IndexID
+
+func (s sortedIndexIDs) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+
+func (s sortedIndexIDs) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s sortedIndexIDs) Len() int {
+	return len(s)
+}
+
+// getLogicallyMergedTableSpans returns all the non-drop index spans of the
+// provided table but after merging them so as to minimize the number of spans
+// generated. The following rules are used to logically merge the sorted set of
+// non-drop index spans:
+// - Contiguous index spans are merged.
+// - Two non-contiguous index spans are merged if a scan request for the index
+// IDs between them does not return any results.
+//
+// Egs: {/Table/51/1 - /Table/51/2}, {/Table/51/3 - /Table/51/4} => {/Table/51/1 - /Table/51/4}
+// provided the dropped index represented by the span
+// {/Table/51/2 - /Table/51/3} has been gc'ed.
+func getLogicallyMergedTableSpans(
+	table catalog.TableDescriptor,
+	added map[tableAndIndex]bool,
+	codec keys.SQLCodec,
+	endTime hlc.Timestamp,
+	checkForKVInBounds func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error),
+) ([]roachpb.Span, error) {
+	var nonDropIndexIDs []descpb.IndexID
+	if err := table.ForeachNonDropIndex(func(idxDesc *descpb.IndexDescriptor) error {
+		key := tableAndIndex{tableID: table.GetID(), indexID: idxDesc.ID}
+		if added[key] {
+			return nil
+		}
+		added[key] = true
+		nonDropIndexIDs = append(nonDropIndexIDs, idxDesc.ID)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if len(nonDropIndexIDs) == 0 {
+		return nil, nil
+	}
+
+	// There is no merging possible with only a single index, short circuit.
+	if len(nonDropIndexIDs) == 1 {
+		return []roachpb.Span{table.IndexSpan(codec, nonDropIndexIDs[0])}, nil
+	}
+
+	sort.Sort(sortedIndexIDs(nonDropIndexIDs))
+
+	var mergedIndexSpans []roachpb.Span
+
+	// mergedSpan starts off as the first span in the set of spans being
+	// considered for a logical merge.
+	// The logical span merge algorithm walks over the table's non drop indexes
+	// using an lhsSpan and rhsSpan  (always offset by 1). It checks all index IDs
+	// between lhsSpan and rhsSpan to look for dropped but non-gced KVs. The
+	// existence of such a KV indicates that the rhsSpan cannot be included in the
+	// current set of spans being logically merged, and so we update the
+	// mergedSpan to encompass the lhsSpan as that is the furthest we can go.
+	// After recording the new "merged" span, we update mergedSpan to be the
+	// rhsSpan, and start processing the next logically mergeable span set.
+	mergedSpan := table.IndexSpan(codec, nonDropIndexIDs[0])
+	for curIndex := 0; curIndex < len(nonDropIndexIDs)-1; curIndex++ {
+		lhsIndexID := nonDropIndexIDs[curIndex]
+		rhsIndexID := nonDropIndexIDs[curIndex+1]
+
+		lhsSpan := table.IndexSpan(codec, lhsIndexID)
+		rhsSpan := table.IndexSpan(codec, rhsIndexID)
+
+		lhsIndex, err := table.FindIndexByID(lhsIndexID)
+		if err != nil {
+			return nil, err
+		}
+		rhsIndex, err := table.FindIndexByID(rhsIndexID)
+		if err != nil {
+			return nil, err
+		}
+
+		// If either the lhs or rhs is an interleaved index, we do not attempt to
+		// perform a logical merge of the spans because the index span for
+		// interleaved contains the tableID/indexID of the furthest ancestor in
+		// the interleaved chain.
+		if lhsIndex.IsInterleaved() || rhsIndex.IsInterleaved() {
+			mergedIndexSpans = append(mergedIndexSpans, mergedSpan)
+			mergedSpan = rhsSpan
+		} else {
+			var foundDroppedKV bool
+			// Iterate over all index IDs between the two candidates (lhs and rhs)
+			// which may be logically merged. These index IDs represent dropped
+			// indexes between the two non-drop index spans.
+			for i := lhsIndexID + 1; i < rhsIndexID; i++ {
+				// If we find an index which has been dropped but not gc'ed, we cannot
+				// merge the lhs and rhs spans.
+				foundDroppedKV, err = checkForKVInBounds(lhsSpan.EndKey, rhsSpan.Key, endTime)
+				if err != nil {
+					return nil, err
+				}
+				if foundDroppedKV {
+					mergedSpan.EndKey = lhsSpan.EndKey
+					mergedIndexSpans = append(mergedIndexSpans, mergedSpan)
+					mergedSpan = rhsSpan
+					break
+				}
+			}
+		}
+
+		// The loop will terminate after this iteration and so we must update the
+		// current mergedSpan to encompass the last element in the nonDropIndexIDs
+		// slice as well.
+		if curIndex == len(nonDropIndexIDs)-2 {
+			mergedSpan.EndKey = rhsSpan.EndKey
+			mergedIndexSpans = append(mergedIndexSpans, mergedSpan)
+		}
+	}
+
+	return mergedIndexSpans, nil
+}
+
 // spansForAllTableIndexes returns non-overlapping spans for every index and
 // table passed in. They would normally overlap if any of them are interleaved.
+// The outputted spans are merged as described by the method
+// getLogicallyMergedTableSpans, so as to optimize the size/number of the spans
+// we BACKUP and lay protected ts records for.
 func spansForAllTableIndexes(
-	codec keys.SQLCodec, tables []catalog.TableDescriptor, revs []BackupManifest_DescriptorRevision,
-) []roachpb.Span {
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	endTime hlc.Timestamp,
+	tables []catalog.TableDescriptor,
+	revs []BackupManifest_DescriptorRevision,
+) ([]roachpb.Span, error) {
 
 	added := make(map[tableAndIndex]bool, len(tables))
 	sstIntervalTree := interval.NewTree(interval.ExclusiveOverlapper)
+	var mergedIndexSpans []roachpb.Span
+	var err error
+
+	// checkForKVInBounds issues a scan request between start and end at endTime,
+	// and returns true if a non-nil result is returned.
+	checkForKVInBounds := func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+		var foundKV bool
+		err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			txn.SetFixedTimestamp(ctx, endTime)
+			res, err := txn.Scan(ctx, start, end, 1 /* maxRows */)
+			if err != nil {
+				return err
+			}
+			foundKV = len(res) != 0
+			return nil
+		})
+		return foundKV, err
+	}
+
 	for _, table := range tables {
-		for _, index := range table.AllNonDropIndexes() {
-			if err := sstIntervalTree.Insert(intervalSpan(table.IndexSpan(codec, index.ID)), false); err != nil {
+		mergedIndexSpans, err = getLogicallyMergedTableSpans(table, added, execCfg.Codec, endTime,
+			checkForKVInBounds)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, indexSpan := range mergedIndexSpans {
+			if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
 			}
-			added[tableAndIndex{tableID: table.GetID(), indexID: index.ID}] = true
 		}
 	}
 	// If there are desc revisions, ensure that we also add any index spans
@@ -175,13 +332,16 @@ func spansForAllTableIndexes(
 		rawTbl := descpb.TableFromDescriptor(rev.Desc, hlc.Timestamp{})
 		if rawTbl != nil && rawTbl.State != descpb.DescriptorState_DROP {
 			tbl := tabledesc.NewImmutable(*rawTbl)
-			for _, idx := range tbl.AllNonDropIndexes() {
-				key := tableAndIndex{tableID: tbl.ID, indexID: idx.ID}
-				if !added[key] {
-					if err := sstIntervalTree.Insert(intervalSpan(tbl.IndexSpan(codec, idx.ID)), false); err != nil {
-						panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
-					}
-					added[key] = true
+			revSpans, err := getLogicallyMergedTableSpans(tbl, added, execCfg.Codec, rev.Time,
+				checkForKVInBounds)
+			if err != nil {
+				return nil, err
+			}
+
+			mergedIndexSpans = append(mergedIndexSpans, revSpans...)
+			for _, indexSpan := range mergedIndexSpans {
+				if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
+					panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
 				}
 			}
 		}
@@ -195,7 +355,19 @@ func spansForAllTableIndexes(
 		})
 		return false
 	})
-	return spans
+
+	// Attempt to merge any contiguous spans generated from the tables and revs.
+	mergedSpans, distinct := roachpb.MergeSpans(spans)
+	if !distinct {
+		return nil, errors.NewAssertionErrorWithWrappedErrf(errors.New("expected all resolved spans for the BACKUP to be distinct"), "IndexSpan")
+	}
+
+	knobs := execCfg.BackupRestoreTestingKnobs
+	if knobs != nil && knobs.CaptureResolvedTableDescSpans != nil {
+		knobs.CaptureResolvedTableDescSpans(mergedSpans)
+	}
+
+	return mergedSpans, nil
 }
 
 func getLocalityAndBaseURI(uri, appendPath string) (string, string, error) {
@@ -769,11 +941,14 @@ func backupPlanHook(
 
 			tenantRows = append(tenantRows, ds)
 		} else {
-			spans = append(spans, spansForAllTableIndexes(p.ExecCfg().Codec, tables, revs)...)
+			tableSpans, err := spansForAllTableIndexes(ctx, p.ExecCfg(), endTime, tables, revs)
+			if err != nil {
+				return err
+			}
+			spans = append(spans, tableSpans...)
 
 			// Include all tenants.
 			// TODO(tbg): make conditional on cluster setting.
-			var err error
 			tenantRows, err = p.ExecCfg().InternalExecutor.Query(
 				ctx, "backup-lookup-tenant", p.ExtendedEvalContext().Txn,
 				`SELECT id, active, info FROM system.tenants`,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
@@ -63,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -5676,7 +5678,283 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 		})
 		require.NoError(t, g.Wait())
 	}
+}
 
+// TestSpanSelectionDuringBackup tests the method spansForAllTableIndexes which
+// is used to resolve the spans which will be backed up, and spans for which
+// protected ts records will be created.
+func TestProtectedTimestampSpanSelectionDuringBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t,
+		"not worth starting/stopping the server for each subtest as they all rely on the shared"+
+			" variable `actualResolvedSpan`")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	params := base.TestClusterArgs{}
+	params.ServerArgs.ExternalIODir = dir
+	var actualResolvedSpans []string
+	params.ServerArgs.Knobs.BackupRestore = &sql.BackupRestoreTestingKnobs{
+		CaptureResolvedTableDescSpans: func(mergedSpans []roachpb.Span) {
+			for _, span := range mergedSpans {
+				actualResolvedSpans = append(actualResolvedSpans, span.String())
+			}
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 3, params)
+	defer tc.Stopper().Stop(ctx)
+
+	tc.WaitForNodeLiveness(t)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	conn := tc.ServerConn(0)
+	runner := sqlutils.MakeSQLRunner(conn)
+	baseBackupURI := "nodelocal://0/foo/"
+
+	t.Run("contiguous-span-merge", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, "+
+			"INDEX baz(name), INDEX bar (v))")
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		require.Equal(t, []string{"/Table/53/{1-4}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("drop-index-span-merge", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, "+
+			"INDEX baz(name), INDEX bar (v))")
+		runner.Exec(t, "INSERT INTO foo VALUES (1, NULL, 'testuser')")
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=60")
+		runner.Exec(t, "DROP INDEX foo@baz")
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		require.Equal(t, []string{"/Table/55/{1-2}", "/Table/55/{3-4}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("drop-index-gced-span-merge", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, "+
+			"INDEX baz(name), INDEX bar (v))")
+		runner.Exec(t, "INSERT INTO foo VALUES (1, NULL, 'testuser')")
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=1")
+		runner.Exec(t, "DROP INDEX foo@baz")
+		time.Sleep(time.Second * 2)
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		require.Equal(t, []string{"/Table/57/{1-4}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("interleaved-spans", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE grandparent (a INT PRIMARY KEY, v BYTES, INDEX gpindex (v))")
+		runner.Exec(t, "CREATE TABLE parent (a INT, b INT, v BYTES, "+
+			"PRIMARY KEY(a, b)) INTERLEAVE IN PARENT grandparent(a)")
+		runner.Exec(t, "CREATE TABLE child (a INT, b INT, c INT, v BYTES, "+
+			"PRIMARY KEY(a, b, c), INDEX childindex(c)) INTERLEAVE IN PARENT parent(a, b)")
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		// /Table/59/{1-2} encompasses the pk of grandparent, and the interleaved
+		// tables parent and child.
+		// /Table/59/2 - /Table/59/3 is for the gpindex
+		// /Table/61/{2-3} is for the childindex
+		require.Equal(t, []string{"/Table/59/{1-3}", "/Table/61/{2-3}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("revs-span-merge", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, "+
+			"INDEX baz(name), INDEX bar (v))")
+		runner.Exec(t, "INSERT INTO foo VALUES (1, NULL, 'testuser')")
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=60")
+		runner.Exec(t, "DROP INDEX foo@baz")
+
+		runner.Exec(t, `BACKUP DATABASE test TO 'nodelocal://0/fooz' WITH revision_history`)
+
+		// The BACKUP with revision history will pickup the dropped index baz as
+		// well because it existed in a non-drop state at some point in the interval
+		// covered by this BACKUP.
+		require.Equal(t, []string{"/Table/63/{1-4}"}, actualResolvedSpans)
+		actualResolvedSpans = nil
+		runner.Exec(t, "DROP TABLE foo")
+
+		runner.Exec(t, "CREATE TABLE foo2 (k INT PRIMARY KEY, v BYTES, name STRING, "+
+			"INDEX baz(name), INDEX bar (v))")
+		runner.Exec(t, "INSERT INTO foo2 VALUES (1, NULL, 'testuser')")
+		runner.Exec(t, "ALTER TABLE foo2 CONFIGURE ZONE USING gc.ttlseconds=60")
+		runner.Exec(t, "DROP INDEX foo2@baz")
+
+		runner.Exec(t, `BACKUP DATABASE test TO 'nodelocal://0/fooz' WITH revision_history`)
+		// We expect to see only the non-drop indexes of table foo in this
+		// incremental backup with revision history. We also expect to see both drop
+		// and non-drop indexes of table foo2 as all the indexes were live at some
+		// point in the interval covered by this BACKUP.
+		require.Equal(t, []string{"/Table/63/{1-2}", "/Table/63/{3-4}", "/Table/64/{1-4}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("last-index-dropped", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, INDEX baz(name))")
+		runner.Exec(t, "CREATE TABLE foo2 (k INT PRIMARY KEY, v BYTES, name STRING, INDEX baz(name))")
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=60")
+		runner.Exec(t, "DROP INDEX foo@baz")
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		require.Equal(t, []string{"/Table/66/{1-2}", "/Table/67/{1-3}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+
+	t.Run("last-index-gced", func(t *testing.T) {
+		runner.Exec(t, "CREATE DATABASE test; USE test;")
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES, name STRING, INDEX baz(name))")
+		runner.Exec(t, "INSERT INTO foo VALUES (1, NULL, 'test')")
+		runner.Exec(t, "CREATE TABLE foo2 (k INT PRIMARY KEY, v BYTES, name STRING, INDEX baz(name))")
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=1")
+		runner.Exec(t, "DROP INDEX foo@baz")
+		time.Sleep(time.Second * 2)
+		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds=60")
+
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		require.Equal(t, []string{"/Table/69/{1-2}", "/Table/70/{1-3}"}, actualResolvedSpans)
+		runner.Exec(t, "DROP DATABASE test;")
+		actualResolvedSpans = nil
+	})
+}
+
+func getMockIndexDesc(indexID descpb.IndexID) descpb.IndexDescriptor {
+	mockIndexDescriptor := descpb.IndexDescriptor{ID: indexID}
+	return mockIndexDescriptor
+}
+
+func getMockTableDesc(
+	tableID descpb.ID, pkIndex descpb.IndexDescriptor, indexes []descpb.IndexDescriptor,
+) tabledesc.Immutable {
+	mockTableDescriptor := descpb.TableDescriptor{
+		ID:           tableID,
+		PrimaryIndex: pkIndex,
+		Indexes:      indexes,
+	}
+	mockImmutableTableDesc := tabledesc.Immutable{TableDescriptor: mockTableDescriptor}
+	return mockImmutableTableDesc
+}
+
+// Unit tests for the getLogicallyMergedTableSpans() method.
+func TestLogicallyMergedTableSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	codec := keys.TODOSQLCodec
+	unusedMap := make(map[tableAndIndex]bool)
+	testCases := []struct {
+		name                       string
+		checkForKVInBoundsOverride func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error)
+		tableID                    descpb.ID
+		pkIndex                    descpb.IndexDescriptor
+		indexes                    []descpb.IndexDescriptor
+		expectedSpans              []string
+	}{
+		{
+			name: "contiguous-spans",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				return false, nil
+			},
+			tableID:       55,
+			pkIndex:       getMockIndexDesc(1),
+			indexes:       []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(2)},
+			expectedSpans: []string{"/Table/55/{1-3}"},
+		},
+		{
+			name: "dropped-span-between-two-spans",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				if start.String() == "/Table/56/2" && end.String() == "/Table/56/3" {
+					return true, nil
+				}
+				return false, nil
+			},
+			tableID:       56,
+			pkIndex:       getMockIndexDesc(1),
+			indexes:       []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3)},
+			expectedSpans: []string{"/Table/56/{1-2}", "/Table/56/{3-4}"},
+		},
+		{
+			name: "gced-span-between-two-spans",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				return false, nil
+			},
+			tableID:       57,
+			pkIndex:       getMockIndexDesc(1),
+			indexes:       []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3)},
+			expectedSpans: []string{"/Table/57/{1-4}"},
+		},
+		{
+			name: "alternate-spans-dropped",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				if (start.String() == "/Table/58/2" && end.String() == "/Table/58/3") ||
+					(start.String() == "/Table/58/4" && end.String() == "/Table/58/5") {
+					return true, nil
+				}
+				return false, nil
+			},
+			tableID: 58,
+			pkIndex: getMockIndexDesc(1),
+			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
+				getMockIndexDesc(5)},
+			expectedSpans: []string{"/Table/58/{1-2}", "/Table/58/{3-4}", "/Table/58/{5-6}"},
+		},
+		{
+			name: "alternate-spans-gced",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				return false, nil
+			},
+			tableID: 59,
+			pkIndex: getMockIndexDesc(1),
+			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
+				getMockIndexDesc(5)},
+			expectedSpans: []string{"/Table/59/{1-6}"},
+		},
+		{
+			name: "one-drop-one-gc",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				if start.String() == "/Table/60/2" && end.String() == "/Table/60/3" {
+					return true, nil
+				}
+				return false, nil
+			},
+			tableID: 60,
+			pkIndex: getMockIndexDesc(1),
+			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
+				getMockIndexDesc(5)},
+			expectedSpans: []string{"/Table/60/{1-2}", "/Table/60/{3-6}"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			tableDesc := getMockTableDesc(test.tableID, test.pkIndex, test.indexes)
+			spans, err := getLogicallyMergedTableSpans(&tableDesc, unusedMap, codec,
+				hlc.Timestamp{}, test.checkForKVInBoundsOverride)
+			var mergedSpans []string
+			for _, span := range spans {
+				mergedSpans = append(mergedSpans, span.String())
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expectedSpans, mergedSpans)
+		})
+	}
 }
 
 func getFirstStoreReplica(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -882,6 +882,11 @@ type BackupRestoreTestingKnobs struct {
 	// AllowImplicitAccess allows implicit access to data sources for non-admin
 	// users. This enables using nodelocal for testing BACKUP/RESTORE permissions.
 	AllowImplicitAccess bool
+
+	// CaptureResolvedTableDescSpans allows for intercepting the spans which are
+	// resolved during backup planning, and will eventually be backed up during
+	// execution.
+	CaptureResolvedTableDescSpans func([]roachpb.Span)
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
Previously, to account for interleaved tables, backup would generate
spans for every table index, which would then be used by the protected
ts record. Recently we saw a couple of instances where this was
resulting in a very large number of spans being generated during backup.
A direct consequence of this is that the record can exceed the default
size of the limits of the protected timestamp subsystem.

In this new scheme we attempt to merge spans using the following
rules:

- Contiguous index spans are merged.
- Two non-contiguous index spans are merged if a scan request for the index
IDs between them does not return any results.

Egs: {/Table/51/1 - /Table/51/2}, {/Table/51/3 - /Table/51/4} => {/Table/51/1 - /Table/51/4}
provided the dropped index represented by the span
{/Table/51/2 - /Table/51/3} has been gc'ed.

The resultant merged spans are what we BACKUP and what we protect from
gc using a protected ts record.

Informs: #54747

Release note: None