### PR TITLE
opt: add cost for table descriptor fetch during virtual scan

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -250,17 +250,17 @@ a  57  true  false  false
 
 # Hibernate query.
 
-query TTTOBIIITTOT
+query TTTOBIIITTOT rowsort
 SELECT * FROM (SELECT n.nspname, c.relname, a.attname, a.atttypid, a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull) AS attnotnull, a.atttypmod, a.attlen, row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS attnum, pg_get_expr(def.adbin, def.adrelid) AS adsrc, dsc.description, t.typbasetype, t.typtype FROM pg_catalog.pg_namespace AS n JOIN pg_catalog.pg_class AS c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute AS a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type AS t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef AS def ON ((a.attrelid = def.adrelid) AND (a.attnum = def.adnum)) LEFT JOIN pg_catalog.pg_description AS dsc ON ((c.oid = dsc.objoid) AND (a.attnum = dsc.objsubid)) LEFT JOIN pg_catalog.pg_class AS dc ON ((dc.oid = dsc.classoid) AND (dc.relname = 'pg_class')) LEFT JOIN pg_catalog.pg_namespace AS dn ON ((dc.relnamespace = dn.oid) AND (dn.nspname = 'pg_catalog')) WHERE (((c.relkind IN ('r', 'v', 'f', 'm')) AND (a.attnum > 0)) AND (NOT a.attisdropped)) AND (n.nspname LIKE 'public')) AS c;
 ----
 public  a          id     20  false  -1  8   1  NULL            NULL  0  b
-public  a          name   25  false  -1  -1  2  NULL            NULL  0  b
 public  a          rowid  20  true   -1  8   3  unique_rowid()  NULL  0  b
-public  customers  name   25  true   -1  -1  1  NULL            NULL  0  b
+public  a          name   25  false  -1  -1  2  NULL            NULL  0  b
 public  customers  id     20  false  -1  8   2  NULL            NULL  0  b
+public  customers  name   25  true   -1  -1  1  NULL            NULL  0  b
+public  b          rowid  20  true   -1  8   3  unique_rowid()  NULL  0  b
 public  b          id     20  false  -1  8   1  NULL            NULL  0  b
 public  b          a_id   20  false  -1  8   2  NULL            NULL  0  b
-public  b          rowid  20  true   -1  8   3  unique_rowid()  NULL  0  b
 public  c          a      20  true   -1  8   1  NULL            NULL  0  b
 public  c          b      20  true   -1  8   2  NULL            NULL  0  b
 public  metatest   a      20  true   -1  8   1  NULL            NULL  0  b

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -59,9 +59,11 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(&stmt.Table)
 
-	// Assume that every table in the "system" or "information_schema" catalog
-	// is a virtual table. This is a simplified assumption for testing purposes.
-	if stmt.Table.CatalogName == "system" || stmt.Table.SchemaName == "information_schema" {
+	// Assume that every table in the "system", "information_schema" or
+	// "pg_catalog" catalog is a virtual table. This is a simplified assumption
+	// for testing purposes.
+	if stmt.Table.CatalogName == "system" || stmt.Table.SchemaName == "information_schema" ||
+		stmt.Table.SchemaName == "pg_catalog" {
 		return tc.createVirtualTable(stmt)
 	}
 
@@ -286,6 +288,18 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 	}
 
 	tab.addPrimaryColumnIndex(string(tab.Columns[0].ColName()))
+
+	// Search for index definitions.
+	for _, def := range stmt.Defs {
+		switch def := def.(type) {
+		case *tree.IndexTableDef:
+			tab.addIndex(def, nonUniqueIndex)
+		}
+	}
+
+	// Add the new table to the catalog.
+	tc.AddTable(tab)
+
 	return tab
 }
 
@@ -643,6 +657,27 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 				Direction: tree.Ascending,
 			}
 			idx.addColumn(tt, elem, nonKeyCol, false /* isLastIndexCol */)
+		}
+	}
+	if tt.IsVirtual {
+		// All indexes of virtual tables automatically STORE all other columns in
+		// the table.
+		idxCols := idx.Columns
+		for _, col := range tt.Columns {
+			found := false
+			for _, idxCol := range idxCols {
+				if col.ColName() == idxCol.ColName() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				elem := tree.IndexElem{
+					Column:    col.ColName(),
+					Direction: tree.Ascending,
+				}
+				idx.addColumn(tt, elem, nonKeyCol, false /* isLastIndexCol */)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -18,6 +18,7 @@ import (
 )
 
 var informationSchemaMap = map[string]*tree.CreateTable{}
+var pgCatalogMap = map[string]*tree.CreateTable{}
 
 var informationSchemaTables = []string{
 	vtable.InformationSchemaColumns,
@@ -28,29 +29,88 @@ var informationSchemaTables = []string{
 	vtable.InformationSchemaTables,
 }
 
+var pgCatalogTables = []string{
+	vtable.PGCatalogAm,
+	vtable.PGCatalogAttrDef,
+	vtable.PGCatalogAttribute,
+	vtable.PGCatalogCast,
+	vtable.PGCatalogAuthID,
+	vtable.PGCatalogAuthMembers,
+	vtable.PGCatalogAvailableExtensions,
+	vtable.PGCatalogClass,
+	vtable.PGCatalogCollation,
+	vtable.PGCatalogConstraint,
+	vtable.PGCatalogConversion,
+	vtable.PGCatalogDatabase,
+	vtable.PGCatalogDefaultACL,
+	vtable.PGCatalogDepend,
+	vtable.PGCatalogDescription,
+	vtable.PGCatalogSharedDescription,
+	vtable.PGCatalogEnum,
+	vtable.PGCatalogEventTrigger,
+	vtable.PGCatalogExtension,
+	vtable.PGCatalogForeignDataWrapper,
+	vtable.PGCatalogForeignServer,
+	vtable.PGCatalogForeignTable,
+	vtable.PGCatalogIndex,
+	vtable.PGCatalogIndexes,
+	vtable.PGCatalogInherits,
+	vtable.PGCatalogLanguage,
+	vtable.PGCatalogLocks,
+	vtable.PGCatalogMatViews,
+	vtable.PGCatalogNamespace,
+	vtable.PGCatalogOperator,
+	vtable.PGCatalogPreparedXacts,
+	vtable.PGCatalogPreparedStatements,
+	vtable.PGCatalogProc,
+	vtable.PGCatalogRange,
+	vtable.PGCatalogRewrite,
+	vtable.PGCatalogRoles,
+	vtable.PGCatalogSecLabels,
+	vtable.PGCatalogSequence,
+	vtable.PGCatalogSettings,
+	vtable.PGCatalogShdepend,
+	vtable.PGCatalogTables,
+	vtable.PGCatalogTablespace,
+	vtable.PGCatalogTrigger,
+	vtable.PGCatalogType,
+	vtable.PGCatalogUser,
+	vtable.PGCatalogUserMapping,
+	vtable.PGCatalogStatActivity,
+	vtable.PGCatalogSecurityLabel,
+	vtable.PGCatalogSharedSecurityLabel,
+	vtable.PGCatalogViews,
+	vtable.PGCatalogAggregate,
+}
+
 func init() {
-	// Build a map that maps the names of the various information_schema tables
+	// Build a map that maps the names of the various virtual tables
 	// to their CREATE TABLE AST.
-	for _, table := range informationSchemaTables {
-		parsed, err := parser.ParseOne(table)
-		if err != nil {
-			panic(errors.Wrap(err, "error initializing virtual table map"))
+	buildMap := func(schemaName string, tableList []string, tableMap map[string]*tree.CreateTable) {
+		for _, table := range tableList {
+			parsed, err := parser.ParseOne(table)
+			if err != nil {
+				panic(errors.Wrap(err, "error initializing virtual table map"))
+			}
+
+			ct, ok := parsed.AST.(*tree.CreateTable)
+			if !ok {
+				panic(errors.New("virtual table schemas must be CREATE TABLE statements"))
+			}
+
+			ct.Table.SchemaName = tree.Name(schemaName)
+			ct.Table.ExplicitSchema = true
+
+			ct.Table.CatalogName = testDB
+			ct.Table.ExplicitCatalog = true
+
+			name := ct.Table
+			tableMap[name.ObjectName.String()] = ct
 		}
-
-		ct, ok := parsed.AST.(*tree.CreateTable)
-		if !ok {
-			panic(errors.New("virtual table schemas must be CREATE TABLE statements"))
-		}
-
-		ct.Table.SchemaName = tree.Name("information_schema")
-		ct.Table.ExplicitSchema = true
-
-		ct.Table.CatalogName = testDB
-		ct.Table.ExplicitCatalog = true
-
-		name := ct.Table
-		informationSchemaMap[name.ObjectName.String()] = ct
 	}
+
+	buildMap("information_schema", informationSchemaTables, informationSchemaMap)
+	buildMap("pg_catalog", pgCatalogTables, pgCatalogMap)
 }
 
 // Resolve returns true and the AST node describing the virtual table referenced.
@@ -59,6 +119,10 @@ func resolveVTable(name *tree.TableName) (*tree.CreateTable, bool) {
 	switch name.SchemaName {
 	case "information_schema":
 		schema, ok := informationSchemaMap[name.ObjectName.String()]
+		return schema, ok
+
+	case "pg_catalog":
+		schema, ok := pgCatalogMap[name.ObjectName.String()]
 		return schema, ok
 	}
 

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -108,6 +108,10 @@ const (
 	// justification for this constant.
 	lookupJoinRetrieveRowCost = 2 * seqIOCostFactor
 
+	// virtualScanTableDescriptorFetchCost is the cost to retrieve the table
+	// descriptors when performing a virtual table scan.
+	virtualScanTableDescriptorFetchCost = 10 * randIOCostFactor
+
 	// Input rows to a join are processed in batches of this size.
 	// See joinreader.go.
 	joinReaderBatchSize = 100.0
@@ -579,6 +583,11 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 	baseCost := memo.Cost(numSpans * randIOCostFactor)
 
+	// If this is a virtual scan, add the cost of fetching table descriptors.
+	if c.mem.Metadata().Table(scan.Table).IsVirtualTable() {
+		baseCost += virtualScanTableDescriptorFetchCost
+	}
+
 	// Add a small cost if the scan is unconstrained, so all else being equal, we
 	// will prefer a constrained scan. This is important if our row count
 	// estimate turns out to be smaller than the actual row count.
@@ -776,6 +785,11 @@ func (c *coster) computeIndexLookupJoinCost(
 		// 100 ranges showed that a "non-parallel" lookup join is about 5 times
 		// slower.
 		perLookupCost *= 5
+	}
+	if c.mem.Metadata().Table(table).IsVirtualTable() {
+		// It's expensive to perform a lookup join into a virtual table because
+		// we need to fetch the table descriptors on each lookup.
+		perLookupCost += virtualScanTableDescriptorFetchCost
 	}
 	cost := memo.Cost(lookupCount) * perLookupCost
 

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -838,3 +838,90 @@ insert c
                 │    ├── key: ()
                 │    └── fd: ()-->(6)
                 └── filters (true)
+
+# Avoid performing a lookup join with virtual tables if the filter is
+# not extremely selective.
+
+opt
+SELECT
+  a.attname,
+  a.atttypid,
+  t.typbasetype,
+  t.typtype
+FROM
+  pg_catalog.pg_attribute AS a
+  JOIN pg_catalog.pg_type AS t ON (a.atttypid = t.oid)
+WHERE
+  a.attname IN ('descriptor_id', 'descriptor_name')
+----
+project
+ ├── columns: attname:3!null atttypid:4!null typbasetype:50 typtype:32
+ ├── stats: [rows=198]
+ ├── cost: 2724.37877
+ └── inner-join (merge)
+      ├── columns: attname:3!null atttypid:4!null oid:26!null typtype:32 typbasetype:50
+      ├── left ordering: +26
+      ├── right ordering: +4
+      ├── stats: [rows=198, distinct(4)=17.2927193, null(4)=0, distinct(26)=17.2927193, null(26)=0]
+      ├── cost: 2722.38877
+      ├── fd: (4)==(26), (26)==(4)
+      ├── scan t@secondary
+      │    ├── columns: oid:26!null typtype:32 typbasetype:50
+      │    ├── stats: [rows=1000, distinct(26)=100, null(26)=0]
+      │    ├── cost: 1394.02
+      │    └── ordering: +26
+      ├── sort
+      │    ├── columns: attname:3!null atttypid:4
+      │    ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927193, null(4)=0.2]
+      │    ├── cost: 1316.17877
+      │    ├── ordering: +4
+      │    └── select
+      │         ├── columns: attname:3!null atttypid:4
+      │         ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927193, null(4)=0.2]
+      │         ├── cost: 1314.04
+      │         ├── scan a
+      │         │    ├── columns: attname:3 atttypid:4
+      │         │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
+      │         │    └── cost: 1304.02
+      │         └── filters
+      │              └── attname:3 IN ('descriptor_id', 'descriptor_name') [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id'] [/'descriptor_name' - /'descriptor_name']; tight)]
+      └── filters (true)
+
+
+# A lookup join should be performed with a virtual table if the filter
+# is very selective.
+opt
+SELECT
+  a.attname,
+  a.atttypid,
+  t.typbasetype,
+  t.typtype
+FROM
+  pg_catalog.pg_attribute AS a
+  JOIN pg_catalog.pg_type AS t ON (a.atttypid = t.oid)
+WHERE
+  a.attname = 'descriptor_id'
+----
+project
+ ├── columns: attname:3!null atttypid:4!null typbasetype:50 typtype:32
+ ├── stats: [rows=99]
+ ├── cost: 2148.69
+ ├── fd: ()-->(3)
+ └── inner-join (lookup pg_type@secondary)
+      ├── columns: attname:3!null atttypid:4!null oid:26!null typtype:32 typbasetype:50
+      ├── key columns: [4] = [26]
+      ├── stats: [rows=99, distinct(4)=8.5617925, null(4)=0, distinct(26)=8.5617925, null(26)=0]
+      ├── cost: 2147.69
+      ├── fd: ()-->(3), (4)==(26), (26)==(4)
+      ├── select
+      │    ├── columns: attname:3!null atttypid:4
+      │    ├── stats: [rows=10, distinct(3)=1, null(3)=0, distinct(4)=9.5617925, null(4)=0.1]
+      │    ├── cost: 1314.04
+      │    ├── fd: ()-->(3)
+      │    ├── scan a
+      │    │    ├── columns: attname:3 atttypid:4
+      │    │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
+      │    │    └── cost: 1304.02
+      │    └── filters
+      │         └── attname:3 = 'descriptor_id' [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id']; tight), fd=()-->(3)]
+      └── filters (true)

--- a/pkg/sql/opt/xform/testdata/coster/virtual-scan
+++ b/pkg/sql/opt/xform/testdata/coster/virtual-scan
@@ -4,11 +4,11 @@ SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME='public'
 select
  ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
  ├── stats: [rows=10, distinct(3)=1, null(3)=0]
- ├── cost: 1124.04
+ ├── cost: 1164.04
  ├── fd: ()-->(3)
  ├── scan information_schema.schemata
  │    ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
  │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0]
- │    └── cost: 1114.02
+ │    └── cost: 1154.02
  └── filters
       └── schema_name:3 = 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -1,52 +1,5 @@
 # Reconstructed from:
 # https://github.com/jordanlewis/pgjdbc/blob/462d505f01ec6180b30eaffabe51839dd126b90c/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2391-L2408
-
-# For testing, create the schema for the builtin tables.
-exec-ddl
-CREATE TABLE pg_type (
-    oid OID NULL,
-    typname NAME NOT NULL,
-    typnamespace OID NULL,
-    typowner OID NULL,
-    typlen INT NULL,
-    typbyval BOOL NULL,
-    typtype STRING NULL,
-    typcategory STRING NULL,
-    typispreferred BOOL NULL,
-    typisdefined BOOL NULL,
-    typdelim STRING NULL,
-    typrelid OID NULL,
-    typelem OID NULL,
-    typarray OID NULL,
-    typinput OID NULL,
-    typoutput OID NULL,
-    typreceive OID NULL,
-    typsend OID NULL,
-    typmodin OID NULL,
-    typmodout OID NULL,
-    typanalyze OID NULL,
-    typalign STRING NULL,
-    typstorage STRING NULL,
-    typnotnull BOOL NULL,
-    typbasetype OID NULL,
-    typtypmod INT NULL,
-    typndims INT NULL,
-    typcollation OID NULL,
-    typdefaultbin STRING NULL,
-    typdefault STRING NULL,
-    typacl STRING[] NULL
-)
-----
-
-exec-ddl
-CREATE TABLE pg_namespace (
-    oid OID NULL,
-    nspname NAME NOT NULL,
-    nspowner OID NULL,
-    nspacl STRING[] NULL
-)
-----
-
 opt
 SELECT
     NULL AS type_cat,
@@ -68,7 +21,7 @@ SELECT
             ELSE 'OTHER'
             END
         FROM
-            pg_type
+            pg_catalog.pg_type
         WHERE
             oid = t.typbasetype
     )
@@ -76,32 +29,32 @@ SELECT
     END
         AS base_type
 FROM
-    pg_type AS t, pg_namespace AS n
+    pg_catalog.pg_type AS t, pg_catalog.pg_namespace AS n
 WHERE
     t.typnamespace = n.oid AND n.nspname != 'pg_catalog';
 ----
 project
- ├── columns: type_cat:74 type_schem:35!null type_name:2!null class_name:74 data_type:75 remarks:76 base_type:77
+ ├── columns: type_cat:71 type_schem:35!null type_name:3!null class_name:71 data_type:72 remarks:73 base_type:74
  ├── stable
- ├── fd: ()-->(74)
+ ├── fd: ()-->(71)
  ├── ensure-distinct-on
- │    ├── columns: t.oid:1 t.typname:2!null t.typtype:7 nspname:35!null case:73 rownum:78!null
- │    ├── grouping columns: rownum:78!null
+ │    ├── columns: t.oid:2!null t.typname:3!null t.typtype:8 nspname:35!null case:70 rownum:75!null
+ │    ├── grouping columns: rownum:75!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
- │    ├── key: (78)
- │    ├── fd: (78)-->(1,2,7,35,73)
+ │    ├── key: (75)
+ │    ├── fd: (75)-->(2,3,8,35,70)
  │    ├── left-join (hash)
- │    │    ├── columns: t.oid:1 t.typname:2!null t.typnamespace:3!null t.typtype:7 t.typbasetype:25 n.oid:34!null nspname:35!null pg_type.oid:40 case:73 rownum:78!null
- │    │    ├── fd: (3)==(34), (34)==(3), (78)-->(1-3,7,25,34,35)
+ │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null pg_catalog.pg_type.oid:39 case:70 rownum:75!null
+ │    │    ├── fd: (4)==(34), (34)==(4), (75)-->(2-4,8,26,34,35)
  │    │    ├── ordinality
- │    │    │    ├── columns: t.oid:1 t.typname:2!null t.typnamespace:3!null t.typtype:7 t.typbasetype:25 n.oid:34!null nspname:35!null rownum:78!null
- │    │    │    ├── key: (78)
- │    │    │    ├── fd: (3)==(34), (34)==(3), (78)-->(1-3,7,25,34,35)
+ │    │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null rownum:75!null
+ │    │    │    ├── key: (75)
+ │    │    │    ├── fd: (4)==(34), (34)==(4), (75)-->(2-4,8,26,34,35)
  │    │    │    └── inner-join (hash)
- │    │    │         ├── columns: t.oid:1 t.typname:2!null t.typnamespace:3!null t.typtype:7 t.typbasetype:25 n.oid:34!null nspname:35!null
- │    │    │         ├── fd: (3)==(34), (34)==(3)
+ │    │    │         ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null
+ │    │    │         ├── fd: (4)==(34), (34)==(4)
  │    │    │         ├── scan t
- │    │    │         │    └── columns: t.oid:1 t.typname:2!null t.typnamespace:3 t.typtype:7 t.typbasetype:25
+ │    │    │         │    └── columns: t.oid:2!null t.typname:3!null t.typnamespace:4 t.typtype:8 t.typbasetype:26
  │    │    │         ├── select
  │    │    │         │    ├── columns: n.oid:34 nspname:35!null
  │    │    │         │    ├── scan n
@@ -109,28 +62,207 @@ project
  │    │    │         │    └── filters
  │    │    │         │         └── nspname:35 != 'pg_catalog' [outer=(35), constraints=(/35: (/NULL - /'pg_catalog') [/e'pg_catalog\x00' - ]; tight)]
  │    │    │         └── filters
- │    │    │              └── t.typnamespace:3 = n.oid:34 [outer=(3,34), constraints=(/3: (/NULL - ]; /34: (/NULL - ]), fd=(3)==(34), (34)==(3)]
+ │    │    │              └── t.typnamespace:4 = n.oid:34 [outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │    │    ├── project
- │    │    │    ├── columns: case:73!null pg_type.oid:40
- │    │    │    ├── scan pg_type
- │    │    │    │    └── columns: pg_type.oid:40 pg_type.typname:41!null
+ │    │    │    ├── columns: case:70!null pg_catalog.pg_type.oid:39!null
+ │    │    │    ├── scan pg_catalog.pg_type
+ │    │    │    │    └── columns: pg_catalog.pg_type.oid:39!null pg_catalog.pg_type.typname:40!null
  │    │    │    └── projections
- │    │    │         └── CASE WHEN pg_type.typname:41 = 'pgType' THEN 'sqlType' ELSE 'OTHER' END [as=case:73, outer=(41)]
+ │    │    │         └── CASE WHEN pg_catalog.pg_type.typname:40 = 'pgType' THEN 'sqlType' ELSE 'OTHER' END [as=case:70, outer=(40)]
  │    │    └── filters
- │    │         └── pg_type.oid:40 = t.typbasetype:25 [outer=(25,40), constraints=(/25: (/NULL - ]; /40: (/NULL - ]), fd=(25)==(40), (40)==(25)]
+ │    │         └── pg_catalog.pg_type.oid:39 = t.typbasetype:26 [outer=(26,39), constraints=(/26: (/NULL - ]; /39: (/NULL - ]), fd=(26)==(39), (39)==(26)]
  │    └── aggregations
- │         ├── const-agg [as=t.oid:1, outer=(1)]
- │         │    └── t.oid:1
- │         ├── const-agg [as=t.typname:2, outer=(2)]
- │         │    └── t.typname:2
- │         ├── const-agg [as=t.typtype:7, outer=(7)]
- │         │    └── t.typtype:7
+ │         ├── const-agg [as=t.oid:2, outer=(2)]
+ │         │    └── t.oid:2
+ │         ├── const-agg [as=t.typname:3, outer=(3)]
+ │         │    └── t.typname:3
+ │         ├── const-agg [as=t.typtype:8, outer=(8)]
+ │         │    └── t.typtype:8
  │         ├── const-agg [as=nspname:35, outer=(35)]
  │         │    └── nspname:35
- │         └── const-agg [as=case:73, outer=(73)]
- │              └── case:73
+ │         └── const-agg [as=case:70, outer=(70)]
+ │              └── case:70
  └── projections
-      ├── NULL [as=type_cat:74]
-      ├── CASE WHEN t.typtype:7 = 'c' THEN 'STRUCT' ELSE 'DISTINCT' END [as=data_type:75, outer=(7)]
-      ├── obj_description(t.oid:1, 'pg_type') [as=remarks:76, outer=(1), stable]
-      └── CASE WHEN t.typtype:7 = 'd' THEN case:73 ELSE CAST(NULL AS STRING) END [as=base_type:77, outer=(7,73)]
+      ├── NULL [as=type_cat:71]
+      ├── CASE WHEN t.typtype:8 = 'c' THEN 'STRUCT' ELSE 'DISTINCT' END [as=data_type:72, outer=(8)]
+      ├── obj_description(t.oid:2, 'pg_type') [as=remarks:73, outer=(2), stable]
+      └── CASE WHEN t.typtype:8 = 'd' THEN case:70 ELSE CAST(NULL AS STRING) END [as=base_type:74, outer=(8,70)]
+
+
+# Regression test for #55140. Avoid lookup joins for virtual tables.
+opt
+SELECT
+  *
+FROM
+  (
+    SELECT
+      n.nspname,
+      c.relname,
+      a.attname,
+      a.atttypid,
+      a.attnotnull
+      OR ((t.typtype = 'd') AND t.typnotnull)
+        AS attnotnull,
+      a.atttypmod,
+      a.attlen,
+      t.typtypmod,
+      row_number() OVER (
+        PARTITION BY a.attrelid ORDER BY a.attnum
+      )
+        AS attnum,
+      NULL AS attidentity,
+      pg_get_expr(def.adbin, def.adrelid) AS adsrc,
+      dsc.description,
+      t.typbasetype,
+      t.typtype
+    FROM
+      pg_catalog.pg_namespace AS n
+      JOIN pg_catalog.pg_class AS c ON (c.relnamespace = n.oid)
+      JOIN pg_catalog.pg_attribute AS a ON (a.attrelid = c.oid)
+      JOIN pg_catalog.pg_type AS t ON (a.atttypid = t.oid)
+      LEFT JOIN pg_catalog.pg_attrdef AS def ON
+          (
+            (a.attrelid = def.adrelid)
+            AND (a.attnum = def.adnum)
+          )
+      LEFT JOIN pg_catalog.pg_description AS dsc ON
+          ((c.oid = dsc.objoid) AND (a.attnum = dsc.objsubid))
+      LEFT JOIN pg_catalog.pg_class AS dc ON
+          (
+            (dc.oid = dsc.classoid)
+            AND (dc.relname = 'pg_class')
+          )
+      LEFT JOIN pg_catalog.pg_namespace AS dn ON
+          (
+            (dc.relnamespace = dn.oid)
+            AND (dn.nspname = 'pg_catalog')
+          )
+    WHERE
+      (
+        (
+          (
+            (c.relkind IN ('r', 'p', 'v', 'f', 'm'))
+            AND (a.attnum > 0)
+          )
+          AND (NOT a.attisdropped)
+        )
+        AND (n.nspname LIKE 'public')
+      )
+      AND (c.relname LIKE '%')
+  )
+    AS c
+WHERE
+  true AND (attname LIKE '%')
+ORDER BY
+  nspname, c.relname, attnum;
+----
+sort
+ ├── columns: nspname:3!null relname:8!null attname:37!null atttypid:38!null attnotnull:137 atttypmod:44 attlen:40 typtypmod:85 attnum:136 attidentity:138 adsrc:139 description:101 typbasetype:84 typtype:66
+ ├── stable
+ ├── fd: ()-->(3,138)
+ ├── ordering: +8,+136 opt(3,138) [actual: +8,+136]
+ └── project
+      ├── columns: attnotnull:137 attidentity:138 adsrc:139 n.nspname:3!null c.relname:8!null attname:37!null atttypid:38!null attlen:40 atttypmod:44 typtype:66 typbasetype:84 typtypmod:85 description:101 row_number:136
+      ├── stable
+      ├── fd: ()-->(3,138)
+      ├── select
+      │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37!null atttypid:38!null attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null t.oid:60!null typtype:66 typnotnull:83 typbasetype:84 typtypmod:85 adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101 dc.oid:103 dc.relname:104 dc.relnamespace:105 dn.oid:132 dn.nspname:133 row_number:136
+      │    ├── fd: ()-->(3,52), (2)==(9), (9)==(2), (7)==(36), (36)==(7), (38)==(60), (60)==(38)
+      │    ├── window partition=(36) ordering=+41 opt(3,7,36,52)
+      │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38!null attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null t.oid:60!null typtype:66 typnotnull:83 typbasetype:84 typtypmod:85 adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101 dc.oid:103 dc.relname:104 dc.relnamespace:105 dn.oid:132 dn.nspname:133 row_number:136
+      │    │    ├── fd: ()-->(3,52), (2)==(9), (9)==(2), (7)==(36), (36)==(7), (38)==(60), (60)==(38)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38!null attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null t.oid:60!null typtype:66 typnotnull:83 typbasetype:84 typtypmod:85 adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101 dc.oid:103 dc.relname:104 dc.relnamespace:105 dn.oid:132 dn.nspname:133
+      │    │    │    ├── left ordering: +60
+      │    │    │    ├── right ordering: +38
+      │    │    │    ├── fd: ()-->(3,52), (2)==(9), (9)==(2), (7)==(36), (36)==(7), (38)==(60), (60)==(38)
+      │    │    │    ├── scan t@secondary
+      │    │    │    │    ├── columns: t.oid:60!null typtype:66 typnotnull:83 typbasetype:84 typtypmod:85
+      │    │    │    │    └── ordering: +60
+      │    │    │    ├── sort
+      │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38 attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101 dc.oid:103 dc.relname:104 dc.relnamespace:105 dn.oid:132 dn.nspname:133
+      │    │    │    │    ├── fd: ()-->(3,52), (7)==(36), (36)==(7), (2)==(9), (9)==(2)
+      │    │    │    │    ├── ordering: +38 opt(3,52) [actual: +38]
+      │    │    │    │    └── left-join (hash)
+      │    │    │    │         ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38 attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101 dc.oid:103 dc.relname:104 dc.relnamespace:105 dn.oid:132 dn.nspname:133
+      │    │    │    │         ├── fd: ()-->(3,52), (7)==(36), (36)==(7), (2)==(9), (9)==(2)
+      │    │    │    │         ├── right-join (hash)
+      │    │    │    │         │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38 attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null adrelid:93 adnum:94 adbin:95 objoid:98 classoid:99 objsubid:100 description:101
+      │    │    │    │         │    ├── fd: ()-->(3,52), (7)==(36), (36)==(7), (2)==(9), (9)==(2)
+      │    │    │    │         │    ├── select
+      │    │    │    │         │    │    ├── columns: adrelid:93!null adnum:94!null adbin:95
+      │    │    │    │         │    │    ├── scan def
+      │    │    │    │         │    │    │    └── columns: adrelid:93!null adnum:94 adbin:95
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         └── adnum:94 > 0 [outer=(94), constraints=(/94: [/1 - ]; tight)]
+      │    │    │    │         │    ├── right-join (hash)
+      │    │    │    │         │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38 attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null objoid:98 classoid:99 objsubid:100 description:101
+      │    │    │    │         │    │    ├── fd: ()-->(3,52), (7)==(36), (36)==(7), (2)==(9), (9)==(2)
+      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    │    ├── columns: objoid:98 classoid:99 objsubid:100!null description:101
+      │    │    │    │         │    │    │    ├── scan dsc
+      │    │    │    │         │    │    │    │    └── columns: objoid:98 classoid:99 objsubid:100 description:101
+      │    │    │    │         │    │    │    └── filters
+      │    │    │    │         │    │    │         └── objsubid:100 > 0 [outer=(100), constraints=(/100: [/1 - ]; tight)]
+      │    │    │    │         │    │    ├── inner-join (lookup pg_attribute@secondary)
+      │    │    │    │         │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:36!null attname:37 atttypid:38 attlen:40 attnum:41!null atttypmod:44 a.attnotnull:48 attisdropped:52!null
+      │    │    │    │         │    │    │    ├── key columns: [7] = [36]
+      │    │    │    │         │    │    │    ├── fd: ()-->(3,52), (2)==(9), (9)==(2), (7)==(36), (36)==(7)
+      │    │    │    │         │    │    │    ├── inner-join (hash)
+      │    │    │    │         │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null
+      │    │    │    │         │    │    │    │    ├── fd: ()-->(3), (2)==(9), (9)==(2)
+      │    │    │    │         │    │    │    │    ├── select
+      │    │    │    │         │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24!null
+      │    │    │    │         │    │    │    │    │    ├── scan c
+      │    │    │    │         │    │    │    │    │    │    └── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24
+      │    │    │    │         │    │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │    │         ├── c.relkind:24 IN ('f', 'm', 'p', 'r', 'v') [outer=(24), constraints=(/24: [/'f' - /'f'] [/'m' - /'m'] [/'p' - /'p'] [/'r' - /'r'] [/'v' - /'v']; tight)]
+      │    │    │    │         │    │    │    │    │         └── c.relname:8 LIKE '%' [outer=(8), constraints=(/8: (/NULL - ])]
+      │    │    │    │         │    │    │    │    ├── select
+      │    │    │    │         │    │    │    │    │    ├── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3)
+      │    │    │    │         │    │    │    │    │    ├── scan n
+      │    │    │    │         │    │    │    │    │    │    └── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │         │    │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │    │         └── n.nspname:3 LIKE 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
+      │    │    │    │         │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      │    │    │    │         │    │    │    └── filters
+      │    │    │    │         │    │    │         ├── attnum:41 > 0 [outer=(41), constraints=(/41: [/1 - ]; tight)]
+      │    │    │    │         │    │    │         └── NOT attisdropped:52 [outer=(52), constraints=(/52: [/false - /false]; tight), fd=()-->(52)]
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         ├── c.oid:7 = objoid:98 [outer=(7,98), constraints=(/7: (/NULL - ]; /98: (/NULL - ]), fd=(7)==(98), (98)==(7)]
+      │    │    │    │         │    │         └── attnum:41 = objsubid:100 [outer=(41,100), constraints=(/41: (/NULL - ]; /100: (/NULL - ]), fd=(41)==(100), (100)==(41)]
+      │    │    │    │         │    └── filters
+      │    │    │    │         │         ├── attrelid:36 = adrelid:93 [outer=(36,93), constraints=(/36: (/NULL - ]; /93: (/NULL - ]), fd=(36)==(93), (93)==(36)]
+      │    │    │    │         │         └── attnum:41 = adnum:94 [outer=(41,94), constraints=(/41: (/NULL - ]; /94: (/NULL - ]), fd=(41)==(94), (94)==(41)]
+      │    │    │    │         ├── left-join (hash)
+      │    │    │    │         │    ├── columns: dc.oid:103!null dc.relname:104!null dc.relnamespace:105 dn.oid:132 dn.nspname:133
+      │    │    │    │         │    ├── fd: ()-->(104)
+      │    │    │    │         │    ├── select
+      │    │    │    │         │    │    ├── columns: dc.oid:103!null dc.relname:104!null dc.relnamespace:105
+      │    │    │    │         │    │    ├── fd: ()-->(104)
+      │    │    │    │         │    │    ├── scan dc
+      │    │    │    │         │    │    │    └── columns: dc.oid:103!null dc.relname:104!null dc.relnamespace:105
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         └── dc.relname:104 = 'pg_class' [outer=(104), constraints=(/104: [/'pg_class' - /'pg_class']; tight), fd=()-->(104)]
+      │    │    │    │         │    ├── select
+      │    │    │    │         │    │    ├── columns: dn.oid:132 dn.nspname:133!null
+      │    │    │    │         │    │    ├── fd: ()-->(133)
+      │    │    │    │         │    │    ├── scan dn
+      │    │    │    │         │    │    │    └── columns: dn.oid:132 dn.nspname:133!null
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         └── dn.nspname:133 = 'pg_catalog' [outer=(133), constraints=(/133: [/'pg_catalog' - /'pg_catalog']; tight), fd=()-->(133)]
+      │    │    │    │         │    └── filters
+      │    │    │    │         │         └── dc.relnamespace:105 = dn.oid:132 [outer=(105,132), constraints=(/105: (/NULL - ]; /132: (/NULL - ]), fd=(105)==(132), (132)==(105)]
+      │    │    │    │         └── filters
+      │    │    │    │              └── dc.oid:103 = classoid:99 [outer=(99,103), constraints=(/99: (/NULL - ]; /103: (/NULL - ]), fd=(99)==(103), (103)==(99)]
+      │    │    │    └── filters (true)
+      │    │    └── windows
+      │    │         └── row-number [as=row_number:136]
+      │    └── filters
+      │         └── attname:37 LIKE '%' [outer=(37), constraints=(/37: (/NULL - ])]
+      └── projections
+           ├── a.attnotnull:48 OR ((typtype:66 = 'd') AND typnotnull:83) [as=attnotnull:137, outer=(48,66,83)]
+           ├── NULL [as=attidentity:138]
+           └── pg_get_expr(adbin:95, adrelid:93) [as=adsrc:139, outer=(93,95), stable]

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -1,0 +1,891 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package vtable
+
+// PGCatalogAm describes the schema of the pg_catalog.pg_am table.
+// The catalog pg_am stores information about relation access methods.
+// It's important to note that this table changed drastically between Postgres
+// versions 9.5 and 9.6. We currently support both versions of this table.
+// See: https://www.postgresql.org/docs/9.5/static/catalog-pg-am.html and
+// https://www.postgresql.org/docs/9.6/static/catalog-pg-am.html.
+const PGCatalogAm = `
+CREATE TABLE pg_catalog.pg_am (
+	oid OID,
+	amname NAME,
+	amstrategies INT2,
+	amsupport INT2,
+	amcanorder BOOL,
+	amcanorderbyop BOOL,
+	amcanbackward BOOL,
+	amcanunique BOOL,
+	amcanmulticol BOOL,
+	amoptionalkey BOOL,
+	amsearcharray BOOL,
+	amsearchnulls BOOL,
+	amstorage BOOL,
+	amclusterable BOOL,
+	ampredlocks BOOL,
+	amkeytype OID,
+	aminsert OID,
+	ambeginscan OID,
+	amgettuple OID,
+	amgetbitmap OID,
+	amrescan OID,
+	amendscan OID,
+	ammarkpos OID,
+	amrestrpos OID,
+	ambuild OID,
+	ambuildempty OID,
+	ambulkdelete OID,
+	amvacuumcleanup OID,
+	amcanreturn OID,
+	amcostestimate OID,
+	amoptions OID,
+	amhandler OID,
+	amtype CHAR
+)`
+
+// PGCatalogAttrDef describes the schema of the pg_catalog.pg_attrdef table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html,
+const PGCatalogAttrDef = `
+CREATE TABLE pg_catalog.pg_attrdef (
+	oid OID,
+	adrelid OID NOT NULL,
+	adnum INT2,
+	adbin STRING,
+	adsrc STRING,
+  INDEX(adrelid)
+)`
+
+// PGCatalogAttribute describes the schema of the pg_catalog.pg_attribute table.
+// https://www.postgresql.org/docs/12/catalog-pg-attribute.html,
+const PGCatalogAttribute = `
+CREATE TABLE pg_catalog.pg_attribute (
+	attrelid OID NOT NULL,
+	attname NAME,
+	atttypid OID,
+	attstattarget INT4,
+	attlen INT2,
+	attnum INT2,
+	attndims INT4,
+	attcacheoff INT4,
+	atttypmod INT4,
+	attbyval BOOL,
+	attstorage CHAR,
+	attalign CHAR,
+	attnotnull BOOL,
+	atthasdef BOOL,
+	attidentity CHAR, 
+	attgenerated CHAR,
+	attisdropped BOOL,
+	attislocal BOOL,
+	attinhcount INT4,
+	attcollation OID,
+	attacl STRING[],
+	attoptions STRING[],
+	attfdwoptions STRING[],
+  INDEX(attrelid)
+)`
+
+// PGCatalogCast describes the schema of the pg_catalog.pg_cast table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-cast.html,
+const PGCatalogCast = `
+CREATE TABLE pg_catalog.pg_cast (
+	oid OID,
+	castsource OID,
+	casttarget OID,
+	castfunc OID,
+	castcontext CHAR,
+	castmethod CHAR
+)`
+
+// PGCatalogAuthID describes the schema of the pg_catalog.pg_authid table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-authid.html,
+const PGCatalogAuthID = `
+CREATE TABLE pg_catalog.pg_authid (
+  oid OID,
+  rolname NAME,
+  rolsuper BOOL,
+  rolinherit BOOL,
+  rolcreaterole BOOL,
+  rolcreatedb BOOL,
+  rolcanlogin BOOL,
+  rolreplication BOOL,
+  rolbypassrls BOOL,
+  rolconnlimit INT4,
+  rolpassword TEXT, 
+  rolvaliduntil TIMESTAMPTZ
+)`
+
+// PGCatalogAuthMembers describes the schema of the pg_catalog.pg_auth_members
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html,
+const PGCatalogAuthMembers = `
+CREATE TABLE pg_catalog.pg_auth_members (
+	roleid OID,
+	member OID,
+	grantor OID,
+	admin_option BOOL
+)`
+
+// PGCatalogAvailableExtensions describes the schema of the
+// pg_catalog.pg_available_extensions table.
+// https://www.postgresql.org/docs/9.6/view-pg-available-extensions.html,
+const PGCatalogAvailableExtensions = `
+CREATE TABLE pg_catalog.pg_available_extensions (
+	name NAME,
+	default_version TEXT,
+	installed_version TEXT,
+	comment TEXT
+)`
+
+// PGCatalogClass describes the schema of the pg_catalog.pg_class table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-class.html,
+const PGCatalogClass = `
+CREATE TABLE pg_catalog.pg_class (
+	oid OID NOT NULL,
+	relname NAME NOT NULL,
+	relnamespace OID,
+	reltype OID,
+	reloftype OID,
+	relowner OID,
+	relam OID,
+	relfilenode OID,
+	reltablespace OID,
+	relpages INT4,
+	reltuples FLOAT4,
+	relallvisible INT4,
+	reltoastrelid OID,
+	relhasindex BOOL,
+	relisshared BOOL,
+	relpersistence CHAR,
+	relistemp BOOL,
+	relkind CHAR,
+	relnatts INT2,
+	relchecks INT2,
+	relhasoids BOOL,
+	relhaspkey BOOL,
+	relhasrules BOOL,
+	relhastriggers BOOL,
+	relhassubclass BOOL,
+	relfrozenxid INT,
+	relacl STRING[],
+	reloptions STRING[],
+  INDEX (oid)
+)`
+
+// PGCatalogCollation describes the schema of the pg_catalog.pg_collation table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-collation.html,
+const PGCatalogCollation = `
+CREATE TABLE pg_catalog.pg_collation (
+  oid OID,
+  collname STRING,
+  collnamespace OID,
+  collowner OID,
+  collencoding INT4,
+  collcollate STRING,
+  collctype STRING
+)`
+
+// PGCatalogConstraint describes the schema of the pg_catalog.pg_constraint
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-constraint.html,
+const PGCatalogConstraint = `
+CREATE TABLE pg_catalog.pg_constraint (
+	oid OID,
+	conname NAME,
+	connamespace OID,
+	contype STRING,
+	condeferrable BOOL,
+	condeferred BOOL,
+	convalidated BOOL,
+	conrelid OID NOT NULL,
+	contypid OID,
+	conindid OID,
+	confrelid OID,
+	confupdtype STRING,
+	confdeltype STRING,
+	confmatchtype STRING,
+	conislocal BOOL,
+	coninhcount INT4,
+	connoinherit BOOL,
+	conkey INT2[],
+	confkey INT2[],
+	conpfeqop OID[],
+	conppeqop OID[],
+	conffeqop OID[],
+	conexclop OID[],
+	conbin STRING,
+	consrc STRING,
+	-- condef is a CockroachDB extension that provides a SHOW CREATE CONSTRAINT
+	-- style string, for use by pg_get_constraintdef().
+	condef STRING,
+  INDEX (conrelid)
+)`
+
+// PGCatalogConversion describes the schema of the pg_catalog.pg_conversion
+// table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-conversion.html,
+const PGCatalogConversion = `
+CREATE TABLE pg_catalog.pg_conversion (
+	oid OID,
+	conname NAME,
+	connamespace OID,
+	conowner OID,
+	conforencoding INT4,
+	contoencoding INT4,
+	conproc OID,
+	condefault BOOL
+)`
+
+// PGCatalogDatabase describes the schema of the pg_catalog.pg_database table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-database.html,
+const PGCatalogDatabase = `
+CREATE TABLE pg_catalog.pg_database (
+	oid OID,
+	datname Name,
+	datdba OID,
+	encoding INT4,
+	datcollate STRING,
+	datctype STRING,
+	datistemplate BOOL,
+	datallowconn BOOL,
+	datconnlimit INT4,
+	datlastsysoid OID,
+	datfrozenxid INT,
+	datminmxid INT,
+	dattablespace OID,
+	datacl STRING[]
+)`
+
+// PGCatalogDefaultACL describes the schema of the pg_catalog.pg_default_acl
+// table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-default-acl.html,
+const PGCatalogDefaultACL = `
+CREATE TABLE pg_catalog.pg_default_acl (
+	oid OID,
+	defaclrole OID,
+	defaclnamespace OID,
+	defaclobjtype CHAR,
+	defaclacl STRING[]
+)`
+
+// PGCatalogDepend describes the schema of the pg_catalog.pg_depend table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-depend.html,
+const PGCatalogDepend = `
+CREATE TABLE pg_catalog.pg_depend (
+  classid OID,
+  objid OID,
+  objsubid INT4,
+  refclassid OID,
+  refobjid OID,
+  refobjsubid INT4,
+  deptype CHAR
+)`
+
+// PGCatalogDescription describes the schema of the pg_catalog.pg_description
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-description.html,
+const PGCatalogDescription = `
+CREATE TABLE pg_catalog.pg_description (
+	objoid OID,
+	classoid OID,
+	objsubid INT4,
+	description STRING
+)`
+
+// PGCatalogSharedDescription describes the schema of the
+// pg_catalog.pg_shdescription table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-shdescription.html,
+const PGCatalogSharedDescription = `
+CREATE TABLE pg_catalog.pg_shdescription (
+	objoid OID,
+	classoid OID,
+	description STRING
+)`
+
+// PGCatalogEnum describes the schema of the pg_catalog.pg_enum table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-enum.html,
+const PGCatalogEnum = `
+CREATE TABLE pg_catalog.pg_enum (
+  oid OID,
+  enumtypid OID,
+  enumsortorder FLOAT4,
+  enumlabel STRING
+)`
+
+// PGCatalogEventTrigger describes the schema of the pg_catalog.pg_event_trigger
+// table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-event-trigger.html,
+const PGCatalogEventTrigger = `
+CREATE TABLE pg_catalog.pg_event_trigger (
+	evtname NAME,
+	evtevent NAME,
+	evtowner OID,
+	evtfoid OID,
+	evtenabled CHAR,
+	evttags TEXT[]
+)`
+
+// PGCatalogExtension describes the schema of the pg_catalog.pg_extension table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-extension.html,
+const PGCatalogExtension = `
+CREATE TABLE pg_catalog.pg_extension (
+  oid OID,
+  extname NAME,
+  extowner OID,
+  extnamespace OID,
+  extrelocatable BOOL,
+  extversion STRING,
+  extconfig STRING,
+  extcondition STRING
+)`
+
+// PGCatalogForeignDataWrapper describes the schema of the
+// pg_catalog.pg_foreign_data_wrapper table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-foreign-data-wrapper.html,
+const PGCatalogForeignDataWrapper = `
+CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
+  oid OID,
+  fdwname NAME,
+  fdwowner OID,
+  fdwhandler OID,
+  fdwvalidator OID,
+  fdwacl STRING[],
+  fdwoptions STRING[]
+)`
+
+// PGCatalogForeignServer describes the schema of the
+// pg_catalog.pg_foreign_server table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-foreign-server.html,
+const PGCatalogForeignServer = `
+CREATE TABLE pg_catalog.pg_foreign_server (
+  oid OID,
+  srvname NAME,
+  srvowner OID,
+  srvfdw OID,
+  srvtype STRING,
+  srvversion STRING,
+  srvacl STRING[],
+  srvoptions STRING[]
+)`
+
+// PGCatalogForeignTable describes the schema of the pg_catalog.pg_foreign_table
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-foreign-table.html,
+const PGCatalogForeignTable = `
+CREATE TABLE pg_catalog.pg_foreign_table (
+  ftrelid OID,
+  ftserver OID,
+  ftoptions STRING[]
+)`
+
+// PGCatalogIndex describes the schema of the pg_catalog.pg_index table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-index.html,
+const PGCatalogIndex = `
+CREATE TABLE pg_catalog.pg_index (
+    indexrelid OID,
+    indrelid OID,
+    indnatts INT2,
+    indisunique BOOL,
+    indisprimary BOOL,
+    indisexclusion BOOL,
+    indimmediate BOOL,
+    indisclustered BOOL,
+    indisvalid BOOL,
+    indcheckxmin BOOL,
+    indisready BOOL,
+    indislive BOOL,
+    indisreplident BOOL,
+    indkey INT2VECTOR,
+    indcollation OIDVECTOR,
+    indclass OIDVECTOR,
+    indoption INT2VECTOR,
+    indexprs STRING,
+    indpred STRING
+)`
+
+// PGCatalogIndexes describes the schema of the pg_catalog.pg_indexes table.
+// https://www.postgresql.org/docs/9.5/view-pg-indexes.html,
+// Note: crdb_oid is an extension of the schema to much more easily map
+// index OIDs to the corresponding index definition.
+const PGCatalogIndexes = `
+CREATE TABLE pg_catalog.pg_indexes (
+	crdb_oid OID,
+	schemaname NAME,
+	tablename NAME,
+	indexname NAME,
+	tablespace NAME,
+	indexdef STRING
+)`
+
+// PGCatalogInherits describes the schema of the pg_catalog.pg_inherits table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-inherits.html,
+const PGCatalogInherits = `
+CREATE TABLE pg_catalog.pg_inherits (
+	inhrelid OID,
+	inhparent OID,
+	inhseqno INT4
+)`
+
+// PGCatalogLanguage describes the schema of the pg_catalog.pg_language table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-language.html,
+const PGCatalogLanguage = `
+CREATE TABLE pg_catalog.pg_language (
+	oid OID,
+	lanname NAME,
+	lanowner OID,
+	lanispl BOOL,
+	lanpltrusted BOOL,
+	lanplcallfoid OID,
+	laninline OID,
+	lanvalidator OID,
+	lanacl STRING[]
+)`
+
+// PGCatalogLocks describes the schema of the pg_catalog.pg_locks table.
+// https://www.postgresql.org/docs/9.6/view-pg-locks.html,
+const PGCatalogLocks = `
+CREATE TABLE pg_catalog.pg_locks (
+  locktype TEXT,
+  database OID,
+  relation OID,
+  page INT4,
+  tuple SMALLINT,
+  virtualxid TEXT,
+  transactionid INT,
+  classid OID,
+  objid OID,
+  objsubid SMALLINT,
+  virtualtransaction TEXT,
+  pid INT4,
+  mode TEXT,
+  granted BOOLEAN,
+  fastpath BOOLEAN
+)`
+
+// PGCatalogMatViews describes the schema of the pg_catalog.pg_matviews table.
+// https://www.postgresql.org/docs/9.6/view-pg-matviews.html,
+const PGCatalogMatViews = `
+CREATE TABLE pg_catalog.pg_matviews (
+  schemaname NAME,
+  matviewname NAME,
+  matviewowner NAME,
+  tablespace NAME,
+  hasindexes BOOL,
+  ispopulated BOOL,
+  definition TEXT
+)`
+
+// PGCatalogNamespace describes the schema of the pg_catalog.pg_namespace table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html,
+const PGCatalogNamespace = `
+CREATE TABLE pg_catalog.pg_namespace (
+	oid OID,
+	nspname NAME NOT NULL,
+	nspowner OID,
+	nspacl STRING[]
+)`
+
+// PGCatalogOperator describes the schema of the pg_catalog.pg_operator table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-operator.html,
+const PGCatalogOperator = `
+CREATE TABLE pg_catalog.pg_operator (
+	oid OID,
+	oprname NAME,
+	oprnamespace OID,
+	oprowner OID,
+	oprkind TEXT,
+	oprcanmerge BOOL,
+	oprcanhash BOOL,
+	oprleft OID,
+	oprright OID,
+	oprresult OID,
+	oprcom OID,
+	oprnegate OID,
+	oprcode OID,
+	oprrest OID,
+	oprjoin OID
+)`
+
+// PGCatalogPreparedXacts describes the schema of the
+// pg_catalog.pg_prepared_xacts table.
+// https://www.postgresql.org/docs/9.6/view-pg-prepared-xacts.html,
+const PGCatalogPreparedXacts = `
+CREATE TABLE pg_catalog.pg_prepared_xacts (
+  transaction INTEGER,
+  gid TEXT,
+  prepared TIMESTAMP WITH TIME ZONE,
+  owner NAME,
+  database NAME
+)`
+
+// PGCatalogPreparedStatements describes the schema of the
+// pg_catalog.pg_prepared_statements table.
+// The statement field differs in that it uses the parsed version
+// of the PREPARE statement.
+// The parameter_types field differs from Postgres as the type names in
+// CockroachDB are slightly different.
+// https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html,
+const PGCatalogPreparedStatements = `
+CREATE TABLE pg_catalog.pg_prepared_statements (
+	name TEXT,
+	statement TEXT,
+	prepare_time TIMESTAMPTZ,
+	parameter_types REGTYPE[],
+	from_sql boolean
+)`
+
+// PGCatalogProc describes the schema of the pg_catalog.pg_proc table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-proc.html,
+const PGCatalogProc = `
+CREATE TABLE pg_catalog.pg_proc (
+	oid OID,
+	proname NAME,
+	pronamespace OID,
+	proowner OID,
+	prolang OID,
+	procost FLOAT4,
+	prorows FLOAT4,
+	provariadic OID,
+	protransform STRING,
+	proisagg BOOL,
+	proiswindow BOOL,
+	prosecdef BOOL,
+	proleakproof BOOL,
+	proisstrict BOOL,
+	proretset BOOL,
+	provolatile CHAR,
+	proparallel CHAR,
+	pronargs INT2,
+	pronargdefaults INT2,
+	prorettype OID,
+	proargtypes OIDVECTOR,
+	proallargtypes OID[],
+	proargmodes STRING[],
+	proargnames STRING[],
+	proargdefaults STRING,
+	protrftypes OID[],
+	prosrc STRING,
+	probin STRING,
+	proconfig STRING[],
+	proacl STRING[]
+)`
+
+// PGCatalogRange describes the schema of the pg_catalog.pg_range table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-range.html,
+const PGCatalogRange = `
+CREATE TABLE pg_catalog.pg_range (
+	rngtypid OID,
+	rngsubtype OID,
+	rngcollation OID,
+	rngsubopc OID,
+	rngcanonical OID,
+	rngsubdiff OID
+)`
+
+// PGCatalogRewrite describes the schema of the pg_catalog.pg_rewrite table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-rewrite.html,
+const PGCatalogRewrite = `
+CREATE TABLE pg_catalog.pg_rewrite (
+	oid OID,
+	rulename NAME,
+	ev_class OID,
+	ev_type TEXT,
+	ev_enabled TEXT,
+	is_instead BOOL,
+	ev_qual TEXT,
+	ev_action TEXT
+)`
+
+// PGCatalogRoles describes the schema of the pg_catalog.pg_roles table.
+// https://www.postgresql.org/docs/9.5/view-pg-roles.html,
+const PGCatalogRoles = `
+CREATE TABLE pg_catalog.pg_roles (
+	oid OID,
+	rolname NAME,
+	rolsuper BOOL,
+	rolinherit BOOL,
+	rolcreaterole BOOL,
+	rolcreatedb BOOL,
+	rolcatupdate BOOL,
+	rolcanlogin BOOL,
+	rolreplication BOOL,
+	rolconnlimit INT4,
+	rolpassword STRING,
+	rolvaliduntil TIMESTAMPTZ,
+	rolbypassrls BOOL,
+	rolconfig STRING[]
+)`
+
+// PGCatalogSecLabels describes the schema of the pg_catalog.pg_seclabels table.
+// https://www.postgresql.org/docs/9.6/view-pg-seclabels.html,
+const PGCatalogSecLabels = `
+CREATE TABLE pg_catalog.pg_seclabels (
+	objoid OID,
+  classoid OID,
+  objsubid INT4,
+  objtype TEXT,
+	objnamespace OID,
+	objname TEXT,
+	provider TEXT,
+	label TEXT
+)`
+
+// PGCatalogSequence describes the schema of the pg_catalog.pg_sequence table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-sequence.html,
+const PGCatalogSequence = `
+CREATE TABLE pg_catalog.pg_sequence (
+	seqrelid OID,
+	seqtypid OID,
+	seqstart INT8,
+	seqincrement INT8,
+	seqmax INT8,
+	seqmin INT8,
+	seqcache INT8,
+	seqcycle BOOL
+)`
+
+// PGCatalogSettings describes the schema of the pg_catalog.pg_settings table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-settings.html,
+const PGCatalogSettings = `
+CREATE TABLE pg_catalog.pg_settings (
+    name STRING,
+    setting STRING,
+    unit STRING,
+    category STRING,
+    short_desc STRING,
+    extra_desc STRING,
+    context STRING,
+    vartype STRING,
+    source STRING,
+    min_val STRING,
+    max_val STRING,
+    enumvals STRING,
+    boot_val STRING,
+    reset_val STRING,
+    sourcefile STRING,
+    sourceline INT4,
+    pending_restart BOOL
+)`
+
+// PGCatalogShdepend describes the schema of the pg_catalog.pg_shdepend table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html,
+const PGCatalogShdepend = `
+CREATE TABLE pg_catalog.pg_shdepend (
+	dbid OID,
+	classid OID,
+	objid OID,
+  objsubid INT4,
+	refclassid OID,
+	refobjid OID,
+	deptype CHAR
+)`
+
+// PGCatalogTables describes the schema of the pg_catalog.pg_tables table.
+// https://www.postgresql.org/docs/9.5/view-pg-tables.html,
+const PGCatalogTables = `
+CREATE TABLE pg_catalog.pg_tables (
+	schemaname NAME,
+	tablename NAME,
+	tableowner NAME,
+	tablespace NAME,
+	hasindexes BOOL,
+	hasrules BOOL,
+	hastriggers BOOL,
+	rowsecurity BOOL
+)`
+
+// PGCatalogTablespace describes the schema of the pg_catalog.pg_tablespace
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-tablespace.html,
+const PGCatalogTablespace = `
+CREATE TABLE pg_catalog.pg_tablespace (
+	oid OID,
+	spcname NAME,
+	spcowner OID,
+	spclocation TEXT,
+	spcacl TEXT[],
+	spcoptions TEXT[]
+)`
+
+// PGCatalogTrigger describes the schema of the pg_catalog.pg_trigger table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-trigger.html,
+const PGCatalogTrigger = `
+CREATE TABLE pg_catalog.pg_trigger (
+	oid OID,
+	tgrelid OID,
+	tgname NAME,
+	tgfoid OID,
+	tgtype INT2,
+	tgenabled TEXT,
+	tgisinternal BOOL,
+	tgconstrrelid OID,
+	tgconstrindid OID,
+	tgconstraint OID,
+	tgdeferrable BOOL,
+	tginitdeferred BOOL,
+	tgnargs INT2,
+	tgattr INT2VECTOR,
+	tgargs BYTEA,
+	tgqual TEXT,
+	tgoldtable NAME,
+	tgnewtable NAME
+)`
+
+// PGCatalogType describes the schema of the pg_catalog.pg_type table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-type.html,
+const PGCatalogType = `
+CREATE TABLE pg_catalog.pg_type (
+	oid OID NOT NULL,
+	typname NAME NOT NULL,
+	typnamespace OID,
+	typowner OID,
+	typlen INT2,
+	typbyval BOOL,
+	typtype CHAR,
+	typcategory CHAR,
+	typispreferred BOOL,
+	typisdefined BOOL,
+	typdelim CHAR,
+	typrelid OID,
+	typelem OID,
+	typarray OID,
+	typinput REGPROC,
+	typoutput REGPROC,
+	typreceive REGPROC,
+	typsend REGPROC,
+	typmodin REGPROC,
+	typmodout REGPROC,
+	typanalyze REGPROC,
+	typalign CHAR,
+	typstorage CHAR,
+	typnotnull BOOL,
+	typbasetype OID,
+	typtypmod INT4,
+	typndims INT4,
+	typcollation OID,
+	typdefaultbin STRING,
+	typdefault STRING,
+	typacl STRING[],
+  INDEX(oid)
+)`
+
+// PGCatalogUser describes the schema of the pg_catalog.pg_user table.
+// https://www.postgresql.org/docs/9.5/view-pg-user.html,
+const PGCatalogUser = `
+CREATE TABLE pg_catalog.pg_user (
+	usename NAME,
+	usesysid OID,
+	usecreatedb BOOL,
+	usesuper BOOL,
+	userepl  BOOL,
+	usebypassrls BOOL,
+	passwd TEXT,
+	valuntil TIMESTAMP,
+	useconfig TEXT[]
+)`
+
+// PGCatalogUserMapping describes the schema of the pg_catalog.pg_user_mapping
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-user-mapping.html,
+const PGCatalogUserMapping = `
+CREATE TABLE pg_catalog.pg_user_mapping (
+	oid OID,
+	umuser OID,
+	umserver OID,
+	umoptions TEXT[]
+)`
+
+// PGCatalogStatActivity describes the schema of the pg_catalog.pg_stat_activity
+// table.
+// https://www.postgresql.org/docs/9.6/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW,
+const PGCatalogStatActivity = `
+CREATE TABLE pg_catalog.pg_stat_activity (
+	datid OID,
+	datname NAME,
+	pid INTEGER,
+	usesysid OID,
+	usename NAME,
+	application_name TEXT,
+	client_addr INET,
+	client_hostname TEXT,
+	client_port INTEGER,
+	backend_start TIMESTAMPTZ,
+	xact_start TIMESTAMPTZ,
+	query_start TIMESTAMPTZ,
+	state_change TIMESTAMPTZ,
+	wait_event_type TEXT,
+	wait_event TEXT,
+	state TEXT,
+	backend_xid INTEGER,
+	backend_xmin INTEGER,
+	query TEXT
+)`
+
+// PGCatalogSecurityLabel describes the schema of the pg_catalog.pg_seclabel
+// table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-seclabel.html,
+const PGCatalogSecurityLabel = `
+CREATE TABLE pg_catalog.pg_seclabel (
+	objoid OID,
+	classoid OID,
+	objsubid INTEGER,
+	provider TEXT,
+	label TEXT
+)`
+
+// PGCatalogSharedSecurityLabel describes the schema of the
+// pg_catalog.pg_shseclabel table.
+// https://www.postgresql.org/docs/9.5/catalog-pg-shseclabel.html,
+const PGCatalogSharedSecurityLabel = `
+CREATE TABLE pg_catalog.pg_shseclabel (
+	objoid OID,
+	classoid OID,
+	provider TEXT,
+	label TEXT
+)`
+
+// PGCatalogViews describes the schema of the pg_catalog.pg_views table.
+// https://www.postgresql.org/docs/9.5/view-pg-views.html,
+const PGCatalogViews = `
+CREATE TABLE pg_catalog.pg_views (
+	schemaname NAME,
+	viewname NAME,
+	viewowner NAME,
+	definition STRING
+)`
+
+// PGCatalogAggregate describes the schema of the pg_catalog.pg_aggregate table.
+// https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html,
+const PGCatalogAggregate = `
+CREATE TABLE pg_catalog.pg_aggregate (
+	aggfnoid REGPROC,
+	aggkind  CHAR,
+	aggnumdirectargs INT2,
+	aggtransfn REGPROC,
+	aggfinalfn REGPROC,
+	aggcombinefn REGPROC,
+	aggserialfn REGPROC,
+	aggdeserialfn REGPROC,
+	aggmtransfn REGPROC,
+	aggminvtransfn REGPROC,
+	aggmfinalfn REGPROC,
+	aggfinalextra BOOL,
+	aggmfinalextra BOOL,
+	aggsortop OID,
+	aggtranstype OID,
+	aggtransspace INT4,
+	aggmtranstype OID,
+	aggmtransspace INT4,
+	agginitval TEXT,
+	aggminitval TEXT
+)`


### PR DESCRIPTION
This commit adds a cost equal to `10*randIOCostFactor` for each virtual
scan in order to represent the cost of fetching table descriptors.
This cost is especially important when perfoming lookup joins, because
the descriptors may need to be fetched on each lookup. As a result of
this change, the optimizer is much less likely to plan a lookup join
into a virtual table.

Fixes #55140

Release note (performance improvement): Adjusted the cost model in
the optimizer so that the optimizer is less likely to plan a lookup
join into a virtual table. Performing a lookup join into a virtual
table is expensive, so this change will generally result in better
performance for queries involving joins with virtual tables.