### PR TITLE
ccl/backupccl: skip TestBackupRestoreAppend under race

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -446,6 +446,7 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t, "flaky test. Issues #50984, #54599")
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 1000


### PR DESCRIPTION
Refs: #50984, #54599

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None