### PR TITLE
release-20.1: sql: fix bug dropping shard column which is not the last column

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -148,14 +148,10 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 	tableDesc.AddColumnMutation(shardColDesc, sqlbase.DescriptorMutation_DROP)
 	for i := range tableDesc.Columns {
 		if tableDesc.Columns[i].ID == shardColDesc.ID {
-			tmp := tableDesc.Columns[:0]
-			for j, col := range tableDesc.Columns {
-				if i == j {
-					continue
-				}
-				tmp = append(tmp, col)
-			}
-			tableDesc.Columns = tmp
+			// Note the third slice parameter which will force a copy of the backing
+			// array if the column being removed is not the last column.
+			tableDesc.Columns = append(tableDesc.Columns[:i:i],
+				tableDesc.Columns[i+1:]...)
 			break
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -560,3 +560,24 @@ ALTER TABLE rename_column RENAME crdb_internal_c2_shard_8 TO foo;
 
 statement ok
 DROP TABLE rename_column;
+
+# This is a regression test for a bug whereby the dropping of a hash column
+# could result in an invalid descriptor and would fail. The underlying bug was
+# due to a column descriptor pointer to a slice being clobbered. See #55766.
+subtest drop_earlier_column_due_to_hash_sharded_index
+
+statement ok
+CREATE TABLE IF NOT EXISTS drop_earlier_hash_column (
+    i INT PRIMARY KEY,
+    j INT,
+    k INT
+);
+
+statement ok
+CREATE INDEX h1 ON drop_earlier_hash_column(j) USING HASH WITH BUCKET_COUNT = 8;
+
+statement ok
+CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH BUCKET_COUNT = 8;
+
+statement ok
+DROP INDEX h1;

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -29,7 +29,7 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":484,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":480,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 


### PR DESCRIPTION
Backport 1/1 commits from #55766.

/cc @cockroachdb/release

---

The bug was due to the fact that we were passing around the column descriptor
as a pointer to an entry in the `Columns` slice. When we overwrote that slice
we'd clobber the descriptor and, in the process, muck up the mutation which
pointed to it. We should look for more bugs like this. Prior to this change
the added logic test would fail with the below error:

```
testdata/logic_test/hash_sharded_index:589:
expected success, but found
(XXUUU) family "fam_1_k_j" contains unknown column "4"
```

Release note (bug fix): Fixed a bug which would prevent the dropping of hash
sharded indexes if they were added prior to other columns.
