### PR TITLE
[wip] kvserver: have autoupgrade process look at decommission status, not just availability

### DIFF
--- a/pkg/server/autoupgrade.go
+++ b/pkg/server/autoupgrade.go
@@ -24,8 +24,9 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// startAttemptUpgrade attempts to upgrade cluster version.
-func (s *Server) startAttemptUpgrade(ctx context.Context) {
+// startAutoUpgrade attempts to auto upgrade cluster version to the binary's
+// current version.
+func (s *Server) startAutoUpgrade(ctx context.Context) {
 	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 	if err := s.stopper.RunAsyncTask(ctx, "auto-upgrade", func(ctx context.Context) {
 		defer cancel()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1772,7 +1772,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// Attempt to upgrade cluster version now that the sql server has been
 	// started. At this point we know that all sqlmigrations have successfully
 	// been run so it is safe to upgrade to the binary's current version.
-	s.startAttemptUpgrade(ctx)
+	s.startAutoUpgrade(ctx)
 
 	log.Event(ctx, "server initialized")
 	return nil

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1256,7 +1256,7 @@ func (s *statusServer) Profile(
 // that status "UNKNOWN" has value 0 (the default) when accessing the
 // map.
 func (s *statusServer) Nodes(
-	ctx context.Context, req *serverpb.NodesRequest,
+	ctx context.Context, _ *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)


### PR DESCRIPTION
Fixes #53515.

We should have the autoupgrade process look at the fully decommissioned
bit we added in #50329, instead of just looking at availability. It
would avoid the hazard described in #53515.

Previously the autoupgrade process was also looking at
NodeStatusLiveness, which we've since soured upon (see #50478). Now that
we always create a liveness record on start up (#53805), we can simply
fetch all liveness records from KV. We add a helper to do this, which
we'll also rely on in future PRs for other purposes. It's a bit
unfortunate that we're further adding on to the NodeLiveness API without
changing the caching structure, but the methods fetching records from KV
is the world we're hoping to move towards going forward.

Release note: None
