### PR TITLE
roachtest: disable range merge queue in tpchvec/tpcdsvec

### DIFF
--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -86,6 +86,16 @@ func scatterTables(t *test, conn *gosql.DB, tableNames []string) {
 	}
 }
 
+// disableRangeMerges disables the range merge queue on the cluster.
+func disableRangeMerges(t *test, conn *gosql.DB) {
+	t.Status("disabling range merges")
+	if _, err := conn.Exec(
+		`SET CLUSTER SETTING kv.range_merge.queue_enabled = false`,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // disableAutoStats disables automatic collection of statistics on the cluster.
 func disableAutoStats(t *test, conn *gosql.DB) {
 	t.Status("disabling automatic collection of stats")

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -98,6 +98,9 @@ func registerTPCDSVec(r *testRegistry) {
 		c.Start(ctx, t)
 
 		clusterConn := c.Conn(ctx, 1)
+		// We will disable range merges in order to remove a possible source of
+		// random query latency spikes during perf runs.
+		disableRangeMerges(t, clusterConn)
 		disableAutoStats(t, clusterConn)
 		disableVectorizeRowCountThresholdHeuristic(t, clusterConn)
 		t.Status("restoring TPCDS dataset for Scale Factor 1")

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -658,6 +658,9 @@ func runTPCHVec(
 	c.Start(ctx, t)
 
 	conn := c.Conn(ctx, 1)
+	// We will disable range merges in order to remove a possible source of
+	// random query latency spikes during perf runs.
+	disableRangeMerges(t, conn)
 	disableAutoStats(t, conn)
 	disableVectorizeRowCountThresholdHeuristic(t, conn)
 	t.Status("restoring TPCH dataset for Scale Factor 1")


### PR DESCRIPTION
This commit disables the range merge queue on tpchvec and tpcdsvec
roachtests in order to - hopefully - reduce some noise about the
performance slowness. I'm guessing that some of the variation that we've
been observing with tpchvec/perf tests might come due to range merge
activity, so let's remove that variable. However, I don't have concrete
data to back this guess up.

Release note: None