### PR TITLE
kvserver: skip non-live nodes when considering candidates for transfers

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -502,8 +502,11 @@ func (a *Allocator) allocateTargetFromList(
 	analyzedConstraints := constraint.AnalyzeConstraints(
 		ctx, a.storePool.getStoreDescriptor, candidateReplicas, zone)
 	candidates := allocateCandidates(
+		ctx,
 		sl, analyzedConstraints, candidateReplicas,
-		a.storePool.getLocalitiesByStore(candidateReplicas), options,
+		a.storePool.getLocalitiesByStore(candidateReplicas),
+		a.storePool.isNodeReadyForRoutineReplicaTransfer,
+		options,
 	)
 	log.VEventf(ctx, 3, "allocate candidates: %s", candidates)
 	if target := candidates.selectGood(a.randGen); target != nil {
@@ -664,6 +667,7 @@ func (a Allocator) RebalanceTarget(
 		analyzedConstraints,
 		existingReplicas,
 		a.storePool.getLocalitiesByStore(existingReplicas),
+		a.storePool.isNodeReadyForRoutineReplicaTransfer,
 		options,
 	)
 

--- a/pkg/kv/kvserver/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator_scorer_test.go
@@ -1213,6 +1213,7 @@ func TestShouldRebalanceDiversity(t *testing.T) {
 			constraint.AnalyzedConstraints{},
 			replicas,
 			existingStoreLocalities,
+			func(context.Context, roachpb.NodeID) bool { return true }, /* isNodeValidForRoutineReplicaTransfer */
 			options)
 		actual := len(targets) > 0
 		if actual != tc.expected {

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.pb.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.pb.go
@@ -81,7 +81,7 @@ var MembershipStatus_value = map[string]int32{
 }
 
 func (MembershipStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_397670cf2529cf3e, []int{0}
+	return fileDescriptor_liveness_19520db8d41703e0, []int{0}
 }
 
 // NodeLivenessStatus describes the status of a node from the perspective of the
@@ -107,6 +107,8 @@ const (
 	// UNAVAILABLE indicates that the node is unavailable - it has not updated its
 	// liveness record recently enough to be considered live, but has not been
 	// unavailable long enough to be considered dead.
+	// UNAVAILABLE is also reported for nodes whose descriptor is marked
+	// as draining.
 	NodeLivenessStatus_UNAVAILABLE NodeLivenessStatus = 2
 	// LIVE indicates a live node.
 	NodeLivenessStatus_LIVE NodeLivenessStatus = 3
@@ -138,7 +140,7 @@ func (x NodeLivenessStatus) String() string {
 	return proto.EnumName(NodeLivenessStatus_name, int32(x))
 }
 func (NodeLivenessStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_397670cf2529cf3e, []int{1}
+	return fileDescriptor_liveness_19520db8d41703e0, []int{1}
 }
 
 // Liveness holds information about a node's latest heartbeat and epoch.
@@ -180,7 +182,7 @@ type Liveness struct {
 func (m *Liveness) Reset()      { *m = Liveness{} }
 func (*Liveness) ProtoMessage() {}
 func (*Liveness) Descriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_397670cf2529cf3e, []int{0}
+	return fileDescriptor_liveness_19520db8d41703e0, []int{0}
 }
 func (m *Liveness) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -696,10 +698,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/liveness/livenesspb/liveness.proto", fileDescriptor_liveness_397670cf2529cf3e)
+	proto.RegisterFile("kv/kvserver/liveness/livenesspb/liveness.proto", fileDescriptor_liveness_19520db8d41703e0)
 }
 
-var fileDescriptor_liveness_397670cf2529cf3e = []byte{
+var fileDescriptor_liveness_19520db8d41703e0 = []byte{
 	// 554 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0x4b, 0x8b, 0xd3, 0x50,
 	0x14, 0xc7, 0x73, 0xfb, 0x9a, 0x72, 0x2b, 0x33, 0xe1, 0x76, 0xc0, 0x12, 0x21, 0x09, 0xea, 0xa2,

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
@@ -125,6 +125,8 @@ enum NodeLivenessStatus {
   // UNAVAILABLE indicates that the node is unavailable - it has not updated its
   // liveness record recently enough to be considered live, but has not been
   // unavailable long enough to be considered dead.
+  // UNAVAILABLE is also reported for nodes whose descriptor is marked
+  // as draining.
   NODE_STATUS_UNAVAILABLE = 2 [(gogoproto.enumvalue_customname) = "UNAVAILABLE"];
   // LIVE indicates a live node.
   NODE_STATUS_LIVE = 3 [(gogoproto.enumvalue_customname) = "LIVE"];


### PR DESCRIPTION
(This PR is forked off #55460 to simplify the discussion. I believe there's no discussion left here? Maybe I can merge it directly?)

Fixes #55440.

Prior to this patch, 3 components could attempt to transfer a replica
to a node currently being drained:

- the store rebalancer, which rebalances replicas based on disk
  usage and QPS.
- the allocator, to place new replicas.
- the allocator, to rebalance replicas depending on load.

This commit introduces a consideration for node liveness when building
the list of candidates, to detect whether a target node is
acceptable. Any node that is not LIVE according to its liveness status
is not considered for a transfer.

Release note (bug fix): In some cases CockroachDB would attempt to
transfer ranges to nodes in the process of being decommissioned or
being shut down; this could cause disruption the moment the node
did actually terminate. This bug has been fixed. It had been
introduced some time before v2.0.