### PR TITLE
importccl: compute expected number of data columns only once

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -3728,8 +3728,8 @@ func TestImportComputed(t *testing.T) {
 	}
 	avroData := createAvroData(t, "t", avroField, avroRows)
 	pgdumpData := `
-CREATE TABLE users (a INT, b INT, c INT AS (a + b) STORED);
-INSERT INTO users (a, b) VALUES (1, 2), (3, 4);
+CREATE TABLE users (a INT, b INT, c INT AS (a + b) STORED);		
+INSERT INTO users (a, b) VALUES (1, 2), (3, 4);		
 `
 	defer srv.Close()
 	tests := []struct {
@@ -3793,18 +3793,16 @@ INSERT INTO users (a, b) VALUES (1, 2), (3, 4);
 			name:          "import-table-csv",
 			data:          "35,23\n67,10",
 			create:        "a INT, c INT AS (a + b) STORED, b INT",
-			targetCols:    "a, b",
 			format:        "CSV",
-			expectedError: "requires targeted column specification",
+			expectedError: "to use computed columns, use IMPORT INTO",
 		},
 		{
 			into:            false,
 			name:            "import-table-avro",
 			data:            avroData,
-			create:          "a INT, b INT, c INT AS (a + b) STORED",
-			targetCols:      "a, b",
+			create:          "a INT, c INT AS (a + b) STORED, b INT",
 			format:          "AVRO",
-			expectedResults: [][]string{{"1", "2", "3"}, {"3", "4", "7"}},
+			expectedResults: [][]string{{"1", "3", "2"}, {"3", "7", "4"}},
 		},
 		{
 			into:            false,

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -345,6 +345,18 @@ type inputConverter interface {
 		format roachpb.IOFileFormat, makeExternalStorage cloud.ExternalStorageFactory, user string) error
 }
 
+// formatHasNamedColumns returns true if the data in the input files can be
+// mapped specifically to a particular data column.
+func formatHasNamedColumns(format roachpb.IOFileFormat_FileFormat) bool {
+	switch format {
+	case roachpb.IOFileFormat_Avro,
+		roachpb.IOFileFormat_Mysqldump,
+		roachpb.IOFileFormat_PgDump:
+		return true
+	}
+	return false
+}
+
 func isMultiTableFormat(format roachpb.IOFileFormat_FileFormat) bool {
 	switch format {
 	case roachpb.IOFileFormat_Mysqldump,

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -26,7 +26,9 @@ import (
 
 type csvInputReader struct {
 	importCtx *parallelImportContext
-	opts      roachpb.CSVOptions
+	// The number of columns that we expect in the CSV data file.
+	numExpectedDataCols int
+	opts                roachpb.CSVOptions
 }
 
 var _ inputConverter = &csvInputReader{}
@@ -40,6 +42,10 @@ func newCSVInputReader(
 	targetCols tree.NameList,
 	evalCtx *tree.EvalContext,
 ) *csvInputReader {
+	numExpectedDataCols := len(targetCols)
+	if numExpectedDataCols == 0 {
+		numExpectedDataCols = len(tableDesc.VisibleColumns())
+	}
 	return &csvInputReader{
 		importCtx: &parallelImportContext{
 			walltime:   walltime,
@@ -49,7 +55,8 @@ func newCSVInputReader(
 			targetCols: targetCols,
 			kvCh:       kvCh,
 		},
-		opts: opts,
+		numExpectedDataCols: numExpectedDataCols,
+		opts:                opts,
 	}
 }
 
@@ -86,14 +93,14 @@ func (c *csvInputReader) readFile(
 }
 
 type csvRowProducer struct {
-	importCtx       *parallelImportContext
-	opts            *roachpb.CSVOptions
-	csv             *csv.Reader
-	rowNum          int64
-	err             error
-	record          []string
-	progress        func() float32
-	expectedColumns tree.NameList
+	importCtx          *parallelImportContext
+	opts               *roachpb.CSVOptions
+	csv                *csv.Reader
+	rowNum             int64
+	err                error
+	record             []string
+	progress           func() float32
+	numExpectedColumns int
 }
 
 var _ importRowProducer = &csvRowProducer{}
@@ -132,10 +139,7 @@ func strRecord(record []string, sep rune) string {
 // Row() implements importRowProducer interface.
 func (p *csvRowProducer) Row() (interface{}, error) {
 	p.rowNum++
-	expectedColsLen := len(p.expectedColumns)
-	if expectedColsLen == 0 {
-		expectedColsLen = len(p.importCtx.tableDesc.VisibleColumns())
-	}
+	expectedColsLen := p.numExpectedColumns
 
 	if len(p.record) == expectedColsLen {
 		// Expected number of columns.
@@ -207,11 +211,11 @@ func newCSVPipeline(c *csvInputReader, input *fileReader) (*csvRowProducer, *csv
 	cr.Comment = c.opts.Comment
 
 	producer := &csvRowProducer{
-		importCtx:       c.importCtx,
-		opts:            &c.opts,
-		csv:             cr,
-		progress:        func() float32 { return input.ReadFraction() },
-		expectedColumns: c.importCtx.targetCols,
+		importCtx:          c.importCtx,
+		opts:               &c.opts,
+		csv:                cr,
+		progress:           func() float32 { return input.ReadFraction() },
+		numExpectedColumns: c.numExpectedDataCols,
 	}
 	consumer := &csvRowConsumer{
 		importCtx: c.importCtx,

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -134,15 +134,6 @@ func (p *csvRowProducer) Row() (interface{}, error) {
 	p.rowNum++
 	expectedColsLen := len(p.expectedColumns)
 	if expectedColsLen == 0 {
-		// TODO(anzoteh96): this should really be only checked once per import instead of every row.
-		for _, col := range p.importCtx.tableDesc.VisibleColumns() {
-			if col.IsComputed() {
-				return nil,
-					errors.Newf(
-						"IMPORT CSV with computed column %q requires targeted column specification",
-						col.Name)
-			}
-		}
 		expectedColsLen = len(p.importCtx.tableDesc.VisibleColumns())
 	}
 


### PR DESCRIPTION
This commit moves the computation of finding the expected number of data
columns to the creation of the input converter, rather than
re-calculating it on every row. The memory footprint of loading all of
the visible columns for every row was noticeable.

Release note (performance improvement): CSV imports should now be
slightly faster.