### PR TITLE
opt: build constraints for multi-column inverted indexes

### DIFF
--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -122,6 +122,13 @@ type Index interface {
 	// columns is data-dependent, not schema-dependent.
 	LaxKeyColumnCount() int
 
+	// NonInvertedPrefixColumnCount returns the number of non-inverted columns
+	// in the inverted index. An inverted index only has non-inverted columns if
+	// it is a multi-column inverted index. Therefore, a non-zero value is only
+	// returned for multi-column inverted indexes. This function panics if the
+	// index is not an inverted index.
+	NonInvertedPrefixColumnCount() int
+
 	// Column returns the ith IndexColumn within the index definition, where
 	// i < ColumnCount.
 	Column(i int) IndexColumn

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
+        "//pkg/sql/opt/constraint",
+        "//pkg/sql/opt/idxconstraint",
         "//pkg/sql/opt/invertedexpr",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -504,8 +504,8 @@ func TestTryConstrainGeoIndex(t *testing.T) {
 		// We're not testing that the correct SpanExpression is returned here;
 		// that is tested elsewhere. This is just testing that we are constraining
 		// the index when we expect to.
-		_, pfState, ok := invertedidx.TryConstrainGeoIndex(
-			evalCtx.Context, &f, filters, tab, md.Table(tab).Index(tc.indexOrd),
+		_, _, _, pfState, ok := invertedidx.TryConstrainGeoIndex(
+			evalCtx, &f, filters, tab, md.Table(tab).Index(tc.indexOrd),
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -381,7 +381,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if ic := t.InvertedConstraint; ic != nil {
 			idx := md.Table(t.Table).Index(t.Index)
 			var b strings.Builder
-			for i := 0; i < idx.KeyColumnCount(); i++ {
+			for i := idx.NonInvertedPrefixColumnCount(); i < idx.KeyColumnCount(); i++ {
 				b.WriteRune('/')
 				b.WriteString(fmt.Sprintf("%d", t.Table.ColumnID(idx.Column(i).Ordinal())))
 			}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -800,7 +800,7 @@ func (sb *statisticsBuilder) invertedConstrainScan(
 	idx := sb.md.Table(scan.Table).Index(scan.Index)
 	// The constrained column is the first (and only) column in the inverted
 	// index. Using scan.Cols here would also include the PK, which we don't want.
-	constrainedCols.Add(scan.Table.ColumnID(idx.Column(0).Ordinal()))
+	constrainedCols.Add(scan.Table.ColumnID(idx.VirtualInvertedColumn().Ordinal()))
 	if sb.shouldUseHistogram(relProps, constrainedCols) {
 		constrainedCols.ForEach(func(col opt.ColumnID) {
 			colSet := opt.MakeColSet(col)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -50,7 +50,8 @@ define ScanPrivate {
     Cols ColSet
 
     # If set, the scan is a constrained scan; the constraint contains the spans
-    # that need to be scanned.
+    # that need to be scanned. If InvertedConstraint is also set, Constraint
+    # contains non-ranging spans that constrain the non-inverted prefix columns.
     Constraint Constraint
 
     # If set, the scan is a constrained scan of an inverted index; the

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -817,6 +817,14 @@ func (ti *Index) LaxKeyColumnCount() int {
 	return ti.LaxKeyCount
 }
 
+// NonInvertedPrefixColumnCount is part of the cat.Index interface.
+func (ti *Index) NonInvertedPrefixColumnCount() int {
+	if !ti.IsInverted() {
+		panic("not supported for non-inverted indexes")
+	}
+	return ti.invertedOrd
+}
+
 // Column is part of the cat.Index interface.
 func (ti *Index) Column(i int) cat.IndexColumn {
 	return ti.Columns[i]

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -131,7 +131,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 		col := index.Column(i)
 		ordinal := col.Ordinal()
 		nullable := col.IsNullable()
-		if isInverted && i == 0 {
+		if isInverted && col == index.VirtualInvertedColumn() {
 			// We pass the real column to the index constraint generator (instead of
 			// the virtual column).
 			// TODO(radu): improve the inverted index constraint generator to handle

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2958,6 +2958,253 @@ project
       ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
       └── key: (1)
 
+# Tests for multi-column inverted indexes.
+
+exec-ddl
+CREATE TABLE m (
+  k INT PRIMARY KEY,
+  a STRING,
+  b STRING,
+  geom GEOMETRY,
+  INVERTED INDEX multicol (a, geom)
+)
+----
+
+# Constrain a single prefix column to one value.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3,4)
+ ├── index-join m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         ├── key: (1)
+ │         └── scan m@multicol
+ │              ├── columns: k:1!null geom_inverted_key:6!null
+ │              ├── constraint: /2: [/'foo' - /'foo']
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Constrain a single prefix column to multiple point values.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a IN ('foo', 'bar') AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── index-join m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         ├── key: (1)
+ │         └── scan m@multicol
+ │              ├── columns: k:1!null geom_inverted_key:6!null
+ │              ├── constraint: /2
+ │              │    ├── [/'bar' - /'bar']
+ │              │    └── [/'foo' - /'foo']
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Do not generate an inverted index scan when a single prefix column is
+# constrained to a range.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a > 'x' AND a < 'y' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── (a:2 > 'x') AND (a:2 < 'y') [outer=(2), constraints=(/2: [/e'x\x00' - /'y'); tight)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+exec-ddl
+DROP INDEX multicol
+----
+
+exec-ddl
+CREATE INVERTED INDEX multicol ON m (a, b, geom)
+----
+
+# Constrain multiple prefix columns to one value.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a = 'foo' AND b = 'bar' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4)
+ ├── index-join m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /7
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         ├── key: (1)
+ │         └── scan m@multicol
+ │              ├── columns: k:1!null geom_inverted_key:7!null
+ │              ├── constraint: /2/3: [/'foo'/'bar' - /'foo'/'bar']
+ │              ├── inverted constraint: /7/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(7)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Constrain multiple prefix columns to multiple point values.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a IN ('foo', 'bar') AND b IN ('baz', 'bob') AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── index-join m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /7
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         ├── key: (1)
+ │         └── scan m@multicol
+ │              ├── columns: k:1!null geom_inverted_key:7!null
+ │              ├── constraint: /2/3
+ │              │    ├── [/'bar'/'baz' - /'bar'/'baz']
+ │              │    ├── [/'bar'/'bob' - /'bar'/'bob']
+ │              │    ├── [/'foo'/'baz' - /'foo'/'baz']
+ │              │    └── [/'foo'/'bob' - /'foo'/'bob']
+ │              ├── inverted constraint: /7/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(7)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+
+# Do not generate an inverted index scan when the first prefix column is
+# constrained to a range.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a > 'x' AND a < 'y' AND b = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── (a:2 > 'x') AND (a:2 < 'y') [outer=(2), constraints=(/2: [/e'x\x00' - /'y'); tight)]
+      ├── b:3 = 'foo' [outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Do not generate an inverted index scan when the second prefix column is
+# constrained to a range.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a = 'foo' AND b > 'x' AND b < 'y' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3,4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── (b:3 > 'x') AND (b:3 < 'y') [outer=(3), constraints=(/3: [/e'x\x00' - /'y'); tight)]
+      ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Do not generate an inverted index scan when neither prefix column is constrained.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2 b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
 # --------------------------------------------------
 # GenerateZigzagJoins
 # --------------------------------------------------

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1174,6 +1174,14 @@ func (oi *optIndex) LaxKeyColumnCount() int {
 	return oi.numLaxKeyCols
 }
 
+// NonInvertedPrefixColumnCount is part of the cat.Index interface.
+func (oi *optIndex) NonInvertedPrefixColumnCount() int {
+	if !oi.IsInverted() {
+		panic("non-inverted indexes do not have inverted prefix columns")
+	}
+	return len(oi.desc.ColumnIDs) - 1
+}
+
 // Column is part of the cat.Index interface.
 func (oi *optIndex) Column(i int) cat.IndexColumn {
 	length := len(oi.desc.ColumnIDs)
@@ -1851,6 +1859,11 @@ func (oi *optVirtualIndex) LaxKeyColumnCount() int {
 	return 2
 }
 
+// NonInvertedPrefixColumnCount is part of the cat.Index interface.
+func (oi *optVirtualIndex) NonInvertedPrefixColumnCount() int {
+	panic("virtual indexes are not inverted")
+}
+
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optVirtualTable) lookupColumnOrdinal(colID descpb.ColumnID) (int, error) {
@@ -1887,7 +1900,7 @@ func (oi *optVirtualIndex) Column(i int) cat.IndexColumn {
 
 // VirtualInvertedColumn is part of the cat.Index interface.
 func (oi *optVirtualIndex) VirtualInvertedColumn() cat.IndexColumn {
-	panic("virtual indexes do not have inverted virtual columns")
+	panic("virtual indexes are not inverted")
 }
 
 // Predicate is part of the cat.Index interface.


### PR DESCRIPTION
opt: build constraints for multi-column inverted indexes

This commit builds constraints for multi-column inverted indexes. A
multi-column inverted index is constrained by both a Constraint and an
InvertedConstraint. The Constraint constrains the scalar columns that
precede the virtual inverted column to a single value. The
InvertedConstraint constrains the virtual inverted column.

Note that this commit only builds the constraints. Future work will
combine them into a single set of `roachpb.Spans`.

Release note: None
