### PR TITLE
CODEOWNERS: add http-api-prs group to http docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,9 @@
 /pkg/geo                     @cockroachdb/geospatial
 
 /pkg/ui/                     @cockroachdb/admin-ui-prs
-/pkg/ui/embedded.go
-/pkg/ui/src/js/protos.d.ts
-/pkg/ui/src/js/protos.js
+/pkg/ui/embedded.go          @cockroachdb/admin-ui-prs
+/pkg/ui/src/js/protos.d.ts   @cockroachdb/admin-ui-prs
+/pkg/ui/src/js/protos.js     @cockroachdb/admin-ui-prs
+
+/docs/generated/http         @cockroachdb/http-api-prs
+/pkg/cmd/docgen/http.go      @cockroachdb/http-api-prs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -90,3 +90,7 @@ cockroachdb/rfc-prs:
   email: TODO@cockroachlabs.com
   slack: TODO
   triage_column_id: 0 # TODO
+cockroachdb/http-api-prs:
+  email: TODO@cockroachlabs.com
+  slack: TODO
+  triage_column_id: 0 # TODO


### PR DESCRIPTION
We have recently added automatically generated
docs for our HTTP APIs that will be aiding the
docs team and engineers in ensuring consistency
and quality in our public APIs.

A new github group `http-api-prs` has been created
which will be assigned to review any changes to
the generated docs or the code that we maintain
that generates the HTML files.

Release note: none