### PR TITLE
server,docgen: enhance the API documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1526,7 +1526,7 @@ bin/.docgen_http: bin/docgen $(PROTOC)
 	--protoc $(PROTOC) \
 	--gendoc ./bin/protoc-gen-doc \
 	--out docs/generated/http \
-	--protobuf pkg:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
+	--protobuf pkg:./vendor/github.com:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
 	touch $@
 
 .PHONY: docs/generated/redact_safe.md

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2,16 +2,21 @@
 
 `GET /_status/certificates/{node_id}`
 
+Certificates retrieves a copy of the TLS certificates.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CertificatesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CertificatesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -24,9 +29,12 @@
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| certificates | [CertificateDetails](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| certificates | [CertificateDetails](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -36,12 +44,14 @@
 <a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails"></a>
 #### CertificateDetails
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  |
-| error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. |
-| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. |
-| fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. | [reserved](#support-status) |
+| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. | [reserved](#support-status) |
+| fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -50,17 +60,19 @@
 <a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields"></a>
 #### CertificateDetails.Fields
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| issuer | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| subject | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| valid_from | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
-| valid_until | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
-| addresses | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
-| signature_algorithm | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| public_key | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
-| extended_key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| issuer | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | [reserved](#support-status) |
+| subject | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | [reserved](#support-status) |
+| valid_from | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  | [reserved](#support-status) |
+| valid_until | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  | [reserved](#support-status) |
+| addresses | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | [reserved](#support-status) |
+| signature_algorithm | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | [reserved](#support-status) |
+| public_key | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | [reserved](#support-status) |
+| key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | [reserved](#support-status) |
+| extended_key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -71,16 +83,22 @@
 
 `GET /_status/details/{node_id}`
 
+Details retrieves details about the nodes in the cluster.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+DetailsRequest requests a nodes details.
+Note: this does *not* check readiness. Use the Health RPC for that purpose.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -93,13 +111,16 @@
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.DetailsResponse-int32) |  |  |
-| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
-| build_info | [cockroach.build.Info](#cockroach.server.serverpb.DetailsResponse-cockroach.build.Info) |  |  |
-| system_info | [SystemInfo](#cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo) |  |  |
-| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DetailsResponse-int32) |  |  | [reserved](#support-status) |
+| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  | [reserved](#support-status) |
+| build_info | [cockroach.build.Info](#cockroach.server.serverpb.DetailsResponse-cockroach.build.Info) |  |  | [reserved](#support-status) |
+| system_info | [SystemInfo](#cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo) |  |  | [reserved](#support-status) |
+| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  | [reserved](#support-status) |
 
 
 
@@ -109,10 +130,12 @@
 <a name="cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo"></a>
 #### SystemInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| system_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | system_info is the output from `uname -a` |
-| kernel_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | kernel_info is the output from `uname -r`. |
+SystemInfo contains information about the host system.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| system_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | system_info is the output from `uname -a` | [reserved](#support-status) |
+| kernel_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | kernel_info is the output from `uname -r`. | [reserved](#support-status) |
 
 
 
@@ -128,12 +151,20 @@ are not included, except in rare cases where the node doing the
 decommissioning crashed before completing the operation. In these cases,
 the decommission operation can be rerun to clean up the status entry.
 
+
+
 Don't introduce additional usages of this RPC. See #50707 for more details.
 The underlying response type is something we're looking to get rid of.
+
+Support status: [alpha](#support-status)
 
 #### Request Parameters
 
 
+
+
+NodesRequest requests a copy of the node information as known to gossip
+and the KV layer.
 
 
 
@@ -147,11 +178,123 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus) | repeated |  |
-| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated |  |
+NodesResponse describe the nodes in the cluster.
 
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus) | repeated | nodes carries the status payloads for all nodes in the cluster. | [alpha](#support-status) |
+| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated | liveness_by_node_id maps each node ID to a liveness status. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus"></a>
+#### NodeStatus
+
+NodeStatus records the most recent values of metrics for a node.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.server.serverpb.NodesResponse-cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | [reserved](#support-status) |
+| build_info | [cockroach.build.Info](#cockroach.server.serverpb.NodesResponse-cockroach.build.Info) |  | build_info describes the `cockroach` executable file. | [alpha](#support-status) |
+| started_at | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | started_at is the unix timestamp at which the node process was last started. | [alpha](#support-status) |
+| updated_at | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | [alpha](#support-status) |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+| store_statuses | [StoreStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | [reserved](#support-status) |
+| args | [string](#cockroach.server.serverpb.NodesResponse-string) | repeated | args is the list of command-line arguments used to last start the node. | [reserved](#support-status) |
+| env | [string](#cockroach.server.serverpb.NodesResponse-string) | repeated | env is the list of environment variables that influenced the node's configuration. | [reserved](#support-status) |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | [reserved](#support-status) |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | [reserved](#support-status) |
+| total_system_memory | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | [alpha](#support-status) |
+| num_cpus | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the `cockroach` process is running. Note that this does not report the number of CPUs actually used by `cockroach`; this parameter is controlled separately. | [alpha](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.NodesResponse-string) |  |  |  |
+| value | [double](#cockroach.server.serverpb.NodesResponse-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.server.serverpb.NodesResponse-cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | [reserved](#support-status) |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.NodesResponse-string) |  |  |  |
+| value | [double](#cockroach.server.serverpb.NodesResponse-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in bytes | [reserved](#support-status) |
+| outgoing | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in bytes | [reserved](#support-status) |
+| latency | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in nanoseconds | [reserved](#support-status) |
 
 
 
@@ -160,10 +303,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry"></a>
 #### NodesResponse.LivenessByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |
-| value | [cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus](#cockroach.server.serverpb.NodesResponse-cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus](#cockroach.server.serverpb.NodesResponse-cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus) |  |  |  |
 
 
 
@@ -174,16 +319,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/nodes/{node_id}`
 
+Node retrieves details about a single node.
 
+Support status: [alpha](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -192,6 +342,116 @@ The underlying response type is something we're looking to get rid of.
 
 
 #### Response Parameters
+
+
+
+
+NodeStatus records the most recent values of metrics for a node.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.server.status.statuspb.NodeStatus-cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | [reserved](#support-status) |
+| build_info | [cockroach.build.Info](#cockroach.server.status.statuspb.NodeStatus-cockroach.build.Info) |  | build_info describes the `cockroach` executable file. | [alpha](#support-status) |
+| started_at | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | started_at is the unix timestamp at which the node process was last started. | [alpha](#support-status) |
+| updated_at | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | [alpha](#support-status) |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+| store_statuses | [StoreStatus](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | [reserved](#support-status) |
+| args | [string](#cockroach.server.status.statuspb.NodeStatus-string) | repeated | args is the list of command-line arguments used to last start the node. | [reserved](#support-status) |
+| env | [string](#cockroach.server.status.statuspb.NodeStatus-string) | repeated | env is the list of environment variables that influenced the node's configuration. | [reserved](#support-status) |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | [reserved](#support-status) |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | [reserved](#support-status) |
+| total_system_memory | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | [alpha](#support-status) |
+| num_cpus | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the `cockroach` process is running. Note that this does not report the number of CPUs actually used by `cockroach`; this parameter is controlled separately. | [alpha](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.status.statuspb.NodeStatus-string) |  |  |  |
+| value | [double](#cockroach.server.status.statuspb.NodeStatus-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.server.status.statuspb.NodeStatus-cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | [reserved](#support-status) |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.status.statuspb.NodeStatus-string) |  |  |  |
+| value | [double](#cockroach.server.status.statuspb.NodeStatus-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  |  |  |
+| value | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in bytes | [reserved](#support-status) |
+| outgoing | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in bytes | [reserved](#support-status) |
+| latency | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in nanoseconds | [reserved](#support-status) |
+
+
+
 
 
 
@@ -199,16 +459,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/raft`
 
+RaftDebug requests internal details about Raft.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_ids | [int64](#cockroach.server.serverpb.RaftDebugRequest-int64) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_ids | [int64](#cockroach.server.serverpb.RaftDebugRequest-int64) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -221,10 +486,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ranges | [RaftDebugResponse.RangesEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry) | repeated |  |
-| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ranges | [RaftDebugResponse.RangesEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry) | repeated |  | [reserved](#support-status) |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -234,10 +502,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry"></a>
 #### RaftDebugResponse.RangesEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
-| value | [RaftRangeStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |  |
+| value | [RaftRangeStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus) |  |  |  |
 
 
 
@@ -246,11 +516,13 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus"></a>
 #### RaftRangeStatus
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
-| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
-| nodes | [RaftRangeNode](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  | [reserved](#support-status) |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  | [reserved](#support-status) |
+| nodes | [RaftRangeNode](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -259,9 +531,11 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
 #### RaftRangeError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -270,10 +544,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode"></a>
 #### RaftRangeNode
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| range | [RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | [reserved](#support-status) |
+| range | [RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo) |  |  | [reserved](#support-status) |
 
 
 
@@ -282,22 +558,24 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RaftDebugResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan) |  |  | [reserved](#support-status) |
+| raft_state | [RaftState](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState) |  |  | [reserved](#support-status) |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | [reserved](#support-status) |
+| source_node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | [reserved](#support-status) |
+| source_store_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RaftDebugResponse-cockroach.roachpb.Lease) | repeated |  | [reserved](#support-status) |
+| problems | [RangeProblems](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems) |  |  | [reserved](#support-status) |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics) |  |  | [reserved](#support-status) |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | [reserved](#support-status) |
+| quiescent | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -306,10 +584,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
+| end_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -318,15 +598,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RaftDebugResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RaftDebugResponse-raftpb.HardState) |  |  | [reserved](#support-status) |
+| lead | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  | Lead is part of Raft's SoftState. | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | [reserved](#support-status) |
+| applied | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | [reserved](#support-status) |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -335,10 +618,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -347,13 +632,15 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
+| next | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
+| paused | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -362,16 +649,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| underreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| overreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| no_lease | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | [reserved](#support-status) |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 
 
 
@@ -380,10 +669,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  | [reserved](#support-status) |
 
 
 
@@ -392,9 +683,11 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
 #### RaftRangeError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -405,17 +698,22 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/ranges/{node_id}`
 
+Ranges requests internal details about ranges on a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -428,9 +726,12 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -440,22 +741,24 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangesResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan) |  |  | [reserved](#support-status) |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState) |  |  | [reserved](#support-status) |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | [reserved](#support-status) |
+| source_node_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  | [reserved](#support-status) |
+| source_store_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | [reserved](#support-status) |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangesResponse-cockroach.roachpb.Lease) | repeated |  | [reserved](#support-status) |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems) |  |  | [reserved](#support-status) |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics) |  |  | [reserved](#support-status) |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | [reserved](#support-status) |
+| quiescent | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -464,10 +767,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | [reserved](#support-status) |
+| end_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -476,15 +781,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangesResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangesResponse-raftpb.HardState) |  |  | [reserved](#support-status) |
+| lead | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  | Lead is part of Raft's SoftState. | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | [reserved](#support-status) |
+| applied | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | [reserved](#support-status) |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -493,10 +801,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -505,13 +815,15 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
+| next | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | [reserved](#support-status) |
+| paused | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -520,16 +832,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| underreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| overreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| no_lease | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | [reserved](#support-status) |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 
 
 
@@ -538,10 +852,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  | [reserved](#support-status) |
 
 
 
@@ -552,16 +868,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/gossip/{node_id}`
 
+Gossip retrieves gossip-level details about a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -577,16 +898,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/enginestats/{node_id}`
 
+EngineStats retrieves statistics about a storage engine.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.EngineStatsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.EngineStatsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -599,9 +925,12 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stats | [EngineStatsInfo](#cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stats | [EngineStatsInfo](#cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -611,11 +940,13 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo"></a>
 #### EngineStatsInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.EngineStatsResponse-int32) |  |  |
-| tickers_and_histograms | [cockroach.storage.enginepb.TickersAndHistograms](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.TickersAndHistograms) |  |  |
-| engine_type | [cockroach.storage.enginepb.EngineType](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.EngineType) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.EngineStatsResponse-int32) |  |  | [reserved](#support-status) |
+| tickers_and_histograms | [cockroach.storage.enginepb.TickersAndHistograms](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.TickersAndHistograms) |  |  | [reserved](#support-status) |
+| engine_type | [cockroach.storage.enginepb.EngineType](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.EngineType) |  |  | [reserved](#support-status) |
 
 
 
@@ -626,17 +957,22 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/allocator/node/{node_id}`
 
+Allocator retrieves statistics about the replica allocator.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.AllocatorRequest-string) |  |  |
-| range_ids | [int64](#cockroach.server.serverpb.AllocatorRequest-int64) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.AllocatorRequest-string) |  |  | [reserved](#support-status) |
+| range_ids | [int64](#cockroach.server.serverpb.AllocatorRequest-int64) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -649,9 +985,12 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| dry_runs | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| dry_runs | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -661,10 +1000,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
 #### AllocatorDryRun
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorResponse-int64) |  |  |
-| events | [TraceEvent](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorResponse-int64) |  |  | [reserved](#support-status) |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -673,10 +1014,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent"></a>
 #### TraceEvent
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorResponse-google.protobuf.Timestamp) |  |  |
-| message | [string](#cockroach.server.serverpb.AllocatorResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.AllocatorResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -687,16 +1030,22 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/allocator/range/{range_id}`
 
+AllocatorRange retrieves statistics about the replica allocator given
+a specific range.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeRequest-int64) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeRequest-int64) |  |  | [reserved](#support-status) |
 
 
 
@@ -709,10 +1058,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  | The NodeID of the store whose dry run is returned. Only the leaseholder for a given range will do an allocator dry run for it. |
-| dry_run | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  | The NodeID of the store whose dry run is returned. Only the leaseholder for a given range will do an allocator dry run for it. | [reserved](#support-status) |
+| dry_run | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun) |  |  | [reserved](#support-status) |
 
 
 
@@ -722,10 +1074,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
 #### AllocatorDryRun
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  |  |
-| events | [TraceEvent](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  |  | [reserved](#support-status) |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -734,10 +1088,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent"></a>
 #### TraceEvent
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorRangeResponse-google.protobuf.Timestamp) |  |  |
-| message | [string](#cockroach.server.serverpb.AllocatorRangeResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorRangeResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.AllocatorRangeResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -748,16 +1104,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/sessions`
 
+ListSessions retrieves the SQL sessions across the entire cluster.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. The caller is responsible to normalize the username (= case fold and perform unicode NFC normalization). |
+Request object for ListSessions and ListLocalSessions.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. The caller is responsible to normalize the username (= case fold and perform unicode NFC normalization). | [reserved](#support-status) |
 
 
 
@@ -770,10 +1131,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
-| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+Response object for ListSessions and ListLocalSessions.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | [reserved](#support-status) |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
 
 
 
@@ -783,20 +1147,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
 #### Session
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
-| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
-| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
-| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
-| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
-| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
-| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
-| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. |
+Session represents one SQL session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. | [reserved](#support-status) |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. | [reserved](#support-status) |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. | [reserved](#support-status) |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. | [reserved](#support-status) |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. | [reserved](#support-status) |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. | [reserved](#support-status) |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). | [reserved](#support-status) |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. | [reserved](#support-status) |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. | [reserved](#support-status) |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. | [reserved](#support-status) |
+| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
 
@@ -805,16 +1171,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
 #### ActiveQuery
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
-| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
-| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
-| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
-| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
-| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. |
+ActiveQuery represents a query in flight on some Session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). | [reserved](#support-status) |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. | [reserved](#support-status) |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | [reserved](#support-status) |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | [reserved](#support-status) |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | [reserved](#support-status) |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | [reserved](#support-status) |
+| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
 
@@ -823,21 +1191,23 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
 #### TxnInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
-| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
-| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. |
-| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. |
-| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. |
-| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. |
-| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. |
-| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  |
+TxnInfo represents an in flight user transaction on some Session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. | [reserved](#support-status) |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. | [reserved](#support-status) |
+| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. | [reserved](#support-status) |
+| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. | [reserved](#support-status) |
+| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. | [reserved](#support-status) |
+| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. | [reserved](#support-status) |
+| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. | [reserved](#support-status) |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. | [reserved](#support-status) |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. | [reserved](#support-status) |
+| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -846,10 +1216,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
 #### ListSessionsError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
-| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+An error wrapper object for ListSessionsResponse.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. | [reserved](#support-status) |
 
 
 
@@ -860,16 +1232,21 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/local_sessions`
 
+ListLocalSessions retrieves the SQL sessions on this node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. The caller is responsible to normalize the username (= case fold and perform unicode NFC normalization). |
+Request object for ListSessions and ListLocalSessions.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. The caller is responsible to normalize the username (= case fold and perform unicode NFC normalization). | [reserved](#support-status) |
 
 
 
@@ -882,10 +1259,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
-| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+Response object for ListSessions and ListLocalSessions.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | [reserved](#support-status) |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
 
 
 
@@ -895,20 +1275,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
 #### Session
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
-| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
-| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
-| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
-| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
-| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
-| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
-| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. |
+Session represents one SQL session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. | [reserved](#support-status) |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. | [reserved](#support-status) |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. | [reserved](#support-status) |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. | [reserved](#support-status) |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. | [reserved](#support-status) |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. | [reserved](#support-status) |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). | [reserved](#support-status) |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. | [reserved](#support-status) |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. | [reserved](#support-status) |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. | [reserved](#support-status) |
+| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
 
@@ -917,16 +1299,18 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
 #### ActiveQuery
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
-| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
-| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
-| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
-| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
-| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. |
+ActiveQuery represents a query in flight on some Session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). | [reserved](#support-status) |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. | [reserved](#support-status) |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | [reserved](#support-status) |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | [reserved](#support-status) |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | [reserved](#support-status) |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | [reserved](#support-status) |
+| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
 
@@ -935,21 +1319,23 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
 #### TxnInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
-| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
-| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. |
-| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. |
-| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. |
-| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. |
-| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. |
-| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  |
+TxnInfo represents an in flight user transaction on some Session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  | [reserved](#support-status) |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. | [reserved](#support-status) |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. | [reserved](#support-status) |
+| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. | [reserved](#support-status) |
+| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. | [reserved](#support-status) |
+| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. | [reserved](#support-status) |
+| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. | [reserved](#support-status) |
+| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. | [reserved](#support-status) |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. | [reserved](#support-status) |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. | [reserved](#support-status) |
+| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -958,10 +1344,12 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
 #### ListSessionsError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
-| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+An error wrapper object for ListSessionsResponse.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. | [reserved](#support-status) |
 
 
 
@@ -972,18 +1360,23 @@ The underlying response type is something we're looking to get rid of.
 
 `POST /_status/cancel_query/{node_id}`
 
+CancelQuery cancels a SQL query given its ID.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of gateway node for the query to be canceled.<br><br>TODO(itsbilal): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| query_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of query to be canceled (converted to string). |
-| username | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelQueryRequest. The caller is responsible for case-folding and NFC normalization. |
+Request object for issing a query cancel request.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of gateway node for the query to be canceled.<br><br>TODO(itsbilal): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| query_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of query to be canceled (converted to string). | [reserved](#support-status) |
+| username | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelQueryRequest. The caller is responsible for case-folding and NFC normalization. | [reserved](#support-status) |
 
 
 
@@ -996,10 +1389,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| canceled | [bool](#cockroach.server.serverpb.CancelQueryResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. |
-| error | [string](#cockroach.server.serverpb.CancelQueryResponse-string) |  | Error message (accompanied with canceled = false). |
+Response returned by target query's gateway node.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelQueryResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.CancelQueryResponse-string) |  | Error message (accompanied with canceled = false). | [reserved](#support-status) |
 
 
 
@@ -1011,18 +1407,23 @@ The underlying response type is something we're looking to get rid of.
 
 `POST /_status/cancel_session/{node_id}`
 
+CancelSessions forcefully terminates a SQL session given its ID.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| session_id | [bytes](#cockroach.server.serverpb.CancelSessionRequest-bytes) |  |  |
-| username | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelSessionRequest. The caller is responsiblef or case-folding and NFC normalization. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| session_id | [bytes](#cockroach.server.serverpb.CancelSessionRequest-bytes) |  |  | [reserved](#support-status) |
+| username | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelSessionRequest. The caller is responsiblef or case-folding and NFC normalization. | [reserved](#support-status) |
 
 
 
@@ -1035,10 +1436,13 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| canceled | [bool](#cockroach.server.serverpb.CancelSessionResponse-bool) |  |  |
-| error | [string](#cockroach.server.serverpb.CancelSessionResponse-string) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelSessionResponse-bool) |  |  | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.CancelSessionResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -1056,16 +1460,21 @@ in that span. This is designed to compute stats specific to a SQL table:
 it will be called with the highest/lowest key for a SQL table, and return
 information about the resources on a node used by that table.
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.SpanStatsRequest-string) |  |  |
-| start_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
-| end_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.SpanStatsRequest-string) |  |  | [reserved](#support-status) |
+| start_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  | [reserved](#support-status) |
+| end_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  | [reserved](#support-status) |
 
 
 
@@ -1078,11 +1487,14 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_count | [int32](#cockroach.server.serverpb.SpanStatsResponse-int32) |  |  |
-| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.SpanStatsResponse-uint64) |  |  |
-| total_stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.SpanStatsResponse-cockroach.storage.enginepb.MVCCStats) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int32](#cockroach.server.serverpb.SpanStatsResponse-int32) |  |  | [reserved](#support-status) |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.SpanStatsResponse-uint64) |  |  | [reserved](#support-status) |
+| total_stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.SpanStatsResponse-cockroach.storage.enginepb.MVCCStats) |  |  | [reserved](#support-status) |
 
 
 
@@ -1094,17 +1506,22 @@ information about the resources on a node used by that table.
 
 `GET /_status/stacks/{node_id}`
 
+Stacks retrieves the stack traces of all goroutines on a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StacksRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| type | [StacksType](#cockroach.server.serverpb.StacksRequest-cockroach.server.serverpb.StacksType) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StacksRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| type | [StacksType](#cockroach.server.serverpb.StacksRequest-cockroach.server.serverpb.StacksType) |  |  | [reserved](#support-status) |
 
 
 
@@ -1117,9 +1534,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | [reserved](#support-status) |
 
 
 
@@ -1131,18 +1551,23 @@ information about the resources on a node used by that table.
 
 `GET /_status/profile/{node_id}`
 
+Profile retrieves a CPU profile on a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. |
-| seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. | [reserved](#support-status) |
+| seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 | [reserved](#support-status) |
 
 
 
@@ -1155,9 +1580,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | [reserved](#support-status) |
 
 
 
@@ -1169,16 +1597,25 @@ information about the resources on a node used by that table.
 
 `GET /_status/metrics/{node_id}`
 
+Metrics retrieves the node metrics for a given node.
 
+Note: this is a “reserved” API and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.MetricsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.MetricsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -1191,9 +1628,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | [reserved](#support-status) |
 
 
 
@@ -1205,19 +1645,24 @@ information about the resources on a node used by that table.
 
 `GET /_status/files/{node_id}`
 
+GetFiles retrieves heap or goroutine dump files from a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.GetFilesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| list_only | [bool](#cockroach.server.serverpb.GetFilesRequest-bool) |  | If list_only is true then the contents of the files will not be populated in the response. Only filenames and sizes will be returned. |
-| type | [FileType](#cockroach.server.serverpb.GetFilesRequest-cockroach.server.serverpb.FileType) |  |  |
-| patterns | [string](#cockroach.server.serverpb.GetFilesRequest-string) | repeated | Each pattern given is matched with Files of the above type in the node using filepath.Glob(). The patterns only match to filenames and so path separators cannot be used. Example: * will match all files of requested type. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.GetFilesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| list_only | [bool](#cockroach.server.serverpb.GetFilesRequest-bool) |  | If list_only is true then the contents of the files will not be populated in the response. Only filenames and sizes will be returned. | [reserved](#support-status) |
+| type | [FileType](#cockroach.server.serverpb.GetFilesRequest-cockroach.server.serverpb.FileType) |  |  | [reserved](#support-status) |
+| patterns | [string](#cockroach.server.serverpb.GetFilesRequest-string) | repeated | Each pattern given is matched with Files of the above type in the node using filepath.Glob(). The patterns only match to filenames and so path separators cannot be used. Example: * will match all files of requested type. | [reserved](#support-status) |
 
 
 
@@ -1230,9 +1675,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| files | [File](#cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| files | [File](#cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1242,11 +1690,13 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File"></a>
 #### File
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#cockroach.server.serverpb.GetFilesResponse-string) |  |  |
-| file_size | [int64](#cockroach.server.serverpb.GetFilesResponse-int64) |  |  |
-| contents | [bytes](#cockroach.server.serverpb.GetFilesResponse-bytes) |  | Contents may not be populated if only a list of Files are requested. |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.GetFilesResponse-string) |  |  | [reserved](#support-status) |
+| file_size | [int64](#cockroach.server.serverpb.GetFilesResponse-int64) |  |  | [reserved](#support-status) |
+| contents | [bytes](#cockroach.server.serverpb.GetFilesResponse-bytes) |  | Contents may not be populated if only a list of Files are requested. | [reserved](#support-status) |
 
 
 
@@ -1257,16 +1707,21 @@ information about the resources on a node used by that table.
 
 `GET /_status/logfiles/{node_id}`
 
+LogFilesList retrieves a list of log files on a given node.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogFilesListRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogFilesListRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -1279,9 +1734,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| files | [cockroach.util.log.FileInfo](#cockroach.server.serverpb.LogFilesListResponse-cockroach.util.log.FileInfo) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| files | [cockroach.util.log.FileInfo](#cockroach.server.serverpb.LogFilesListResponse-cockroach.util.log.FileInfo) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1293,18 +1751,23 @@ information about the resources on a node used by that table.
 
 `GET /_status/logfiles/{node_id}/{file}`
 
+LogFile retrieves a given log file.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  |  |
-| redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  |  | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. | [reserved](#support-status) |
 
 
 
@@ -1317,9 +1780,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1331,22 +1797,27 @@ information about the resources on a node used by that table.
 
 `GET /_status/logs/{node_id}`
 
+Logs retrieves individual log entries.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| level | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| start_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| end_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| max | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| pattern | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| redact | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| level | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | [reserved](#support-status) |
+| start_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | [reserved](#support-status) |
+| end_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | [reserved](#support-status) |
+| max | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | [reserved](#support-status) |
+| pattern | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. | [reserved](#support-status) |
 
 
 
@@ -1359,9 +1830,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1373,16 +1847,21 @@ information about the resources on a node used by that table.
 
 `GET /_status/problemranges`
 
+ProblemRanges retrieves the list of “problem ranges”.
 
+Support status: [reserved](#support-status)
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.ProblemRangesRequest-string) |  | If left empty, problem ranges for all nodes/stores will be returned. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.ProblemRangesRequest-string) |  | If left empty, problem ranges for all nodes/stores will be returned. | [reserved](#support-status) |
 
 
 
@@ -1395,10 +1874,13 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  | NodeID is the node that submitted all the requests. |
-| problems_by_node_id | [ProblemRangesResponse.ProblemsByNodeIdEntry](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  | NodeID is the node that submitted all the requests. | [reserved](#support-status) |
+| problems_by_node_id | [ProblemRangesResponse.ProblemsByNodeIdEntry](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1408,10 +1890,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry"></a>
 #### ProblemRangesResponse.ProblemsByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  |  |
-| value | [ProblemRangesResponse.NodeProblems](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  |  |  |
+| value | [ProblemRangesResponse.NodeProblems](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems) |  |  |  |
 
 
 
@@ -1420,17 +1904,19 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems"></a>
 #### ProblemRangesResponse.NodeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| error_message | [string](#cockroach.server.serverpb.ProblemRangesResponse-string) |  |  |
-| unavailable_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| raft_leader_not_lease_holder_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| no_raft_leader_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| no_lease_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| underreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| overreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| quiescent_equals_ticking_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#cockroach.server.serverpb.ProblemRangesResponse-string) |  |  | [reserved](#support-status) |
+| unavailable_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| raft_leader_not_lease_holder_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| no_raft_leader_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| no_lease_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| underreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| overreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| quiescent_equals_ticking_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1443,14 +1929,20 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. |
+HotRangesRequest queries one or more cluster nodes for a list
+of ranges currently considered “hot” by the node(s).
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
 
 
 
@@ -1463,10 +1955,14 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). |
-| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. |
+HotRangesResponse is the payload produced in response
+to a HotRangesRequest.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). | [alpha](#support-status) |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. | [alpha](#support-status) |
 
 
 
@@ -1476,10 +1972,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
 #### HotRangesResponse.HotRangesByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
-| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |  |
 
 
 
@@ -1488,10 +1986,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
 #### HotRangesResponse.NodeResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. |
-| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. |
+NodeResponse is a hot range report for a single target node.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. | [alpha](#support-status) |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. | [alpha](#support-status) |
 
 
 
@@ -1500,10 +2000,13 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
 #### HotRangesResponse.StoreResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | StoreID identifies the store for which the report was produced. |
-| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. |
+StoreResponse contains the part of a hot ranges report that
+pertains to a single store on a target node.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | StoreID identifies the store for which the report was produced. | [alpha](#support-status) |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. | [alpha](#support-status) |
 
 
 
@@ -1512,10 +2015,13 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
 #### HotRangesResponse.HotRange
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>Note: this field is generally RESERVED and will likely be removed or replaced in a later version. See: https://github.com/cockroachdb/cockroach/issues/53212 |
-| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. |
+HotRange is a hot range report for a single store on one of the
+target node(s) selected in a HotRangesRequest.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
 
 
 
@@ -1528,14 +2034,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.RangeRequest-int64) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RangeRequest-int64) |  |  | [reserved](#support-status) |
 
 
 
@@ -1548,11 +2059,14 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  | NodeID is the node that submitted all the requests. |
-| range_id | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  |
-| responses_by_node_id | [RangeResponse.ResponsesByNodeIdEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  | NodeID is the node that submitted all the requests. | [reserved](#support-status) |
+| range_id | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
+| responses_by_node_id | [RangeResponse.ResponsesByNodeIdEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1562,10 +2076,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry"></a>
 #### RangeResponse.ResponsesByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| value | [RangeResponse.NodeResponse](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |  |
+| value | [RangeResponse.NodeResponse](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse) |  |  |  |
 
 
 
@@ -1574,11 +2090,13 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse"></a>
 #### RangeResponse.NodeResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| response | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| infos | [RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| response | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | [reserved](#support-status) |
+| infos | [RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1587,22 +2105,24 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangeResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan) |  |  | [reserved](#support-status) |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState) |  |  | [reserved](#support-status) |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | [reserved](#support-status) |
+| source_node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  | [reserved](#support-status) |
+| source_store_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | [reserved](#support-status) |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangeResponse-cockroach.roachpb.Lease) | repeated |  | [reserved](#support-status) |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems) |  |  | [reserved](#support-status) |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics) |  |  | [reserved](#support-status) |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | [reserved](#support-status) |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | [reserved](#support-status) |
+| quiescent | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -1611,10 +2131,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | [reserved](#support-status) |
+| end_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -1623,15 +2145,18 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangeResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangeResponse-raftpb.HardState) |  |  | [reserved](#support-status) |
+| lead | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  | Lead is part of Raft's SoftState. | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | [reserved](#support-status) |
+| applied | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | [reserved](#support-status) |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -1640,10 +2165,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -1652,13 +2179,15 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
+| next | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | [reserved](#support-status) |
+| paused | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -1667,16 +2196,18 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| underreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| overreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| no_lease | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | [reserved](#support-status) |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 
 
 
@@ -1685,10 +2216,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  | [reserved](#support-status) |
 
 
 
@@ -1701,14 +2234,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.DiagnosticsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+DiagnosticsRequest requests a diagnostics report.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.DiagnosticsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -1726,14 +2264,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StoresRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StoresRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 
 
 
@@ -1746,9 +2289,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stores | [StoreDetails](#cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stores | [StoreDetails](#cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1758,14 +2304,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails"></a>
 #### StoreDetails
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  |
-| encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. |
-| total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. |
-| total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
-| active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. |
-| active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  | [reserved](#support-status) |
+| encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. | [reserved](#support-status) |
+| total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. | [reserved](#support-status) |
+| total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | [reserved](#support-status) |
+| active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. | [reserved](#support-status) |
+| active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | [reserved](#support-status) |
 
 
 
@@ -1778,14 +2326,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StatementsRequest-string) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StatementsRequest-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -1798,12 +2351,15 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  |
-| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. |
-| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. |
-| transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  | [reserved](#support-status) |
+| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. | [reserved](#support-status) |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
+| transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. | [reserved](#support-status) |
 
 
 
@@ -1813,11 +2369,13 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics"></a>
 #### StatementsResponse.CollectedStatementStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  |
-| id | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) |  |  |
-| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  | [reserved](#support-status) |
+| id | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) |  |  | [reserved](#support-status) |
+| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  | [reserved](#support-status) |
 
 
 
@@ -1826,10 +2384,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey"></a>
 #### StatementsResponse.ExtendedStatementStatisticsKey
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  |
-| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | [reserved](#support-status) |
 
 
 
@@ -1838,10 +2398,12 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics"></a>
 #### StatementsResponse.ExtendedCollectedTransactionStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stats_data | [cockroach.sql.CollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.CollectedTransactionStatistics) |  |  |
-| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stats_data | [cockroach.sql.CollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.CollectedTransactionStatistics) |  |  | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | [reserved](#support-status) |
 
 
 
@@ -1854,14 +2416,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest-string) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -1874,9 +2441,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| report | [StatementDiagnosticsReport](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| report | [StatementDiagnosticsReport](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport) |  |  | [reserved](#support-status) |
 
 
 
@@ -1886,13 +2456,15 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
 #### StatementDiagnosticsReport
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
-| completed | [bool](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-bool) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-string) |  |  |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
-| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-google.protobuf.Timestamp) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  | [reserved](#support-status) |
+| completed | [bool](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-bool) |  |  | [reserved](#support-status) |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-string) |  |  | [reserved](#support-status) |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  | [reserved](#support-status) |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 
 
@@ -1905,7 +2477,12 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
+
+
+
 
 
 
@@ -1921,9 +2498,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| reports | [StatementDiagnosticsReport](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| reports | [StatementDiagnosticsReport](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -1933,13 +2513,15 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
 #### StatementDiagnosticsReport
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
-| completed | [bool](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-bool) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-string) |  |  |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
-| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-google.protobuf.Timestamp) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  | [reserved](#support-status) |
+| completed | [bool](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-bool) |  |  | [reserved](#support-status) |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-string) |  |  | [reserved](#support-status) |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  | [reserved](#support-status) |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 
 
@@ -1952,14 +2534,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsRequest-int64) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsRequest-int64) |  |  | [reserved](#support-status) |
 
 
 
@@ -1972,9 +2559,12 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| diagnostics | [StatementDiagnostics](#cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| diagnostics | [StatementDiagnostics](#cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics) |  |  | [reserved](#support-status) |
 
 
 
@@ -1984,12 +2574,14 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics"></a>
 #### StatementDiagnostics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
-| collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  |
-| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  | [reserved](#support-status) |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | [reserved](#support-status) |
+| collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -2002,14 +2594,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.JobRegistryStatusRequest-string) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.JobRegistryStatusRequest-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -2022,10 +2619,13 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.JobRegistryStatusResponse-int32) |  |  |
-| running_jobs | [JobRegistryStatusResponse.Job](#cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job) | repeated |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.JobRegistryStatusResponse-int32) |  |  | [reserved](#support-status) |
+| running_jobs | [JobRegistryStatusResponse.Job](#cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -2035,9 +2635,11 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job"></a>
 #### JobRegistryStatusResponse.Job
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.JobRegistryStatusResponse-int64) |  |  |
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.JobRegistryStatusResponse-int64) |  |  | [reserved](#support-status) |
 
 
 
@@ -2050,14 +2652,19 @@ information about the resources on a node used by that table.
 
 
 
+Support status: [reserved](#support-status)
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| job_id | [int64](#cockroach.server.serverpb.JobStatusRequest-int64) |  |  |
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| job_id | [int64](#cockroach.server.serverpb.JobStatusRequest-int64) |  |  | [reserved](#support-status) |
 
 
 
@@ -2070,10 +2677,1646 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| job | [cockroach.sql.jobs.jobspb.Job](#cockroach.server.serverpb.JobStatusResponse-cockroach.sql.jobs.jobspb.Job) |  |  |
 
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| job | [cockroach.sql.jobs.jobspb.Job](#cockroach.server.serverpb.JobStatusResponse-cockroach.sql.jobs.jobspb.Job) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+## Users
+
+`GET /_admin/v1/users`
+
+URL: /_admin/v1/users
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+UsersRequest requests a list of users.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+UsersResponse returns a list of users.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| users | [UsersResponse.User](#cockroach.server.serverpb.UsersResponse-cockroach.server.serverpb.UsersResponse.User) | repeated | usernames is a list of users for the CockroachDB cluster. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.UsersResponse-cockroach.server.serverpb.UsersResponse.User"></a>
+#### UsersResponse.User
+
+User is a CockroachDB user.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.UsersResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## Databases
+
+`GET /_admin/v1/databases`
+
+URL: /_admin/v1/databases
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+DatabasesRequest requests a list of databases.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DatabasesResponse contains a list of databases.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| databases | [string](#cockroach.server.serverpb.DatabasesResponse-string) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+## DatabaseDetails
+
+`GET /_admin/v1/databases/{database}`
+
+Example URL: /_admin/v1/databases/system
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+DatabaseDetailsRequest requests detailed information about the specified
+database
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.DatabaseDetailsRequest-string) |  | database is the name of the database we are querying. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DatabaseDetailsResponse contains grant information and table names for a
+database.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| grants | [DatabaseDetailsResponse.Grant](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.DatabaseDetailsResponse.Grant) | repeated | grants are the results of SHOW GRANTS for this database. | [reserved](#support-status) |
+| table_names | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) | repeated | table_names contains the names of all tables in this database. Note that all responses will be schema-qualified (schema.table) and that every schema or table that contains a "sql unsafe character" such as uppercase letters or dots will be surrounded with double quotes, such as "naughty schema".table. | [reserved](#support-status) |
+| descriptor_id | [int64](#cockroach.server.serverpb.DatabaseDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this database. It can be used to find events pertaining to this database by filtering on the 'target_id' field of events. | [reserved](#support-status) |
+| zone_config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.config.zonepb.ZoneConfig) |  | The zone configuration in effect for this database. | [reserved](#support-status) |
+| zone_config_level | [ZoneConfigurationLevel](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.ZoneConfigurationLevel) |  | The level at which this object's zone configuration is set. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.DatabaseDetailsResponse.Grant"></a>
+#### DatabaseDetailsResponse.Grant
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| user | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) |  | user is the user that this grant applies to. | [reserved](#support-status) |
+| privileges | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) | repeated | privileges are the abilities this grant gives to the user. | [reserved](#support-status) |
+
+
+
+
+
+
+## TableDetails
+
+`GET /_admin/v1/databases/{database}/tables/{table}`
+
+Example URL: /_admin/v1/databases/system/tables/ui
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+TableDetailsRequest is a request for detailed information about a table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.TableDetailsRequest-string) |  | database is the database that contains the table we're interested in. | [reserved](#support-status) |
+| table | [string](#cockroach.server.serverpb.TableDetailsRequest-string) |  | table is the name of the table that we're querying. Table may be schema-qualified (schema.table) and each name component that contains sql unsafe characters such as . or uppercase letters must be surrounded in double quotes like "naughty schema".table. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+TableDetailsResponse contains grants, column names, and indexes for
+a table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| grants | [TableDetailsResponse.Grant](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Grant) | repeated |  | [reserved](#support-status) |
+| columns | [TableDetailsResponse.Column](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Column) | repeated |  | [reserved](#support-status) |
+| indexes | [TableDetailsResponse.Index](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Index) | repeated |  | [reserved](#support-status) |
+| range_count | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | range_count is the size of the table in ranges. This provides a rough estimate of the storage requirements for the table. TODO(mrtracy): The TableStats method also returns a range_count field which is more accurate than this one; TableDetails calculates this number using a potentially faster method that is subject to cache staleness. We should consider removing or renaming this field to reflect that difference. See Github issue #5435 for more information. | [reserved](#support-status) |
+| create_table_statement | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | create_table_statement is the output of "SHOW CREATE" for this table; it is a SQL statement that would re-create the table's current schema if executed. | [reserved](#support-status) |
+| zone_config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.TableDetailsResponse-cockroach.config.zonepb.ZoneConfig) |  | The zone configuration in effect for this table. | [reserved](#support-status) |
+| zone_config_level | [ZoneConfigurationLevel](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.ZoneConfigurationLevel) |  | The level at which this object's zone configuration is set. | [reserved](#support-status) |
+| descriptor_id | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this table. It can be used to find events pertaining to this table by filtering on the 'target_id' field of events. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Grant"></a>
+#### TableDetailsResponse.Grant
+
+Grant is an entry from SHOW GRANTS.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| user | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | user is the user that this grant applies to. | [reserved](#support-status) |
+| privileges | [string](#cockroach.server.serverpb.TableDetailsResponse-string) | repeated | privileges are the abilities this grant gives to the user. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Column"></a>
+#### TableDetailsResponse.Column
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | name is the name of the column. | [reserved](#support-status) |
+| type | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | type is the SQL type (INT, STRING, etc.) of this column. | [reserved](#support-status) |
+| nullable | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | nullable is whether this column can contain NULL. | [reserved](#support-status) |
+| default_value | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | default_value is the default value of this column. | [reserved](#support-status) |
+| generation_expression | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | generation_expression is the generator expression if the column is computed. | [reserved](#support-status) |
+| hidden | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | hidden is whether this column is hidden. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Index"></a>
+#### TableDetailsResponse.Index
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | name is the name of this index. | [reserved](#support-status) |
+| unique | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | unique is whether this a unique index (i.e. CREATE UNIQUE INDEX). | [reserved](#support-status) |
+| seq | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | seq is an internal variable that's passed along. | [reserved](#support-status) |
+| column | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | column is the column that this index indexes. | [reserved](#support-status) |
+| direction | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | direction is either "ASC" (ascending) or "DESC" (descending). | [reserved](#support-status) |
+| storing | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | storing is an internal variable that's passed along. | [reserved](#support-status) |
+| implicit | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | implicit is an internal variable that's passed along. | [reserved](#support-status) |
+
+
+
+
+
+
+## TableStats
+
+`GET /_admin/v1/databases/{database}/tables/{table}/stats`
+
+Example URL: /_admin/v1/databases/system/tables/ui/stats
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+TableStatsRequest is a request for detailed, computationally expensive
+information about a table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.TableStatsRequest-string) |  | database is the database that contains the table we're interested in. | [reserved](#support-status) |
+| table | [string](#cockroach.server.serverpb.TableStatsRequest-string) |  | table is the name of the table that we're querying. Table may be schema-qualified (schema.table) and each name component that contains sql unsafe characters such as . or uppercase letters must be surrounded in double quotes like "naughty schema".table. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | [reserved](#support-status) |
+| replica_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | [reserved](#support-status) |
+| node_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | [reserved](#support-status) |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.TableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | [reserved](#support-status) |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.TableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | [reserved](#support-status) |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.TableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode"></a>
+#### TableStatsResponse.MissingNode
+
+MissingNode represents information on a node which should contain data
+for this table, but could not be contacted during this request.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.TableStatsResponse-string) |  | The ID of the missing node. | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.TableStatsResponse-string) |  | The error message that resulted when the query sent to this node failed. | [reserved](#support-status) |
+
+
+
+
+
+
+## NonTableStats
+
+`GET /_admin/v1/nontablestats`
+
+Example URL: /_admin/v1/nontablestats
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+NonTableStatsRequest requests statistics on cluster data ranges that do not
+belong to SQL tables.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+NonTableStatsResponse returns statistics on various cluster data ranges
+that do not belong to SQL tables. The statistics for each range are returned
+as a TableStatsResponse.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time_series_stats | [TableStatsResponse](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse) |  | Information on time series ranges. | [reserved](#support-status) |
+| internal_use_stats | [TableStatsResponse](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse) |  | Information for remaining (non-table, non-time-series) ranges. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse"></a>
+#### TableStatsResponse
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | [reserved](#support-status) |
+| replica_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | [reserved](#support-status) |
+| node_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | [reserved](#support-status) |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | [reserved](#support-status) |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.NonTableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | [reserved](#support-status) |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode"></a>
+#### TableStatsResponse.MissingNode
+
+MissingNode represents information on a node which should contain data
+for this table, but could not be contacted during this request.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NonTableStatsResponse-string) |  | The ID of the missing node. | [reserved](#support-status) |
+| error_message | [string](#cockroach.server.serverpb.NonTableStatsResponse-string) |  | The error message that resulted when the query sent to this node failed. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse"></a>
+#### TableStatsResponse
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | [reserved](#support-status) |
+| replica_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | [reserved](#support-status) |
+| node_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | [reserved](#support-status) |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | [reserved](#support-status) |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.NonTableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | [reserved](#support-status) |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | [reserved](#support-status) |
+
+
+
+
+
+
+## Events
+
+`GET /_admin/v1/events`
+
+Example URLs:
+Example URLs:
+- /_admin/v1/events
+- /_admin/v1/events?limit=100
+- /_admin/v1/events?type=create_table
+- /_admin/v1/events?type=create_table&limit=100
+- /_admin/v1/events?type=drop_table&target_id=4
+- /_admin/v1/events?type=drop_table&target_id=4&limit=100
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+EventsRequest is a request for event log entries, optionally filtered
+by the specified event type and/or target_id.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| type | [string](#cockroach.server.serverpb.EventsRequest-string) |  |  | [reserved](#support-status) |
+| target_id | [int64](#cockroach.server.serverpb.EventsRequest-int64) |  |  | [reserved](#support-status) |
+| limit | [int32](#cockroach.server.serverpb.EventsRequest-int32) |  | limit is the total number of results that are retrieved by the query. If this is omitted or set to 0, the default maximum number of results are returned. When set to > 0, at most only that number of results are returned. When set to < 0, an unlimited number of results are returned. | [reserved](#support-status) |
+| unredacted_events | [bool](#cockroach.server.serverpb.EventsRequest-bool) |  | unredacted_events indicates that the values in the events should not be redacted. The default is to redact, so that older versions of `cockroach zip` do not see un-redacted values by default. For good security, this field is only obeyed by the server after checking that the client of the RPC is an admin user. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+EventsResponse contains a set of event log entries. This is always limited
+to the latest N entries (N is enforced in the associated endpoint).
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| events | [EventsResponse.Event](#cockroach.server.serverpb.EventsResponse-cockroach.server.serverpb.EventsResponse.Event) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.EventsResponse-cockroach.server.serverpb.EventsResponse.Event"></a>
+#### EventsResponse.Event
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.EventsResponse-google.protobuf.Timestamp) |  | timestamp is the time at which the event occurred. | [reserved](#support-status) |
+| event_type | [string](#cockroach.server.serverpb.EventsResponse-string) |  | event_type is the type of the event (e.g. "create_table", "drop_table". | [reserved](#support-status) |
+| target_id | [int64](#cockroach.server.serverpb.EventsResponse-int64) |  | target_id is the target for this event. | [reserved](#support-status) |
+| reporting_id | [int64](#cockroach.server.serverpb.EventsResponse-int64) |  | reporting_id is the reporting ID for this event. | [reserved](#support-status) |
+| info | [string](#cockroach.server.serverpb.EventsResponse-string) |  | info has more detailed information for the event. The contents vary depending on the event. | [reserved](#support-status) |
+| unique_id | [bytes](#cockroach.server.serverpb.EventsResponse-bytes) |  | unique_id is a unique identifier for this event. | [reserved](#support-status) |
+
+
+
+
+
+
+## SetUIData
+
+`POST /_admin/v1/uidata`
+
+This requires a POST. Because of the libraries we're using, the POST body
+must be in the following format:
+
+{"key_values":
+  { "key1": "base64_encoded_value1"},
+  ...
+  { "keyN": "base64_encoded_valueN"},
+}
+
+Note that all keys are quoted strings and that all values are base64-
+encoded.
+
+Together, SetUIData and GetUIData provide access to a "cookie jar" for the
+admin UI. The structure of the underlying data is meant to be opaque to the
+server.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+SetUIDataRequest stores the given key/value pairs in the system.ui table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [SetUIDataRequest.KeyValuesEntry](#cockroach.server.serverpb.SetUIDataRequest-cockroach.server.serverpb.SetUIDataRequest.KeyValuesEntry) | repeated | key_values is a map of keys to bytes values. Each key will be stored with its corresponding value as a separate row in system.ui. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.SetUIDataRequest-cockroach.server.serverpb.SetUIDataRequest.KeyValuesEntry"></a>
+#### SetUIDataRequest.KeyValuesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.SetUIDataRequest-string) |  |  |  |
+| value | [bytes](#cockroach.server.serverpb.SetUIDataRequest-bytes) |  |  |  |
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+SetUIDataResponse is currently an empty response.
+
+
+
+
+
+
+
+
+## GetUIData
+
+`GET /_admin/v1/uidata`
+
+Example URLs:
+- /_admin/v1/uidata?keys=MYKEY
+- /_admin/v1/uidata?keys=MYKEY1&keys=MYKEY2
+
+Yes, it's a little odd that the query parameter is named "keys" instead of
+"key". I would've preferred that the URL parameter be named "key". However,
+it's clearer for the protobuf field to be named "keys," which makes the URL
+parameter "keys" as well.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+GETUIDataRequest requests the values for the given keys from the system.ui
+table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| keys | [string](#cockroach.server.serverpb.GetUIDataRequest-string) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+GetUIDataResponse contains the requested values and the times at which
+the values were last updated.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [GetUIDataResponse.KeyValuesEntry](#cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.KeyValuesEntry) | repeated | key_values maps keys to their retrieved values. If this doesn't contain a a requested key, that key was not found. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.KeyValuesEntry"></a>
+#### GetUIDataResponse.KeyValuesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.GetUIDataResponse-string) |  |  |  |
+| value | [GetUIDataResponse.Value](#cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.Value) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.Value"></a>
+#### GetUIDataResponse.Value
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| value | [bytes](#cockroach.server.serverpb.GetUIDataResponse-bytes) |  | value is the value of the requested key. | [reserved](#support-status) |
+| last_updated | [google.protobuf.Timestamp](#cockroach.server.serverpb.GetUIDataResponse-google.protobuf.Timestamp) |  | last_updated is the time at which the value was last updated. | [reserved](#support-status) |
+
+
+
+
+
+
+## Cluster
+
+`GET /_admin/v1/cluster`
+
+Cluster returns metadata for the cluster.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+ClusterRequest requests metadata for the cluster.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+ClusterResponse contains metadata for the cluster.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| cluster_id | [string](#cockroach.server.serverpb.ClusterResponse-string) |  | The unique ID used to identify this cluster. | [reserved](#support-status) |
+| reporting_enabled | [bool](#cockroach.server.serverpb.ClusterResponse-bool) |  | True if diagnostics reporting is enabled for the cluster. | [reserved](#support-status) |
+| enterprise_enabled | [bool](#cockroach.server.serverpb.ClusterResponse-bool) |  | True if enterprise features are enabled for the cluster. | [reserved](#support-status) |
+
+
+
+
+
+
+
+## Settings
+
+`GET /_admin/v1/settings`
+
+Settings returns the cluster-wide settings for the cluster.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+SettingsRequest inquires what are the current settings in the cluster.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| keys | [string](#cockroach.server.serverpb.SettingsRequest-string) | repeated | The array of setting names to retrieve. An empty keys array means "all". | [reserved](#support-status) |
+| unredacted_values | [bool](#cockroach.server.serverpb.SettingsRequest-bool) |  | Indicate whether to see unredacted setting values. This is opt-in so that a previous version `cockroach zip` does not start reporting values when this becomes active. For good security, the server only obeys this after it checks that the logger-in user has admin privilege. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+SettingsResponse is the response to SettingsRequest.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [SettingsResponse.KeyValuesEntry](#cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.KeyValuesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.KeyValuesEntry"></a>
+#### SettingsResponse.KeyValuesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  |  |
+| value | [SettingsResponse.Value](#cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.Value) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.Value"></a>
+#### SettingsResponse.Value
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| value | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | [reserved](#support-status) |
+| type | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | [reserved](#support-status) |
+| description | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | [reserved](#support-status) |
+| public | [bool](#cockroach.server.serverpb.SettingsResponse-bool) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## Health
+
+`GET /health`
+
+Health returns liveness for the node target of the request.
+
+Support status: [public](#support-status)
+
+#### Request Parameters
+
+
+
+
+HealthRequest requests a liveness or readiness check.
+
+A liveness check is triggered via ready set to false. In this mode,
+an empty response is returned immediately, that is, the caller merely
+learns that the process is running.
+
+A readiness check (ready == true) is suitable for determining whether
+user traffic should be directed at a given node, for example by a load
+balancer. In this mode, a successful response is returned only if the
+node:
+
+- is not in the process of shutting down or booting up (including
+  waiting for cluster bootstrap);
+- is regarded as healthy by the cluster via the recent broadcast of
+  a liveness beacon. Absent either of these conditions, an error
+  code will result.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ready | [bool](#cockroach.server.serverpb.HealthRequest-bool) |  | ready specifies whether the client wants to know whether the target node is ready to receive traffic. If a node is unready, an error will be returned. | [public](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+HealthResponse is the response to HealthRequest. It currently does not
+contain any information.
+
+
+
+
+
+
+
+
+## Liveness
+
+`GET /_admin/v1/liveness`
+
+Liveness returns the liveness state of all nodes on the cluster.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+LivenessRequest requests liveness data for all nodes on the cluster.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+LivenessResponse contains the liveness status of each node on the cluster.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| livenesses | [cockroach.kv.kvserver.liveness.livenesspb.Liveness](#cockroach.server.serverpb.LivenessResponse-cockroach.kv.kvserver.liveness.livenesspb.Liveness) | repeated |  | [reserved](#support-status) |
+| statuses | [LivenessResponse.StatusesEntry](#cockroach.server.serverpb.LivenessResponse-cockroach.server.serverpb.LivenessResponse.StatusesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.LivenessResponse-cockroach.server.serverpb.LivenessResponse.StatusesEntry"></a>
+#### LivenessResponse.StatusesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.LivenessResponse-int32) |  |  |  |
+| value | [cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus](#cockroach.server.serverpb.LivenessResponse-cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus) |  |  |  |
+
+
+
+
+
+
+## Jobs
+
+`GET /_admin/v1/jobs`
+
+Jobs returns the job records for all jobs of the given status and type.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+JobsRequest requests system job information of the given status and type.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| limit | [int32](#cockroach.server.serverpb.JobsRequest-int32) |  |  | [reserved](#support-status) |
+| status | [string](#cockroach.server.serverpb.JobsRequest-string) |  |  | [reserved](#support-status) |
+| type | [cockroach.sql.jobs.jobspb.Type](#cockroach.server.serverpb.JobsRequest-cockroach.sql.jobs.jobspb.Type) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+JobsResponse contains the job record for each matching job.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| jobs | [JobsResponse.Job](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobsResponse.Job) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobsResponse.Job"></a>
+#### JobsResponse.Job
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  |  | [reserved](#support-status) |
+| type | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| description | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| statement | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| username | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| descriptor_ids | [uint32](#cockroach.server.serverpb.JobsResponse-uint32) | repeated |  | [reserved](#support-status) |
+| status | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| created | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| started | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| finished | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| modified | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| fraction_completed | [float](#cockroach.server.serverpb.JobsResponse-float) |  |  | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| highwater_timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  | highwater_timestamp is the highwater timestamp returned as normal timestamp. This is appropriate for display to humans. | [reserved](#support-status) |
+| highwater_decimal | [string](#cockroach.server.serverpb.JobsResponse-string) |  | highwater_decimal is the highwater timestamp in the proprietary decimal form used by logical timestamps internally. This is appropriate to pass to a "AS OF SYSTEM TIME" SQL statement. | [reserved](#support-status) |
+| running_status | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## Locations
+
+`GET /_admin/v1/locations`
+
+Locations returns the locality location records.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+LocationsRequest requests system locality location information.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+JobsResponse contains the job record for each matching job.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| locations | [LocationsResponse.Location](#cockroach.server.serverpb.LocationsResponse-cockroach.server.serverpb.LocationsResponse.Location) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.LocationsResponse-cockroach.server.serverpb.LocationsResponse.Location"></a>
+#### LocationsResponse.Location
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| locality_key | [string](#cockroach.server.serverpb.LocationsResponse-string) |  |  | [reserved](#support-status) |
+| locality_value | [string](#cockroach.server.serverpb.LocationsResponse-string) |  |  | [reserved](#support-status) |
+| latitude | [double](#cockroach.server.serverpb.LocationsResponse-double) |  |  | [reserved](#support-status) |
+| longitude | [double](#cockroach.server.serverpb.LocationsResponse-double) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## QueryPlan
+
+`GET /_admin/v1/queryplan`
+
+QueryPlan returns the query plans for a SQL string.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+QueryPlanRequest requests the query plans for a SQL string.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| query | [string](#cockroach.server.serverpb.QueryPlanRequest-string) |  | query is the SQL query string. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+QueryPlanResponse contains the query plans for a SQL string (currently only
+the distsql physical query plan).
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| distsql_physical_query_plan | [string](#cockroach.server.serverpb.QueryPlanResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+## Drain
+
+
+
+Drain puts the node into the specified drain mode(s) and optionally
+instructs the process to terminate.
+We do not expose this via HTTP unless we have a way to authenticate
++ authorize streaming RPC connections. See #42567.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+DrainRequest instructs the receiving node to drain.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| pre201_marker | [int32](#cockroach.server.serverpb.DrainRequest-int32) | repeated | pre_201_marker represents a field that clients stopped using in 20.1. It's maintained to reject requests from such clients, since they're not setting other required fields. | [reserved](#support-status) |
+| shutdown | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, terminates the process after the server has started draining. Setting both shutdown and do_drain to false causes the request to only operate as a probe. Setting do_drain to false and shutdown to true causes the server to shut down immediately without first draining. | [reserved](#support-status) |
+| do_drain | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, perform the drain phase. See the comment above on shutdown for an explanation of the interaction between the two. do_drain is also implied by a non-nil deprecated_probe_indicator. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DrainResponse is the response to a successful DrainRequest.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| is_draining | [bool](#cockroach.server.serverpb.DrainResponse-bool) |  | is_draining is set to true iff the server is currently draining. This is set to true in response to a request where skip_drain is false; but it can also be set to true in response to a probe request (!shutdown && skip_drain) if another drain request has been issued prior or asynchronously. | [reserved](#support-status) |
+| drain_remaining_indicator | [uint64](#cockroach.server.serverpb.DrainResponse-uint64) |  | drain_remaining_indicator measures, at the time of starting to process the corresponding drain request, how many actions to fully drain the node were deemed to be necessary. Some, but not all, of these actions may already have been carried out by the time this indicator is received by the client. The client should issue requests until this indicator first reaches zero, which indicates that the node is fully drained.<br><br>The API contract is the following:<br><br>- upon a first Drain call with do_drain set, the remaining   indicator will have some value >=0. If >0, it indicates that   drain is pushing state away from the node. (What this state   precisely means is left unspecified for this field. See below   for details.)<br><br>- upon a subsequent Drain call with do_drain set, the remaining   indicator should have reduced in value. The drain process does best   effort at shedding state away from the node; hopefully, all the   state is shed away upon the first call and the progress   indicator can be zero as early as the second call. However,   if there was a lot of state to shed, it is possible for   timeout to be encountered upon the first call. In that case, the   second call will do some more work and return a non-zero value   as well.<br><br>- eventually, in an iterated sequence of DrainRequests with   do_drain set, the remaining indicator should reduce to zero. At   that point the client can conclude that no state is left to   shed, and it should be safe to shut down the node with a   DrainRequest with shutdown = true.<br><br>Note that this field is left unpopulated (and thus remains at zero) for pre-20.1 nodes. A client can recognize this by observing is_draining to be false after a request with do_drain = true: the is_draining field is also left unpopulated by pre-20.1 nodes. | [reserved](#support-status) |
+| drain_remaining_description | [string](#cockroach.server.serverpb.DrainResponse-string) |  | drain_remaining_description is an informal (= not machine-parsable) string that explains the progress of the drain process to human eyes. This is intended for use mainly for troubleshooting.<br><br>The field is only populated if do_drain is true in the request. | [reserved](#support-status) |
+
+
+
+
+
+
+
+## Decommission
+
+
+
+Decommission puts the node(s) into the specified decommissioning state.
+If this ever becomes exposed via HTTP, ensure that it performs
+authorization. See #42567.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+DecommissionRequest requests the server to set the membership status on
+all nodes specified by NodeIDs to the value of TargetMembership.
+
+If no NodeIDs are given, it targets the recipient node.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_ids | [int32](#cockroach.server.serverpb.DecommissionRequest-int32) | repeated |  | [reserved](#support-status) |
+| target_membership | [cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus](#cockroach.server.serverpb.DecommissionRequest-cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DecommissionStatusResponse lists decommissioning statuses for a number of NodeIDs.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| status | [DecommissionStatusResponse.Status](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status) | repeated | Status of all affected nodes. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status"></a>
+#### DecommissionStatusResponse.Status
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DecommissionStatusResponse-int32) |  |  | [reserved](#support-status) |
+| is_live | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | [reserved](#support-status) |
+| replica_count | [int64](#cockroach.server.serverpb.DecommissionStatusResponse-int64) |  | The number of replicas on the node, computed by scanning meta2 ranges. | [reserved](#support-status) |
+| membership | [cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus) |  | The membership status of the given node. | [reserved](#support-status) |
+| draining | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## DecommissionStatus
+
+
+
+DecommissionStatus retrieves the decommissioning status of the specified nodes.
+If this ever becomes exposed via HTTP, ensure that it performs
+authorization. See #42567.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+DecommissionStatusRequest requests the decommissioning status for the
+specified or, if none are specified, all nodes.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_ids | [int32](#cockroach.server.serverpb.DecommissionStatusRequest-int32) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DecommissionStatusResponse lists decommissioning statuses for a number of NodeIDs.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| status | [DecommissionStatusResponse.Status](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status) | repeated | Status of all affected nodes. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status"></a>
+#### DecommissionStatusResponse.Status
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DecommissionStatusResponse-int32) |  |  | [reserved](#support-status) |
+| is_live | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | [reserved](#support-status) |
+| replica_count | [int64](#cockroach.server.serverpb.DecommissionStatusResponse-int64) |  | The number of replicas on the node, computed by scanning meta2 ranges. | [reserved](#support-status) |
+| membership | [cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus) |  | The membership status of the given node. | [reserved](#support-status) |
+| draining | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## RangeLog
+
+`GET /_admin/v1/rangelog/{range_id}`
+
+URL: /_admin/v1/rangelog
+URL: /_admin/v1/rangelog?limit=100
+URL: /_admin/v1/rangelog/1
+URL: /_admin/v1/rangelog/1?limit=100
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+RangeLogRequest request the history of a range from the range log.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RangeLogRequest-int64) |  | TODO(tamird): use [(gogoproto.customname) = "RangeID"] below. Need to figure out how to teach grpc-gateway about custom names. If RangeID is 0, returns range log history without filtering by range. | [reserved](#support-status) |
+| limit | [int32](#cockroach.server.serverpb.RangeLogRequest-int32) |  | limit is the total number of results that are retrieved by the query. If this is omitted or set to 0, the default maximum number of results are returned. When set to > 0, at most only that number of results are returned. When set to < 0, an unlimited number of results are returned. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+RangeLogResponse contains a list of entries from the range log table.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| events | [RangeLogResponse.Event](#cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.Event) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.Event"></a>
+#### RangeLogResponse.Event
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| event | [cockroach.kv.kvserver.storagepb.RangeLogEvent](#cockroach.server.serverpb.RangeLogResponse-cockroach.kv.kvserver.storagepb.RangeLogEvent) |  |  | [reserved](#support-status) |
+| pretty_info | [RangeLogResponse.PrettyInfo](#cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.PrettyInfo) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.PrettyInfo"></a>
+#### RangeLogResponse.PrettyInfo
+
+To avoid porting the pretty printing of keys and descriptors to
+javascript, they will be precomputed on the serverside.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| updated_desc | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+| new_desc | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+| added_replica | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+| removed_replica | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+| reason | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+| details | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+## DataDistribution
+
+`GET /_admin/v1/data_distribution`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database_info | [DataDistributionResponse.DatabaseInfoEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfoEntry) | repeated | By database name. | [reserved](#support-status) |
+| zone_configs | [DataDistributionResponse.ZoneConfigsEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfigsEntry) | repeated | By zone name. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfoEntry"></a>
+#### DataDistributionResponse.DatabaseInfoEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.DatabaseInfo](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo"></a>
+#### DataDistributionResponse.DatabaseInfo
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| table_info | [DataDistributionResponse.DatabaseInfo.TableInfoEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo.TableInfoEntry) | repeated | By table name. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo.TableInfoEntry"></a>
+#### DataDistributionResponse.DatabaseInfo.TableInfoEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.TableInfo](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo"></a>
+#### DataDistributionResponse.TableInfo
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_count_by_node_id | [DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry) | repeated |  | [reserved](#support-status) |
+| zone_config_id | [int64](#cockroach.server.serverpb.DataDistributionResponse-int64) |  |  | [reserved](#support-status) |
+| dropped_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.DataDistributionResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry"></a>
+#### DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.DataDistributionResponse-int32) |  |  |  |
+| value | [int64](#cockroach.server.serverpb.DataDistributionResponse-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfigsEntry"></a>
+#### DataDistributionResponse.ZoneConfigsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.ZoneConfig](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfig) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfig"></a>
+#### DataDistributionResponse.ZoneConfig
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| target | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  | target is the object the zone config applies to, e.g. "DATABASE db" or "PARTITION north_america OF TABLE users". | [reserved](#support-status) |
+| config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.DataDistributionResponse-cockroach.config.zonepb.ZoneConfig) |  |  | [reserved](#support-status) |
+| config_sql | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  | config_sql is the SQL representation of config. | [reserved](#support-status) |
+
+
+
+
+
+
+## AllMetricMetadata
+
+`GET /_admin/v1/metricmetadata`
+
+URL: /_admin/v1/metricmetadata
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+MetricMetadataRequest requests metadata for all metrics.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+MetricMetadataResponse contains the metadata for all metics.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| metadata | [MetricMetadataResponse.MetadataEntry](#cockroach.server.serverpb.MetricMetadataResponse-cockroach.server.serverpb.MetricMetadataResponse.MetadataEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.MetricMetadataResponse-cockroach.server.serverpb.MetricMetadataResponse.MetadataEntry"></a>
+#### MetricMetadataResponse.MetadataEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.MetricMetadataResponse-string) |  |  |  |
+| value | [cockroach.util.metric.Metadata](#cockroach.server.serverpb.MetricMetadataResponse-cockroach.util.metric.Metadata) |  |  |  |
+
+
+
+
+
+
+## ChartCatalog
+
+`GET /_admin/v1/chartcatalog`
+
+URL: /_admin/v1/chartcatalog
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+ChartCatalogRequest requests returns a catalog of Admin UI charts.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+ChartCatalogResponse returns a catalog of Admin UI charts useful for debugging.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| catalog | [cockroach.ts.catalog.ChartSection](#cockroach.server.serverpb.ChartCatalogResponse-cockroach.ts.catalog.ChartSection) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+## EnqueueRange
+
+`POST /_admin/v1/enqueue_range`
+
+EnqueueRange runs the specified range through the specified queue on the
+range's leaseholder store, returning the detailed trace and error
+information from doing so. Parameters must be provided in the body of the
+POST request.
+For example:
+
+{
+  "queue": "raftlog",
+  "rangeId": 10
+}
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.EnqueueRangeRequest-int32) |  | The node on which the queue should process the range. If node_id is 0, the request will be forwarded to all other nodes. | [reserved](#support-status) |
+| queue | [string](#cockroach.server.serverpb.EnqueueRangeRequest-string) |  | The name of the replica queue to run the range through. Matched against each queue's name field. See the implementation of baseQueue for details. | [reserved](#support-status) |
+| range_id | [int32](#cockroach.server.serverpb.EnqueueRangeRequest-int32) |  | The ID of the range to run through the queue. | [reserved](#support-status) |
+| skip_should_queue | [bool](#cockroach.server.serverpb.EnqueueRangeRequest-bool) |  | If set, run the queue's process method without first checking whether the replica should be processed by calling shouldQueue. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| details | [EnqueueRangeResponse.Details](#cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.EnqueueRangeResponse.Details) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.EnqueueRangeResponse.Details"></a>
+#### EnqueueRangeResponse.Details
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.EnqueueRangeResponse-int32) |  |  | [reserved](#support-status) |
+| events | [TraceEvent](#cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated | All trace events collected while processing the range in the queue. | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.EnqueueRangeResponse-string) |  | The error message from the queue's processing, if any. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.TraceEvent"></a>
+#### TraceEvent
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.EnqueueRangeResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.EnqueueRangeResponse-string) |  |  | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/health-request.md
+++ b/docs/generated/http/health-request.md
@@ -1,0 +1,30 @@
+
+
+<a name="cockroach.server.serverpb.HealthRequest"></a>
+#### HealthRequest
+
+HealthRequest requests a liveness or readiness check.
+
+A liveness check is triggered via ready set to false. In this mode,
+an empty response is returned immediately, that is, the caller merely
+learns that the process is running.
+
+A readiness check (ready == true) is suitable for determining whether
+user traffic should be directed at a given node, for example by a load
+balancer. In this mode, a successful response is returned only if the
+node:
+
+- is not in the process of shutting down or booting up (including
+  waiting for cluster bootstrap);
+- is regarded as healthy by the cluster via the recent broadcast of
+  a liveness beacon. Absent either of these conditions, an error
+  code will result.
+
+Support status: [public](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ready | [bool](#bool) |  | ready specifies whether the client wants to know whether the target node is ready to receive traffic. If a node is unready, an error will be returned. | [public](#support-status) |
+
+

--- a/docs/generated/http/health-response.md
+++ b/docs/generated/http/health-response.md
@@ -1,0 +1,12 @@
+
+
+<a name="cockroach.server.serverpb.HealthResponse"></a>
+#### HealthResponse
+
+HealthResponse is the response to HealthRequest. It currently does not
+contain any information.
+
+Support status: [public](#support-status)
+
+
+

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -3,10 +3,15 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
 #### HotRangesResponse.HotRangesByNodeIdEntry
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| key | [int32](#int32) |  |
-| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |  |
 
 
 
@@ -14,10 +19,15 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
 #### HotRangesResponse.NodeResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| error_message | [string](#string) |  |
-| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated |
+NodeResponse is a hot range report for a single target node.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. | [alpha](#support-status) |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. | [alpha](#support-status) |
 
 
 
@@ -25,10 +35,16 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
 #### HotRangesResponse.StoreResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| store_id | [int32](#int32) |  |
-| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated |
+StoreResponse contains the part of a hot ranges report that
+pertains to a single store on a target node.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#int32) |  | StoreID identifies the store for which the report was produced. | [alpha](#support-status) |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. | [alpha](#support-status) |
 
 
 
@@ -36,9 +52,15 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
 #### HotRangesResponse.HotRange
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  |
-| queries_per_second | [double](#double) |  |
+HotRange is a hot range report for a single store on one of the
+target node(s) selected in a HotRangesRequest.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
+| queries_per_second | [double](#double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
 
 

--- a/docs/generated/http/hotranges-request.md
+++ b/docs/generated/http/hotranges-request.md
@@ -3,8 +3,14 @@
 <a name="cockroach.server.serverpb.HotRangesRequest"></a>
 #### HotRangesRequest
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| node_id | [string](#string) |  |
+HotRangesRequest queries one or more cluster nodes for a list
+of ranges currently considered “hot” by the node(s).
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
 
 

--- a/docs/generated/http/hotranges-response.md
+++ b/docs/generated/http/hotranges-response.md
@@ -3,9 +3,15 @@
 <a name="cockroach.server.serverpb.HotRangesResponse"></a>
 #### HotRangesResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| node_id | [int32](#int32) |  |
-| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated |
+HotRangesResponse is the payload produced in response
+to a HotRangesRequest.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). | [alpha](#support-status) |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. | [alpha](#support-status) |
 
 

--- a/docs/generated/http/nodes-other.md
+++ b/docs/generated/http/nodes-other.md
@@ -1,0 +1,139 @@
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus"></a>
+#### NodeStatus
+
+NodeStatus records the most recent values of metrics for a node.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | [reserved](#support-status) |
+| build_info | [cockroach.build.Info](#cockroach.build.Info) |  | build_info describes the `cockroach` executable file. | [alpha](#support-status) |
+| started_at | [int64](#int64) |  | started_at is the unix timestamp at which the node process was last started. | [alpha](#support-status) |
+| updated_at | [int64](#int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | [alpha](#support-status) |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+| store_statuses | [StoreStatus](#cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | [reserved](#support-status) |
+| args | [string](#string) | repeated | args is the list of command-line arguments used to last start the node. | [reserved](#support-status) |
+| env | [string](#string) | repeated | env is the list of environment variables that influenced the node's configuration. | [reserved](#support-status) |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | [reserved](#support-status) |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | [reserved](#support-status) |
+| total_system_memory | [int64](#int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | [alpha](#support-status) |
+| num_cpus | [int32](#int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the `cockroach` process is running. Note that this does not report the number of CPUs actually used by `cockroach`; this parameter is controlled separately. | [alpha](#support-status) |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#string) |  |  |  |
+| value | [double](#double) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+Support status: [reserved](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | [reserved](#support-status) |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | [reserved](#support-status) |
+
+
+
+
+<a name="cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#string) |  |  |  |
+| value | [double](#double) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [int64](#int64) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+Support status: [reserved](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#int64) |  | in bytes | [reserved](#support-status) |
+| outgoing | [int64](#int64) |  | in bytes | [reserved](#support-status) |
+| latency | [int64](#int64) |  | in nanoseconds | [reserved](#support-status) |
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry"></a>
+#### NodesResponse.LivenessByNodeIdEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus](#cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus) |  |  |  |
+
+

--- a/docs/generated/http/nodes-request.md
+++ b/docs/generated/http/nodes-request.md
@@ -1,0 +1,12 @@
+
+
+<a name="cockroach.server.serverpb.NodesRequest"></a>
+#### NodesRequest
+
+NodesRequest requests a copy of the node information as known to gossip
+and the KV layer.
+
+Support status: [alpha](#support-status)
+
+
+

--- a/docs/generated/http/nodes-response.md
+++ b/docs/generated/http/nodes-response.md
@@ -1,0 +1,16 @@
+
+
+<a name="cockroach.server.serverpb.NodesResponse"></a>
+#### NodesResponse
+
+NodesResponse describe the nodes in the cluster.
+
+Support status: [alpha](#support-status)
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.status.statuspb.NodeStatus) | repeated | nodes carries the status payloads for all nodes in the cluster. | [alpha](#support-status) |
+| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated | liveness_by_node_id maps each node ID to a liveness status. | [reserved](#support-status) |
+
+

--- a/pkg/build/info.pb.go
+++ b/pkg/build/info.pb.go
@@ -22,17 +22,28 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 // Info describes build information for this CockroachDB binary.
 type Info struct {
-	GoVersion       string `protobuf:"bytes,1,opt,name=go_version,json=goVersion" json:"go_version"`
-	Tag             string `protobuf:"bytes,2,opt,name=tag" json:"tag"`
-	Time            string `protobuf:"bytes,3,opt,name=time" json:"time"`
-	Revision        string `protobuf:"bytes,4,opt,name=revision" json:"revision"`
-	CgoCompiler     string `protobuf:"bytes,5,opt,name=cgo_compiler,json=cgoCompiler" json:"cgo_compiler"`
+	// go_version is the version of the Go toolchain used to compile this executable.
+	GoVersion string `protobuf:"bytes,1,opt,name=go_version,json=goVersion" json:"go_version"`
+	// tag is the git tag for the revision of the source code for this executable.
+	Tag string `protobuf:"bytes,2,opt,name=tag" json:"tag"`
+	// time is the time at which the build started.
+	Time string `protobuf:"bytes,3,opt,name=time" json:"time"`
+	// revision is the git commit identifier for the source code of this executable.
+	Revision string `protobuf:"bytes,4,opt,name=revision" json:"revision"`
+	// cgo_compiler is the C/C++ compiler used to build non-go dependencies.
+	CgoCompiler string `protobuf:"bytes,5,opt,name=cgo_compiler,json=cgoCompiler" json:"cgo_compiler"`
+	// cgo_target_triple is the platform identifier that identifies the cross-compilation target for C/C++ components.
 	CgoTargetTriple string `protobuf:"bytes,10,opt,name=cgo_target_triple,json=cgoTargetTriple" json:"cgo_target_triple"`
-	Platform        string `protobuf:"bytes,6,opt,name=platform" json:"platform"`
-	Distribution    string `protobuf:"bytes,7,opt,name=distribution" json:"distribution"`
-	Type            string `protobuf:"bytes,8,opt,name=type" json:"type"`
-	Channel         string `protobuf:"bytes,9,opt,name=channel" json:"channel"`
-	EnvChannel      string `protobuf:"bytes,11,opt,name=env_channel,json=envChannel" json:"env_channel"`
+	// platform is the platform identifiers that identifies the cross-compilation target for Go code.
+	Platform string `protobuf:"bytes,6,opt,name=platform" json:"platform"`
+	// distribution indicates which licensing conditions apply (OSS: full open source; CCL: includes CCL code).
+	Distribution string `protobuf:"bytes,7,opt,name=distribution" json:"distribution"`
+	// type indicates whether this is a development or release build.
+	Type string `protobuf:"bytes,8,opt,name=type" json:"type"`
+	// channel identifies through which product channel the executable was released.
+	Channel string `protobuf:"bytes,9,opt,name=channel" json:"channel"`
+	// env_channel identifies the product channel as overridden by the COCKROACH_CHANNEL environment variable.
+	EnvChannel string `protobuf:"bytes,11,opt,name=env_channel,json=envChannel" json:"env_channel"`
 	// dependencies exists to allow tests that run against old clusters
 	// to unmarshal JSON containing this field. The tag is unimportant,
 	// but the field name must remain unchanged.
@@ -47,7 +58,7 @@ func (m *Info) Reset()         { *m = Info{} }
 func (m *Info) String() string { return proto.CompactTextString(m) }
 func (*Info) ProtoMessage()    {}
 func (*Info) Descriptor() ([]byte, []int) {
-	return fileDescriptor_info_144091887156c658, []int{0}
+	return fileDescriptor_info_6120d08447ce7654, []int{0}
 }
 func (m *Info) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,9 +719,9 @@ var (
 	ErrIntOverflowInfo   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_144091887156c658) }
+func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_6120d08447ce7654) }
 
-var fileDescriptor_info_144091887156c658 = []byte{
+var fileDescriptor_info_6120d08447ce7654 = []byte{
 	// 339 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x54, 0x91, 0x41, 0x8e, 0xda, 0x30,
 	0x14, 0x86, 0x93, 0x12, 0x0a, 0x18, 0x24, 0x5a, 0xab, 0xaa, 0xac, 0x2e, 0x5c, 0x54, 0x54, 0xc1,

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -16,16 +16,27 @@ import "gogoproto/gogo.proto";
 
 // Info describes build information for this CockroachDB binary.
 message Info {
+  // go_version is the version of the Go toolchain used to compile this executable.
   optional string go_version = 1 [(gogoproto.nullable) = false];
+  // tag is the git tag for the revision of the source code for this executable.
   optional string tag = 2 [(gogoproto.nullable) = false];
+  // time is the time at which the build started.
   optional string time = 3 [(gogoproto.nullable) = false];
+  // revision is the git commit identifier for the source code of this executable.
   optional string revision = 4 [(gogoproto.nullable) = false];
+  // cgo_compiler is the C/C++ compiler used to build non-go dependencies.
   optional string cgo_compiler = 5 [(gogoproto.nullable) = false];
+  // cgo_target_triple is the platform identifier that identifies the cross-compilation target for C/C++ components.
   optional string cgo_target_triple = 10 [(gogoproto.nullable) = false];
+  // platform is the platform identifiers that identifies the cross-compilation target for Go code.
   optional string platform = 6 [(gogoproto.nullable) = false];
+  // distribution indicates which licensing conditions apply (OSS: full open source; CCL: includes CCL code).
   optional string distribution = 7 [(gogoproto.nullable) = false];
+  // type indicates whether this is a development or release build.
   optional string type = 8 [(gogoproto.nullable) = false];
+  // channel identifies through which product channel the executable was released.
   optional string channel = 9 [(gogoproto.nullable) = false];
+  // env_channel identifies the product channel as overridden by the COCKROACH_CHANNEL environment variable.
   optional string env_channel = 11 [(gogoproto.nullable) = false];
 
   // dependencies exists to allow tests that run against old clusters

--- a/pkg/cmd/docgen/http.go
+++ b/pkg/cmd/docgen/http.go
@@ -52,6 +52,8 @@ func init() {
 
 var singleMethods = []string{
 	"HotRanges",
+	"Nodes",
+	"Health",
 }
 
 // runHTTP extracts HTTP endpoint documentation. It does this by reading the
@@ -86,6 +88,8 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 		fmt.Sprintf("--doc_out=%s", tmpJSON),
 		fmt.Sprintf("--doc_opt=%s,http.json", jsonTmpl),
 		"./pkg/server/serverpb/status.proto",
+		"./pkg/server/serverpb/admin.proto",
+		"./pkg/server/status/statuspb/status.proto",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Println(string(out))
@@ -99,20 +103,53 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 	if err := json.Unmarshal(dataFile, &data); err != nil {
 		return fmt.Errorf("json unmarshal: %w", err)
 	}
-	if len(data.Files) != 1 || len(data.Files[0].Services) != 1 {
-		return fmt.Errorf("expected 1 file with 1 service")
+
+	// Annotate all non-public message, method and field descriptions
+	// with a disclaimer.
+	for k := range data.Files {
+		file := &data.Files[k]
+		for i := range file.Messages {
+			m := &file.Messages[i]
+			if !(strings.HasSuffix(m.Name, "Entry") && len(m.Fields) == 2 && m.Fields[0].Name == "key" && m.Fields[1].Name == "value") {
+				// We only annotate the support status for non-KV
+				// (auto-generated, intermediate) message types.
+				annotateStatus(&m.Description, &m.SupportStatus, "payload")
+				for j := range m.Fields {
+					f := &m.Fields[j]
+					annotateStatus(&f.Description, &f.SupportStatus, "field")
+				}
+			}
+		}
+		for j := range file.Services {
+			service := &file.Services[j]
+			for i := range service.Methods {
+				m := &service.Methods[i]
+				annotateStatus(&m.Description, &m.SupportStatus, "endpoint")
+				if len(m.Options.GoogleAPIHTTP.Rules) > 0 {
+					// Just keep the last entry. This is a special accommodation for
+					// "/health" which aliases "/_admin/v1/health": we only
+					// want to document the latter.
+					m.Options.GoogleAPIHTTP.Rules = m.Options.GoogleAPIHTTP.Rules[len(m.Options.GoogleAPIHTTP.Rules)-1:]
+				}
+			}
+		}
 	}
-	file := data.Files[0]
-	service := file.Services[0]
 
 	// Start by making maps of methods and messages for lookup.
 	messages := make(map[string]*protoMessage)
-	for i := range file.Messages {
-		messages[file.Messages[i].FullName] = &file.Messages[i]
-	}
 	methods := make(map[string]*protoMethod)
-	for i := range service.Methods {
-		methods[service.Methods[i].Name] = &service.Methods[i]
+	for f := range data.Files {
+		file := &data.Files[f]
+		for i := range file.Messages {
+			messages[file.Messages[i].FullName] = &file.Messages[i]
+		}
+
+		for j := range file.Services {
+			service := &file.Services[j]
+			for i := range service.Methods {
+				methods[service.Methods[i].Name] = &service.Methods[i]
+			}
+		}
 	}
 
 	// Given a message type, returns all message types in its type field that are
@@ -165,7 +202,7 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 	tmplMessages := template.Must(template.New("single").Funcs(tmplFuncs).Parse(messagesTemplate))
 
 	// JSON data is now in memory. Generate full doc page.
-	if err := execHTTPTmpl(tmplFull, &file, filepath.Join(outPath, "full.md")); err != nil {
+	if err := execHTTPTmpl(tmplFull, &data, filepath.Join(outPath, "full.md")); err != nil {
 		return fmt.Errorf("execHTTPTmpl: %w", err)
 	}
 
@@ -186,6 +223,21 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 		}
 	}
 	return nil
+}
+
+func annotateStatus(desc *string, status *string, kind string) {
+	if !strings.Contains(*desc, "API: PUBLIC") {
+		*status = `[reserved](#support-status)`
+	}
+	if strings.Contains(*desc, "API: PUBLIC ALPHA") {
+		*status = `[alpha](#support-status)`
+	}
+	if *status == "" {
+		*status = `[public](#support-status)`
+	}
+	*desc = strings.Replace(*desc, "API: PUBLIC ALPHA", "", 1)
+	*desc = strings.Replace(*desc, "API: PUBLIC", "", 1)
+	*desc = strings.TrimSpace(*desc)
 }
 
 func execHTTPTmpl(tmpl *template.Template, data interface{}, path string) error {
@@ -242,6 +294,7 @@ type protoData struct {
 type protoMethod struct {
 	Name              string `json:"name"`
 	Description       string `json:"description"`
+	SupportStatus     string `json:"supportStatus"`
 	RequestType       string `json:"requestType"`
 	RequestLongType   string `json:"requestLongType"`
 	RequestFullType   string `json:"requestFullType"`
@@ -265,18 +318,20 @@ type protoMessage struct {
 	LongName      string        `json:"longName"`
 	FullName      string        `json:"fullName"`
 	Description   string        `json:"description"`
+	SupportStatus string        `json:"supportStatus"`
 	HasExtensions bool          `json:"hasExtensions"`
 	HasFields     bool          `json:"hasFields"`
 	Extensions    []interface{} `json:"extensions"`
 	Fields        []struct {
-		Name         string `json:"name"`
-		Description  string `json:"description"`
-		Label        string `json:"label"`
-		Type         string `json:"type"`
-		LongType     string `json:"longType"`
-		FullType     string `json:"fullType"`
-		Ismap        bool   `json:"ismap"`
-		DefaultValue string `json:"defaultValue"`
+		Name          string `json:"name"`
+		Description   string `json:"description"`
+		SupportStatus string `json:"supportStatus"`
+		Label         string `json:"label"`
+		Type          string `json:"type"`
+		LongType      string `json:"longType"`
+		FullType      string `json:"fullType"`
+		Ismap         bool   `json:"ismap"`
+		DefaultValue  string `json:"defaultValue"`
 	} `json:"fields"`
 }
 
@@ -286,11 +341,14 @@ const fullTemplate = `
 {{- define "FIELDS" -}}
 {{with getMessage .}}
 {{$message := .}}
+
+{{with .Description}}{{.}}{{end}}
+
 {{with .Fields}}
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .}}
-| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}} {{- /* with .Fields */}}
 
@@ -301,10 +359,12 @@ const fullTemplate = `
 <a name="{{$message.FullName}}-{{.FullName}}"></a>
 #### {{.LongName}}
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
+{{with .Description}}{{.}}{{end}}
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .Fields}}
-| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}} {{- /* if .Fields */}}
 {{end}} {{- /* with getMessage */}}
@@ -313,16 +373,20 @@ const fullTemplate = `
 {{end}} {{- /* with getMessage */}}
 {{- end}} {{- /* template */}}
 
+{{- range .Files}}
+
 {{- range .Services}}
 
 {{- range .Methods -}}
 ## {{.Name}}
 
 {{range .Options.GoogleAPIHTTP.Rules -}}
-` + "`{{.Method}} {{.Pattern}}`" + `
+` + "`{{.Method}} {{.Pattern}}` " + `
 {{- end}}
 
 {{with .Description}}{{.}}{{end}}
+
+{{with .SupportStatus}}Support status: {{.}}{{end}}
 
 #### Request Parameters
 
@@ -335,6 +399,7 @@ const fullTemplate = `
 {{end}} {{- /* methods */}}
 
 {{- end -}} {{- /* services */ -}}
+{{- end -}} {{- /* files */ -}}
 `
 
 var messagesTemplate = `
@@ -342,11 +407,16 @@ var messagesTemplate = `
 {{with getMessage .}}
 <a name="{{.FullName}}"></a>
 #### {{.LongName}}
+
+{{with .Description}}{{.}}{{end}}
+
+{{with .SupportStatus}}Support status: {{.}}{{end}}
+
 {{with .Fields}}
-| Field | Type | Label |
-| ----- | ---- | ----- |
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .}}
-| {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} |
+| {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} | {{.Description|tableCell}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}}{{- /* with .Fields */}}
 {{end}}{{- /* with getMessage */}}

--- a/pkg/server/serverpb/admin.pb.go
+++ b/pkg/server/serverpb/admin.pb.go
@@ -74,7 +74,7 @@ func (x ZoneConfigurationLevel) String() string {
 	return proto.EnumName(ZoneConfigurationLevel_name, int32(x))
 }
 func (ZoneConfigurationLevel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{0}
 }
 
 // DatabasesRequest requests a list of databases.
@@ -85,7 +85,7 @@ func (m *DatabasesRequest) Reset()         { *m = DatabasesRequest{} }
 func (m *DatabasesRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabasesRequest) ProtoMessage()    {}
 func (*DatabasesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{0}
 }
 func (m *DatabasesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -119,7 +119,7 @@ func (m *DatabasesResponse) Reset()         { *m = DatabasesResponse{} }
 func (m *DatabasesResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabasesResponse) ProtoMessage()    {}
 func (*DatabasesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{1}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{1}
 }
 func (m *DatabasesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -155,7 +155,7 @@ func (m *DatabaseDetailsRequest) Reset()         { *m = DatabaseDetailsRequest{}
 func (m *DatabaseDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsRequest) ProtoMessage()    {}
 func (*DatabaseDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{2}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{2}
 }
 func (m *DatabaseDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -204,7 +204,7 @@ func (m *DatabaseDetailsResponse) Reset()         { *m = DatabaseDetailsResponse
 func (m *DatabaseDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse) ProtoMessage()    {}
 func (*DatabaseDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{3}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{3}
 }
 func (m *DatabaseDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -240,7 +240,7 @@ func (m *DatabaseDetailsResponse_Grant) Reset()         { *m = DatabaseDetailsRe
 func (m *DatabaseDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse_Grant) ProtoMessage()    {}
 func (*DatabaseDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{3, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{3, 0}
 }
 func (m *DatabaseDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -280,7 +280,7 @@ func (m *TableDetailsRequest) Reset()         { *m = TableDetailsRequest{} }
 func (m *TableDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsRequest) ProtoMessage()    {}
 func (*TableDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{4}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{4}
 }
 func (m *TableDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -337,7 +337,7 @@ func (m *TableDetailsResponse) Reset()         { *m = TableDetailsResponse{} }
 func (m *TableDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse) ProtoMessage()    {}
 func (*TableDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{5}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5}
 }
 func (m *TableDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -374,7 +374,7 @@ func (m *TableDetailsResponse_Grant) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Grant) ProtoMessage()    {}
 func (*TableDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{5, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 0}
 }
 func (m *TableDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -418,7 +418,7 @@ func (m *TableDetailsResponse_Column) Reset()         { *m = TableDetailsRespons
 func (m *TableDetailsResponse_Column) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Column) ProtoMessage()    {}
 func (*TableDetailsResponse_Column) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{5, 1}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 1}
 }
 func (m *TableDetailsResponse_Column) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -464,7 +464,7 @@ func (m *TableDetailsResponse_Index) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Index) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Index) ProtoMessage()    {}
 func (*TableDetailsResponse_Index) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{5, 2}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 2}
 }
 func (m *TableDetailsResponse_Index) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -505,7 +505,7 @@ func (m *TableStatsRequest) Reset()         { *m = TableStatsRequest{} }
 func (m *TableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableStatsRequest) ProtoMessage()    {}
 func (*TableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{6}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{6}
 }
 func (m *TableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -559,7 +559,7 @@ func (m *TableStatsResponse) Reset()         { *m = TableStatsResponse{} }
 func (m *TableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse) ProtoMessage()    {}
 func (*TableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{7}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{7}
 }
 func (m *TableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -597,7 +597,7 @@ func (m *TableStatsResponse_MissingNode) Reset()         { *m = TableStatsRespon
 func (m *TableStatsResponse_MissingNode) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse_MissingNode) ProtoMessage()    {}
 func (*TableStatsResponse_MissingNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{7, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{7, 0}
 }
 func (m *TableStatsResponse_MissingNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -631,7 +631,7 @@ func (m *NonTableStatsRequest) Reset()         { *m = NonTableStatsRequest{} }
 func (m *NonTableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsRequest) ProtoMessage()    {}
 func (*NonTableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{8}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{8}
 }
 func (m *NonTableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -670,7 +670,7 @@ func (m *NonTableStatsResponse) Reset()         { *m = NonTableStatsResponse{} }
 func (m *NonTableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsResponse) ProtoMessage()    {}
 func (*NonTableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{9}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{9}
 }
 func (m *NonTableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -703,7 +703,7 @@ func (m *UsersRequest) Reset()         { *m = UsersRequest{} }
 func (m *UsersRequest) String() string { return proto.CompactTextString(m) }
 func (*UsersRequest) ProtoMessage()    {}
 func (*UsersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{10}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{10}
 }
 func (m *UsersRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -738,7 +738,7 @@ func (m *UsersResponse) Reset()         { *m = UsersResponse{} }
 func (m *UsersResponse) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse) ProtoMessage()    {}
 func (*UsersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{11}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{11}
 }
 func (m *UsersResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -772,7 +772,7 @@ func (m *UsersResponse_User) Reset()         { *m = UsersResponse_User{} }
 func (m *UsersResponse_User) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse_User) ProtoMessage()    {}
 func (*UsersResponse_User) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{11, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{11, 0}
 }
 func (m *UsersResponse_User) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -819,7 +819,7 @@ func (m *EventsRequest) Reset()         { *m = EventsRequest{} }
 func (m *EventsRequest) String() string { return proto.CompactTextString(m) }
 func (*EventsRequest) ProtoMessage()    {}
 func (*EventsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{12}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{12}
 }
 func (m *EventsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -854,7 +854,7 @@ func (m *EventsResponse) Reset()         { *m = EventsResponse{} }
 func (m *EventsResponse) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse) ProtoMessage()    {}
 func (*EventsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{13}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{13}
 }
 func (m *EventsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -899,7 +899,7 @@ func (m *EventsResponse_Event) Reset()         { *m = EventsResponse_Event{} }
 func (m *EventsResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse_Event) ProtoMessage()    {}
 func (*EventsResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{13, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{13, 0}
 }
 func (m *EventsResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -935,7 +935,7 @@ func (m *SetUIDataRequest) Reset()         { *m = SetUIDataRequest{} }
 func (m *SetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataRequest) ProtoMessage()    {}
 func (*SetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{14}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{14}
 }
 func (m *SetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -968,7 +968,7 @@ func (m *SetUIDataResponse) Reset()         { *m = SetUIDataResponse{} }
 func (m *SetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataResponse) ProtoMessage()    {}
 func (*SetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{15}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{15}
 }
 func (m *SetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1003,7 +1003,7 @@ func (m *GetUIDataRequest) Reset()         { *m = GetUIDataRequest{} }
 func (m *GetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataRequest) ProtoMessage()    {}
 func (*GetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{16}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{16}
 }
 func (m *GetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1040,7 +1040,7 @@ func (m *GetUIDataResponse) Reset()         { *m = GetUIDataResponse{} }
 func (m *GetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse) ProtoMessage()    {}
 func (*GetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{17}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{17}
 }
 func (m *GetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1076,7 +1076,7 @@ func (m *GetUIDataResponse_Value) Reset()         { *m = GetUIDataResponse_Value
 func (m *GetUIDataResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse_Value) ProtoMessage()    {}
 func (*GetUIDataResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{17, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{17, 0}
 }
 func (m *GetUIDataResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1109,7 +1109,7 @@ func (m *ClusterRequest) Reset()         { *m = ClusterRequest{} }
 func (m *ClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterRequest) ProtoMessage()    {}
 func (*ClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{18}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{18}
 }
 func (m *ClusterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1148,7 +1148,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{19}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{19}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1196,7 +1196,7 @@ func (m *DrainRequest) Reset()         { *m = DrainRequest{} }
 func (m *DrainRequest) String() string { return proto.CompactTextString(m) }
 func (*DrainRequest) ProtoMessage()    {}
 func (*DrainRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{20}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{20}
 }
 func (m *DrainRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1281,7 +1281,7 @@ func (m *DrainResponse) Reset()         { *m = DrainResponse{} }
 func (m *DrainResponse) String() string { return proto.CompactTextString(m) }
 func (*DrainResponse) ProtoMessage()    {}
 func (*DrainResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{21}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{21}
 }
 func (m *DrainResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1316,7 +1316,7 @@ func (m *DecommissionStatusRequest) Reset()         { *m = DecommissionStatusReq
 func (m *DecommissionStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusRequest) ProtoMessage()    {}
 func (*DecommissionStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{22}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{22}
 }
 func (m *DecommissionStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1354,7 +1354,7 @@ func (m *DecommissionRequest) Reset()         { *m = DecommissionRequest{} }
 func (m *DecommissionRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionRequest) ProtoMessage()    {}
 func (*DecommissionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{23}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{23}
 }
 func (m *DecommissionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1389,7 +1389,7 @@ func (m *DecommissionStatusResponse) Reset()         { *m = DecommissionStatusRe
 func (m *DecommissionStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse) ProtoMessage()    {}
 func (*DecommissionStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{24}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{24}
 }
 func (m *DecommissionStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1428,7 +1428,7 @@ func (m *DecommissionStatusResponse_Status) Reset()         { *m = DecommissionS
 func (m *DecommissionStatusResponse_Status) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse_Status) ProtoMessage()    {}
 func (*DecommissionStatusResponse_Status) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{24, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{24, 0}
 }
 func (m *DecommissionStatusResponse_Status) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1470,7 +1470,7 @@ func (m *SettingsRequest) Reset()         { *m = SettingsRequest{} }
 func (m *SettingsRequest) String() string { return proto.CompactTextString(m) }
 func (*SettingsRequest) ProtoMessage()    {}
 func (*SettingsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{25}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{25}
 }
 func (m *SettingsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1504,7 +1504,7 @@ func (m *SettingsResponse) Reset()         { *m = SettingsResponse{} }
 func (m *SettingsResponse) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse) ProtoMessage()    {}
 func (*SettingsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{26}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{26}
 }
 func (m *SettingsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1540,7 +1540,7 @@ func (m *SettingsResponse_Value) Reset()         { *m = SettingsResponse_Value{}
 func (m *SettingsResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse_Value) ProtoMessage()    {}
 func (*SettingsResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{26, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{26, 0}
 }
 func (m *SettingsResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1582,10 +1582,12 @@ var xxx_messageInfo_SettingsResponse_Value proto.InternalMessageInfo
 //   a liveness beacon. Absent either of these conditions, an error
 //   code will result.
 //
+// API: PUBLIC
 type HealthRequest struct {
 	// ready specifies whether the client wants to know whether the
 	// target node is ready to receive traffic. If a node is unready, an
 	// error will be returned.
+	// API: PUBLIC
 	Ready bool `protobuf:"varint,1,opt,name=ready,proto3" json:"ready,omitempty"`
 }
 
@@ -1593,7 +1595,7 @@ func (m *HealthRequest) Reset()         { *m = HealthRequest{} }
 func (m *HealthRequest) String() string { return proto.CompactTextString(m) }
 func (*HealthRequest) ProtoMessage()    {}
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{27}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{27}
 }
 func (m *HealthRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1620,6 +1622,7 @@ var xxx_messageInfo_HealthRequest proto.InternalMessageInfo
 
 // HealthResponse is the response to HealthRequest. It currently does not
 // contain any information.
+// API: PUBLIC
 type HealthResponse struct {
 }
 
@@ -1627,7 +1630,7 @@ func (m *HealthResponse) Reset()         { *m = HealthResponse{} }
 func (m *HealthResponse) String() string { return proto.CompactTextString(m) }
 func (*HealthResponse) ProtoMessage()    {}
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{28}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{28}
 }
 func (m *HealthResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1660,7 +1663,7 @@ func (m *LivenessRequest) Reset()         { *m = LivenessRequest{} }
 func (m *LivenessRequest) String() string { return proto.CompactTextString(m) }
 func (*LivenessRequest) ProtoMessage()    {}
 func (*LivenessRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{29}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{29}
 }
 func (m *LivenessRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1695,7 +1698,7 @@ func (m *LivenessResponse) Reset()         { *m = LivenessResponse{} }
 func (m *LivenessResponse) String() string { return proto.CompactTextString(m) }
 func (*LivenessResponse) ProtoMessage()    {}
 func (*LivenessResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{30}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{30}
 }
 func (m *LivenessResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1731,7 +1734,7 @@ func (m *JobsRequest) Reset()         { *m = JobsRequest{} }
 func (m *JobsRequest) String() string { return proto.CompactTextString(m) }
 func (*JobsRequest) ProtoMessage()    {}
 func (*JobsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{31}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{31}
 }
 func (m *JobsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1765,7 +1768,7 @@ func (m *JobsResponse) Reset()         { *m = JobsResponse{} }
 func (m *JobsResponse) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse) ProtoMessage()    {}
 func (*JobsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{32}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{32}
 }
 func (m *JobsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1818,7 +1821,7 @@ func (m *JobsResponse_Job) Reset()         { *m = JobsResponse_Job{} }
 func (m *JobsResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse_Job) ProtoMessage()    {}
 func (*JobsResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{32, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{32, 0}
 }
 func (m *JobsResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1851,7 +1854,7 @@ func (m *LocationsRequest) Reset()         { *m = LocationsRequest{} }
 func (m *LocationsRequest) String() string { return proto.CompactTextString(m) }
 func (*LocationsRequest) ProtoMessage()    {}
 func (*LocationsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{33}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{33}
 }
 func (m *LocationsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1885,7 +1888,7 @@ func (m *LocationsResponse) Reset()         { *m = LocationsResponse{} }
 func (m *LocationsResponse) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse) ProtoMessage()    {}
 func (*LocationsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{34}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{34}
 }
 func (m *LocationsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1921,7 +1924,7 @@ func (m *LocationsResponse_Location) Reset()         { *m = LocationsResponse_Lo
 func (m *LocationsResponse_Location) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse_Location) ProtoMessage()    {}
 func (*LocationsResponse_Location) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{34, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{34, 0}
 }
 func (m *LocationsResponse_Location) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1963,7 +1966,7 @@ func (m *RangeLogRequest) Reset()         { *m = RangeLogRequest{} }
 func (m *RangeLogRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeLogRequest) ProtoMessage()    {}
 func (*RangeLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{35}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{35}
 }
 func (m *RangeLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1997,7 +2000,7 @@ func (m *RangeLogResponse) Reset()         { *m = RangeLogResponse{} }
 func (m *RangeLogResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse) ProtoMessage()    {}
 func (*RangeLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{36}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36}
 }
 func (m *RangeLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2037,7 +2040,7 @@ func (m *RangeLogResponse_PrettyInfo) Reset()         { *m = RangeLogResponse_Pr
 func (m *RangeLogResponse_PrettyInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_PrettyInfo) ProtoMessage()    {}
 func (*RangeLogResponse_PrettyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{36, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36, 0}
 }
 func (m *RangeLogResponse_PrettyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2071,7 +2074,7 @@ func (m *RangeLogResponse_Event) Reset()         { *m = RangeLogResponse_Event{}
 func (m *RangeLogResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_Event) ProtoMessage()    {}
 func (*RangeLogResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{36, 1}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36, 1}
 }
 func (m *RangeLogResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2106,7 +2109,7 @@ func (m *QueryPlanRequest) Reset()         { *m = QueryPlanRequest{} }
 func (m *QueryPlanRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanRequest) ProtoMessage()    {}
 func (*QueryPlanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{37}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{37}
 }
 func (m *QueryPlanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2141,7 +2144,7 @@ func (m *QueryPlanResponse) Reset()         { *m = QueryPlanResponse{} }
 func (m *QueryPlanResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanResponse) ProtoMessage()    {}
 func (*QueryPlanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{38}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{38}
 }
 func (m *QueryPlanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2173,7 +2176,7 @@ func (m *DataDistributionRequest) Reset()         { *m = DataDistributionRequest
 func (m *DataDistributionRequest) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionRequest) ProtoMessage()    {}
 func (*DataDistributionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{39}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{39}
 }
 func (m *DataDistributionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2209,7 +2212,7 @@ func (m *DataDistributionResponse) Reset()         { *m = DataDistributionRespon
 func (m *DataDistributionResponse) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse) ProtoMessage()    {}
 func (*DataDistributionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{40}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40}
 }
 func (m *DataDistributionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2247,7 +2250,7 @@ func (m *DataDistributionResponse_ZoneConfig) Reset()         { *m = DataDistrib
 func (m *DataDistributionResponse_ZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_ZoneConfig) ProtoMessage()    {}
 func (*DataDistributionResponse_ZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{40, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 0}
 }
 func (m *DataDistributionResponse_ZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2282,7 +2285,7 @@ func (m *DataDistributionResponse_TableInfo) Reset()         { *m = DataDistribu
 func (m *DataDistributionResponse_TableInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_TableInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_TableInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{40, 1}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 1}
 }
 func (m *DataDistributionResponse_TableInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2316,7 +2319,7 @@ func (m *DataDistributionResponse_DatabaseInfo) Reset()         { *m = DataDistr
 func (m *DataDistributionResponse_DatabaseInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_DatabaseInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_DatabaseInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{40, 2}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 2}
 }
 func (m *DataDistributionResponse_DatabaseInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2349,7 +2352,7 @@ func (m *MetricMetadataRequest) Reset()         { *m = MetricMetadataRequest{} }
 func (m *MetricMetadataRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataRequest) ProtoMessage()    {}
 func (*MetricMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{41}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{41}
 }
 func (m *MetricMetadataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2383,7 +2386,7 @@ func (m *MetricMetadataResponse) Reset()         { *m = MetricMetadataResponse{}
 func (m *MetricMetadataResponse) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataResponse) ProtoMessage()    {}
 func (*MetricMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{42}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{42}
 }
 func (m *MetricMetadataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2426,7 +2429,7 @@ func (m *EnqueueRangeRequest) Reset()         { *m = EnqueueRangeRequest{} }
 func (m *EnqueueRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeRequest) ProtoMessage()    {}
 func (*EnqueueRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{43}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{43}
 }
 func (m *EnqueueRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2459,7 +2462,7 @@ func (m *EnqueueRangeResponse) Reset()         { *m = EnqueueRangeResponse{} }
 func (m *EnqueueRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse) ProtoMessage()    {}
 func (*EnqueueRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{44}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{44}
 }
 func (m *EnqueueRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2496,7 +2499,7 @@ func (m *EnqueueRangeResponse_Details) Reset()         { *m = EnqueueRangeRespon
 func (m *EnqueueRangeResponse_Details) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse_Details) ProtoMessage()    {}
 func (*EnqueueRangeResponse_Details) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{44, 0}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{44, 0}
 }
 func (m *EnqueueRangeResponse_Details) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2529,7 +2532,7 @@ func (m *ChartCatalogRequest) Reset()         { *m = ChartCatalogRequest{} }
 func (m *ChartCatalogRequest) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogRequest) ProtoMessage()    {}
 func (*ChartCatalogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{45}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{45}
 }
 func (m *ChartCatalogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2563,7 +2566,7 @@ func (m *ChartCatalogResponse) Reset()         { *m = ChartCatalogResponse{} }
 func (m *ChartCatalogResponse) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogResponse) ProtoMessage()    {}
 func (*ChartCatalogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a864e42949dbbfc6, []int{46}
+	return fileDescriptor_admin_a0ddd78db2160a9e, []int{46}
 }
 func (m *ChartCatalogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2729,6 +2732,7 @@ type AdminClient interface {
 	// Settings returns the cluster-wide settings for the cluster.
 	Settings(ctx context.Context, in *SettingsRequest, opts ...grpc.CallOption) (*SettingsResponse, error)
 	// Health returns liveness for the node target of the request.
+	// API: PUBLIC
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
 	// Liveness returns the liveness state of all nodes on the cluster.
 	Liveness(ctx context.Context, in *LivenessRequest, opts ...grpc.CallOption) (*LivenessResponse, error)
@@ -3074,6 +3078,7 @@ type AdminServer interface {
 	// Settings returns the cluster-wide settings for the cluster.
 	Settings(context.Context, *SettingsRequest) (*SettingsResponse, error)
 	// Health returns liveness for the node target of the request.
+	// API: PUBLIC
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
 	// Liveness returns the liveness state of all nodes on the cluster.
 	Liveness(context.Context, *LivenessRequest) (*LivenessResponse, error)
@@ -15676,9 +15681,9 @@ var (
 	ErrIntOverflowAdmin   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_a864e42949dbbfc6) }
+func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_a0ddd78db2160a9e) }
 
-var fileDescriptor_admin_a864e42949dbbfc6 = []byte{
+var fileDescriptor_admin_a0ddd78db2160a9e = []byte{
 	// 4167 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x3a, 0x5d, 0x73, 0x1b, 0xd7,
 	0x75, 0x5a, 0x80, 0xf8, 0x3a, 0x04, 0x48, 0xf0, 0x8a, 0xa2, 0x40, 0x48, 0x21, 0xe8, 0x55, 0x1c,

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -497,15 +497,18 @@ message SettingsResponse {
 //   a liveness beacon. Absent either of these conditions, an error
 //   code will result.
 //
+// API: PUBLIC
 message HealthRequest {
   // ready specifies whether the client wants to know whether the
   // target node is ready to receive traffic. If a node is unready, an
   // error will be returned.
+  // API: PUBLIC
   bool ready = 1;
 }
 
 // HealthResponse is the response to HealthRequest. It currently does not
 // contain any information.
+// API: PUBLIC
 message HealthResponse {
 }
 
@@ -816,6 +819,7 @@ service Admin {
   }
 
   // Health returns liveness for the node target of the request.
+  // API: PUBLIC
   rpc Health(HealthRequest) returns (HealthResponse) {
     option (google.api.http) = {
       get: "/_admin/v1/health"

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -66,7 +66,7 @@ func (x StacksType) String() string {
 	return proto.EnumName(StacksType_name, int32(x))
 }
 func (StacksType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{0}
 }
 
 // Represents the type of file.
@@ -93,7 +93,7 @@ func (x FileType) String() string {
 	return proto.EnumName(FileType_name, int32(x))
 }
 func (FileType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{1}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{1}
 }
 
 // We use an enum to allow reporting of client certs and potential others (eg:
@@ -130,7 +130,7 @@ func (x CertificateDetails_CertificateType) String() string {
 	return proto.EnumName(CertificateDetails_CertificateType_name, int32(x))
 }
 func (CertificateDetails_CertificateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{1, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{1, 0}
 }
 
 type ProfileRequest_Type int32
@@ -153,7 +153,7 @@ func (x ProfileRequest_Type) String() string {
 	return proto.EnumName(ProfileRequest_Type_name, int32(x))
 }
 func (ProfileRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{37, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{37, 0}
 }
 
 // Enum for phase of execution.
@@ -177,7 +177,7 @@ func (x ActiveQuery_Phase) String() string {
 	return proto.EnumName(ActiveQuery_Phase_name, int32(x))
 }
 func (ActiveQuery_Phase) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{45, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{45, 0}
 }
 
 type CertificatesRequest struct {
@@ -190,7 +190,7 @@ func (m *CertificatesRequest) Reset()         { *m = CertificatesRequest{} }
 func (m *CertificatesRequest) String() string { return proto.CompactTextString(m) }
 func (*CertificatesRequest) ProtoMessage()    {}
 func (*CertificatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{0}
 }
 func (m *CertificatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -229,7 +229,7 @@ func (m *CertificateDetails) Reset()         { *m = CertificateDetails{} }
 func (m *CertificateDetails) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails) ProtoMessage()    {}
 func (*CertificateDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{1}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{1}
 }
 func (m *CertificateDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -270,7 +270,7 @@ func (m *CertificateDetails_Fields) Reset()         { *m = CertificateDetails_Fi
 func (m *CertificateDetails_Fields) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails_Fields) ProtoMessage()    {}
 func (*CertificateDetails_Fields) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{1, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{1, 0}
 }
 func (m *CertificateDetails_Fields) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +303,7 @@ func (m *CertificatesResponse) Reset()         { *m = CertificatesResponse{} }
 func (m *CertificatesResponse) String() string { return proto.CompactTextString(m) }
 func (*CertificatesResponse) ProtoMessage()    {}
 func (*CertificatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{2}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{2}
 }
 func (m *CertificatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -340,7 +340,7 @@ func (m *DetailsRequest) Reset()         { *m = DetailsRequest{} }
 func (m *DetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DetailsRequest) ProtoMessage()    {}
 func (*DetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{3}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{3}
 }
 func (m *DetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -377,7 +377,7 @@ func (m *SystemInfo) Reset()         { *m = SystemInfo{} }
 func (m *SystemInfo) String() string { return proto.CompactTextString(m) }
 func (*SystemInfo) ProtoMessage()    {}
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{4}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{4}
 }
 func (m *SystemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -414,7 +414,7 @@ func (m *DetailsResponse) Reset()         { *m = DetailsResponse{} }
 func (m *DetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DetailsResponse) ProtoMessage()    {}
 func (*DetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{5}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{5}
 }
 func (m *DetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -439,6 +439,9 @@ func (m *DetailsResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DetailsResponse proto.InternalMessageInfo
 
+// NodesRequest requests a copy of the node information as known to gossip
+// and the KV layer.
+// API: PUBLIC ALPHA
 type NodesRequest struct {
 }
 
@@ -446,7 +449,7 @@ func (m *NodesRequest) Reset()         { *m = NodesRequest{} }
 func (m *NodesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodesRequest) ProtoMessage()    {}
 func (*NodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{6}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{6}
 }
 func (m *NodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -471,8 +474,13 @@ func (m *NodesRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_NodesRequest proto.InternalMessageInfo
 
+// NodesResponse describe the nodes in the cluster.
+// API: PUBLIC ALPHA
 type NodesResponse struct {
-	Nodes            []statuspb.NodeStatus                                                                 `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes"`
+	// nodes carries the status payloads for all nodes in the cluster.
+	// API: PUBLIC ALPHA
+	Nodes []statuspb.NodeStatus `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes"`
+	// liveness_by_node_id maps each node ID to a liveness status.
 	LivenessByNodeID map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]livenesspb.NodeLivenessStatus `protobuf:"bytes,2,rep,name=liveness_by_node_id,json=livenessByNodeId,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"liveness_by_node_id" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus"`
 }
 
@@ -480,7 +488,7 @@ func (m *NodesResponse) Reset()         { *m = NodesResponse{} }
 func (m *NodesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodesResponse) ProtoMessage()    {}
 func (*NodesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{7}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{7}
 }
 func (m *NodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -515,7 +523,7 @@ func (m *NodeRequest) Reset()         { *m = NodeRequest{} }
 func (m *NodeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeRequest) ProtoMessage()    {}
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{8}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{8}
 }
 func (m *NodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -560,7 +568,7 @@ func (m *RaftState) Reset()         { *m = RaftState{} }
 func (m *RaftState) String() string { return proto.CompactTextString(m) }
 func (*RaftState) ProtoMessage()    {}
 func (*RaftState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{9}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{9}
 }
 func (m *RaftState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -597,7 +605,7 @@ func (m *RaftState_Progress) Reset()         { *m = RaftState_Progress{} }
 func (m *RaftState_Progress) String() string { return proto.CompactTextString(m) }
 func (*RaftState_Progress) ProtoMessage()    {}
 func (*RaftState_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{9, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{9, 0}
 }
 func (m *RaftState_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -642,7 +650,7 @@ func (m *RangeProblems) Reset()         { *m = RangeProblems{} }
 func (m *RangeProblems) String() string { return proto.CompactTextString(m) }
 func (*RangeProblems) ProtoMessage()    {}
 func (*RangeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{10}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{10}
 }
 func (m *RangeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -678,7 +686,7 @@ func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
 func (m *RangeStatistics) String() string { return proto.CompactTextString(m) }
 func (*RangeStatistics) ProtoMessage()    {}
 func (*RangeStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{11}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{11}
 }
 func (m *RangeStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -712,7 +720,7 @@ func (m *PrettySpan) Reset()         { *m = PrettySpan{} }
 func (m *PrettySpan) String() string { return proto.CompactTextString(m) }
 func (*PrettySpan) ProtoMessage()    {}
 func (*PrettySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{12}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{12}
 }
 func (m *PrettySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -758,7 +766,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{13}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{13}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -794,7 +802,7 @@ func (m *RangesRequest) Reset()         { *m = RangesRequest{} }
 func (m *RangesRequest) String() string { return proto.CompactTextString(m) }
 func (*RangesRequest) ProtoMessage()    {}
 func (*RangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{14}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{14}
 }
 func (m *RangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -827,7 +835,7 @@ func (m *RangesResponse) Reset()         { *m = RangesResponse{} }
 func (m *RangesResponse) String() string { return proto.CompactTextString(m) }
 func (*RangesResponse) ProtoMessage()    {}
 func (*RangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{15}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{15}
 }
 func (m *RangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -862,7 +870,7 @@ func (m *GossipRequest) Reset()         { *m = GossipRequest{} }
 func (m *GossipRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipRequest) ProtoMessage()    {}
 func (*GossipRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{16}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{16}
 }
 func (m *GossipRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -897,7 +905,7 @@ func (m *EngineStatsInfo) Reset()         { *m = EngineStatsInfo{} }
 func (m *EngineStatsInfo) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsInfo) ProtoMessage()    {}
 func (*EngineStatsInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{17}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{17}
 }
 func (m *EngineStatsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -932,7 +940,7 @@ func (m *EngineStatsRequest) Reset()         { *m = EngineStatsRequest{} }
 func (m *EngineStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsRequest) ProtoMessage()    {}
 func (*EngineStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{18}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{18}
 }
 func (m *EngineStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -965,7 +973,7 @@ func (m *EngineStatsResponse) Reset()         { *m = EngineStatsResponse{} }
 func (m *EngineStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsResponse) ProtoMessage()    {}
 func (*EngineStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{19}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{19}
 }
 func (m *EngineStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -999,7 +1007,7 @@ func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
 func (m *TraceEvent) String() string { return proto.CompactTextString(m) }
 func (*TraceEvent) ProtoMessage()    {}
 func (*TraceEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{20}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{20}
 }
 func (m *TraceEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1033,7 +1041,7 @@ func (m *AllocatorDryRun) Reset()         { *m = AllocatorDryRun{} }
 func (m *AllocatorDryRun) String() string { return proto.CompactTextString(m) }
 func (*AllocatorDryRun) ProtoMessage()    {}
 func (*AllocatorDryRun) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{21}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{21}
 }
 func (m *AllocatorDryRun) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1066,7 +1074,7 @@ func (m *AllocatorRangeRequest) Reset()         { *m = AllocatorRangeRequest{} }
 func (m *AllocatorRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeRequest) ProtoMessage()    {}
 func (*AllocatorRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{22}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{22}
 }
 func (m *AllocatorRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1102,7 +1110,7 @@ func (m *AllocatorRangeResponse) Reset()         { *m = AllocatorRangeResponse{}
 func (m *AllocatorRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeResponse) ProtoMessage()    {}
 func (*AllocatorRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{23}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{23}
 }
 func (m *AllocatorRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1136,7 +1144,7 @@ func (m *AllocatorRequest) Reset()         { *m = AllocatorRequest{} }
 func (m *AllocatorRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRequest) ProtoMessage()    {}
 func (*AllocatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{24}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{24}
 }
 func (m *AllocatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1169,7 +1177,7 @@ func (m *AllocatorResponse) Reset()         { *m = AllocatorResponse{} }
 func (m *AllocatorResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorResponse) ProtoMessage()    {}
 func (*AllocatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{25}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{25}
 }
 func (m *AllocatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1202,7 +1210,7 @@ func (m *JSONResponse) Reset()         { *m = JSONResponse{} }
 func (m *JSONResponse) String() string { return proto.CompactTextString(m) }
 func (*JSONResponse) ProtoMessage()    {}
 func (*JSONResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{26}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{26}
 }
 func (m *JSONResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1238,7 +1246,7 @@ func (m *ResponseError) Reset()         { *m = ResponseError{} }
 func (m *ResponseError) String() string { return proto.CompactTextString(m) }
 func (*ResponseError) ProtoMessage()    {}
 func (*ResponseError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{27}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{27}
 }
 func (m *ResponseError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1282,7 +1290,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{28}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{28}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1315,7 +1323,7 @@ func (m *LogEntriesResponse) Reset()         { *m = LogEntriesResponse{} }
 func (m *LogEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*LogEntriesResponse) ProtoMessage()    {}
 func (*LogEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{29}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{29}
 }
 func (m *LogEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1350,7 +1358,7 @@ func (m *LogFilesListRequest) Reset()         { *m = LogFilesListRequest{} }
 func (m *LogFilesListRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListRequest) ProtoMessage()    {}
 func (*LogFilesListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{30}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{30}
 }
 func (m *LogFilesListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1383,7 +1391,7 @@ func (m *LogFilesListResponse) Reset()         { *m = LogFilesListResponse{} }
 func (m *LogFilesListResponse) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListResponse) ProtoMessage()    {}
 func (*LogFilesListResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{31}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{31}
 }
 func (m *LogFilesListResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1423,7 +1431,7 @@ func (m *LogFileRequest) Reset()         { *m = LogFileRequest{} }
 func (m *LogFileRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFileRequest) ProtoMessage()    {}
 func (*LogFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{32}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{32}
 }
 func (m *LogFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1459,7 +1467,7 @@ func (m *StacksRequest) Reset()         { *m = StacksRequest{} }
 func (m *StacksRequest) String() string { return proto.CompactTextString(m) }
 func (*StacksRequest) ProtoMessage()    {}
 func (*StacksRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{33}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{33}
 }
 func (m *StacksRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1495,7 +1503,7 @@ func (m *File) Reset()         { *m = File{} }
 func (m *File) String() string { return proto.CompactTextString(m) }
 func (*File) ProtoMessage()    {}
 func (*File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{34}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{34}
 }
 func (m *File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1539,7 +1547,7 @@ func (m *GetFilesRequest) Reset()         { *m = GetFilesRequest{} }
 func (m *GetFilesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFilesRequest) ProtoMessage()    {}
 func (*GetFilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{35}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{35}
 }
 func (m *GetFilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1572,7 +1580,7 @@ func (m *GetFilesResponse) Reset()         { *m = GetFilesResponse{} }
 func (m *GetFilesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFilesResponse) ProtoMessage()    {}
 func (*GetFilesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{36}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{36}
 }
 func (m *GetFilesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1610,7 +1618,7 @@ func (m *ProfileRequest) Reset()         { *m = ProfileRequest{} }
 func (m *ProfileRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfileRequest) ProtoMessage()    {}
 func (*ProfileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{37}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{37}
 }
 func (m *ProfileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1645,7 +1653,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{38}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{38}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1679,7 +1687,7 @@ func (m *RaftRangeNode) Reset()         { *m = RaftRangeNode{} }
 func (m *RaftRangeNode) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeNode) ProtoMessage()    {}
 func (*RaftRangeNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{39}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{39}
 }
 func (m *RaftRangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1712,7 +1720,7 @@ func (m *RaftRangeError) Reset()         { *m = RaftRangeError{} }
 func (m *RaftRangeError) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeError) ProtoMessage()    {}
 func (*RaftRangeError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{40}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{40}
 }
 func (m *RaftRangeError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1747,7 +1755,7 @@ func (m *RaftRangeStatus) Reset()         { *m = RaftRangeStatus{} }
 func (m *RaftRangeStatus) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeStatus) ProtoMessage()    {}
 func (*RaftRangeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{41}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{41}
 }
 func (m *RaftRangeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1780,7 +1788,7 @@ func (m *RaftDebugRequest) Reset()         { *m = RaftDebugRequest{} }
 func (m *RaftDebugRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugRequest) ProtoMessage()    {}
 func (*RaftDebugRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{42}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{42}
 }
 func (m *RaftDebugRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1814,7 +1822,7 @@ func (m *RaftDebugResponse) Reset()         { *m = RaftDebugResponse{} }
 func (m *RaftDebugResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugResponse) ProtoMessage()    {}
 func (*RaftDebugResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{43}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{43}
 }
 func (m *RaftDebugResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1872,7 +1880,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{44}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{44}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1920,7 +1928,7 @@ func (m *ActiveQuery) Reset()         { *m = ActiveQuery{} }
 func (m *ActiveQuery) String() string { return proto.CompactTextString(m) }
 func (*ActiveQuery) ProtoMessage()    {}
 func (*ActiveQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{45}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{45}
 }
 func (m *ActiveQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1957,7 +1965,7 @@ func (m *ListSessionsRequest) Reset()         { *m = ListSessionsRequest{} }
 func (m *ListSessionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsRequest) ProtoMessage()    {}
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{46}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{46}
 }
 func (m *ListSessionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2016,7 +2024,7 @@ func (m *Session) Reset()         { *m = Session{} }
 func (m *Session) String() string { return proto.CompactTextString(m) }
 func (*Session) ProtoMessage()    {}
 func (*Session) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{47}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{47}
 }
 func (m *Session) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2053,7 +2061,7 @@ func (m *ListSessionsError) Reset()         { *m = ListSessionsError{} }
 func (m *ListSessionsError) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsError) ProtoMessage()    {}
 func (*ListSessionsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{48}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{48}
 }
 func (m *ListSessionsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2090,7 +2098,7 @@ func (m *ListSessionsResponse) Reset()         { *m = ListSessionsResponse{} }
 func (m *ListSessionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsResponse) ProtoMessage()    {}
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{49}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{49}
 }
 func (m *ListSessionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2137,7 +2145,7 @@ func (m *CancelQueryRequest) Reset()         { *m = CancelQueryRequest{} }
 func (m *CancelQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryRequest) ProtoMessage()    {}
 func (*CancelQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{50}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{50}
 }
 func (m *CancelQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2174,7 +2182,7 @@ func (m *CancelQueryResponse) Reset()         { *m = CancelQueryResponse{} }
 func (m *CancelQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryResponse) ProtoMessage()    {}
 func (*CancelQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{51}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{51}
 }
 func (m *CancelQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2217,7 +2225,7 @@ func (m *CancelSessionRequest) Reset()         { *m = CancelSessionRequest{} }
 func (m *CancelSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionRequest) ProtoMessage()    {}
 func (*CancelSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{52}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{52}
 }
 func (m *CancelSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2251,7 +2259,7 @@ func (m *CancelSessionResponse) Reset()         { *m = CancelSessionResponse{} }
 func (m *CancelSessionResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionResponse) ProtoMessage()    {}
 func (*CancelSessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{53}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{53}
 }
 func (m *CancelSessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2286,7 +2294,7 @@ func (m *SpanStatsRequest) Reset()         { *m = SpanStatsRequest{} }
 func (m *SpanStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsRequest) ProtoMessage()    {}
 func (*SpanStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{54}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{54}
 }
 func (m *SpanStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2321,7 +2329,7 @@ func (m *SpanStatsResponse) Reset()         { *m = SpanStatsResponse{} }
 func (m *SpanStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsResponse) ProtoMessage()    {}
 func (*SpanStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{55}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{55}
 }
 func (m *SpanStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2355,7 +2363,7 @@ func (m *ProblemRangesRequest) Reset()         { *m = ProblemRangesRequest{} }
 func (m *ProblemRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesRequest) ProtoMessage()    {}
 func (*ProblemRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{56}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{56}
 }
 func (m *ProblemRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2390,7 +2398,7 @@ func (m *ProblemRangesResponse) Reset()         { *m = ProblemRangesResponse{} }
 func (m *ProblemRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse) ProtoMessage()    {}
 func (*ProblemRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{57}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{57}
 }
 func (m *ProblemRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2431,7 +2439,7 @@ func (m *ProblemRangesResponse_NodeProblems) Reset()         { *m = ProblemRange
 func (m *ProblemRangesResponse_NodeProblems) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse_NodeProblems) ProtoMessage()    {}
 func (*ProblemRangesResponse_NodeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{57, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{57, 0}
 }
 func (m *ProblemRangesResponse_NodeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2458,8 +2466,7 @@ var xxx_messageInfo_ProblemRangesResponse_NodeProblems proto.InternalMessageInfo
 
 // HotRangesRequest queries one or more cluster nodes for a list
 // of ranges currently considered “hot” by the node(s).
-//
-// The server responds with a HotRangesResponse payload.
+// API: PUBLIC ALPHA
 type HotRangesRequest struct {
 	// NodeID indicates which node to query for a hot range report.
 	// It is posssible to populate any node ID; if the node receiving
@@ -2468,6 +2475,7 @@ type HotRangesRequest struct {
 	//
 	// If left empty, the request is forwarded to every node
 	// in the cluster.
+	// API: PUBLIC ALPHA
 	NodeID string `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
 }
 
@@ -2475,7 +2483,7 @@ func (m *HotRangesRequest) Reset()         { *m = HotRangesRequest{} }
 func (m *HotRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*HotRangesRequest) ProtoMessage()    {}
 func (*HotRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{58}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{58}
 }
 func (m *HotRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2502,12 +2510,15 @@ var xxx_messageInfo_HotRangesRequest proto.InternalMessageInfo
 
 // HotRangesResponse is the payload produced in response
 // to a HotRangesRequest.
+// API: PUBLIC ALPHA
 type HotRangesResponse struct {
 	// NodeID is the node that received the HotRangesRequest and
 	// forwarded requests to the selected target node(s).
+	// API: PUBLIC ALPHA
 	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
 	// HotRangesByNodeID contains a hot range report for each selected
 	// target node ID in the HotRangesRequest.
+	// API: PUBLIC ALPHA
 	HotRangesByNodeID map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]HotRangesResponse_NodeResponse `protobuf:"bytes,2,rep,name=hot_ranges_by_node_id,json=hotRangesByNodeId,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"hot_ranges_by_node_id" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -2515,7 +2526,7 @@ func (m *HotRangesResponse) Reset()         { *m = HotRangesResponse{} }
 func (m *HotRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse) ProtoMessage()    {}
 func (*HotRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{59}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{59}
 }
 func (m *HotRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2542,16 +2553,17 @@ var xxx_messageInfo_HotRangesResponse proto.InternalMessageInfo
 
 // HotRange is a hot range report for a single store on one of the
 // target node(s) selected in a HotRangesRequest.
+// API: PUBLIC ALPHA
 type HotRangesResponse_HotRange struct {
 	// Desc is the descriptor of the range for which the report
 	// was produced.
 	//
-	// Note: this field is generally RESERVED and will likely be removed
-	// or replaced in a later version.
+	// TODO(knz): This field should be removed.
 	// See: https://github.com/cockroachdb/cockroach/issues/53212
 	Desc roachpb.RangeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
 	// QueriesPerSecond is the recent number of queries per second
 	// on this range.
+	// API: PUBLIC ALPHA
 	QueriesPerSecond float64 `protobuf:"fixed64,2,opt,name=queries_per_second,json=queriesPerSecond,proto3" json:"queries_per_second,omitempty"`
 }
 
@@ -2559,7 +2571,7 @@ func (m *HotRangesResponse_HotRange) Reset()         { *m = HotRangesResponse_Ho
 func (m *HotRangesResponse_HotRange) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_HotRange) ProtoMessage()    {}
 func (*HotRangesResponse_HotRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{59, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 0}
 }
 func (m *HotRangesResponse_HotRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2586,12 +2598,15 @@ var xxx_messageInfo_HotRangesResponse_HotRange proto.InternalMessageInfo
 
 // StoreResponse contains the part of a hot ranges report that
 // pertains to a single store on a target node.
+// API: PUBLIC ALPHA
 type HotRangesResponse_StoreResponse struct {
 	// StoreID identifies the store for which the report was
 	// produced.
+	// API: PUBLIC ALPHA
 	StoreID github_com_cockroachdb_cockroach_pkg_roachpb.StoreID `protobuf:"varint,1,opt,name=store_id,json=storeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.StoreID" json:"store_id,omitempty"`
 	// HotRanges is the hot ranges report for this store
 	// on the target node.
+	// API: PUBLIC ALPHA
 	HotRanges []HotRangesResponse_HotRange `protobuf:"bytes,2,rep,name=hot_ranges,json=hotRanges,proto3" json:"hot_ranges"`
 }
 
@@ -2599,7 +2614,7 @@ func (m *HotRangesResponse_StoreResponse) Reset()         { *m = HotRangesRespon
 func (m *HotRangesResponse_StoreResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_StoreResponse) ProtoMessage()    {}
 func (*HotRangesResponse_StoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{59, 1}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 1}
 }
 func (m *HotRangesResponse_StoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2625,15 +2640,18 @@ func (m *HotRangesResponse_StoreResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_HotRangesResponse_StoreResponse proto.InternalMessageInfo
 
 // NodeResponse is a hot range report for a single target node.
+// API: PUBLIC ALPHA
 type HotRangesResponse_NodeResponse struct {
 	// ErrorMessage is set to a non-empty string if this target
 	// node was unable to produce a hot range report.
 	//
 	// The contents of this string indicates the cause of the failure.
+	// API: PUBLIC ALPHA
 	ErrorMessage string `protobuf:"bytes,1,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
 	// Stores contains the hot ranges report if no error was encountered.
 	// There is one part to the report for each store in the
 	// target node.
+	// API: PUBLIC ALPHA
 	Stores []*HotRangesResponse_StoreResponse `protobuf:"bytes,2,rep,name=stores,proto3" json:"stores,omitempty"`
 }
 
@@ -2641,7 +2659,7 @@ func (m *HotRangesResponse_NodeResponse) Reset()         { *m = HotRangesRespons
 func (m *HotRangesResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_NodeResponse) ProtoMessage()    {}
 func (*HotRangesResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{59, 2}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 2}
 }
 func (m *HotRangesResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2674,7 +2692,7 @@ func (m *RangeRequest) Reset()         { *m = RangeRequest{} }
 func (m *RangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeRequest) ProtoMessage()    {}
 func (*RangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{60}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{60}
 }
 func (m *RangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2710,7 +2728,7 @@ func (m *RangeResponse) Reset()         { *m = RangeResponse{} }
 func (m *RangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse) ProtoMessage()    {}
 func (*RangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{61}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{61}
 }
 func (m *RangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2745,7 +2763,7 @@ func (m *RangeResponse_NodeResponse) Reset()         { *m = RangeResponse_NodeRe
 func (m *RangeResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse_NodeResponse) ProtoMessage()    {}
 func (*RangeResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{61, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{61, 0}
 }
 func (m *RangeResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2781,7 +2799,7 @@ func (m *DiagnosticsRequest) Reset()         { *m = DiagnosticsRequest{} }
 func (m *DiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticsRequest) ProtoMessage()    {}
 func (*DiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{62}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{62}
 }
 func (m *DiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2816,7 +2834,7 @@ func (m *StoresRequest) Reset()         { *m = StoresRequest{} }
 func (m *StoresRequest) String() string { return proto.CompactTextString(m) }
 func (*StoresRequest) ProtoMessage()    {}
 func (*StoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{63}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{63}
 }
 func (m *StoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2859,7 +2877,7 @@ func (m *StoreDetails) Reset()         { *m = StoreDetails{} }
 func (m *StoreDetails) String() string { return proto.CompactTextString(m) }
 func (*StoreDetails) ProtoMessage()    {}
 func (*StoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{64}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{64}
 }
 func (m *StoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2892,7 +2910,7 @@ func (m *StoresResponse) Reset()         { *m = StoresResponse{} }
 func (m *StoresResponse) String() string { return proto.CompactTextString(m) }
 func (*StoresResponse) ProtoMessage()    {}
 func (*StoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{65}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{65}
 }
 func (m *StoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2925,7 +2943,7 @@ func (m *StatementsRequest) Reset()         { *m = StatementsRequest{} }
 func (m *StatementsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementsRequest) ProtoMessage()    {}
 func (*StatementsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{66}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{66}
 }
 func (m *StatementsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2966,7 +2984,7 @@ func (m *StatementsResponse) Reset()         { *m = StatementsResponse{} }
 func (m *StatementsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementsResponse) ProtoMessage()    {}
 func (*StatementsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{67}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{67}
 }
 func (m *StatementsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3004,7 +3022,7 @@ func (m *StatementsResponse_ExtendedStatementStatisticsKey) String() string {
 }
 func (*StatementsResponse_ExtendedStatementStatisticsKey) ProtoMessage() {}
 func (*StatementsResponse_ExtendedStatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{67, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 0}
 }
 func (m *StatementsResponse_ExtendedStatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3043,7 +3061,7 @@ func (m *StatementsResponse_CollectedStatementStatistics) String() string {
 }
 func (*StatementsResponse_CollectedStatementStatistics) ProtoMessage() {}
 func (*StatementsResponse_CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{67, 1}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 1}
 }
 func (m *StatementsResponse_CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3081,7 +3099,7 @@ func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) String() str
 }
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) ProtoMessage() {}
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{67, 2}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 2}
 }
 func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3118,7 +3136,7 @@ func (m *StatementDiagnosticsReport) Reset()         { *m = StatementDiagnostics
 func (m *StatementDiagnosticsReport) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReport) ProtoMessage()    {}
 func (*StatementDiagnosticsReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{68}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{68}
 }
 func (m *StatementDiagnosticsReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3153,7 +3171,7 @@ func (m *CreateStatementDiagnosticsReportRequest) Reset() {
 func (m *CreateStatementDiagnosticsReportRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportRequest) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{69}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{69}
 }
 func (m *CreateStatementDiagnosticsReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3188,7 +3206,7 @@ func (m *CreateStatementDiagnosticsReportResponse) Reset() {
 func (m *CreateStatementDiagnosticsReportResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportResponse) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{70}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{70}
 }
 func (m *CreateStatementDiagnosticsReportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3220,7 +3238,7 @@ func (m *StatementDiagnosticsReportsRequest) Reset()         { *m = StatementDia
 func (m *StatementDiagnosticsReportsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{71}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{71}
 }
 func (m *StatementDiagnosticsReportsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3253,7 +3271,7 @@ func (m *StatementDiagnosticsReportsResponse) Reset()         { *m = StatementDi
 func (m *StatementDiagnosticsReportsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{72}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{72}
 }
 func (m *StatementDiagnosticsReportsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3289,7 +3307,7 @@ func (m *StatementDiagnostics) Reset()         { *m = StatementDiagnostics{} }
 func (m *StatementDiagnostics) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnostics) ProtoMessage()    {}
 func (*StatementDiagnostics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{73}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{73}
 }
 func (m *StatementDiagnostics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3322,7 +3340,7 @@ func (m *StatementDiagnosticsRequest) Reset()         { *m = StatementDiagnostic
 func (m *StatementDiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{74}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{74}
 }
 func (m *StatementDiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3355,7 +3373,7 @@ func (m *StatementDiagnosticsResponse) Reset()         { *m = StatementDiagnosti
 func (m *StatementDiagnosticsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{75}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{75}
 }
 func (m *StatementDiagnosticsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3388,7 +3406,7 @@ func (m *JobRegistryStatusRequest) Reset()         { *m = JobRegistryStatusReque
 func (m *JobRegistryStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusRequest) ProtoMessage()    {}
 func (*JobRegistryStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{76}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{76}
 }
 func (m *JobRegistryStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3422,7 +3440,7 @@ func (m *JobRegistryStatusResponse) Reset()         { *m = JobRegistryStatusResp
 func (m *JobRegistryStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse) ProtoMessage()    {}
 func (*JobRegistryStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{77}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{77}
 }
 func (m *JobRegistryStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3455,7 +3473,7 @@ func (m *JobRegistryStatusResponse_Job) Reset()         { *m = JobRegistryStatus
 func (m *JobRegistryStatusResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse_Job) ProtoMessage()    {}
 func (*JobRegistryStatusResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{77, 0}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{77, 0}
 }
 func (m *JobRegistryStatusResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3488,7 +3506,7 @@ func (m *JobStatusRequest) Reset()         { *m = JobStatusRequest{} }
 func (m *JobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobStatusRequest) ProtoMessage()    {}
 func (*JobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{78}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{78}
 }
 func (m *JobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3521,7 +3539,7 @@ func (m *JobStatusResponse) Reset()         { *m = JobStatusResponse{} }
 func (m *JobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobStatusResponse) ProtoMessage()    {}
 func (*JobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_888e32a70da35e6b, []int{79}
+	return fileDescriptor_status_e91e4bae4876eefb, []int{79}
 }
 func (m *JobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3690,26 +3708,43 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type StatusClient interface {
+	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(ctx context.Context, in *CertificatesRequest, opts ...grpc.CallOption) (*CertificatesResponse, error)
+	// Details retrieves details about the nodes in the cluster.
 	Details(ctx context.Context, in *DetailsRequest, opts ...grpc.CallOption) (*DetailsResponse, error)
 	// Nodes returns status info for all commissioned nodes. Decommissioned nodes
 	// are not included, except in rare cases where the node doing the
 	// decommissioning crashed before completing the operation. In these cases,
 	// the decommission operation can be rerun to clean up the status entry.
 	//
+	// API: PUBLIC ALPHA
+	//
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(ctx context.Context, in *NodesRequest, opts ...grpc.CallOption) (*NodesResponse, error)
+	// Node retrieves details about a single node.
+	// API: PUBLIC ALPHA
 	Node(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (*statuspb.NodeStatus, error)
+	// RaftDebug requests internal details about Raft.
 	RaftDebug(ctx context.Context, in *RaftDebugRequest, opts ...grpc.CallOption) (*RaftDebugResponse, error)
+	// Ranges requests internal details about ranges on a given node.
 	Ranges(ctx context.Context, in *RangesRequest, opts ...grpc.CallOption) (*RangesResponse, error)
+	// Gossip retrieves gossip-level details about a given node.
 	Gossip(ctx context.Context, in *GossipRequest, opts ...grpc.CallOption) (*gossip.InfoStatus, error)
+	// EngineStats retrieves statistics about a storage engine.
 	EngineStats(ctx context.Context, in *EngineStatsRequest, opts ...grpc.CallOption) (*EngineStatsResponse, error)
+	// Allocator retrieves statistics about the replica allocator.
 	Allocator(ctx context.Context, in *AllocatorRequest, opts ...grpc.CallOption) (*AllocatorResponse, error)
+	// AllocatorRange retrieves statistics about the replica allocator given
+	// a specific range.
 	AllocatorRange(ctx context.Context, in *AllocatorRangeRequest, opts ...grpc.CallOption) (*AllocatorRangeResponse, error)
+	// ListSessions retrieves the SQL sessions across the entire cluster.
 	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
+	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
+	// CancelQuery cancels a SQL query given its ID.
 	CancelQuery(ctx context.Context, in *CancelQueryRequest, opts ...grpc.CallOption) (*CancelQueryResponse, error)
+	// CancelSessions forcefully terminates a SQL session given its ID.
 	CancelSession(ctx context.Context, in *CancelSessionRequest, opts ...grpc.CallOption) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -3717,13 +3752,25 @@ type StatusClient interface {
 	// it will be called with the highest/lowest key for a SQL table, and return
 	// information about the resources on a node used by that table.
 	SpanStats(ctx context.Context, in *SpanStatsRequest, opts ...grpc.CallOption) (*SpanStatsResponse, error)
+	// Stacks retrieves the stack traces of all goroutines on a given node.
 	Stacks(ctx context.Context, in *StacksRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// Profile retrieves a CPU profile on a given node.
 	Profile(ctx context.Context, in *ProfileRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// Metrics retrieves the node metrics for a given node.
+	//
+	// Note: this is a “reserved” API and should not be relied upon to
+	// build external tools. No guarantee is made about its
+	// availability and stability in external uses.
 	Metrics(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// GetFiles retrieves heap or goroutine dump files from a given node.
 	GetFiles(ctx context.Context, in *GetFilesRequest, opts ...grpc.CallOption) (*GetFilesResponse, error)
+	// LogFilesList retrieves a list of log files on a given node.
 	LogFilesList(ctx context.Context, in *LogFilesListRequest, opts ...grpc.CallOption) (*LogFilesListResponse, error)
+	// LogFile retrieves a given log file.
 	LogFile(ctx context.Context, in *LogFileRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
+	// Logs retrieves individual log entries.
 	Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
+	// ProblemRanges retrieves the list of “problem ranges”.
 	ProblemRanges(ctx context.Context, in *ProblemRangesRequest, opts ...grpc.CallOption) (*ProblemRangesResponse, error)
 	HotRanges(ctx context.Context, in *HotRangesRequest, opts ...grpc.CallOption) (*HotRangesResponse, error)
 	Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error)
@@ -4044,26 +4091,43 @@ func (c *statusClient) JobStatus(ctx context.Context, in *JobStatusRequest, opts
 
 // StatusServer is the server API for Status service.
 type StatusServer interface {
+	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(context.Context, *CertificatesRequest) (*CertificatesResponse, error)
+	// Details retrieves details about the nodes in the cluster.
 	Details(context.Context, *DetailsRequest) (*DetailsResponse, error)
 	// Nodes returns status info for all commissioned nodes. Decommissioned nodes
 	// are not included, except in rare cases where the node doing the
 	// decommissioning crashed before completing the operation. In these cases,
 	// the decommission operation can be rerun to clean up the status entry.
 	//
+	// API: PUBLIC ALPHA
+	//
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
+	// Node retrieves details about a single node.
+	// API: PUBLIC ALPHA
 	Node(context.Context, *NodeRequest) (*statuspb.NodeStatus, error)
+	// RaftDebug requests internal details about Raft.
 	RaftDebug(context.Context, *RaftDebugRequest) (*RaftDebugResponse, error)
+	// Ranges requests internal details about ranges on a given node.
 	Ranges(context.Context, *RangesRequest) (*RangesResponse, error)
+	// Gossip retrieves gossip-level details about a given node.
 	Gossip(context.Context, *GossipRequest) (*gossip.InfoStatus, error)
+	// EngineStats retrieves statistics about a storage engine.
 	EngineStats(context.Context, *EngineStatsRequest) (*EngineStatsResponse, error)
+	// Allocator retrieves statistics about the replica allocator.
 	Allocator(context.Context, *AllocatorRequest) (*AllocatorResponse, error)
+	// AllocatorRange retrieves statistics about the replica allocator given
+	// a specific range.
 	AllocatorRange(context.Context, *AllocatorRangeRequest) (*AllocatorRangeResponse, error)
+	// ListSessions retrieves the SQL sessions across the entire cluster.
 	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
+	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
+	// CancelQuery cancels a SQL query given its ID.
 	CancelQuery(context.Context, *CancelQueryRequest) (*CancelQueryResponse, error)
+	// CancelSessions forcefully terminates a SQL session given its ID.
 	CancelSession(context.Context, *CancelSessionRequest) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -4071,13 +4135,25 @@ type StatusServer interface {
 	// it will be called with the highest/lowest key for a SQL table, and return
 	// information about the resources on a node used by that table.
 	SpanStats(context.Context, *SpanStatsRequest) (*SpanStatsResponse, error)
+	// Stacks retrieves the stack traces of all goroutines on a given node.
 	Stacks(context.Context, *StacksRequest) (*JSONResponse, error)
+	// Profile retrieves a CPU profile on a given node.
 	Profile(context.Context, *ProfileRequest) (*JSONResponse, error)
+	// Metrics retrieves the node metrics for a given node.
+	//
+	// Note: this is a “reserved” API and should not be relied upon to
+	// build external tools. No guarantee is made about its
+	// availability and stability in external uses.
 	Metrics(context.Context, *MetricsRequest) (*JSONResponse, error)
+	// GetFiles retrieves heap or goroutine dump files from a given node.
 	GetFiles(context.Context, *GetFilesRequest) (*GetFilesResponse, error)
+	// LogFilesList retrieves a list of log files on a given node.
 	LogFilesList(context.Context, *LogFilesListRequest) (*LogFilesListResponse, error)
+	// LogFile retrieves a given log file.
 	LogFile(context.Context, *LogFileRequest) (*LogEntriesResponse, error)
+	// Logs retrieves individual log entries.
 	Logs(context.Context, *LogsRequest) (*LogEntriesResponse, error)
+	// ProblemRanges retrieves the list of “problem ranges”.
 	ProblemRanges(context.Context, *ProblemRangesRequest) (*ProblemRangesResponse, error)
 	HotRanges(context.Context, *HotRangesRequest) (*HotRangesResponse, error)
 	Range(context.Context, *RangeRequest) (*RangeResponse, error)
@@ -22375,10 +22451,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_888e32a70da35e6b)
+	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_e91e4bae4876eefb)
 }
 
-var fileDescriptor_status_888e32a70da35e6b = []byte{
+var fileDescriptor_status_e91e4bae4876eefb = []byte{
 	// 6183 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x5c, 0x6f, 0x6c, 0x1b, 0xc9,
 	0x75, 0xf7, 0x92, 0x14, 0x45, 0x3e, 0xea, 0x0f, 0x35, 0xfa, 0x63, 0x9a, 0xf6, 0x49, 0xbe, 0xf5,

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -108,10 +108,18 @@ message DetailsResponse {
   util.UnresolvedAddr sql_address = 5 [ (gogoproto.nullable) = false, (gogoproto.customname) = "SQLAddress" ];
 }
 
+// NodesRequest requests a copy of the node information as known to gossip
+// and the KV layer.
+// API: PUBLIC ALPHA
 message NodesRequest {}
 
+// NodesResponse describe the nodes in the cluster.
+// API: PUBLIC ALPHA
 message NodesResponse {
+  // nodes carries the status payloads for all nodes in the cluster.
+  // API: PUBLIC ALPHA
   repeated server.status.statuspb.NodeStatus nodes = 1 [ (gogoproto.nullable) = false ];
+  // liveness_by_node_id maps each node ID to a liveness status.
   map<int32, kv.kvserver.liveness.livenesspb.NodeLivenessStatus> liveness_by_node_id = 2 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
     (gogoproto.nullable) = false,
@@ -717,8 +725,7 @@ message ProblemRangesResponse {
 
 // HotRangesRequest queries one or more cluster nodes for a list
 // of ranges currently considered “hot” by the node(s).
-//
-// The server responds with a HotRangesResponse payload.
+// API: PUBLIC ALPHA
 message HotRangesRequest {
   // NodeID indicates which node to query for a hot range report.
   // It is posssible to populate any node ID; if the node receiving
@@ -727,14 +734,17 @@ message HotRangesRequest {
   //
   // If left empty, the request is forwarded to every node
   // in the cluster.
+  // API: PUBLIC ALPHA
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
 }
 
 // HotRangesResponse is the payload produced in response
 // to a HotRangesRequest.
+// API: PUBLIC ALPHA
 message HotRangesResponse {
   // NodeID is the node that received the HotRangesRequest and
   // forwarded requests to the selected target node(s).
+  // API: PUBLIC ALPHA
   int32 node_id = 1 [
     (gogoproto.customname) = "NodeID",
     (gogoproto.casttype) =
@@ -743,25 +753,28 @@ message HotRangesResponse {
 
   // HotRange is a hot range report for a single store on one of the
   // target node(s) selected in a HotRangesRequest.
+  // API: PUBLIC ALPHA
   message HotRange {
     // Desc is the descriptor of the range for which the report
     // was produced.
     //
-    // Note: this field is generally RESERVED and will likely be removed
-    // or replaced in a later version.
+    // TODO(knz): This field should be removed.
     // See: https://github.com/cockroachdb/cockroach/issues/53212
     cockroach.roachpb.RangeDescriptor desc = 1 [(gogoproto.nullable) = false];
 
     // QueriesPerSecond is the recent number of queries per second
     // on this range.
+    // API: PUBLIC ALPHA
     double queries_per_second = 2;
   }
 
   // StoreResponse contains the part of a hot ranges report that
   // pertains to a single store on a target node.
+  // API: PUBLIC ALPHA
   message StoreResponse {
     // StoreID identifies the store for which the report was
     // produced.
+    // API: PUBLIC ALPHA
     int32 store_id = 1 [
       (gogoproto.customname) = "StoreID",
       (gogoproto.casttype) =
@@ -770,25 +783,30 @@ message HotRangesResponse {
 
     // HotRanges is the hot ranges report for this store
     // on the target node.
+    // API: PUBLIC ALPHA
     repeated HotRange hot_ranges = 2 [(gogoproto.nullable) = false];
   }
 
   // NodeResponse is a hot range report for a single target node.
+  // API: PUBLIC ALPHA
   message NodeResponse {
     // ErrorMessage is set to a non-empty string if this target
     // node was unable to produce a hot range report.
     //
     // The contents of this string indicates the cause of the failure.
+    // API: PUBLIC ALPHA
     string error_message = 1;
 
     // Stores contains the hot ranges report if no error was encountered.
     // There is one part to the report for each store in the
     // target node.
+    // API: PUBLIC ALPHA
     repeated StoreResponse stores = 2;
   }
 
   // HotRangesByNodeID contains a hot range report for each selected
   // target node ID in the HotRangesRequest.
+  // API: PUBLIC ALPHA
   map<int32, NodeResponse> hot_ranges_by_node_id = 2 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
     (gogoproto.customname) = "HotRangesByNodeID",
@@ -968,11 +986,14 @@ message JobStatusResponse {
 }
 
 service Status {
+  // Certificates retrieves a copy of the TLS certificates.
   rpc Certificates(CertificatesRequest) returns (CertificatesResponse) {
     option (google.api.http) = {
       get : "/_status/certificates/{node_id}"
     };
   }
+
+  // Details retrieves details about the nodes in the cluster.
   rpc Details(DetailsRequest) returns (DetailsResponse) {
     option (google.api.http) = {
       get : "/_status/details/{node_id}"
@@ -983,7 +1004,9 @@ service Status {
   // are not included, except in rare cases where the node doing the
   // decommissioning crashed before completing the operation. In these cases,
   // the decommission operation can be rerun to clean up the status entry.
-  // 
+  //
+  // API: PUBLIC ALPHA
+  //
   // Don't introduce additional usages of this RPC. See #50707 for more details.
   // The underlying response type is something we're looking to get rid of.
   rpc Nodes(NodesRequest) returns (NodesResponse) {
@@ -991,57 +1014,82 @@ service Status {
       get : "/_status/nodes"
     };
   }
+
+  // Node retrieves details about a single node.
+  // API: PUBLIC ALPHA
   rpc Node(NodeRequest) returns (server.status.statuspb.NodeStatus) {
     option (google.api.http) = {
       get : "/_status/nodes/{node_id}"
     };
   }
+
+
+  // RaftDebug requests internal details about Raft.
   rpc RaftDebug(RaftDebugRequest) returns (RaftDebugResponse) {
     option (google.api.http) = {
       get : "/_status/raft"
     };
   }
+
+  // Ranges requests internal details about ranges on a given node.
   rpc Ranges(RangesRequest) returns (RangesResponse) {
     option (google.api.http) = {
       get : "/_status/ranges/{node_id}"
     };
   }
+
+  // Gossip retrieves gossip-level details about a given node.
   rpc Gossip(GossipRequest) returns (gossip.InfoStatus) {
     option (google.api.http) = {
       get : "/_status/gossip/{node_id}"
     };
   }
+
+  // EngineStats retrieves statistics about a storage engine.
   rpc EngineStats(EngineStatsRequest) returns (EngineStatsResponse) {
     option (google.api.http) = {
       get : "/_status/enginestats/{node_id}"
     };
   }
+
+  // Allocator retrieves statistics about the replica allocator.
   rpc Allocator(AllocatorRequest) returns (AllocatorResponse) {
     option (google.api.http) = {
       get : "/_status/allocator/node/{node_id}"
     };
   }
+
+  // AllocatorRange retrieves statistics about the replica allocator given
+  // a specific range.
   rpc AllocatorRange(AllocatorRangeRequest) returns (AllocatorRangeResponse) {
     option (google.api.http) = {
       get : "/_status/allocator/range/{range_id}"
     };
   }
+
+  // ListSessions retrieves the SQL sessions across the entire cluster.
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option (google.api.http) = {
       get : "/_status/sessions"
     };
   }
+
+  // ListLocalSessions retrieves the SQL sessions on this node.
   rpc ListLocalSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option (google.api.http) = {
       get : "/_status/local_sessions"
     };
   }
+
+  // CancelQuery cancels a SQL query given its ID.
   rpc CancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_query/{node_id}"
 			body: "*"
     };
   }
+
+  // CancelSessions forcefully terminates a SQL session given its ID.
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_session/{node_id}"
@@ -1060,46 +1108,67 @@ service Status {
       body : "*"
     };
   }
+
+  // Stacks retrieves the stack traces of all goroutines on a given node.
   rpc Stacks(StacksRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/stacks/{node_id}"
     };
   }
+
+  // Profile retrieves a CPU profile on a given node.
   rpc Profile(ProfileRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/profile/{node_id}"
     };
   }
+
+  // Metrics retrieves the node metrics for a given node.
+  //
+  // Note: this is a “reserved” API and should not be relied upon to
+  // build external tools. No guarantee is made about its
+  // availability and stability in external uses.
   rpc Metrics(MetricsRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/metrics/{node_id}"
     };
   }
+
+  // GetFiles retrieves heap or goroutine dump files from a given node.
   rpc GetFiles(GetFilesRequest) returns (GetFilesResponse) {
     option (google.api.http) = {
       get : "/_status/files/{node_id}"
     };
   }
+
+  // LogFilesList retrieves a list of log files on a given node.
   rpc LogFilesList(LogFilesListRequest) returns (LogFilesListResponse) {
     option (google.api.http) = {
       get : "/_status/logfiles/{node_id}"
     };
   }
+
+  // LogFile retrieves a given log file.
   rpc LogFile(LogFileRequest) returns (LogEntriesResponse) {
     option (google.api.http) = {
       get : "/_status/logfiles/{node_id}/{file}"
     };
   }
+
+  // Logs retrieves individual log entries.
   rpc Logs(LogsRequest) returns (LogEntriesResponse) {
     option (google.api.http) = {
       get : "/_status/logs/{node_id}"
     };
   }
+
+  // ProblemRanges retrieves the list of “problem ranges”.
   rpc ProblemRanges(ProblemRangesRequest) returns (ProblemRangesResponse) {
     option (google.api.http) = {
       get : "/_status/problemranges"
     };
   }
+
   rpc HotRanges(HotRangesRequest) returns (HotRangesResponse) {
     option (google.api.http) = {
       get : "/_status/hotranges"

--- a/pkg/server/status/statuspb/status.pb.go
+++ b/pkg/server/status/statuspb/status.pb.go
@@ -47,20 +47,22 @@ func (x HealthAlert_Category) String() string {
 	return proto.EnumName(HealthAlert_Category_name, int32(x))
 }
 func (HealthAlert_Category) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{2, 0}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{2, 0}
 }
 
 // StoreStatus records the most recent values of metrics for a store.
 type StoreStatus struct {
-	Desc    roachpb.StoreDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
-	Metrics map[string]float64      `protobuf:"bytes,2,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
+	// desc is the store descriptor.
+	Desc roachpb.StoreDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
+	// metrics contains the last sampled values for the node metrics.
+	Metrics map[string]float64 `protobuf:"bytes,2,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
 }
 
 func (m *StoreStatus) Reset()         { *m = StoreStatus{} }
 func (m *StoreStatus) String() string { return proto.CompactTextString(m) }
 func (*StoreStatus) ProtoMessage()    {}
 func (*StoreStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{0}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{0}
 }
 func (m *StoreStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -86,15 +88,31 @@ func (m *StoreStatus) XXX_DiscardUnknown() {
 var xxx_messageInfo_StoreStatus proto.InternalMessageInfo
 
 // NodeStatus records the most recent values of metrics for a node.
+// API: PUBLIC ALPHA
 type NodeStatus struct {
-	Desc          roachpb.NodeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
-	BuildInfo     build.Info             `protobuf:"bytes,2,opt,name=build_info,json=buildInfo,proto3" json:"build_info"`
-	StartedAt     int64                  `protobuf:"varint,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
-	UpdatedAt     int64                  `protobuf:"varint,4,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	Metrics       map[string]float64     `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
-	StoreStatuses []StoreStatus          `protobuf:"bytes,6,rep,name=store_statuses,json=storeStatuses,proto3" json:"store_statuses"`
-	Args          []string               `protobuf:"bytes,7,rep,name=args,proto3" json:"args,omitempty"`
-	Env           []string               `protobuf:"bytes,8,rep,name=env,proto3" json:"env,omitempty"`
+	// desc is the node descriptor.
+	Desc roachpb.NodeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
+	// build_info describes the `cockroach` executable file.
+	// API: PUBLIC ALPHA
+	BuildInfo build.Info `protobuf:"bytes,2,opt,name=build_info,json=buildInfo,proto3" json:"build_info"`
+	// started_at is the unix timestamp at which the node process was
+	// last started.
+	// API: PUBLIC ALPHA
+	StartedAt int64 `protobuf:"varint,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	// updated_at is the unix timestamp at which the node status record
+	// was last updated.
+	// API: PUBLIC ALPHA
+	UpdatedAt int64 `protobuf:"varint,4,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// metrics contains the last sampled values for the node metrics.
+	Metrics map[string]float64 `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
+	// store_statuses provides the store status payloads for all
+	// the stores on that node.
+	StoreStatuses []StoreStatus `protobuf:"bytes,6,rep,name=store_statuses,json=storeStatuses,proto3" json:"store_statuses"`
+	// args is the list of command-line arguments used to last start the node.
+	Args []string `protobuf:"bytes,7,rep,name=args,proto3" json:"args,omitempty"`
+	// env is the list of environment variables that influenced
+	// the node's configuration.
+	Env []string `protobuf:"bytes,8,rep,name=env,proto3" json:"env,omitempty"`
 	// latencies is a map of nodeIDs to nanoseconds which is the latency
 	// between this node and the other node.
 	//
@@ -105,10 +123,15 @@ type NodeStatus struct {
 	// to other nodes.
 	Activity map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]NodeStatus_NetworkActivity `protobuf:"bytes,10,rep,name=activity,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"activity" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// total_system_memory is the total RAM available to the system
-	// (or, if possible, the memory available to the cgroup this process is in)
+	// (or, if detected, the memory available to the cgroup this process is in)
 	// in bytes.
+	// API: PUBLIC ALPHA
 	TotalSystemMemory int64 `protobuf:"varint,11,opt,name=total_system_memory,json=totalSystemMemory,proto3" json:"total_system_memory,omitempty"`
-	// num_cpus is the number of logical CPUs on this machine.
+	// num_cpus is the number of logical CPUs as reported by the operating system
+	// on the host where the `cockroach` process is running. Note that
+	// this does not report the number of CPUs actually used by `cockroach`;
+	// this parameter is controlled separately.
+	// API: PUBLIC ALPHA
 	NumCpus int32 `protobuf:"varint,12,opt,name=num_cpus,json=numCpus,proto3" json:"num_cpus,omitempty"`
 }
 
@@ -116,7 +139,7 @@ func (m *NodeStatus) Reset()         { *m = NodeStatus{} }
 func (m *NodeStatus) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus) ProtoMessage()    {}
 func (*NodeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{1}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{1}
 }
 func (m *NodeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -151,7 +174,7 @@ func (m *NodeStatus_NetworkActivity) Reset()         { *m = NodeStatus_NetworkAc
 func (m *NodeStatus_NetworkActivity) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus_NetworkActivity) ProtoMessage()    {}
 func (*NodeStatus_NetworkActivity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{1, 2}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{1, 2}
 }
 func (m *NodeStatus_NetworkActivity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -190,7 +213,7 @@ func (m *HealthAlert) Reset()         { *m = HealthAlert{} }
 func (m *HealthAlert) String() string { return proto.CompactTextString(m) }
 func (*HealthAlert) ProtoMessage()    {}
 func (*HealthAlert) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{2}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{2}
 }
 func (m *HealthAlert) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +247,7 @@ func (m *HealthCheckResult) Reset()         { *m = HealthCheckResult{} }
 func (m *HealthCheckResult) String() string { return proto.CompactTextString(m) }
 func (*HealthCheckResult) ProtoMessage()    {}
 func (*HealthCheckResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{3}
+	return fileDescriptor_status_46c3b5d63ad7300e, []int{3}
 }
 func (m *HealthCheckResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1929,10 +1952,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_f9872bd1035fefcc)
+	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_46c3b5d63ad7300e)
 }
 
-var fileDescriptor_status_f9872bd1035fefcc = []byte{
+var fileDescriptor_status_46c3b5d63ad7300e = []byte{
 	// 817 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x55, 0x5f, 0x6f, 0xe3, 0x44,
 	0x10, 0xcf, 0x36, 0x69, 0xe3, 0x8c, 0xef, 0x4a, 0x6f, 0x39, 0x90, 0x89, 0x44, 0x6a, 0x02, 0x0f,

--- a/pkg/server/status/statuspb/status.proto
+++ b/pkg/server/status/statuspb/status.proto
@@ -18,20 +18,47 @@ import "gogoproto/gogo.proto";
 
 // StoreStatus records the most recent values of metrics for a store.
 message StoreStatus {
+  // desc is the store descriptor.
   roachpb.StoreDescriptor desc = 1 [(gogoproto.nullable) = false];
+
+  // metrics contains the last sampled values for the node metrics.
   map<string, double> metrics = 2;
 }
 
 // NodeStatus records the most recent values of metrics for a node.
+// API: PUBLIC ALPHA
 message NodeStatus {
+  // desc is the node descriptor.
   roachpb.NodeDescriptor desc = 1 [(gogoproto.nullable) = false];
+
+  // build_info describes the `cockroach` executable file.
+  // API: PUBLIC ALPHA
   build.Info build_info = 2 [(gogoproto.nullable) = false];
+
+  // started_at is the unix timestamp at which the node process was
+  // last started.
+  // API: PUBLIC ALPHA
   int64 started_at = 3;
+
+  // updated_at is the unix timestamp at which the node status record
+  // was last updated.
+  // API: PUBLIC ALPHA
   int64 updated_at = 4;
+
+  // metrics contains the last sampled values for the node metrics.
   map<string, double> metrics = 5;
+
+  // store_statuses provides the store status payloads for all
+  // the stores on that node.
   repeated StoreStatus store_statuses = 6 [(gogoproto.nullable) = false];
+
+  // args is the list of command-line arguments used to last start the node.
   repeated string args = 7;
+
+  // env is the list of environment variables that influenced
+  // the node's configuration.
   repeated string env = 8;
+
   // latencies is a map of nodeIDs to nanoseconds which is the latency
   // between this node and the other node.
   //
@@ -53,11 +80,18 @@ message NodeStatus {
     (gogoproto.nullable) = false,
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
   ];
+
   // total_system_memory is the total RAM available to the system
-  // (or, if possible, the memory available to the cgroup this process is in)
+  // (or, if detected, the memory available to the cgroup this process is in)
   // in bytes.
+  // API: PUBLIC ALPHA
   int64 total_system_memory = 11;
-  // num_cpus is the number of logical CPUs on this machine.
+
+  // num_cpus is the number of logical CPUs as reported by the operating system
+  // on the host where the `cockroach` process is running. Note that
+  // this does not report the number of CPUs actually used by `cockroach`;
+  // this parameter is controlled separately.
+  // API: PUBLIC ALPHA
   int32 num_cpus = 12;
 }
 


### PR DESCRIPTION
Informs https://github.com/cockroachdb/docs/issues/8602

This commit makes three changes:

- it extends the API doc generator to recognize
  annotations to distinguish “reserved”, “alpha” and “public” APIs
  and report this level of support in the generated output.

  [Example full output here](https://github.com/knz/cockroach/blob/20201022-nodes/docs/generated/http/full.md)

- it makes it possible to annotate different levels of support
  for different fields inside a single API payload. This makes
  it possible to document that certain fields of public APIs
  are “reserved”.

- it marks all the APIs as “reserved” except for the following three:

  - `/health` which has been stabilized and is safely documentable.

    [See doc here](https://github.com/knz/cockroach/blob/20201022-nodes/docs/generated/http/full.md#health)

  - `/_status/nodes` ([generated doc](https://github.com/knz/cockroach/blob/20201022-nodes/docs/generated/http/full.md#nodes)) and `/_status/hotranges` ([generated doc](https://github.com/knz/cockroach/blob/20201022-nodes/docs/generated/http/full.md#hotranges)) are marked
    as “alpha” as requested by
    @piyush-singh, to serve as example of how we could
    document an API.

Note that some other API endpoints could probably be marked as “alpha”
but the upcoming release cycle will see the introduction of a new
namespace for public APIs, so we wish to not over-commit at this time.

Release note: None