### PR TITLE
util: add skip.UnderMetamorphic; skip a test

### DIFF
--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -424,6 +425,9 @@ func TestLimitScans(t *testing.T) {
 	if rows != limit {
 		t.Fatalf("expected %d rows, got: %d", limit, rows)
 	}
+
+	skip.UnderMetamorphic(t, "the rest of this test isn't metamorphic: its output "+
+		"depends on the batch size, which varies the number of spans searched.")
 
 	// We're now going to count how many distinct scans we've done. This regex is
 	// specific so that we don't count range resolving requests, and we dedupe

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -70,3 +70,11 @@ func UnderStressRace(t SkippableTest, args ...interface{}) {
 		t.Skip(append([]interface{}{"disabled under stressrace"}, args...))
 	}
 }
+
+// UnderMetamorphic skips this test during metamorphic runs, which are tests
+// run with the metamorphic build tag.
+func UnderMetamorphic(t SkippableTest, args ...interface{}) {
+	if util.MetamorphicBuild {
+		t.Skip(append([]interface{}{"disabled under metamorphic"}, args...))
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -43,18 +43,18 @@ import (
 // This will give your code a batch size of 1 in the test_constants build
 // configuration, increasing the amount of exercise the edge conditions get.
 func ConstantWithMetamorphicTestValue(defaultValue, metamorphicValue int) int {
-	if metamorphicBuild {
+	if MetamorphicBuild {
 		logMetamorphicValue(metamorphicValue)
 		return metamorphicValue
 	}
 	return defaultValue
 }
 
-// rng is initialized to a rand.Rand if metamorphicBuild is enabled.
+// rng is initialized to a rand.Rand if MetamorphicBuild is enabled.
 var rng *rand.Rand
 
 func init() {
-	if metamorphicBuild {
+	if MetamorphicBuild {
 		rng, _ = randutil.NewPseudoRand()
 	}
 }
@@ -63,7 +63,7 @@ func init() {
 // except instead of returning a single metamorphic test value, it returns a
 // random test value in a range.
 func ConstantWithMetamorphicTestRange(defaultValue, min, max int) int {
-	if metamorphicBuild {
+	if MetamorphicBuild {
 		ret := int(rng.Int31())%(max-min) + min
 		logMetamorphicValue(ret)
 		return ret
@@ -72,6 +72,6 @@ func ConstantWithMetamorphicTestRange(defaultValue, min, max int) int {
 }
 
 func logMetamorphicValue(value int) {
-	fmt.Fprintf(os.Stderr, "initialized metamorphic constant with value %d: %s",
+	fmt.Fprintf(os.Stderr, "initialized metamorphic constant with value %d: %s\n",
 		value, GetSmallTrace(1))
 }

--- a/pkg/util/metamorphic_off.go
+++ b/pkg/util/metamorphic_off.go
@@ -12,8 +12,8 @@
 
 package util
 
-// metamorphicBuild is a flag that is set to true if the binary was compiled with
+// MetamorphicBuild is a flag that is set to true if the binary was compiled with
 // the test_constants build tag. This flag can be used to enable expensive
 // checks, test randomizations, or other metamorphic-style perturbations that
 // will not affect test results but will exercise different parts of the code.
-const metamorphicBuild = false
+const MetamorphicBuild = false

--- a/pkg/util/metamorphic_on.go
+++ b/pkg/util/metamorphic_on.go
@@ -12,8 +12,8 @@
 
 package util
 
-// metamorphicBuild is a flag that is set to true if the binary was compiled with
+// MetamorphicBuild is a flag that is set to true if the binary was compiled with
 // the test_constants build tag. This flag can be used to enable expensive
 // checks, test randomizations, or other metamorphic-style perturbations that
 // will not affect test results but will exercise different parts of the code.
-const metamorphicBuild = true
+const MetamorphicBuild = true


### PR DESCRIPTION
One test cannot be run under the metamorphic build configuration, since
its output depends on the batch size: the test counts the number of
spans scanned, which will go up with a small batch size due to the table
reader resuming the scan until its finished.

Release note: None