### PR TITLE
sql: refactor max batch size to unblock metamorphic tests

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -37,18 +36,10 @@ var insertFastPathNodePool = sync.Pool{
 	},
 }
 
-// Check that exec.InsertFastPathMaxRows does not exceed the default
-// mutations.MaxBatchSize.
-func init() {
-	if mutations.MaxBatchSize() < exec.InsertFastPathMaxRows {
-		panic("decrease exec.InsertFastPathMaxRows")
-	}
-}
-
 // insertFastPathNode is a faster implementation of inserting values in a table
 // and performing FK checks. It is used when all the foreign key checks can be
 // performed via a direct lookup in an index, and when the input is VALUES of
-// limited size (at most exec.InsertFastPathMaxRows).
+// limited size (at most mutations.MaxBatchSize).
 type insertFastPathNode struct {
 	// input values, similar to a valuesNode.
 	input [][]tree.TypedExpr

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -234,10 +234,6 @@ type Cascade struct {
 	) (Plan, error)
 }
 
-// InsertFastPathMaxRows is the maximum number of rows for which we can use the
-// insert fast path.
-const InsertFastPathMaxRows = 10000
-
 // InsertFastPathFKCheck contains information about a foreign key check to be
 // performed by the insert fast-path (see ConstructInsertFastPath). It
 // identifies the index into which we can perform the lookup.

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -369,7 +369,7 @@ define Insert {
 
 # InsertFastPath implements a special (but very common) case of insert,
 # satisfying the following conditions:
-#  - the input is Values with at most InsertFastPathMaxRows, and there are no
+#  - the input is Values with at most mutations.MaxBatchSize, and there are no
 #    subqueries;
 #  - there are no other mutations in the statement, and the output of the
 #    insert is not processed through side-effecting expressions.


### PR DESCRIPTION
Previously, the max mutation batch size variable was duplicated across
optimizer and execution and couldn't be modified at program start time
for metamorphic testing. This is now corrected.