### PR TITLE
sql: allow parsing of DROP OWNED BY

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -14,7 +14,8 @@ stmt ::=
 	| prepare_stmt
 	| revoke_stmt
 	| savepoint_stmt
-	| reassign_owned_stmt
+	| reassign_owned_by_stmt
+	| drop_owned_by_stmt
 	| release_stmt
 	| refresh_stmt
 	| nonpreparable_set_stmt
@@ -90,8 +91,11 @@ revoke_stmt ::=
 savepoint_stmt ::=
 	'SAVEPOINT' name
 
-reassign_owned_stmt ::=
+reassign_owned_by_stmt ::=
 	'REASSIGN' 'OWNED' 'BY' role_spec_list 'TO' role_spec
+
+drop_owned_by_stmt ::=
+	'DROP' 'OWNED' 'BY' role_spec_list opt_drop_behavior
 
 release_stmt ::=
 	'RELEASE' savepoint_name
@@ -313,6 +317,11 @@ role_spec ::=
 	non_reserved_word_or_sconst
 	| 'CURRENT_USER'
 	| 'SESSION_USER'
+
+opt_drop_behavior ::=
+	'CASCADE'
+	| 'RESTRICT'
+	| 
 
 savepoint_name ::=
 	'SAVEPOINT' name
@@ -708,11 +717,6 @@ opt_table ::=
 
 relation_expr_list ::=
 	( relation_expr ) ( ( ',' relation_expr ) )*
-
-opt_drop_behavior ::=
-	'CASCADE'
-	| 'RESTRICT'
-	| 
 
 set_clause_list ::=
 	( set_clause ) ( ( ',' set_clause ) )*

--- a/pkg/sql/drop_owned_by.go
+++ b/pkg/sql/drop_owned_by.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+// dropOwnedByNode represents a DROP OWNED BY <role(s)> statement.
+type dropOwnedByNode struct {
+	// TODO(angelaw): Uncomment when implementing - commenting out due to linting error.
+	// n *tree.DropOwnedBy
+}
+
+func (p *planner) DropOwnedBy(ctx context.Context) (planNode, error) {
+	telemetry.Inc(sqltelemetry.CreateDropOwnedByCounter())
+	// TODO(angelaw): Implementation.
+	return nil, unimplemented.NewWithIssue(55381, "drop owned by is not yet implemented")
+}
+
+func (n *dropOwnedByNode) startExec(params runParams) error {
+	// TODO(angelaw): Implementation.
+	return nil
+}
+func (n *dropOwnedByNode) Next(runParams) (bool, error) { return false, nil }
+func (n *dropOwnedByNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *dropOwnedByNode) Close(context.Context)        {}

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -105,18 +105,20 @@ func buildOpaque(
 		plan, err = p.DropDatabase(ctx, n)
 	case *tree.DropIndex:
 		plan, err = p.DropIndex(ctx, n)
+	case *tree.DropOwnedBy:
+		plan, err = p.DropOwnedBy(ctx)
 	case *tree.DropRole:
 		plan, err = p.DropRole(ctx, n)
 	case *tree.DropSchema:
 		plan, err = p.DropSchema(ctx, n)
+	case *tree.DropSequence:
+		plan, err = p.DropSequence(ctx, n)
 	case *tree.DropTable:
 		plan, err = p.DropTable(ctx, n)
 	case *tree.DropType:
 		plan, err = p.DropType(ctx, n)
 	case *tree.DropView:
 		plan, err = p.DropView(ctx, n)
-	case *tree.DropSequence:
-		plan, err = p.DropSequence(ctx, n)
 	case *tree.Grant:
 		plan, err = p.Grant(ctx, n)
 	case *tree.GrantRole:
@@ -219,12 +221,13 @@ func init() {
 		&tree.Discard{},
 		&tree.DropDatabase{},
 		&tree.DropIndex{},
+		&tree.DropOwnedBy{},
+		&tree.DropRole{},
 		&tree.DropSchema{},
+		&tree.DropSequence{},
 		&tree.DropTable{},
 		&tree.DropType{},
 		&tree.DropView{},
-		&tree.DropRole{},
-		&tree.DropSequence{},
 		&tree.Grant{},
 		&tree.GrantRole{},
 		&tree.ReassignOwnedBy{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -246,6 +246,7 @@ func TestContextualHelp(t *testing.T) {
 
 		{`REASSIGN OWNED BY ?? TO ??`, `REASSIGN OWNED BY`},
 		{`REASSIGN OWNED BY foo, bar TO ??`, `REASSIGN OWNED BY`},
+		{`DROP OWNED BY ??`, `DROP OWNED BY`},
 
 		{`RESUME ??`, `RESUME`},
 		{`RESUME JOB ??`, `RESUME JOBS`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1555,6 +1555,10 @@ func TestParse(t *testing.T) {
 
 		{`REASSIGN OWNED BY foo TO bar`},
 		{`REASSIGN OWNED BY foo, bar TO third`},
+		{`DROP OWNED BY foo`},
+		{`DROP OWNED BY foo, bar`},
+		{`DROP OWNED BY foo CASCADE`},
+		{`DROP OWNED BY foo RESTRICT`},
 
 		{`COMMENT ON COLUMN a.b IS 'a'`},
 		{`COMMENT ON COLUMN a.b IS NULL`},
@@ -2673,6 +2677,8 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 
 		{`REASSIGN OWNED BY CURRENT_USER TO foo`, `REASSIGN OWNED BY "current_user" TO foo`},
 		{`REASSIGN OWNED BY SESSION_USER TO foo`, `REASSIGN OWNED BY "session_user" TO foo`},
+		{`DROP OWNED BY CURRENT_USER`, `DROP OWNED BY "current_user"`},
+		{`DROP OWNED BY SESSION_USER`, `DROP OWNED BY "session_user"`},
 
 		// Validate that GRANT and REVOKE can accept optional PRIVILEGES syntax
 		{`GRANT ALL PRIVILEGES ON DATABASE foo TO root`, `GRANT ALL ON DATABASE foo TO root`},

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
-// ReassignOwnedByNode represents a REASSIGN OWNED BY <name> TO <name> statement.
+// ReassignOwnedByNode represents a REASSIGN OWNED BY <role(s)> TO <role> statement.
 type reassignOwnedByNode struct {
 	n *tree.ReassignOwnedBy
 }

--- a/pkg/sql/sem/tree/drop_owned_by.go
+++ b/pkg/sql/sem/tree/drop_owned_by.go
@@ -10,23 +10,25 @@
 
 package tree
 
-// ReassignOwnedBy represents a REASSIGN OWNED BY <name> TO <name> statement.
-type ReassignOwnedBy struct {
-	OldRoles []string
-	NewRole  string
+// DropOwnedBy represents a DROP OWNED BY command.
+type DropOwnedBy struct {
+	Roles        []string
+	DropBehavior DropBehavior
 }
 
-var _ Statement = &ReassignOwnedBy{}
+var _ Statement = &DropOwnedBy{}
 
 // Format implements the NodeFormatter interface.
-func (node *ReassignOwnedBy) Format(ctx *FmtCtx) {
-	ctx.WriteString("REASSIGN OWNED BY ")
-	for i := range node.OldRoles {
+func (node *DropOwnedBy) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP OWNED BY ")
+	for i := range node.Roles {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNameP(&node.OldRoles[i])
+		ctx.FormatNameP(&node.Roles[i])
 	}
-	ctx.WriteString(" TO ")
-	ctx.FormatNameP(&node.NewRole)
+	if node.DropBehavior != DropDefault {
+		ctx.WriteString(" ")
+		ctx.WriteString(node.DropBehavior.String())
+	}
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -602,7 +602,13 @@ func (*Prepare) StatementTag() string { return "PREPARE" }
 func (*ReassignOwnedBy) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ReassignOwnedBy) StatementTag() string { return "REASSIGN OWNED" }
+func (*ReassignOwnedBy) StatementTag() string { return "REASSIGN OWNED BY" }
+
+// StatementType implements the Statement interface.
+func (*DropOwnedBy) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropOwnedBy) StatementTag() string { return "DROP OWNED BY" }
 
 // StatementType implements the Statement interface.
 func (*RefreshMaterializedView) StatementType() StatementType { return DDL }
@@ -1094,11 +1100,12 @@ func (n *Deallocate) String() string                     { return AsString(n) }
 func (n *Delete) String() string                         { return AsString(n) }
 func (n *DropDatabase) String() string                   { return AsString(n) }
 func (n *DropIndex) String() string                      { return AsString(n) }
+func (n *DropOwnedBy) String() string                    { return AsString(n) }
 func (n *DropSchema) String() string                     { return AsString(n) }
+func (n *DropSequence) String() string                   { return AsString(n) }
 func (n *DropTable) String() string                      { return AsString(n) }
 func (n *DropType) String() string                       { return AsString(n) }
 func (n *DropView) String() string                       { return AsString(n) }
-func (n *DropSequence) String() string                   { return AsString(n) }
 func (n *DropRole) String() string                       { return AsString(n) }
 func (n *Execute) String() string                        { return AsString(n) }
 func (n *Explain) String() string                        { return AsString(n) }

--- a/pkg/sql/sqltelemetry/drop_owned_by.go
+++ b/pkg/sql/sqltelemetry/drop_owned_by.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// CreateDropOwnedByCounter returns a counter to increment for the DROP OWNED BY command.
+func CreateDropOwnedByCounter() telemetry.Counter {
+	return telemetry.GetCounter("sql.drop_owned_by")
+}

--- a/pkg/sql/testdata/telemetry/drop_owned_by
+++ b/pkg/sql/testdata/telemetry/drop_owned_by
@@ -1,0 +1,19 @@
+# This file contains telemetry tests for the sql.drop_owned_by counter.
+
+feature-allowlist
+sql.drop_owned_by.*
+----
+
+exec
+CREATE ROLE testuser;
+CREATE TABLE t();
+GRANT CREATE ON DATABASE defaultdb TO testuser;
+ALTER TABLE t OWNER TO testuser
+----
+
+# TODO(angelaw): Remove unimplemented message after implementation.
+feature-usage
+DROP OWNED BY testuser
+----
+error: pq: unimplemented: drop owned by is not yet implemented
+sql.drop_owned_by

--- a/pkg/sql/testdata/telemetry/reassign_owned_by
+++ b/pkg/sql/testdata/telemetry/reassign_owned_by
@@ -8,7 +8,6 @@ exec
 CREATE ROLE testuser;
 CREATE ROLE testuser2;
 CREATE TABLE t();
-GRANT testuser, testuser2 TO root;
 GRANT CREATE ON DATABASE defaultdb TO testuser, testuser2;
 ALTER TABLE t OWNER TO testuser
 ----

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -395,6 +395,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&ordinalityNode{}):              "ordinality",
 	reflect.TypeOf(&projectSetNode{}):              "project set",
 	reflect.TypeOf(&reassignOwnedByNode{}):         "reassign owned by",
+	reflect.TypeOf(&dropOwnedByNode{}):             "drop owned by",
 	reflect.TypeOf(&recursiveCTENode{}):            "recursive cte",
 	reflect.TypeOf(&refreshMaterializedViewNode{}): "refresh materialized view",
 	reflect.TypeOf(&relocateNode{}):                "relocate",


### PR DESCRIPTION
Part 1 of addressing #55381.

Add parsing and telemetry support for DROP OWNED BY command.
Includes small refactors of the related REASSIGN OWNED BY
command such as appending "_by" to some instances of
"reassign_owned" for readability.

Plan to follow up with implementation of DROP OWNED BY for
feature parity with PostgresQL, which will resolve the issue
linked.

Note that this command is also making use of `role_spec_list` 
which as noted in #54696 does not properly parse 
`CURRENT_USER` or `SESSION_USER` and uses strings for
roles/usernames rather than expressions. This issue is out of 
scope for this PR and will be resolved separately.

Release note: None