### PR TITLE
kvserver: improve logging of draining lease transfer failures 

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -770,6 +770,8 @@ func (a *Allocator) scorerOptions() scorerOptions {
 // to from the provided list. It excludes the current lease holder replica
 // unless asked to do otherwise by the checkTransferLeaseSource parameter.
 //
+// Returns an empty descriptor if no target is found.
+//
 // TODO(aayush, andrei): If a draining leaseholder doesn't see any other voters
 // in its locality, but sees a learner, rather than allowing the lease to be
 // transferred outside of its current locality (likely violating leaseholder

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -52,9 +52,10 @@ func (s *Store) Transport() *RaftTransport {
 func (s *Store) FindTargetAndTransferLease(
 	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, zone *zonepb.ZoneConfig,
 ) (bool, error) {
-	return s.replicateQueue.findTargetAndTransferLease(
+	transferStatus, err := s.replicateQueue.shedLease(
 		ctx, repl, desc, zone, transferLeaseOptions{},
 	)
+	return transferStatus == transferOK, err
 }
 
 // AddReplica adds the replica to the store's replica map and to the sorted


### PR DESCRIPTION
The respective log message now tells you more about why the transfer
failed; in particular it tells you when no transfer targets were found.

Release note: None