### PR TITLE
sql - Implement SHOW REGIONS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -15,5 +15,10 @@ ALTER DATABASE new_db ADD REGION "us-west-1"
 statement error implementation pending
 ALTER DATABASE new_db DROP REGION "us-west-1"
 
-statement error implementation pending
+query TT colnames
 SHOW REGIONS
+----
+region  availability_zones
+test1   {test1-az1,test1-az2,test1-az3}
+test2   {test2-az1,test2-az2,test2-az3}
+test3   {test3-az1,test3-az2,test3-az3}


### PR DESCRIPTION
Previously, SHOW REGIONS was an unimplemented stub.  This
PR implements the SHOW REGIONS such that when issued, it
shows all of the regions available to the cluster.

Release note (sql change): Implement SHOW REGIONS so that
customers can easily see all of the regions available in their cluster.

example:

SHOW REGIONS

    region
---------------
  asia-east
  europe-east
  us-central
  us-east
  us-west
(5 rows)