### PR TITLE
roachpb: track a few auto-generated files as binary files

### DIFF
--- a/pkg/roachpb/.gitattributes
+++ b/pkg/roachpb/.gitattributes
@@ -1,0 +1,2 @@
+batch_generated.go -diff
+*_string.go -diff


### PR DESCRIPTION
Makes the `git` invocations a bit more useful.

Release note: None