### PR TITLE
sql: single-column EXPLAIN output

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -24,15 +24,16 @@ ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -70,15 +71,16 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]
 statement ok
 ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@tertiary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@tertiary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -116,15 +118,16 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]
 statement ok
 ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 # ------------------------------------------------------------------------------
 # Swap location of primary and secondary indexes and ensure that primary index
@@ -137,15 +140,16 @@ ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -178,17 +182,18 @@ scan t
 # ------------------------------------------------------------------------------
 
 statement
-PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WHERE k=10]
+PREPARE p AS SELECT * FROM [EXPLAIN SELECT k, v FROM t WHERE k=10]
 
-query TTT retry
+query T retry
 EXECUTE p
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/10 - /10]
 
 statement ok
 ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
@@ -196,15 +201,16 @@ ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 
-query TTT retry
+query T retry
 EXECUTE p
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 statement ok
 DEALLOCATE p
@@ -222,15 +228,16 @@ statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE
 USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 # ------------------------------------------------------------------------------
 # Move secondary lease preference to dc3 and put tertiary lease preference in
@@ -245,15 +252,16 @@ statement ok
 ALTER INDEX t@tertiary CONFIGURE ZONE
 USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@tertiary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@tertiary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -301,15 +309,16 @@ statement ok
 ALTER INDEX t@tertiary CONFIGURE ZONE
 USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -345,31 +354,33 @@ scan t@secondary
 # ------------------------------------------------------------------------------
 
 statement ok
-PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WHERE k=10]
+PREPARE p AS SELECT * FROM [EXPLAIN SELECT k, v FROM t WHERE k=10]
 
-query TTT retry
+query T retry
 EXECUTE p
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@secondary
+  spans: [/10 - /10]
 
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE
 USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 
-query TTT retry
+query T retry
 EXECUTE p
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/10 - /10]
 
 statement ok
 DEALLOCATE p
@@ -392,15 +403,16 @@ CREATE TABLE t36642 (
 statement ok
 ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t36642@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t36642@secondary
+  spans: [/10 - /10]
 
 statement ok
 ALTER INDEX t36642@tertiary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
@@ -408,15 +420,16 @@ ALTER INDEX t36642@tertiary CONFIGURE ZONE USING constraints='[+region=test]', l
 statement ok
 ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t36642@tertiary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t36642@tertiary
+  spans: [/10 - /10]
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -465,15 +478,16 @@ statement ok
 ALTER INDEX t36644@secondary
 CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t36644@secondary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t36644@secondary
+  spans: [/10 - /10]
 
 statement ok
 ALTER INDEX t36644@secondary CONFIGURE ZONE USING lease_preferences='[[+dc=dc3]]'
@@ -482,15 +496,16 @@ statement ok
 ALTER INDEX t36644@tertiary
 CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]]'
 
-query TTT retry
+query T retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t36644@tertiary
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: t36644@tertiary
+  spans: [/10 - /10]
 
 subtest regression_35756
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1365,16 +1365,18 @@ func Example_misc_table() {
 	//     hai
 	// (1 row)
 	// sql --format=table -e explain select s, 'foo' from t.t
-	//     tree    |     field     | description
-	// ------------+---------------+--------------
-	//             | distribution  | full
-	//             | vectorized    | false
-	//   render    |               |
-	//    └── scan |               |
-	//             | missing stats |
-	//             | table         | t@primary
-	//             | spans         | FULL SCAN
-	// (7 rows)
+	//            info
+	// --------------------------
+	//   distribution: full
+	//   vectorized: false
+	//
+	//   • render
+	//   │
+	//   └── • scan
+	//         missing stats
+	//         table: t@primary
+	//         spans: FULL SCAN
+	// (9 rows)
 }
 
 func Example_cert() {

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -149,34 +149,7 @@ func (r ResultColumns) String(printTypes bool, showHidden bool) string {
 // ExplainPlanColumns are the result columns of an EXPLAIN (PLAN) ...
 // statement.
 var ExplainPlanColumns = ResultColumns{
-	// Tree shows the node type with the tree structure.
-	{Name: "tree", Typ: types.String},
-	// Field is the part of the node that a row of output pertains to.
-	{Name: "field", Typ: types.String},
-	// Description contains details about the field.
-	{Name: "description", Typ: types.String},
-}
-
-// ExplainPlanVerboseColumns are the result columns of an
-// EXPLAIN (PLAN, ...) ...
-// statement when a flag like VERBOSE or TYPES is passed.
-var ExplainPlanVerboseColumns = ResultColumns{
-	// Tree shows the node type with the tree structure.
-	{Name: "tree", Typ: types.String},
-	// Level is the depth of the node in the tree. Hidden by default; can be
-	// retrieved using:
-	//   SELECT level FROM [ EXPLAIN (VERBOSE) ... ].
-	{Name: "level", Typ: types.Int, Hidden: true},
-	// Type is the node type. Hidden by default.
-	{Name: "node_type", Typ: types.String, Hidden: true},
-	// Field is the part of the node that a row of output pertains to.
-	{Name: "field", Typ: types.String},
-	// Description contains details about the field.
-	{Name: "description", Typ: types.String},
-	// Columns is the type signature of the data source.
-	{Name: "columns", Typ: types.String},
-	// Ordering indicates the known ordering of the data from this source.
-	{Name: "ordering", Typ: types.String},
+	{Name: "info", Typ: types.String},
 }
 
 // ExplainDistSQLColumns are the result columns of an

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -51,8 +51,11 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		return err
 	}
 	v := params.p.newContainerValuesNode(e.columns, 0)
-	for _, row := range ob.BuildExplainRows() {
-		if _, err := v.rows.AddRow(params.ctx, row); err != nil {
+	rows := ob.BuildStringRows()
+	datums := make([]tree.DString, len(rows))
+	for i, row := range rows {
+		datums[i] = tree.DString(row)
+		if _, err := v.rows.AddRow(params.ctx, tree.Datums{&datums[i]}); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -117,15 +117,17 @@ SELECT * FROM parent
 1 2
 4 5
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM child WHERE x >= 1 AND x < 5 AND y >= 2 AND y <= 6] OFFSET 2
 ----
-filter     ·              ·
- │         filter         (y >= 2) AND (y <= 6)
- └── scan  ·              ·
-·          missing stats  ·
-·          table          child@primary
-·          spans          [/1/2 - /4/6]
+·
+• filter
+│ filter: (y >= 2) AND (y <= 6)
+│
+└── • scan
+      missing stats
+      table: child@primary
+      spans: [/1/2 - /4/6]
 
 query III rowsort
 SELECT * FROM child WHERE x >= 1 AND x < 5 AND y >= 2 AND y <= 6
@@ -172,13 +174,14 @@ child  CREATE TABLE public.child (
        FAMILY fam_0_x_y_z (x, y, z)
 )
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM child WHERE y >=2 AND y <= 6] OFFSET 2
 ----
-scan  ·              ·
-·     missing stats  ·
-·     table          child@primary
-·     spans          [/2 - /6]
+·
+• scan
+  missing stats
+  table: child@primary
+  spans: [/2 - /6]
 
 query III rowsort
 SELECT * FROM child WHERE y >=2 AND y <= 6
@@ -220,13 +223,14 @@ child                                     CREATE TABLE public.child (
 
 # If child@i was not properly rewritten, we wouldn't be able to select
 # all columns in child from it without an index join
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM child@i] OFFSET 2
 ----
-scan  ·              ·
-·     missing stats  ·
-·     table          child@i
-·     spans          FULL SCAN
+·
+• scan
+  missing stats
+  table: child@i
+  spans: FULL SCAN
 
 query IIII
 SELECT * FROM child@i
@@ -381,90 +385,102 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 
 # Make sure that each index can index join against the new primary key;
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i1] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i1
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i1
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i1
 ----
 1 2 3 4 {}
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i2] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i2
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i2
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i2
 ----
 1 2 3 4 {}
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i3] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i3
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i3
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i3
 ----
 1 2 3 4 {}
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i4] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i4
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i4
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i4
 ----
 1 2 3 4 {}
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i5] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i5
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i5
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i5
 ----
 1 2 3 4 {}
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM t@i7] OFFSET 2
 ----
-index join  ·              ·
- │          table          t@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          t@i7
-·           spans          FULL SCAN
+·
+• index join
+│ table: t@primary
+│
+└── • scan
+      missing stats
+      table: t@i7
+      spans: FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i5
@@ -498,13 +514,14 @@ t  CREATE TABLE public.t (
    FAMILY fam_0_x_y_z_crdb_internal_z_shard_5 (x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
 )
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN INSERT INTO t VALUES (4, 5, 6)] OFFSET 2
 ----
-insert fast path  ·            ·
-·                 into         t(x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
-·                 auto commit  ·
-·                 size         7 columns, 1 row
+·
+• insert fast path
+  into: t(x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
+  auto commit
+  size: 7 columns, 1 row
 
 # Ensure that all of the indexes have been rewritten.
 query IT

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1082,10 +1082,10 @@ CREATE TYPE local_type AS ENUM ('local');
 CREATE TABLE local_table (x INT);
 INSERT INTO local_table VALUES (1), (2)
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
 ----
-·     distribution  local
+distribution: local
 
 statement ok
 ROLLBACK
@@ -1096,10 +1096,10 @@ ALTER TYPE greeting RENAME TO greeting_local;
 CREATE TABLE local_table (x INT);
 INSERT INTO local_table VALUES (1), (2)
 
-query TTT
+query T
 SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
 ----
-·     distribution  local
+distribution: local
 
 statement ok
 ROLLBACK

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -294,11 +294,11 @@ SELECT a FROM t1 WHERE a = 10
 ----
 10
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a FROM t1 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a FROM t1 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@primary
-spans  [/10 - /10]
+  table: t1@primary
+  spans: [/10 - /10]
 
 # A point lookup on a non-nullable column allows us to scan only that column
 # family.
@@ -307,11 +307,11 @@ SELECT b FROM t1 WHERE a = 10
 ----
 20
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT b FROM t1 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT b FROM t1 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@primary
-spans  [/10 - /10]
+  table: t1@primary
+  spans: [/10 - /10]
 
 # Even if we also select the primary key column, we can still scan the single
 # column family because that column can be decoded from the key.
@@ -320,11 +320,11 @@ SELECT a, b FROM t1 WHERE a = 10
 ----
 10  20
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a, b FROM t1 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a, b FROM t1 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@primary
-spans  [/10 - /10]
+  table: t1@primary
+  spans: [/10 - /10]
 
 # A point lookup on a nullable column requires also scanning column family 0 as
 # a sentinel.
@@ -333,11 +333,11 @@ SELECT c FROM t1 WHERE a = 10
 ----
 30
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT c FROM t1 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT c FROM t1 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@primary
-spans  [/10 - /10]
+  table: t1@primary
+  spans: [/10 - /10]
 
 # A point lookup on two columns in non-adjacent column families results in two
 # spans.
@@ -346,11 +346,11 @@ SELECT b, d FROM t1 WHERE a = 10
 ----
 20  40
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT b, d FROM t1 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT b, d FROM t1 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@primary
-spans  [/10 - /10]
+  table: t1@primary
+  spans: [/10 - /10]
 
 # Unique secondary indexes store non-indexed primary key columns in column
 # family 0.
@@ -362,11 +362,11 @@ SELECT a FROM t1 WHERE b = 20
 ----
 10
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a FROM t1 WHERE b = 20] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a FROM t1 WHERE b = 20] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t1@b_idx
-spans  [/20 - /20]
+  table: t1@b_idx
+  spans: [/20 - /20]
 
 # If the primary key column is composite, we do need to scan its column family
 # to retrieve its value.
@@ -383,11 +383,11 @@ SELECT a FROM t2 WHERE a = 10
 ----
 10.00
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a FROM t2 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a FROM t2 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t2@primary
-spans  [/10 - /10]
+  table: t2@primary
+  spans: [/10 - /10]
 
 # A point lookup on `a` and `b` should scan both of their families.
 query TI
@@ -395,11 +395,11 @@ SELECT a, b FROM t2 WHERE a = 10
 ----
 10.00  20
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a, b FROM t2 WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a, b FROM t2 WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t2@primary
-spans  [/10 - /10]
+  table: t2@primary
+  spans: [/10 - /10]
 
 # Secondary indexes always store their composite values in column family 0.
 statement ok
@@ -411,11 +411,11 @@ SELECT a, b FROM t2@a_idx WHERE a = 10
 ----
 10.00  20
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a FROM t2@a_idx WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a FROM t2@a_idx WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t2@a_idx
-spans  [/10 - /10]
+  table: t2@a_idx
+  spans: [/10 - /10]
 
 # A point lookup on `a` and `b` should use column family 0 and b's family.
 query TI
@@ -423,11 +423,11 @@ SELECT a, b FROM t2@a_idx WHERE a = 10
 ----
 10.00  20
 
-query TT
-SELECT field, description FROM [EXPLAIN SELECT a, b FROM t2@a_idx WHERE a = 10] WHERE field IN ('table', 'spans')
+query T
+SELECT info FROM [EXPLAIN SELECT a, b FROM t2@a_idx WHERE a = 10] WHERE info LIKE '%table%' OR info LIKE '%spans%'
 ----
-table  t2@a_idx
-spans  [/10 - /10]
+  table: t2@a_idx
+  spans: [/10 - /10]
 
 # ------------------------------------------------------------------------------
 # UPSERT/INSERT..ON CONFLICT cases.

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5435,7 +5435,7 @@ SELECT ST_MemSize(g) FROM ( VALUES
 121
 119
 
-subtest  st_pointinsidecircle
+subtest st_pointinsidecircle
 
 query B
 SELECT ST_PointInsideCircle(point, x, y, radius) FROM ( VALUES

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
@@ -24,108 +24,132 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT k, k_plus_one FROM geo_table2 WHERE ST
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUk11v0zAUhu_5Fda5aSuZ1U5AIF-FjwyCura0lQDNURXqQ4mW2sF2UFDV_46SDG3dlI72wtL5eOzzvj3Zg_tVgIBlPInfrUhlC3K5mF2R6_jrfPImmZLh-2S5Wn6ejMhtyw0lN-uyqNzaaOyat2jWPvteYEC-fIwXMXF-nWuP1uHGu-FgPkumq2F4wUh4wUYDIT7Es6t4tfhGG3Q3SoGCNgqn2Q4diGvgkFIordmgc8Y2qX3bkKgaBKOQ67LyTTqlsDEWQezB575AELBqBllgptCOGVBQ6LO8aK-9mzNq3l3nWmENFJZlpp0gYwlvpax_KClrzqSs2VMHPD-X4RJIphUJGTH-J1oHFGaVFyTiNAppFEB6oGAqfyfQ-WyLIPiB_r8Jif6N1qO6zAuPFu2YHzvxrx7XpSVGkygQxDUuEOcz60WrKnz1UkoWMCkZe-oAglqdizVm9LvRb0VwjhWfTK5v1yHoXYfS5rvM_gEKnWPi4Qozzjh7_Hv94lE8EPf3OwpGR_9wr6bwHE0LdKXRDo_09N3MDikFVFvsviNnKrvBuTWb9pkunLVcm1DofFflXZDortQMeB_mJ-HgNBychMMHcHp49jcAAP__Crh0gQ==
 
-query TTT
+query T
 EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           st_intersects('010100000000000000000008400000000000000840', geom)
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        31
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            31 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: st_intersects('010100000000000000000008400000000000000840', geom)
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 31
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 31 spans
 
-query TTT
+query T
 EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_DFullyWithin('POINT(3.0 3.0)'::geometry, geom, 1)
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           st_dfullywithin('010100000000000000000008400000000000000840', geom, 1.0)
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        30
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            30 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: st_dfullywithin('010100000000000000000008400000000000000840', geom, 1.0)
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 30
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 30 spans
 
 # Bounding box operations.
 statement ok
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
-query TTT
+query T
 EXPLAIN SELECT k FROM geo_table2 WHERE geom && 'POINT(3.0 3.0)'::geometry
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           geom && '010100000000000000000008400000000000000840'
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        31
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            31 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: geom && '010100000000000000000008400000000000000840'
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 31
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 31 spans
 
-query TTT
+query T
 EXPLAIN SELECT k FROM geo_table2 WHERE 'POINT(3.0 3.0)'::geometry::box2d && geom
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           'BOX(3 3,3 3)' && geom
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        31
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            31 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: 'BOX(3 3,3 3)' && geom
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 31
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 31 spans
 
-query TTT
+query T
 EXPLAIN SELECT k FROM geo_table2 WHERE 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry ~ geom
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           '010200000002000000000000000000F03F000000000000F03F00000000000014400000000000001440' ~ geom
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        33
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            33 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: '010200000002000000000000000000F03F000000000000F03F00000000000014400000000000001440' ~ geom
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 33
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 33 spans
 
-query TTT
+query T
 EXPLAIN SELECT k FROM geo_table2 WHERE geom ~ 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry::box2d
 ----
-·                          distribution     local
-·                          vectorized       false
-filter                     ·                ·
- │                         filter           geom ~ 'BOX(1 1,5 5)'
- └── index join            ·                ·
-      │                    table            geo_table2@primary
-      └── inverted filter  ·                ·
-           │               inverted column  geom_inverted_key
-           │               num spans        30
-           └── scan        ·                ·
-·                          missing stats    ·
-·                          table            geo_table2@geom_index
-·                          spans            30 spans
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: geom ~ 'BOX(1 1,5 5)'
+│
+└── • index join
+    │ table: geo_table2@primary
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 30
+        │
+        └── • scan
+              missing stats
+              table: geo_table2@geom_index
+              spans: 30 spans

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
@@ -24,182 +24,263 @@ SELECT lk, rk1 FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom1,
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUksGO0zAQhu88xWhOW2lgm3Th4FMQFCmr0ixtD0iraBWSUWWa2sF2UFHVd0e2K5YUWm1vmfH_jT9NvEf7o0WBy-ls-mEFvWnh06L4DI_Trw-z9_kcbj7my9Xyy2wEx0i7ITCbJMZaV31rGe6LfA4mfGdr1tsnqRreQTEH656kcmws187exPgbH0noCIRqVCKh0g3Pqy1bFI-YYEnYGV2ztdr41j4E8maHYkwoVdc73y4Ja20YxR6ddC2jwJWfu-CqYXM7RsKGXSXbMDYaZJ2R28r8QsJlVykr4DUSFr0TkCWUpVgeCHXvnq-wrloziuRAL9fI1U82jpt7LRWb22Ro8s-6kP4Q011nTlaXpQTZ3WigSdmEsrdnZdNrZL3kcWXpf0WfVzbTetN38F1LBVoJ8BZ3Xuz0dwfndwPnyVnbyTW2C7adVpYHpucmjw8lITdrjq_I6t7U_GB0Ha6JZRG40GjYuniaxCJX8cgL_g0nF-H0MpxehCcncHl49TsAAP__Nmgycw==
 
-query TTT
+query T
 EXPLAIN SELECT lk, rk1, rk2, rtable.geom
 FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom1, rtable.geom)
 ----
-·                   distribution           local
-·                   vectorized             true
-lookup join         ·                      ·
- │                  table                  rtable@primary
- │                  equality               (rk1, rk2) = (rk1,rk2)
- │                  equality cols are key  ·
- │                  pred                   st_intersects(geom1, geom)
- └── inverted join  ·                      ·
-      │             table                  rtable@geom_index
-      └── scan      ·                      ·
-·                   missing stats          ·
-·                   table                  ltable@primary
-·                   spans                  FULL SCAN
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: rtable@primary
+│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality cols are key
+│ pred: st_intersects(geom1, geom)
+│
+└── • inverted join
+    │ table: rtable@geom_index
+    │
+    └── • scan
+          missing stats
+          table: ltable@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT lk, rk1, rk2, rtable.geom
 FROM ltable JOIN rtable@geom_index ON ST_DWithin(ltable.geom1, rtable.geom, 5)
 ----
-·                   distribution           local
-·                   vectorized             true
-lookup join         ·                      ·
- │                  table                  rtable@primary
- │                  equality               (rk1, rk2) = (rk1,rk2)
- │                  equality cols are key  ·
- │                  pred                   st_dwithin(geom1, geom, 5.0)
- └── inverted join  ·                      ·
-      │             table                  rtable@geom_index
-      └── scan      ·                      ·
-·                   missing stats          ·
-·                   table                  ltable@primary
-·                   spans                  FULL SCAN
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: rtable@primary
+│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality cols are key
+│ pred: st_dwithin(geom1, geom, 5.0)
+│
+└── • inverted join
+    │ table: rtable@geom_index
+    │
+    └── • scan
+          missing stats
+          table: ltable@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1 FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(rtable.geom, ltable.geom1) OR ST_DWithin(ltable.geom1, rtable.geom, 2) ORDER BY (lk, rk1)
 ----
-·                                               distribution           local                                                                                 ·                                         ·
-·                                               vectorized             true                                                                                  ·                                         ·
-project                                         ·                      ·                                                                                     (lk, rk1)                                 +lk,+rk1
- │                                              estimated row count    326700 (missing stats)                                                                ·                                         ·
- └── project                                    ·                      ·                                                                                     (lk, geom1, rk1, geom)                    +lk,+rk1
-      │                                         estimated row count    326700 (missing stats)                                                                ·                                         ·
-      └── lookup join (inner)                   ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom)               +lk,+rk1
-           │                                    table                  rtable@primary                                                                        ·                                         ·
-           │                                    equality               (rk1, rk2) = (rk1,rk2)                                                                ·                                         ·
-           │                                    equality cols are key  ·                                                                                     ·                                         ·
-           │                                    pred                   st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)                            ·                                         ·
-           └── sort                             ·                      ·                                                                                     (lk, geom1, rk1, rk2)                     +lk,+rk1
-                │                               estimated row count    10000 (missing stats)                                                                 ·                                         ·
-                │                               order                  +lk,+rk1                                                                              ·                                         ·
-                └── project                     ·                      ·                                                                                     (lk, geom1, rk1, rk2)                     ·
-                     │                          estimated row count    10000 (missing stats)                                                                 ·                                         ·
-                     └── inverted join (inner)  ·                      ·                                                                                     (lk, geom1, rk1, rk2, geom_inverted_key)  ·
-                          │                     table                  rtable@geom_index                                                                     ·                                         ·
-                          │                     inverted expr          st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
-                          └── scan              ·                      ·                                                                                     (lk, geom1)                               ·
-·                                               estimated row count    1000 (missing stats)                                                                  ·                                         ·
-·                                               table                  ltable@primary                                                                        ·                                         ·
-·                                               spans                  FULL SCAN                                                                             ·                                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1)
+│ ordering: +lk,+rk1
+│ estimated row count: 326700 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom1, rk1, geom)
+    │ ordering: +lk,+rk1
+    │ estimated row count: 326700 (missing stats)
+    │
+    └── • lookup join (inner)
+        │ columns: (lk, geom1, rk1, rk2, geom)
+        │ ordering: +lk,+rk1
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)
+        │
+        └── • sort
+            │ columns: (lk, geom1, rk1, rk2)
+            │ ordering: +lk,+rk1
+            │ estimated row count: 10000 (missing stats)
+            │ order: +lk,+rk1
+            │
+            └── • project
+                │ columns: (lk, geom1, rk1, rk2)
+                │ estimated row count: 10000 (missing stats)
+                │
+                └── • inverted join (inner)
+                    │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+                    │ table: rtable@geom_index
+                    │ inverted expr: st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)
+                    │
+                    └── • scan
+                          columns: (lk, geom1)
+                          estimated row count: 1000 (missing stats)
+                          table: ltable@primary
+                          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1 FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(ltable.geom1, rtable.geom) AND ST_DWithin(rtable.geom, ltable.geom1, 2) ORDER BY (lk, rk1)
 ----
-·                                               distribution           local                                                                                  ·                                         ·
-·                                               vectorized             true                                                                                   ·                                         ·
-sort                                            ·                      ·                                                                                      (lk, rk1)                                 +lk,+rk1
- │                                              estimated row count    9801 (missing stats)                                                                   ·                                         ·
- │                                              order                  +lk,+rk1                                                                               ·                                         ·
- │                                              already ordered        +lk                                                                                    ·                                         ·
- └── project                                    ·                      ·                                                                                      (lk, rk1)                                 +lk
-      │                                         estimated row count    9801 (missing stats)                                                                   ·                                         ·
-      └── project                               ·                      ·                                                                                      (lk, geom1, rk1, geom)                    +lk
-           │                                    estimated row count    9801 (missing stats)                                                                   ·                                         ·
-           └── lookup join (inner)              ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom)               +lk
-                │                               table                  rtable@primary                                                                         ·                                         ·
-                │                               equality               (rk1, rk2) = (rk1,rk2)                                                                 ·                                         ·
-                │                               equality cols are key  ·                                                                                      ·                                         ·
-                │                               pred                   st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)                            ·                                         ·
-                └── project                     ·                      ·                                                                                      (lk, geom1, rk1, rk2)                     +lk
-                     │                          estimated row count    10000 (missing stats)                                                                  ·                                         ·
-                     └── inverted join (inner)  ·                      ·                                                                                      (lk, geom1, rk1, rk2, geom_inverted_key)  +lk
-                          │                     table                  rtable@geom_index                                                                      ·                                         ·
-                          │                     inverted expr          st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)  ·                                         ·
-                          └── scan              ·                      ·                                                                                      (lk, geom1)                               +lk
-·                                               estimated row count    1000 (missing stats)                                                                   ·                                         ·
-·                                               table                  ltable@primary                                                                         ·                                         ·
-·                                               spans                  FULL SCAN                                                                              ·                                         ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (lk, rk1)
+│ ordering: +lk,+rk1
+│ estimated row count: 9801 (missing stats)
+│ order: +lk,+rk1
+│ already ordered: +lk
+│
+└── • project
+    │ columns: (lk, rk1)
+    │ ordering: +lk
+    │ estimated row count: 9801 (missing stats)
+    │
+    └── • project
+        │ columns: (lk, geom1, rk1, geom)
+        │ ordering: +lk
+        │ estimated row count: 9801 (missing stats)
+        │
+        └── • lookup join (inner)
+            │ columns: (lk, geom1, rk1, rk2, geom)
+            │ ordering: +lk
+            │ table: rtable@primary
+            │ equality: (rk1, rk2) = (rk1,rk2)
+            │ equality cols are key
+            │ pred: st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)
+            │
+            └── • project
+                │ columns: (lk, geom1, rk1, rk2)
+                │ ordering: +lk
+                │ estimated row count: 10000 (missing stats)
+                │
+                └── • inverted join (inner)
+                    │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+                    │ ordering: +lk
+                    │ table: rtable@geom_index
+                    │ inverted expr: st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)
+                    │
+                    └── • scan
+                          columns: (lk, geom1)
+                          ordering: +lk
+                          estimated row count: 1000 (missing stats)
+                          table: ltable@primary
+                          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1 FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(ltable.geom1, rtable.geom) AND ST_Covers(ltable.geom2, rtable.geom)
 AND (ST_DFullyWithin(rtable.geom, ltable.geom1, 100) OR ST_Intersects('POINT(1.0 1.0)', rtable.geom))
 ----
-·                                          distribution           local                                                                                                                                                                                                                       ·                                                ·
-·                                          vectorized             true                                                                                                                                                                                                                        ·                                                ·
-project                                    ·                      ·                                                                                                                                                                                                                           (lk, rk1)                                        ·
- │                                         estimated row count    3267 (missing stats)                                                                                                                                                                                                        ·                                                ·
- └── project                               ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, geom)                    ·
-      │                                    estimated row count    3267 (missing stats)                                                                                                                                                                                                        ·                                                ·
-      └── lookup join (inner)              ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom)               ·
-           │                               table                  rtable@primary                                                                                                                                                                                                              ·                                                ·
-           │                               equality               (rk1, rk2) = (rk1,rk2)                                                                                                                                                                                                      ·                                                ·
-           │                               equality cols are key  ·                                                                                                                                                                                                                           ·                                                ·
-           │                               pred                   (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))                                                      ·                                                ·
-           └── project                     ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2)                     ·
-                │                          estimated row count    10000 (missing stats)                                                                                                                                                                                                       ·                                                ·
-                └── inverted join (inner)  ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2, rk1, rk2, geom_inverted_key)  ·
-                     │                     table                  rtable@geom_index                                                                                                                                                                                                           ·                                                ·
-                     │                     inverted expr          (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))  ·                                                ·
-                     └── scan              ·                      ·                                                                                                                                                                                                                           (lk, geom1, geom2)                               ·
-·                                          estimated row count    1000 (missing stats)                                                                                                                                                                                                        ·                                                ·
-·                                          table                  ltable@primary                                                                                                                                                                                                              ·                                                ·
-·                                          spans                  FULL SCAN                                                                                                                                                                                                                   ·                                                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1)
+│ estimated row count: 3267 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom1, geom2, rk1, geom)
+    │ estimated row count: 3267 (missing stats)
+    │
+    └── • lookup join (inner)
+        │ columns: (lk, geom1, geom2, rk1, rk2, geom)
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))
+        │
+        └── • project
+            │ columns: (lk, geom1, geom2, rk1, rk2)
+            │ estimated row count: 10000 (missing stats)
+            │
+            └── • inverted join (inner)
+                │ columns: (lk, geom1, geom2, rk1, rk2, geom_inverted_key)
+                │ table: rtable@geom_index
+                │ inverted expr: (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))
+                │
+                └── • scan
+                      columns: (lk, geom1, geom2)
+                      estimated row count: 1000 (missing stats)
+                      table: ltable@primary
+                      spans: FULL SCAN
 
 # This query performs a semi-join, which is converted to paired joins by the
 # optimizer.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk FROM ltable WHERE EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
-·                                          distribution           local                                    ·                                               ·
-·                                          vectorized             true                                     ·                                               ·
-project                                    ·                      ·                                        (lk)                                            ·
- │                                         estimated row count    10 (missing stats)                       ·                                               ·
- └── project                               ·                      ·                                        (lk, geom2)                                     ·
-      │                                    estimated row count    10 (missing stats)                       ·                                               ·
-      └── lookup join (semi)               ·                      ·                                        (lk, geom2, rk1, rk2, cont)                     ·
-           │                               table                  rtable@primary                           ·                                               ·
-           │                               equality               (rk1, rk2) = (rk1,rk2)                   ·                                               ·
-           │                               equality cols are key  ·                                        ·                                               ·
-           │                               pred                   st_intersects(geom2, geom)               ·                                               ·
-           └── project                     ·                      ·                                        (lk, geom2, rk1, rk2, cont)                     ·
-                │                          estimated row count    10000 (missing stats)                    ·                                               ·
-                └── inverted join (inner)  ·                      ·                                        (lk, geom2, rk1, rk2, geom_inverted_key, cont)  ·
-                     │                     table                  rtable@geom_index                        ·                                               ·
-                     │                     inverted expr          st_intersects(geom2, geom_inverted_key)  ·                                               ·
-                     └── scan              ·                      ·                                        (lk, geom2)                                     ·
-·                                          estimated row count    1000 (missing stats)                     ·                                               ·
-·                                          table                  ltable@primary                           ·                                               ·
-·                                          spans                  FULL SCAN                                ·                                               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk)
+│ estimated row count: 10 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom2)
+    │ estimated row count: 10 (missing stats)
+    │
+    └── • lookup join (semi)
+        │ columns: (lk, geom2, rk1, rk2, cont)
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: st_intersects(geom2, geom)
+        │
+        └── • project
+            │ columns: (lk, geom2, rk1, rk2, cont)
+            │ estimated row count: 10000 (missing stats)
+            │
+            └── • inverted join (inner)
+                │ columns: (lk, geom2, rk1, rk2, geom_inverted_key, cont)
+                │ table: rtable@geom_index
+                │ inverted expr: st_intersects(geom2, geom_inverted_key)
+                │
+                └── • scan
+                      columns: (lk, geom2)
+                      estimated row count: 1000 (missing stats)
+                      table: ltable@primary
+                      spans: FULL SCAN
 
 # Left outer joins are also converted to paired joins by the optimizer.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1 FROM ltable LEFT JOIN rtable ON ST_Intersects(ltable.geom1, rtable.geom)
 ----
-·                                               distribution           local                                    ·                                               ·
-·                                               vectorized             true                                     ·                                               ·
-project                                         ·                      ·                                        (lk, rk1)                                       ·
- │                                              estimated row count    10000 (missing stats)                    ·                                               ·
- └── project                                    ·                      ·                                        (lk, geom1, rk1, geom)                          ·
-      │                                         estimated row count    10000 (missing stats)                    ·                                               ·
-      └── lookup join (left outer)              ·                      ·                                        (lk, geom1, rk1, rk2, cont, geom)               ·
-           │                                    table                  rtable@primary                           ·                                               ·
-           │                                    equality               (rk1, rk2) = (rk1,rk2)                   ·                                               ·
-           │                                    equality cols are key  ·                                        ·                                               ·
-           │                                    pred                   st_intersects(geom1, geom)               ·                                               ·
-           └── project                          ·                      ·                                        (lk, geom1, rk1, rk2, cont)                     ·
-                │                               estimated row count    10000 (missing stats)                    ·                                               ·
-                └── inverted join (left outer)  ·                      ·                                        (lk, geom1, rk1, rk2, geom_inverted_key, cont)  ·
-                     │                          table                  rtable@geom_index                        ·                                               ·
-                     │                          inverted expr          st_intersects(geom1, geom_inverted_key)  ·                                               ·
-                     └── scan                   ·                      ·                                        (lk, geom1)                                     ·
-·                                               estimated row count    1000 (missing stats)                     ·                                               ·
-·                                               table                  ltable@primary                           ·                                               ·
-·                                               spans                  FULL SCAN                                ·                                               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1)
+│ estimated row count: 10000 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom1, rk1, geom)
+    │ estimated row count: 10000 (missing stats)
+    │
+    └── • lookup join (left outer)
+        │ columns: (lk, geom1, rk1, rk2, cont, geom)
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: st_intersects(geom1, geom)
+        │
+        └── • project
+            │ columns: (lk, geom1, rk1, rk2, cont)
+            │ estimated row count: 10000 (missing stats)
+            │
+            └── • inverted join (left outer)
+                │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+                │ table: rtable@geom_index
+                │ inverted expr: st_intersects(geom1, geom_inverted_key)
+                │
+                └── • scan
+                      columns: (lk, geom1)
+                      estimated row count: 1000 (missing stats)
+                      table: ltable@primary
+                      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 WITH q AS (
   SELECT * FROM ltable WHERE lk > 2
@@ -210,186 +291,272 @@ SELECT count(*), (SELECT count(*) FROM q) FROM (
   LEFT JOIN rtable ON ST_Intersects(q.geom1, rtable.geom)
 ) GROUP BY lk
 ----
-·                                                              distribution           local                                    ·                                               ·
-·                                                              vectorized             false                                    ·                                               ·
-root                                                           ·                      ·                                        (count, count)                                  ·
- ├── render                                                    ·                      ·                                        (count, count)                                  ·
- │    │                                                        estimated row count    333 (missing stats)                      ·                                               ·
- │    │                                                        render 0               @S2                                      ·                                               ·
- │    │                                                        render 1               count_rows                               ·                                               ·
- │    └── group                                                ·                      ·                                        (lk, count_rows)                                ·
- │         │                                                   estimated row count    333 (missing stats)                      ·                                               ·
- │         │                                                   aggregate 0            count_rows()                             ·                                               ·
- │         │                                                   group by               lk                                       ·                                               ·
- │         └── project                                         ·                      ·                                        (lk)                                            ·
- │              └── project                                    ·                      ·                                        (lk, geom1, geom)                               ·
- │                   │                                         estimated row count    3333 (missing stats)                     ·                                               ·
- │                   └── lookup join (left outer)              ·                      ·                                        (lk, geom1, rk1, rk2, cont, geom)               ·
- │                        │                                    table                  rtable@primary                           ·                                               ·
- │                        │                                    equality               (rk1, rk2) = (rk1,rk2)                   ·                                               ·
- │                        │                                    equality cols are key  ·                                        ·                                               ·
- │                        │                                    pred                   st_intersects(geom1, geom)               ·                                               ·
- │                        └── project                          ·                      ·                                        (lk, geom1, rk1, rk2, cont)                     ·
- │                             │                               estimated row count    3333 (missing stats)                     ·                                               ·
- │                             └── inverted join (left outer)  ·                      ·                                        (lk, geom1, rk1, rk2, geom_inverted_key, cont)  ·
- │                                  │                          table                  rtable@geom_index                        ·                                               ·
- │                                  │                          inverted expr          st_intersects(geom1, geom_inverted_key)  ·                                               ·
- │                                  └── project                ·                      ·                                        (lk, geom1)                                     ·
- │                                       │                     estimated row count    333 (missing stats)                      ·                                               ·
- │                                       └── scan buffer       ·                      ·                                        (lk, geom1, geom2)                              ·
- │                                                             label                  buffer 1 (q)                             ·                                               ·
- ├── subquery                                                  ·                      ·                                        ·                                               ·
- │    │                                                        id                     @S1                                      ·                                               ·
- │    │                                                        original sql           SELECT * FROM ltable WHERE lk > 2        ·                                               ·
- │    │                                                        exec mode              all rows                                 ·                                               ·
- │    └── buffer                                               ·                      ·                                        (lk, geom1, geom2)                              ·
- │         │                                                   label                  buffer 1 (q)                             ·                                               ·
- │         └── scan                                            ·                      ·                                        (lk, geom1, geom2)                              ·
- │                                                             estimated row count    333 (missing stats)                      ·                                               ·
- │                                                             table                  ltable@primary                           ·                                               ·
- │                                                             spans                  /3-                                      ·                                               ·
- └── subquery                                                  ·                      ·                                        ·                                               ·
-      │                                                        id                     @S2                                      ·                                               ·
-      │                                                        original sql           (SELECT count(*) FROM q)                 ·                                               ·
-      │                                                        exec mode              one row                                  ·                                               ·
-      └── group (scalar)                                       ·                      ·                                        (count_rows)                                    ·
-           │                                                   estimated row count    1 (missing stats)                        ·                                               ·
-           │                                                   aggregate 0            count_rows()                             ·                                               ·
-           └── project                                         ·                      ·                                        ()                                              ·
-                │                                              estimated row count    333 (missing stats)                      ·                                               ·
-                └── scan buffer                                ·                      ·                                        (lk, geom1, geom2)                              ·
-·                                                              label                  buffer 1 (q)                             ·                                               ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (count, count)
+│
+├── • render
+│   │ columns: (count, count)
+│   │ estimated row count: 333 (missing stats)
+│   │ render 0: @S2
+│   │ render 1: count_rows
+│   │
+│   └── • group
+│       │ columns: (lk, count_rows)
+│       │ estimated row count: 333 (missing stats)
+│       │ aggregate 0: count_rows()
+│       │ group by: lk
+│       │
+│       └── • project
+│           │ columns: (lk)
+│           │
+│           └── • project
+│               │ columns: (lk, geom1, geom)
+│               │ estimated row count: 3333 (missing stats)
+│               │
+│               └── • lookup join (left outer)
+│                   │ columns: (lk, geom1, rk1, rk2, cont, geom)
+│                   │ table: rtable@primary
+│                   │ equality: (rk1, rk2) = (rk1,rk2)
+│                   │ equality cols are key
+│                   │ pred: st_intersects(geom1, geom)
+│                   │
+│                   └── • project
+│                       │ columns: (lk, geom1, rk1, rk2, cont)
+│                       │ estimated row count: 3333 (missing stats)
+│                       │
+│                       └── • inverted join (left outer)
+│                           │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+│                           │ table: rtable@geom_index
+│                           │ inverted expr: st_intersects(geom1, geom_inverted_key)
+│                           │
+│                           └── • project
+│                               │ columns: (lk, geom1)
+│                               │ estimated row count: 333 (missing stats)
+│                               │
+│                               └── • scan buffer
+│                                     columns: (lk, geom1, geom2)
+│                                     label: buffer 1 (q)
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: SELECT * FROM ltable WHERE lk > 2
+│   │ exec mode: all rows
+│   │
+│   └── • buffer
+│       │ columns: (lk, geom1, geom2)
+│       │ label: buffer 1 (q)
+│       │
+│       └── • scan
+│             columns: (lk, geom1, geom2)
+│             estimated row count: 333 (missing stats)
+│             table: ltable@primary
+│             spans: /3-
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: (SELECT count(*) FROM q)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │ columns: (count_rows)
+        │ estimated row count: 1 (missing stats)
+        │ aggregate 0: count_rows()
+        │
+        └── • project
+            │ columns: ()
+            │ estimated row count: 333 (missing stats)
+            │
+            └── • scan buffer
+                  columns: (lk, geom1, geom2)
+                  label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk FROM ltable WHERE NOT EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
-·                                               distribution           local                                    ·                                               ·
-·                                               vectorized             true                                     ·                                               ·
-project                                         ·                      ·                                        (lk)                                            ·
- │                                              estimated row count    990 (missing stats)                      ·                                               ·
- └── project                                    ·                      ·                                        (lk, geom2)                                     ·
-      │                                         estimated row count    990 (missing stats)                      ·                                               ·
-      └── lookup join (anti)                    ·                      ·                                        (lk, geom2, rk1, rk2, cont)                     ·
-           │                                    table                  rtable@primary                           ·                                               ·
-           │                                    equality               (rk1, rk2) = (rk1,rk2)                   ·                                               ·
-           │                                    equality cols are key  ·                                        ·                                               ·
-           │                                    pred                   st_intersects(geom2, geom)               ·                                               ·
-           └── project                          ·                      ·                                        (lk, geom2, rk1, rk2, cont)                     ·
-                │                               estimated row count    10000 (missing stats)                    ·                                               ·
-                └── inverted join (left outer)  ·                      ·                                        (lk, geom2, rk1, rk2, geom_inverted_key, cont)  ·
-                     │                          table                  rtable@geom_index                        ·                                               ·
-                     │                          inverted expr          st_intersects(geom2, geom_inverted_key)  ·                                               ·
-                     └── scan                   ·                      ·                                        (lk, geom2)                                     ·
-·                                               estimated row count    1000 (missing stats)                     ·                                               ·
-·                                               table                  ltable@primary                           ·                                               ·
-·                                               spans                  FULL SCAN                                ·                                               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk)
+│ estimated row count: 990 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom2)
+    │ estimated row count: 990 (missing stats)
+    │
+    └── • lookup join (anti)
+        │ columns: (lk, geom2, rk1, rk2, cont)
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: st_intersects(geom2, geom)
+        │
+        └── • project
+            │ columns: (lk, geom2, rk1, rk2, cont)
+            │ estimated row count: 10000 (missing stats)
+            │
+            └── • inverted join (left outer)
+                │ columns: (lk, geom2, rk1, rk2, geom_inverted_key, cont)
+                │ table: rtable@geom_index
+                │ inverted expr: st_intersects(geom2, geom_inverted_key)
+                │
+                └── • scan
+                      columns: (lk, geom2)
+                      estimated row count: 1000 (missing stats)
+                      table: ltable@primary
+                      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk FROM ltable
 WHERE NOT EXISTS (
   SELECT * FROM rtable WHERE ST_Covers(ltable.geom1, rtable.geom) AND lk > 5 AND rk1 > 12
 )
 ----
-·                                               distribution           local                                ·                                               ·
-·                                               vectorized             true                                 ·                                               ·
-project                                         ·                      ·                                    (lk)                                            ·
- │                                              estimated row count    997 (missing stats)                  ·                                               ·
- └── project                                    ·                      ·                                    (lk, geom1, rk1)                                ·
-      │                                         estimated row count    997 (missing stats)                  ·                                               ·
-      └── lookup join (anti)                    ·                      ·                                    (lk, geom1, rk1, rk2, cont)                     ·
-           │                                    table                  rtable@primary                       ·                                               ·
-           │                                    equality               (rk1, rk2) = (rk1,rk2)               ·                                               ·
-           │                                    equality cols are key  ·                                    ·                                               ·
-           │                                    pred                   st_covers(geom1, geom)               ·                                               ·
-           └── project                          ·                      ·                                    (lk, geom1, rk1, rk2, cont)                     ·
-                │                               estimated row count    1111 (missing stats)                 ·                                               ·
-                └── inverted join (left outer)  ·                      ·                                    (lk, geom1, rk1, rk2, geom_inverted_key, cont)  ·
-                     │                          table                  rtable@geom_index                    ·                                               ·
-                     │                          inverted expr          st_covers(geom1, geom_inverted_key)  ·                                               ·
-                     │                          on                     (lk > 5) AND (rk1 > 12)              ·                                               ·
-                     └── scan                   ·                      ·                                    (lk, geom1)                                     ·
-·                                               estimated row count    1000 (missing stats)                 ·                                               ·
-·                                               table                  ltable@primary                       ·                                               ·
-·                                               spans                  FULL SCAN                            ·                                               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk)
+│ estimated row count: 997 (missing stats)
+│
+└── • project
+    │ columns: (lk, geom1, rk1)
+    │ estimated row count: 997 (missing stats)
+    │
+    └── • lookup join (anti)
+        │ columns: (lk, geom1, rk1, rk2, cont)
+        │ table: rtable@primary
+        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality cols are key
+        │ pred: st_covers(geom1, geom)
+        │
+        └── • project
+            │ columns: (lk, geom1, rk1, rk2, cont)
+            │ estimated row count: 1111 (missing stats)
+            │
+            └── • inverted join (left outer)
+                │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+                │ table: rtable@geom_index
+                │ inverted expr: st_covers(geom1, geom_inverted_key)
+                │ on: (lk > 5) AND (rk1 > 12)
+                │
+                └── • scan
+                      columns: (lk, geom1)
+                      estimated row count: 1000 (missing stats)
+                      table: ltable@primary
+                      spans: FULL SCAN
 
 # Bounding box operations.
 statement ok
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1, rk2 FROM ltable JOIN rtable@geom_index ON ltable.geom1 ~ rtable.geom
 ----
-·                                     distribution           local                                ·                                         ·
-·                                     vectorized             true                                 ·                                         ·
-project                               ·                      ·                                    (lk, rk1, rk2)                            ·
- │                                    estimated row count    326700 (missing stats)               ·                                         ·
- └── lookup join (inner)              ·                      ·                                    (lk, geom1, rk1, rk2, geom)               ·
-      │                               estimated row count    326700 (missing stats)               ·                                         ·
-      │                               table                  rtable@primary                       ·                                         ·
-      │                               equality               (rk1, rk2) = (rk1,rk2)               ·                                         ·
-      │                               equality cols are key  ·                                    ·                                         ·
-      │                               pred                   geom1 ~ geom                         ·                                         ·
-      └── project                     ·                      ·                                    (lk, geom1, rk1, rk2)                     ·
-           │                          estimated row count    10000 (missing stats)                ·                                         ·
-           └── inverted join (inner)  ·                      ·                                    (lk, geom1, rk1, rk2, geom_inverted_key)  ·
-                │                     table                  rtable@geom_index                    ·                                         ·
-                │                     inverted expr          st_covers(geom1, geom_inverted_key)  ·                                         ·
-                └── scan              ·                      ·                                    (lk, geom1)                               ·
-·                                     estimated row count    1000 (missing stats)                 ·                                         ·
-·                                     table                  ltable@primary                       ·                                         ·
-·                                     spans                  FULL SCAN                            ·                                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1, rk2)
+│ estimated row count: 326700 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (lk, geom1, rk1, rk2, geom)
+    │ estimated row count: 326700 (missing stats)
+    │ table: rtable@primary
+    │ equality: (rk1, rk2) = (rk1,rk2)
+    │ equality cols are key
+    │ pred: geom1 ~ geom
+    │
+    └── • project
+        │ columns: (lk, geom1, rk1, rk2)
+        │ estimated row count: 10000 (missing stats)
+        │
+        └── • inverted join (inner)
+            │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+            │ table: rtable@geom_index
+            │ inverted expr: st_covers(geom1, geom_inverted_key)
+            │
+            └── • scan
+                  columns: (lk, geom1)
+                  estimated row count: 1000 (missing stats)
+                  table: ltable@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1, rk2 FROM ltable JOIN rtable@geom_index ON rtable.geom ~ ltable.geom1
 ----
-·                                     distribution           local                                   ·                                         ·
-·                                     vectorized             true                                    ·                                         ·
-project                               ·                      ·                                       (lk, rk1, rk2)                            ·
- │                                    estimated row count    326700 (missing stats)                  ·                                         ·
- └── lookup join (inner)              ·                      ·                                       (lk, geom1, rk1, rk2, geom)               ·
-      │                               estimated row count    326700 (missing stats)                  ·                                         ·
-      │                               table                  rtable@primary                          ·                                         ·
-      │                               equality               (rk1, rk2) = (rk1,rk2)                  ·                                         ·
-      │                               equality cols are key  ·                                       ·                                         ·
-      │                               pred                   geom ~ geom1                            ·                                         ·
-      └── project                     ·                      ·                                       (lk, geom1, rk1, rk2)                     ·
-           │                          estimated row count    10000 (missing stats)                   ·                                         ·
-           └── inverted join (inner)  ·                      ·                                       (lk, geom1, rk1, rk2, geom_inverted_key)  ·
-                │                     table                  rtable@geom_index                       ·                                         ·
-                │                     inverted expr          st_coveredby(geom1, geom_inverted_key)  ·                                         ·
-                └── scan              ·                      ·                                       (lk, geom1)                               ·
-·                                     estimated row count    1000 (missing stats)                    ·                                         ·
-·                                     table                  ltable@primary                          ·                                         ·
-·                                     spans                  FULL SCAN                               ·                                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1, rk2)
+│ estimated row count: 326700 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (lk, geom1, rk1, rk2, geom)
+    │ estimated row count: 326700 (missing stats)
+    │ table: rtable@primary
+    │ equality: (rk1, rk2) = (rk1,rk2)
+    │ equality cols are key
+    │ pred: geom ~ geom1
+    │
+    └── • project
+        │ columns: (lk, geom1, rk1, rk2)
+        │ estimated row count: 10000 (missing stats)
+        │
+        └── • inverted join (inner)
+            │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+            │ table: rtable@geom_index
+            │ inverted expr: st_coveredby(geom1, geom_inverted_key)
+            │
+            └── • scan
+                  columns: (lk, geom1)
+                  estimated row count: 1000 (missing stats)
+                  table: ltable@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT lk, rk1, rk2 FROM ltable JOIN rtable@geom_index ON rtable.geom && ltable.geom1
 ----
-·                                     distribution           local                                    ·                                         ·
-·                                     vectorized             true                                     ·                                         ·
-project                               ·                      ·                                        (lk, rk1, rk2)                            ·
- │                                    estimated row count    326700 (missing stats)                   ·                                         ·
- └── lookup join (inner)              ·                      ·                                        (lk, geom1, rk1, rk2, geom)               ·
-      │                               estimated row count    326700 (missing stats)                   ·                                         ·
-      │                               table                  rtable@primary                           ·                                         ·
-      │                               equality               (rk1, rk2) = (rk1,rk2)                   ·                                         ·
-      │                               equality cols are key  ·                                        ·                                         ·
-      │                               pred                   geom && geom1                            ·                                         ·
-      └── project                     ·                      ·                                        (lk, geom1, rk1, rk2)                     ·
-           │                          estimated row count    10000 (missing stats)                    ·                                         ·
-           └── inverted join (inner)  ·                      ·                                        (lk, geom1, rk1, rk2, geom_inverted_key)  ·
-                │                     table                  rtable@geom_index                        ·                                         ·
-                │                     inverted expr          st_intersects(geom1, geom_inverted_key)  ·                                         ·
-                └── scan              ·                      ·                                        (lk, geom1)                               ·
-·                                     estimated row count    1000 (missing stats)                     ·                                         ·
-·                                     table                  ltable@primary                           ·                                         ·
-·                                     spans                  FULL SCAN                                ·                                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lk, rk1, rk2)
+│ estimated row count: 326700 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (lk, geom1, rk1, rk2, geom)
+    │ estimated row count: 326700 (missing stats)
+    │ table: rtable@primary
+    │ equality: (rk1, rk2) = (rk1,rk2)
+    │ equality cols are key
+    │ pred: geom && geom1
+    │
+    └── • project
+        │ columns: (lk, geom1, rk1, rk2)
+        │ estimated row count: 10000 (missing stats)
+        │
+        └── • inverted join (inner)
+            │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+            │ table: rtable@geom_index
+            │ inverted expr: st_intersects(geom1, geom_inverted_key)
+            │
+            └── • scan
+                  columns: (lk, geom1)
+                  estimated row count: 1000 (missing stats)
+                  table: ltable@primary
+                  spans: FULL SCAN
 
 statement ok
 CREATE TABLE g (
@@ -401,89 +568,106 @@ statement ok
 CREATE INVERTED INDEX foo_inv ON g(geom)
 
 # This query performs an inverted join.
-query TTT
+query T
 EXPLAIN SELECT g1.k, g2.k FROM g@foo_inv AS g1, g@primary AS g2 WHERE ST_Contains(g1.geom, g2.geom) ORDER BY g1.k, g2.k
 ----
-·                        distribution           local
-·                        vectorized             true
-sort                     ·                      ·
- │                       order                  +k,+k
- └── lookup join         ·                      ·
-      │                  table                  g@primary
-      │                  equality               (k) = (k)
-      │                  equality cols are key  ·
-      │                  pred                   st_contains(geom, geom)
-      └── inverted join  ·                      ·
-           │             table                  g@foo_inv
-           └── scan      ·                      ·
-·                        missing stats          ·
-·                        table                  g@primary
-·                        spans                  FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +k,+k
+│
+└── • lookup join
+    │ table: g@primary
+    │ equality: (k) = (k)
+    │ equality cols are key
+    │ pred: st_contains(geom, geom)
+    │
+    └── • inverted join
+        │ table: g@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: g@primary
+              spans: FULL SCAN
 
 # This query performs a cross join followed by a filter.
-query TTT
+query T
 EXPLAIN SELECT g1.k, g2.k FROM g@primary AS g1, g@primary AS g2 WHERE ST_Contains(g1.geom, g2.geom) ORDER BY g1.k, g2.k
 ----
-·                distribution   local
-·                vectorized     true
-sort             ·              ·
- │               order          +k,+k
- └── cross join  ·              ·
-      │          pred           st_contains(geom, geom)
-      ├── scan   ·              ·
-      │          missing stats  ·
-      │          table          g@primary
-      │          spans          FULL SCAN
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          g@primary
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +k,+k
+│
+└── • cross join
+    │ pred: st_contains(geom, geom)
+    │
+    ├── • scan
+    │     missing stats
+    │     table: g@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: g@primary
+          spans: FULL SCAN
 
 # This query performs an inverted join with an additional filter.
-query TTT
+query T
 EXPLAIN SELECT g1.k, g2.k FROM g@foo_inv AS g1, g@primary AS g2
 WHERE ST_Contains(g1.geom, g2.geom)
   AND ST_Contains(g1.geom, ST_MakePolygon('LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)'::geometry))
   AND g2.k < 20
 ORDER BY g1.k, g2.k
 ----
-·                        distribution           local
-·                        vectorized             true
-sort                     ·                      ·
- │                       order                  +k,+k
- └── lookup join         ·                      ·
-      │                  table                  g@primary
-      │                  equality               (k) = (k)
-      │                  equality cols are key  ·
-      │                  pred                   st_contains(geom, geom) AND st_contains(geom, '010300000001000000050000000000000000000000000000000000000000000000000000000000000000001440000000000000144000000000000014400000000000001440000000000000000000000000000000000000000000000000')
-      └── inverted join  ·                      ·
-           │             table                  g@foo_inv
-           └── scan      ·                      ·
-·                        missing stats          ·
-·                        table                  g@primary
-·                        spans                  [ - /19]
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +k,+k
+│
+└── • lookup join
+    │ table: g@primary
+    │ equality: (k) = (k)
+    │ equality cols are key
+    │ pred: st_contains(geom, geom) AND st_contains(geom, '010300000001000000050000000000000000000000000000000000000000000000000000000000000000001440000000000000144000000000000014400000000000001440000000000000000000000000000000000000000000000000')
+    │
+    └── • inverted join
+        │ table: g@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: g@primary
+              spans: [ - /19]
 
 # This query performs a cross join followed by a filter.
-query TTT
+query T
 EXPLAIN SELECT g1.k, g2.k FROM g@primary AS g1, g@primary AS g2
 WHERE ST_Contains(g1.geom, g2.geom)
   AND ST_Contains(g1.geom, ST_MakePolygon('LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)'::geometry))
   AND g2.k < 20
 ORDER BY g1.k, g2.k
 ----
-·                    distribution   local
-·                    vectorized     true
-sort                 ·              ·
- │                   order          +k,+k
- └── cross join      ·              ·
-      │              pred           st_contains(geom, geom)
-      ├── scan       ·              ·
-      │              missing stats  ·
-      │              table          g@primary
-      │              spans          [ - /19]
-      └── filter     ·              ·
-           │         filter         st_contains(geom, '010300000001000000050000000000000000000000000000000000000000000000000000000000000000001440000000000000144000000000000014400000000000001440000000000000000000000000000000000000000000000000')
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          g@primary
-·                    spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +k,+k
+│
+└── • cross join
+    │ pred: st_contains(geom, geom)
+    │
+    ├── • scan
+    │     missing stats
+    │     table: g@primary
+    │     spans: [ - /19]
+    │
+    └── • filter
+        │ filter: st_contains(geom, '010300000001000000050000000000000000000000000000000000000000000000000000000000000000001440000000000000144000000000000014400000000000001440000000000000000000000000000000000000000000000000')
+        │
+        └── • scan
+              missing stats
+              table: g@primary
+              spans: FULL SCAN

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -117,12 +117,13 @@ id
 username
 species
 
-query TTT
+query T
 EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
 ----
-·            distribution  local
-·            vectorized    false
-alter table  ·             ·
+distribution: local
+vectorized: false
+·
+• alter table
 
 # Verify that EXPLAIN did not actually rename the column
 query T

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -189,12 +189,13 @@ system     node
 t          root
 v          root
 
-query TTT
+query T
 EXPLAIN ALTER DATABASE v RENAME TO x
 ----
-·                distribution  local
-·                vectorized    false
-rename database  ·             ·
+distribution: local
+vectorized: false
+·
+• rename database
 
 # Verify that the EXPLAIN above does not actually rename the database (#30543)
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -138,12 +138,13 @@ SELECT * FROM users@pk
 1 tom   cat
 2 jerry rat
 
-query TTT
+query T
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
 ----
-·             distribution  local
-·             vectorized    false
-rename index  ·             ·
+distribution: local
+vectorized: false
+·
+• rename index
 
 # Verify that EXPLAIN did not actually rename the index (#30543)
 query T rowsort

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -249,12 +249,13 @@ SHOW TABLES
 ----
 public  kv  table  root  0
 
-query TTT
+query T
 EXPLAIN ALTER TABLE kv RENAME TO kv2
 ----
-·             distribution  local
-·             vectorized    false
-rename table  ·             ·
+distribution: local
+vectorized: false
+·
+• rename table
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
 query TTTTI

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -160,12 +160,13 @@ subtest truncate_30547
 statement ok
 CREATE TABLE tt AS SELECT 'foo'
 
-query TTT
+query T
 EXPLAIN TRUNCATE TABLE tt
 ----
-·         distribution  local
-·         vectorized    false
-truncate  ·             ·
+distribution: local
+vectorized: false
+·
+• truncate
 
 # Verify that EXPLAIN did not cause the truncate to be performed.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -15,32 +15,36 @@ SET vectorize_row_count_threshold = 1000
 
 # There are no stats available, so this should run through the row execution
 # engine.
-query TTT
+query T
 EXPLAIN SELECT count(*) from small
 ----
-·               distribution   full
-·               vectorized     false
-group (scalar)  ·              ·
- └── scan       ·              ·
-·               missing stats  ·
-·               table          small@primary
-·               spans          FULL SCAN
+distribution: full
+vectorized: false
+·
+• group (scalar)
+│
+└── • scan
+      missing stats
+      table: small@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 0
 
 # This should run through the vectorized execution engine because we disabled
 # the threshold.
-query TTT
+query T
 EXPLAIN SELECT count(*) from small
 ----
-·               distribution   full
-·               vectorized     true
-group (scalar)  ·              ·
- └── scan       ·              ·
-·               missing stats  ·
-·               table          small@primary
-·               spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• group (scalar)
+│
+└── • scan
+      missing stats
+      table: small@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -56,32 +60,36 @@ ALTER TABLE small INJECT STATISTICS '[
 ]'
 
 # This should run through the row execution engine.
-query TTT
+query T
 EXPLAIN SELECT count(*) from small
 ----
-·               distribution         full
-·               vectorized           false
-group (scalar)  ·                    ·
- └── scan       ·                    ·
-·               estimated row count  100
-·               table                small@primary
-·               spans                FULL SCAN
+distribution: full
+vectorized: false
+·
+• group (scalar)
+│
+└── • scan
+      estimated row count: 100
+      table: small@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1
 
 # This should run through the vectorized execution engine because we lowered
 # the threshold.
-query TTT
+query T
 EXPLAIN SELECT count(*) from small
 ----
-·               distribution         full
-·               vectorized           true
-group (scalar)  ·                    ·
- └── scan       ·                    ·
-·               estimated row count  100
-·               table                small@primary
-·               spans                FULL SCAN
+distribution: full
+vectorized: true
+·
+• group (scalar)
+│
+└── • scan
+      estimated row count: 100
+      table: small@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -100,52 +108,59 @@ ALTER TABLE large INJECT STATISTICS '[
 ]'
 
 # This should run through the vectorized execution engine.
-query TTT
+query T
 EXPLAIN SELECT count(*) from large
 ----
-·               distribution         full
-·               vectorized           true
-group (scalar)  ·                    ·
- └── scan       ·                    ·
-·               estimated row count  100000
-·               table                large@primary
-·               spans                FULL SCAN
+distribution: full
+vectorized: true
+·
+• group (scalar)
+│
+└── • scan
+      estimated row count: 100000
+      table: large@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000000
 
 # This should run through the row execution engine because we increased the
 # threshold.
-query TTT
+query T
 EXPLAIN SELECT count(*) from large
 ----
-·               distribution         full
-·               vectorized           false
-group (scalar)  ·                    ·
- └── scan       ·                    ·
-·               estimated row count  100000
-·               table                large@primary
-·               spans                FULL SCAN
+distribution: full
+vectorized: false
+·
+• group (scalar)
+│
+└── • scan
+      estimated row count: 100000
+      table: large@primary
+      spans: FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
 
 # Check that we estimate the row count correctly when multiple tables are
 # scanned.
-query TTT
+query T
 EXPLAIN SELECT * FROM small INNER MERGE JOIN large ON small.a = large.a
 ----
-·           distribution         full
-·           vectorized           true
-merge join  ·                    ·
- │          equality             (a) = (a)
- │          left cols are key    ·
- │          right cols are key   ·
- ├── scan   ·                    ·
- │          estimated row count  100
- │          table                small@primary
- │          spans                FULL SCAN
- └── scan   ·                    ·
-·           estimated row count  100000
-·           table                large@primary
-·           spans                FULL SCAN
+distribution: full
+vectorized: true
+·
+• merge join
+│ equality: (a) = (a)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     estimated row count: 100
+│     table: small@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      estimated row count: 100000
+      table: large@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -8,325 +8,419 @@ CREATE TABLE kv (
   s STRING
 )
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(1), max(1), count(NULL), sum_int(1), avg(1), sum(1), stddev(1), variance(1), bool_and(true), bool_or(false), xor_agg(b'\x01') FROM kv
 ----
-·               distribution         local                 ·                                                                                                                                                   ·
-·               vectorized           true                  ·                                                                                                                                                   ·
-group (scalar)  ·                    ·                     (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
- │              estimated row count  1 (missing stats)     ·                                                                                                                                                   ·
- │              aggregate 0          min(column7)          ·                                                                                                                                                   ·
- │              aggregate 1          max(column7)          ·                                                                                                                                                   ·
- │              aggregate 2          count(column10)       ·                                                                                                                                                   ·
- │              aggregate 3          sum_int(column7)      ·                                                                                                                                                   ·
- │              aggregate 4          avg(column7)          ·                                                                                                                                                   ·
- │              aggregate 5          sum(column7)          ·                                                                                                                                                   ·
- │              aggregate 6          stddev(column7)       ·                                                                                                                                                   ·
- │              aggregate 7          variance(column7)     ·                                                                                                                                                   ·
- │              aggregate 8          bool_and(column17)    ·                                                                                                                                                   ·
- │              aggregate 9          bool_or(column19)     ·                                                                                                                                                   ·
- │              aggregate 10         xor_agg(column21)     ·                                                                                                                                                   ·
- └── render     ·                    ·                     (column7 int, column10 unknown, column17 bool, column19 bool, column21 bytes)                                                                       ·
-      │         estimated row count  1000 (missing stats)  ·                                                                                                                                                   ·
-      │         render 0             (1)[int]              ·                                                                                                                                                   ·
-      │         render 1             (NULL)[unknown]       ·                                                                                                                                                   ·
-      │         render 2             (true)[bool]          ·                                                                                                                                                   ·
-      │         render 3             (false)[bool]         ·                                                                                                                                                   ·
-      │         render 4             ('\x01')[bytes]       ·                                                                                                                                                   ·
-      └── scan  ·                    ·                     ()                                                                                                                                                  ·
-·               estimated row count  1000 (missing stats)  ·                                                                                                                                                   ·
-·               table                kv@primary            ·                                                                                                                                                   ·
-·               spans                FULL SCAN             ·                                                                                                                                                   ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: min(column7)
+│ aggregate 1: max(column7)
+│ aggregate 2: count(column10)
+│ aggregate 3: sum_int(column7)
+│ aggregate 4: avg(column7)
+│ aggregate 5: sum(column7)
+│ aggregate 6: stddev(column7)
+│ aggregate 7: variance(column7)
+│ aggregate 8: bool_and(column17)
+│ aggregate 9: bool_or(column19)
+│ aggregate 10: xor_agg(column21)
+│
+└── • render
+    │ columns: (column7 int, column10 unknown, column17 bool, column19 bool, column21 bytes)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: (1)[int]
+    │ render 1: (NULL)[unknown]
+    │ render 2: (true)[bool]
+    │ render 3: (false)[bool]
+    │ render 4: ('\x01')[bytes]
+    │
+    └── • scan
+          columns: ()
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
 ----
-·                    distribution         local                        ·                                                                                                                                                    ·
-·                    vectorized           true                         ·                                                                                                                                                    ·
-project              ·                    ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
- └── group (scalar)  ·                    ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)                 ·
-      │              estimated row count  1 (missing stats)            ·                                                                                                                                                    ·
-      │              aggregate 0          min(v)                       ·                                                                                                                                                    ·
-      │              aggregate 1          max(v)                       ·                                                                                                                                                    ·
-      │              aggregate 2          count(v)                     ·                                                                                                                                                    ·
-      │              aggregate 3          sum_int(column10)            ·                                                                                                                                                    ·
-      │              aggregate 4          avg(v)                       ·                                                                                                                                                    ·
-      │              aggregate 5          sum(v)                       ·                                                                                                                                                    ·
-      │              aggregate 6          stddev(v)                    ·                                                                                                                                                    ·
-      │              aggregate 7          variance(v)                  ·                                                                                                                                                    ·
-      │              aggregate 8          bool_and(column16)           ·                                                                                                                                                    ·
-      │              aggregate 9          xor_agg(column18)            ·                                                                                                                                                    ·
-      └── render     ·                    ·                            (column10 int, column16 bool, column18 bytes, v int)                                                                                                 ·
-           │         estimated row count  1000 (missing stats)         ·                                                                                                                                                    ·
-           │         render 0             (1)[int]                     ·                                                                                                                                                    ·
-           │         render 1             ((v)[int] = (1)[int])[bool]  ·                                                                                                                                                    ·
-           │         render 2             ((s)[string]::BYTES)[bytes]  ·                                                                                                                                                    ·
-           │         render 3             (v)[int]                     ·                                                                                                                                                    ·
-           └── scan  ·                    ·                            (v int, s string)                                                                                                                                    ·
-·                    estimated row count  1000 (missing stats)         ·                                                                                                                                                    ·
-·                    table                kv@primary                   ·                                                                                                                                                    ·
-·                    spans                FULL SCAN                    ·                                                                                                                                                    ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)
+│
+└── • group (scalar)
+    │ columns: (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)
+    │ estimated row count: 1 (missing stats)
+    │ aggregate 0: min(v)
+    │ aggregate 1: max(v)
+    │ aggregate 2: count(v)
+    │ aggregate 3: sum_int(column10)
+    │ aggregate 4: avg(v)
+    │ aggregate 5: sum(v)
+    │ aggregate 6: stddev(v)
+    │ aggregate 7: variance(v)
+    │ aggregate 8: bool_and(column16)
+    │ aggregate 9: xor_agg(column18)
+    │
+    └── • render
+        │ columns: (column10 int, column16 bool, column18 bytes, v int)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: (1)[int]
+        │ render 1: ((v)[int] = (1)[int])[bool]
+        │ render 2: ((s)[string]::BYTES)[bytes]
+        │ render 3: (v)[int]
+        │
+        └── • scan
+              columns: (v int, s string)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 # Aggregate functions trigger aggregation and computation when there is no source.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(1), count(NULL), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
-·                    distribution         local                               ·                                                                                                                                                   ·
-·                    vectorized           false                               ·                                                                                                                                                   ·
-render               ·                    ·                                   (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)    ·
- │                   estimated row count  1                                   ·                                                                                                                                                   ·
- │                   render 0             ((avg)[decimal]::FLOAT8)[float]     ·                                                                                                                                                   ·
- │                   render 1             (to_hex((xor_agg)[bytes]))[string]  ·                                                                                                                                                   ·
- │                   render 2             (min)[int]                          ·                                                                                                                                                   ·
- │                   render 3             (count)[int]                        ·                                                                                                                                                   ·
- │                   render 4             (max)[int]                          ·                                                                                                                                                   ·
- │                   render 5             (sum_int)[int]                      ·                                                                                                                                                   ·
- │                   render 6             (sum)[decimal]                      ·                                                                                                                                                   ·
- │                   render 7             (stddev)[decimal]                   ·                                                                                                                                                   ·
- │                   render 8             (variance)[decimal]                 ·                                                                                                                                                   ·
- │                   render 9             (bool_and)[bool]                    ·                                                                                                                                                   ·
- │                   render 10            (bool_or)[bool]                     ·                                                                                                                                                   ·
- └── group (scalar)  ·                    ·                                   (min int, count int, max int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
-      │              estimated row count  1                                   ·                                                                                                                                                   ·
-      │              aggregate 0          min(column1)                        ·                                                                                                                                                   ·
-      │              aggregate 1          count(column3)                      ·                                                                                                                                                   ·
-      │              aggregate 2          max(column1)                        ·                                                                                                                                                   ·
-      │              aggregate 3          sum_int(column1)                    ·                                                                                                                                                   ·
-      │              aggregate 4          avg(column1)                        ·                                                                                                                                                   ·
-      │              aggregate 5          sum(column1)                        ·                                                                                                                                                   ·
-      │              aggregate 6          stddev(column1)                     ·                                                                                                                                                   ·
-      │              aggregate 7          variance(column1)                   ·                                                                                                                                                   ·
-      │              aggregate 8          bool_and(column11)                  ·                                                                                                                                                   ·
-      │              aggregate 9          bool_or(column11)                   ·                                                                                                                                                   ·
-      │              aggregate 10         xor_agg(column14)                   ·                                                                                                                                                   ·
-      └── values     ·                    ·                                   (column1 int, column3 unknown, column11 bool, column14 bytes)                                                                                       ·
-·                    size                 4 columns, 1 row                    ·                                                                                                                                                   ·
-·                    row 0, expr 0        (1)[int]                            ·                                                                                                                                                   ·
-·                    row 0, expr 1        (NULL)[unknown]                     ·                                                                                                                                                   ·
-·                    row 0, expr 2        (true)[bool]                        ·                                                                                                                                                   ·
-·                    row 0, expr 3        ('\x01')[bytes]                     ·                                                                                                                                                   ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)
+│ estimated row count: 1
+│ render 0: ((avg)[decimal]::FLOAT8)[float]
+│ render 1: (to_hex((xor_agg)[bytes]))[string]
+│ render 2: (min)[int]
+│ render 3: (count)[int]
+│ render 4: (max)[int]
+│ render 5: (sum_int)[int]
+│ render 6: (sum)[decimal]
+│ render 7: (stddev)[decimal]
+│ render 8: (variance)[decimal]
+│ render 9: (bool_and)[bool]
+│ render 10: (bool_or)[bool]
+│
+└── • group (scalar)
+    │ columns: (min int, count int, max int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)
+    │ estimated row count: 1
+    │ aggregate 0: min(column1)
+    │ aggregate 1: count(column3)
+    │ aggregate 2: max(column1)
+    │ aggregate 3: sum_int(column1)
+    │ aggregate 4: avg(column1)
+    │ aggregate 5: sum(column1)
+    │ aggregate 6: stddev(column1)
+    │ aggregate 7: variance(column1)
+    │ aggregate 8: bool_and(column11)
+    │ aggregate 9: bool_or(column11)
+    │ aggregate 10: xor_agg(column14)
+    │
+    └── • values
+          columns: (column1 int, column3 unknown, column11 bool, column14 bytes)
+          size: 4 columns, 1 row
+          row 0, expr 0: (1)[int]
+          row 0, expr 1: (NULL)[unknown]
+          row 0, expr 2: (true)[bool]
+          row 0, expr 3: ('\x01')[bytes]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT count(*), k FROM kv GROUP BY 2
 ----
-·          distribution         local                 ·                   ·
-·          vectorized           true                  ·                   ·
-group      ·                    ·                     (count int, k int)  ·
- │         estimated row count  1000 (missing stats)  ·                   ·
- │         aggregate 0          count_rows()          ·                   ·
- │         group by             k                     ·                   ·
- │         ordered              +k                    ·                   ·
- └── scan  ·                    ·                     (k int)             +k
-·          estimated row count  1000 (missing stats)  ·                   ·
-·          table                kv@primary            ·                   ·
-·          spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• group
+│ columns: (count int, k int)
+│ estimated row count: 1000 (missing stats)
+│ aggregate 0: count_rows()
+│ group by: k
+│ ordered: +k
+│
+└── • scan
+      columns: (k int)
+      ordering: +k
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
 # Selecting and grouping on a more complex expression works.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
-·               distribution         local                       ·                   ·
-·               vectorized           true                        ·                   ·
-group           ·                    ·                           (count int, r int)  ·
- │              estimated row count  1000 (missing stats)        ·                   ·
- │              aggregate 0          count_rows()                ·                   ·
- │              group by             column8                     ·                   ·
- └── render     ·                    ·                           (column8 int)       ·
-      │         estimated row count  1000 (missing stats)        ·                   ·
-      │         render 0             ((k)[int] + (v)[int])[int]  ·                   ·
-      └── scan  ·                    ·                           (k int, v int)      ·
-·               estimated row count  1000 (missing stats)        ·                   ·
-·               table                kv@primary                  ·                   ·
-·               spans                FULL SCAN                   ·                   ·
+distribution: local
+vectorized: true
+·
+• group
+│ columns: (count int, r int)
+│ estimated row count: 1000 (missing stats)
+│ aggregate 0: count_rows()
+│ group by: column8
+│
+└── • render
+    │ columns: (column8 int)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: ((k)[int] + (v)[int])[int]
+    │
+    └── • scan
+          columns: (k int, v int)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k, v
 ----
-·               distribution         local                                  ·                                          ·
-·               vectorized           true                                   ·                                          ·
-render          ·                    ·                                      (count int, r int)                         ·
- │              estimated row count  1000 (missing stats)                   ·                                          ·
- │              render 0             ((k)[int] + (any_not_null)[int])[int]  ·                                          ·
- │              render 1             (count_rows)[int]                      ·                                          ·
- └── group      ·                    ·                                      (k int, count_rows int, any_not_null int)  ·
-      │         estimated row count  1000 (missing stats)                   ·                                          ·
-      │         aggregate 0          count_rows()                           ·                                          ·
-      │         aggregate 1          any_not_null(v)                        ·                                          ·
-      │         group by             k                                      ·                                          ·
-      │         ordered              +k                                     ·                                          ·
-      └── scan  ·                    ·                                      (k int, v int)                             +k
-·               estimated row count  1000 (missing stats)                   ·                                          ·
-·               table                kv@primary                             ·                                          ·
-·               spans                FULL SCAN                              ·                                          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (count int, r int)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((k)[int] + (any_not_null)[int])[int]
+│ render 1: (count_rows)[int]
+│
+└── • group
+    │ columns: (k int, count_rows int, any_not_null int)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: count_rows()
+    │ aggregate 1: any_not_null(v)
+    │ group by: k
+    │ ordered: +k
+    │
+    └── • scan
+          columns: (k int, v int)
+          ordering: +k
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT count(k) FROM kv
 ----
-·               distribution         local                 ·            ·
-·               vectorized           true                  ·            ·
-group (scalar)  ·                    ·                     (count int)  ·
- │              estimated row count  1 (missing stats)     ·            ·
- │              aggregate 0          count_rows()          ·            ·
- └── scan       ·                    ·                     ()           ·
-·               estimated row count  1000 (missing stats)  ·            ·
-·               table                kv@primary            ·            ·
-·               spans                FULL SCAN             ·            ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count_rows()
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT count(k), sum(k), max(k) FROM kv
 ----
-·               distribution         local                 ·                                  ·
-·               vectorized           true                  ·                                  ·
-group (scalar)  ·                    ·                     (count int, sum decimal, max int)  ·
- │              estimated row count  1 (missing stats)     ·                                  ·
- │              aggregate 0          count_rows()          ·                                  ·
- │              aggregate 1          sum(k)                ·                                  ·
- │              aggregate 2          max(k)                ·                                  ·
- └── scan       ·                    ·                     (k int)                            ·
-·               estimated row count  1000 (missing stats)  ·                                  ·
-·               table                kv@primary            ·                                  ·
-·               spans                FULL SCAN             ·                                  ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count int, sum decimal, max int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count_rows()
+│ aggregate 1: sum(k)
+│ aggregate 2: max(k)
+│
+└── • scan
+      columns: (k int)
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
 ----
-·               distribution         local                 ·                                   ·
-·               vectorized           true                  ·                                   ·
-group (scalar)  ·                    ·                     (count, count, sum, sum, min, min)  ·
- │              estimated row count  1 (missing stats)     ·                                   ·
- │              aggregate 0          count(v)              ·                                   ·
- │              aggregate 1          count(DISTINCT v)     ·                                   ·
- │              aggregate 2          sum(v)                ·                                   ·
- │              aggregate 3          sum(DISTINCT v)       ·                                   ·
- │              aggregate 4          min(v)                ·                                   ·
- │              aggregate 5          min(v)                ·                                   ·
- └── scan       ·                    ·                     (v)                                 ·
-·               estimated row count  1000 (missing stats)  ·                                   ·
-·               table                kv@primary            ·                                   ·
-·               spans                FULL SCAN             ·                                   ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count, count, sum, sum, min, min)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count(v)
+│ aggregate 1: count(DISTINCT v)
+│ aggregate 2: sum(v)
+│ aggregate 3: sum(DISTINCT v)
+│ aggregate 4: min(v)
+│ aggregate 5: min(v)
+│
+└── • scan
+      columns: (v)
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-·                                  distribution         local                         ·             ·
-·                                  vectorized           true                          ·             ·
-group (scalar)                     ·                    ·                             (count)       ·
- │                                 estimated row count  1 (missing stats)             ·             ·
- │                                 aggregate 0          count(column13)               ·             ·
- └── distinct                      ·                    ·                             (column13)    ·
-      │                            estimated row count  1000 (missing stats)          ·             ·
-      │                            distinct on          column13                      ·             ·
-      └── render                   ·                    ·                             (column13)    ·
-           │                       estimated row count  1000000 (missing stats)       ·             ·
-           │                       render 0             ((k, v, w, s) AS k, v, w, s)  ·             ·
-           └── cross join (inner)  ·                    ·                             (k, v, w, s)  ·
-                │                  estimated row count  1000000 (missing stats)       ·             ·
-                ├── scan           ·                    ·                             (k, v, w, s)  ·
-                │                  estimated row count  1000 (missing stats)          ·             ·
-                │                  table                kv@primary                    ·             ·
-                │                  spans                FULL SCAN                     ·             ·
-                └── scan           ·                    ·                             ()            ·
-·                                  estimated row count  1000 (missing stats)          ·             ·
-·                                  table                kv@primary                    ·             ·
-·                                  spans                FULL SCAN                     ·             ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count(column13)
+│
+└── • distinct
+    │ columns: (column13)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: column13
+    │
+    └── • render
+        │ columns: (column13)
+        │ estimated row count: 1000000 (missing stats)
+        │ render 0: ((k, v, w, s) AS k, v, w, s)
+        │
+        └── • cross join (inner)
+            │ columns: (k, v, w, s)
+            │ estimated row count: 1000000 (missing stats)
+            │
+            ├── • scan
+            │     columns: (k, v, w, s)
+            │     estimated row count: 1000 (missing stats)
+            │     table: kv@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  columns: ()
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
-]
 ----
-·                             distribution         local
-·                             vectorized           true
-project                       ·                    ·
- │                            estimated row count  1000 (missing stats)
- └── group                    ·                    ·
-      │                       estimated row count  1000 (missing stats)
-      │                       aggregate 0          min(k)
-      │                       group by             k
-      └── cross join (inner)  ·                    ·
-           │                  estimated row count  1000000 (missing stats)
-           ├── scan           ·                    ·
-           │                  estimated row count  1000 (missing stats)
-           │                  table                kv@primary
-           │                  spans                FULL SCAN
-           └── scan           ·                    ·
-·                             estimated row count  1000 (missing stats)
-·                             table                kv@primary
-·                             spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min)
+│ estimated row count: 1000 (missing stats)
+│
+└── • group
+    │ columns: (k, min)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: min(k)
+    │ group by: k
+    │
+    └── • cross join (inner)
+        │ columns: (k, k)
+        │ estimated row count: 1000000 (missing stats)
+        │
+        ├── • scan
+        │     columns: (k)
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (k)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
-]
 ----
-·                             distribution         local
-·                             vectorized           true
-project                       ·                    ·
- │                            estimated row count  1000 (missing stats)
- └── group                    ·                    ·
-      │                       estimated row count  1000 (missing stats)
-      │                       aggregate 0          min(k)
-      │                       group by             k
-      └── cross join (inner)  ·                    ·
-           │                  estimated row count  1000000 (missing stats)
-           ├── scan           ·                    ·
-           │                  estimated row count  1000 (missing stats)
-           │                  table                kv@primary
-           │                  spans                FULL SCAN
-           └── scan           ·                    ·
-·                             estimated row count  1000 (missing stats)
-·                             table                kv@primary
-·                             spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min)
+│ estimated row count: 1000 (missing stats)
+│
+└── • group
+    │ columns: (k, min)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: min(k)
+    │ group by: k
+    │
+    └── • cross join (inner)
+        │ columns: (k, k)
+        │ estimated row count: 1000000 (missing stats)
+        │
+        ├── • scan
+        │     columns: (k)
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (k)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
-]
 ----
-·                             distribution         local
-·                             vectorized           true
-project                       ·                    ·
- │                            estimated row count  1000 (missing stats)
- └── group                    ·                    ·
-      │                       estimated row count  1000 (missing stats)
-      │                       aggregate 0          min(k)
-      │                       group by             k
-      └── cross join (inner)  ·                    ·
-           │                  estimated row count  1000000 (missing stats)
-           ├── scan           ·                    ·
-           │                  estimated row count  1000 (missing stats)
-           │                  table                kv@primary
-           │                  spans                FULL SCAN
-           └── scan           ·                    ·
-·                             estimated row count  1000 (missing stats)
-·                             table                kv@primary
-·                             spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min)
+│ estimated row count: 1000 (missing stats)
+│
+└── • group
+    │ columns: (k, min)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: min(k)
+    │ group by: k
+    │
+    └── • cross join (inner)
+        │ columns: (k, k)
+        │ estimated row count: 1000000 (missing stats)
+        │
+        ├── • scan
+        │     columns: (k)
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (k)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 # Show reuse of renders expression inside an expansion.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT a.v FROM kv a, kv b GROUP BY a.v, a.w, a.s
-]
 ----
-·                             distribution         local
-·                             vectorized           true
-project                       ·                    ·
- │                            estimated row count  1000 (missing stats)
- └── distinct                 ·                    ·
-      │                       estimated row count  1000 (missing stats)
-      │                       distinct on          v, w, s
-      └── cross join (inner)  ·                    ·
-           │                  estimated row count  1000000 (missing stats)
-           ├── scan           ·                    ·
-           │                  estimated row count  1000 (missing stats)
-           │                  table                kv@primary
-           │                  spans                FULL SCAN
-           └── scan           ·                    ·
-·                             estimated row count  1000 (missing stats)
-·                             table                kv@primary
-·                             spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (v)
+│ estimated row count: 1000 (missing stats)
+│
+└── • distinct
+    │ columns: (v, w, s)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: v, w, s
+    │
+    └── • cross join (inner)
+        │ columns: (v, w, s)
+        │ estimated row count: 1000000 (missing stats)
+        │
+        ├── • scan
+        │     columns: (v, w, s)
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: ()
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 statement ok
 CREATE TABLE abc (
@@ -336,19 +430,23 @@ CREATE TABLE abc (
   d DECIMAL
 )
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(a) FROM abc
 ----
-·               distribution         local              ·           ·
-·               vectorized           true               ·           ·
-group (scalar)  ·                    ·                  (min char)  ·
- │              estimated row count  1 (missing stats)  ·           ·
- │              aggregate 0          any_not_null(a)    ·           ·
- └── scan       ·                    ·                  (a char)    ·
-·               estimated row count  1 (missing stats)  ·           ·
-·               table                abc@primary        ·           ·
-·               spans                LIMITED SCAN       ·           ·
-·               limit                1                  ·           ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min char)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(a)
+│
+└── • scan
+      columns: (a char)
+      estimated row count: 1 (missing stats)
+      table: abc@primary
+      spans: LIMITED SCAN
+      limit: 1
 
 statement ok
 CREATE TABLE xyz (
@@ -365,119 +463,161 @@ CREATE TABLE xyz (
 statement ok
 INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(x) FROM xyz
 ----
-·               distribution         local              ·          ·
-·               vectorized           true               ·          ·
-group (scalar)  ·                    ·                  (min int)  ·
- │              estimated row count  1 (missing stats)  ·          ·
- │              aggregate 0          any_not_null(x)    ·          ·
- └── scan       ·                    ·                  (x int)    ·
-·               estimated row count  1 (missing stats)  ·          ·
-·               table                xyz@xy             ·          ·
-·               spans                LIMITED SCAN       ·          ·
-·               limit                1                  ·          ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(x)
+│
+└── • scan
+      columns: (x int)
+      estimated row count: 1 (missing stats)
+      table: xyz@xy
+      spans: LIMITED SCAN
+      limit: 1
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-·               distribution         local              ·          ·
-·               vectorized           true               ·          ·
-group (scalar)  ·                    ·                  (min int)  ·
- │              estimated row count  1 (missing stats)  ·          ·
- │              aggregate 0          any_not_null(x)    ·          ·
- └── scan       ·                    ·                  (x int)    ·
-·               estimated row count  1 (missing stats)  ·          ·
-·               table                xyz@xy             ·          ·
-·               spans                /0-/1 /4-/5 /7-/8  ·          ·
-·               limit                1                  ·          ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(x)
+│
+└── • scan
+      columns: (x int)
+      estimated row count: 1 (missing stats)
+      table: xyz@xy
+      spans: /0-/1 /4-/5 /7-/8
+      limit: 1
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(x) FROM xyz
 ----
-·               distribution         local              ·          ·
-·               vectorized           true               ·          ·
-group (scalar)  ·                    ·                  (max int)  ·
- │              estimated row count  1 (missing stats)  ·          ·
- │              aggregate 0          any_not_null(x)    ·          ·
- └── revscan    ·                    ·                  (x int)    ·
-·               estimated row count  1 (missing stats)  ·          ·
-·               table                xyz@xy             ·          ·
-·               spans                LIMITED SCAN       ·          ·
-·               limit                1                  ·          ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(x)
+│
+└── • revscan
+      columns: (x int)
+      estimated row count: 1 (missing stats)
+      table: xyz@xy
+      spans: LIMITED SCAN
+      limit: 1
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
 ----
-·               distribution         local              ·               ·
-·               vectorized           true               ·               ·
-group (scalar)  ·                    ·                  (min int)       ·
- │              estimated row count  1 (missing stats)  ·               ·
- │              aggregate 0          any_not_null(y)    ·               ·
- └── project    ·                    ·                  (y int)         ·
-      └── scan  ·                    ·                  (x int, y int)  ·
-·               estimated row count  1 (missing stats)  ·               ·
-·               table                xyz@xy             ·               ·
-·               spans                /1/!NULL-/2        ·               ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(y)
+│
+└── • project
+    │ columns: (y int)
+    │
+    └── • scan
+          columns: (x int, y int)
+          estimated row count: 1 (missing stats)
+          table: xyz@xy
+          spans: /1/!NULL-/2
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
-·               distribution         local              ·               ·
-·               vectorized           true               ·               ·
-group (scalar)  ·                    ·                  (max int)       ·
- │              estimated row count  1 (missing stats)  ·               ·
- │              aggregate 0          any_not_null(y)    ·               ·
- └── project    ·                    ·                  (y int)         ·
-      └── scan  ·                    ·                  (x int, y int)  ·
-·               estimated row count  1 (missing stats)  ·               ·
-·               table                xyz@xy             ·               ·
-·               spans                /1/!NULL-/2        ·               ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(y)
+│
+└── • project
+    │ columns: (y int)
+    │
+    └── • scan
+          columns: (x int, y int)
+          estimated row count: 1 (missing stats)
+          table: xyz@xy
+          spans: /1/!NULL-/2
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE z = 7
 ----
-·               distribution         local                        ·                 ·
-·               vectorized           true                         ·                 ·
-group (scalar)  ·                    ·                            (min int)         ·
- │              estimated row count  1 (missing stats)            ·                 ·
- │              aggregate 0          any_not_null(y)              ·                 ·
- └── project    ·                    ·                            (y int)           ·
-      └── scan  ·                    ·                            (y int, z float)  ·
-·               estimated row count  1 (missing stats)            ·                 ·
-·               table                xyz@zyx                      ·                 ·
-·               spans                /7/!NULL-/7.000000000000001  ·                 ·
-·               limit                1                            ·                 ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(y)
+│
+└── • project
+    │ columns: (y int)
+    │
+    └── • scan
+          columns: (y int, z float)
+          estimated row count: 1 (missing stats)
+          table: xyz@zyx
+          spans: /7/!NULL-/7.000000000000001
+          limit: 1
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
 ----
-·                  distribution         local                        ·                 ·
-·                  vectorized           true                         ·                 ·
-group (scalar)     ·                    ·                            (max int)         ·
- │                 estimated row count  1 (missing stats)            ·                 ·
- │                 aggregate 0          any_not_null(y)              ·                 ·
- └── project       ·                    ·                            (y int)           ·
-      └── revscan  ·                    ·                            (y int, z float)  ·
-·                  estimated row count  1 (missing stats)            ·                 ·
-·                  table                xyz@zyx                      ·                 ·
-·                  spans                /7/!NULL-/7.000000000000001  ·                 ·
-·                  limit                1                            ·                 ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(y)
+│
+└── • project
+    │ columns: (y int)
+    │
+    └── • revscan
+          columns: (y int, z float)
+          estimated row count: 1 (missing stats)
+          table: xyz@zyx
+          spans: /7/!NULL-/7.000000000000001
+          limit: 1
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-·               distribution         local              ·                        ·
-·               vectorized           true               ·                        ·
-group (scalar)  ·                    ·                  (min int)                ·
- │              estimated row count  1 (missing stats)  ·                        ·
- │              aggregate 0          min(x)             ·                        ·
- └── project    ·                    ·                  (x int)                  ·
-      └── scan  ·                    ·                  (x int, y int, z float)  ·
-·               estimated row count  1 (missing stats)  ·                        ·
-·               table                xyz@zyx            ·                        ·
-·               spans                /3/2-/3/3          ·                        ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: min(x)
+│
+└── • project
+    │ columns: (x int)
+    │
+    └── • scan
+          columns: (x int, y int, z float)
+          estimated row count: 1 (missing stats)
+          table: xyz@zyx
+          spans: /3/2-/3/3
 
 statement ok
 SET tracing = on,kv,results; SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0); SET tracing = off
@@ -490,19 +630,25 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 fetched: /xyz/zyx/3.0/2/1 -> NULL
 output row: [1]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-·               distribution         local              ·                        ·
-·               vectorized           true               ·                        ·
-group (scalar)  ·                    ·                  (max int)                ·
- │              estimated row count  1 (missing stats)  ·                        ·
- │              aggregate 0          max(x)             ·                        ·
- └── project    ·                    ·                  (x int)                  ·
-      └── scan  ·                    ·                  (x int, y int, z float)  ·
-·               estimated row count  1 (missing stats)  ·                        ·
-·               table                xyz@zyx            ·                        ·
-·               spans                /3/2-/3/3          ·                        ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: max(x)
+│
+└── • project
+    │ columns: (x int)
+    │
+    └── • scan
+          columns: (x int, y int, z float)
+          estimated row count: 1 (missing stats)
+          table: xyz@zyx
+          spans: /3/2-/3/3
 
 # VARIANCE/STDDEV
 
@@ -524,18 +670,22 @@ fetched: /xyz/primary/7 -> NULL
 fetched: /xyz/primary/7/z -> 8.0
 output row: [9 4.5 6.33333333333333]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT variance(x) FROM xyz WHERE x = 1
 ----
-·               distribution         local              ·                   ·
-·               vectorized           true               ·                   ·
-group (scalar)  ·                    ·                  (variance decimal)  ·
- │              estimated row count  1 (missing stats)  ·                   ·
- │              aggregate 0          variance(x)        ·                   ·
- └── scan       ·                    ·                  (x int)             ·
-·               estimated row count  1 (missing stats)  ·                   ·
-·               table                xyz@xy             ·                   ·
-·               spans                /1-/2              ·                   ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (variance decimal)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: variance(x)
+│
+└── • scan
+      columns: (x int)
+      estimated row count: 1 (missing stats)
+      table: xyz@xy
+      spans: /1-/2
 
 ## Tests for the single-row optimization.
 statement ok
@@ -596,84 +746,117 @@ INSERT INTO ab VALUES
 #fetched: /ab/primary/5 -> NULL
 #output row: [5]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 ----
-·               distribution         local                 ·                        ·
-·               vectorized           true                  ·                        ·
-sort            ·                    ·                     (v int, count int)       +count
- │              estimated row count  100 (missing stats)   ·                        ·
- │              order                +count_rows           ·                        ·
- └── group      ·                    ·                     (v int, count_rows int)  ·
-      │         estimated row count  100 (missing stats)   ·                        ·
-      │         aggregate 0          count_rows()          ·                        ·
-      │         group by             v                     ·                        ·
-      └── scan  ·                    ·                     (v int)                  ·
-·               estimated row count  1000 (missing stats)  ·                        ·
-·               table                kv@primary            ·                        ·
-·               spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (v int, count int)
+│ ordering: +count
+│ estimated row count: 100 (missing stats)
+│ order: +count_rows
+│
+└── • group
+    │ columns: (v int, count_rows int)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: count_rows()
+    │ group by: v
+    │
+    └── • scan
+          columns: (v int)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 ----
-·               distribution         local                 ·                        ·
-·               vectorized           true                  ·                        ·
-sort            ·                    ·                     (v int, count int)       +count
- │              estimated row count  100 (missing stats)   ·                        ·
- │              order                +count_rows           ·                        ·
- └── group      ·                    ·                     (v int, count_rows int)  ·
-      │         estimated row count  100 (missing stats)   ·                        ·
-      │         aggregate 0          count_rows()          ·                        ·
-      │         group by             v                     ·                        ·
-      └── scan  ·                    ·                     (v int)                  ·
-·               estimated row count  1000 (missing stats)  ·                        ·
-·               table                kv@primary            ·                        ·
-·               spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (v int, count int)
+│ ordering: +count
+│ estimated row count: 100 (missing stats)
+│ order: +count_rows
+│
+└── • group
+    │ columns: (v int, count_rows int)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: count_rows()
+    │ group by: v
+    │
+    └── • scan
+          columns: (v int)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT v, count(NULL) FROM kv GROUP BY v ORDER BY count(1)
 ----
-·                         distribution         local                 ·                                   ·
-·                         vectorized           true                  ·                                   ·
-project                   ·                    ·                     (v int, count int)                  ·
- └── sort                 ·                    ·                     (v int, count int, count_rows int)  +count_rows
-      │                   estimated row count  100 (missing stats)   ·                                   ·
-      │                   order                +count_rows           ·                                   ·
-      └── group           ·                    ·                     (v int, count int, count_rows int)  ·
-           │              estimated row count  100 (missing stats)   ·                                   ·
-           │              aggregate 0          count(column7)        ·                                   ·
-           │              aggregate 1          count_rows()          ·                                   ·
-           │              group by             v                     ·                                   ·
-           └── render     ·                    ·                     (column7 unknown, v int)            ·
-                │         estimated row count  1000 (missing stats)  ·                                   ·
-                │         render 0             (NULL)[unknown]       ·                                   ·
-                │         render 1             (v)[int]              ·                                   ·
-                └── scan  ·                    ·                     (v int)                             ·
-·                         estimated row count  1000 (missing stats)  ·                                   ·
-·                         table                kv@primary            ·                                   ·
-·                         spans                FULL SCAN             ·                                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (v int, count int)
+│
+└── • sort
+    │ columns: (v int, count int, count_rows int)
+    │ ordering: +count_rows
+    │ estimated row count: 100 (missing stats)
+    │ order: +count_rows
+    │
+    └── • group
+        │ columns: (v int, count int, count_rows int)
+        │ estimated row count: 100 (missing stats)
+        │ aggregate 0: count(column7)
+        │ aggregate 1: count_rows()
+        │ group by: v
+        │
+        └── • render
+            │ columns: (column7 unknown, v int)
+            │ estimated row count: 1000 (missing stats)
+            │ render 0: (NULL)[unknown]
+            │ render 1: (v)[int]
+            │
+            └── • scan
+                  columns: (v int)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Check that filters propagate through no-op aggregation.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(NULL) FROM kv GROUP BY v) WHERE v > 10
 ----
-·                    distribution         local                 ·             ·
-·                    vectorized           true                  ·             ·
-group                ·                    ·                     (v, count)    ·
- │                   estimated row count  33 (missing stats)    ·             ·
- │                   aggregate 0          count(column7)        ·             ·
- │                   group by             v                     ·             ·
- └── render          ·                    ·                     (column7, v)  ·
-      │              estimated row count  333 (missing stats)   ·             ·
-      │              render 0             NULL                  ·             ·
-      │              render 1             v                     ·             ·
-      └── filter     ·                    ·                     (v)           ·
-           │         estimated row count  333 (missing stats)   ·             ·
-           │         filter               v > 10                ·             ·
-           └── scan  ·                    ·                     (v)           ·
-·                    estimated row count  1000 (missing stats)  ·             ·
-·                    table                kv@primary            ·             ·
-·                    spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• group
+│ columns: (v, count)
+│ estimated row count: 33 (missing stats)
+│ aggregate 0: count(column7)
+│ group by: v
+│
+└── • render
+    │ columns: (column7, v)
+    │ estimated row count: 333 (missing stats)
+    │ render 0: NULL
+    │ render 1: v
+    │
+    └── • filter
+        │ columns: (v)
+        │ estimated row count: 333 (missing stats)
+        │ filter: v > 10
+        │
+        └── • scan
+              columns: (v)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 # Verify that FILTER works.
 
@@ -685,204 +868,277 @@ CREATE TABLE filter_test (
 )
 
 # Check that filter expressions are only rendered once.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k>5), max(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
 ----
-·                    distribution         local                                  ·                      ·
-·                    vectorized           true                                   ·                      ·
-project              ·                    ·                                      (count, max)           ·
- │                   estimated row count  100 (missing stats)                    ·                      ·
- └── group           ·                    ·                                      (v, count, max)        ·
-      │              estimated row count  100 (missing stats)                    ·                      ·
-      │              aggregate 0          count(column7) FILTER (WHERE column8)  ·                      ·
-      │              aggregate 1          max(column8) FILTER (WHERE column8)    ·                      ·
-      │              group by             v                                      ·                      ·
-      └── render     ·                    ·                                      (column7, column8, v)  ·
-           │         estimated row count  1000 (missing stats)                   ·                      ·
-           │         render 0             true                                   ·                      ·
-           │         render 1             k > 5                                  ·                      ·
-           │         render 2             v                                      ·                      ·
-           └── scan  ·                    ·                                      (k, v)                 ·
-·                    estimated row count  1000 (missing stats)                   ·                      ·
-·                    table                filter_test@primary                    ·                      ·
-·                    spans                FULL SCAN                              ·                      ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (count, max)
+│ estimated row count: 100 (missing stats)
+│
+└── • group
+    │ columns: (v, count, max)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: count(column7) FILTER (WHERE column8)
+    │ aggregate 1: max(column8) FILTER (WHERE column8)
+    │ group by: v
+    │
+    └── • render
+        │ columns: (column7, column8, v)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: true
+        │ render 1: k > 5
+        │ render 2: v
+        │
+        └── • scan
+              columns: (k, v)
+              estimated row count: 1000 (missing stats)
+              table: filter_test@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-·                    distribution         local                                  ·                      ·
-·                    vectorized           true                                   ·                      ·
-project              ·                    ·                                      (count)                ·
- │                   estimated row count  100 (missing stats)                    ·                      ·
- └── group           ·                    ·                                      (v, count)             ·
-      │              estimated row count  100 (missing stats)                    ·                      ·
-      │              aggregate 0          count(column7) FILTER (WHERE column8)  ·                      ·
-      │              group by             v                                      ·                      ·
-      └── render     ·                    ·                                      (column7, column8, v)  ·
-           │         estimated row count  1000 (missing stats)                   ·                      ·
-           │         render 0             true                                   ·                      ·
-           │         render 1             k > 5                                  ·                      ·
-           │         render 2             v                                      ·                      ·
-           └── scan  ·                    ·                                      (k, v)                 ·
-·                    estimated row count  1000 (missing stats)                   ·                      ·
-·                    table                filter_test@primary                    ·                      ·
-·                    spans                FULL SCAN                              ·                      ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (count)
+│ estimated row count: 100 (missing stats)
+│
+└── • group
+    │ columns: (v, count)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: count(column7) FILTER (WHERE column8)
+    │ group by: v
+    │
+    └── • render
+        │ columns: (column7, column8, v)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: true
+        │ render 1: k > 5
+        │ render 2: v
+        │
+        └── • scan
+              columns: (k, v)
+              estimated row count: 1000 (missing stats)
+              table: filter_test@primary
+              spans: FULL SCAN
 
 # Tests with * inside GROUP BY.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY kv.*;
 ----
-·          distribution         local                 ·        ·
-·          vectorized           true                  ·        ·
-render     ·                    ·                     (a int)  ·
- │         estimated row count  1000 (missing stats)  ·        ·
- │         render 0             (1)[int]              ·        ·
- └── scan  ·                    ·                     ()       ·
-·          estimated row count  1000 (missing stats)  ·        ·
-·          table                kv@primary            ·        ·
-·          spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a int)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (1)[int]
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-·                             distribution         local                             ·                     ·
-·                             vectorized           true                              ·                     ·
-project                       ·                    ·                                 (sum decimal)         ·
- │                            estimated row count  1000 (missing stats)              ·                     ·
- └── group                    ·                    ·                                 (k int, sum decimal)  ·
-      │                       estimated row count  1000 (missing stats)              ·                     ·
-      │                       aggregate 0          sum(d)                            ·                     ·
-      │                       group by             k                                 ·                     ·
-      └── cross join (inner)  ·                    ·                                 (k int, d decimal)    ·
-           │                  estimated row count  330000 (missing stats)            ·                     ·
-           │                  pred                 ((k)[int] >= (d)[decimal])[bool]  ·                     ·
-           ├── scan           ·                    ·                                 (k int)               ·
-           │                  estimated row count  1000 (missing stats)              ·                     ·
-           │                  table                kv@primary                        ·                     ·
-           │                  spans                FULL SCAN                         ·                     ·
-           └── scan           ·                    ·                                 (d decimal)           ·
-·                             estimated row count  1000 (missing stats)              ·                     ·
-·                             table                abc@primary                       ·                     ·
-·                             spans                FULL SCAN                         ·                     ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (sum decimal)
+│ estimated row count: 1000 (missing stats)
+│
+└── • group
+    │ columns: (k int, sum decimal)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: sum(d)
+    │ group by: k
+    │
+    └── • cross join (inner)
+        │ columns: (k int, d decimal)
+        │ estimated row count: 330000 (missing stats)
+        │ pred: ((k)[int] >= (d)[decimal])[bool]
+        │
+        ├── • scan
+        │     columns: (k int)
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (d decimal)
+              estimated row count: 1000 (missing stats)
+              table: abc@primary
+              spans: FULL SCAN
 
 # opt_test is used for tests around the single-row optimization for MIN/MAX.
 statement ok
 CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 
 # Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test
 ----
-·               distribution         local              ·          ·
-·               vectorized           true               ·          ·
-group (scalar)  ·                    ·                  (min int)  ·
- │              estimated row count  1 (missing stats)  ·          ·
- │              aggregate 0          any_not_null(v)    ·          ·
- └── scan       ·                    ·                  (v int)    ·
-·               estimated row count  1 (missing stats)  ·          ·
-·               table                opt_test@v         ·          ·
-·               spans                /!NULL-            ·          ·
-·               limit                1                  ·          ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(v)
+│
+└── • scan
+      columns: (v int)
+      estimated row count: 1 (missing stats)
+      table: opt_test@v
+      spans: /!NULL-
+      limit: 1
 
 # Repeat test when there is an existing filter.
 # TODO(radu): the best plan for this would be to use index v; in this case the scan
 # will end early but that is not reflected by the cost.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
-·                         distribution         local                         ·               ·
-·                         vectorized           true                          ·               ·
-group (scalar)            ·                    ·                             (min int)       ·
- │                        estimated row count  1 (missing stats)             ·               ·
- │                        aggregate 0          any_not_null(v)               ·               ·
- └── project              ·                    ·                             (v int)         ·
-      └── limit           ·                    ·                             (k int, v int)  ·
-           │              estimated row count  1 (missing stats)             ·               ·
-           │              count                (1)[int]                      ·               ·
-           └── filter     ·                    ·                             (k int, v int)  +v
-                │         estimated row count  333 (missing stats)           ·               ·
-                │         filter               ((k)[int] != (4)[int])[bool]  ·               ·
-                └── scan  ·                    ·                             (k int, v int)  +v
-·                         estimated row count  990 (missing stats)           ·               ·
-·                         table                opt_test@v                    ·               ·
-·                         spans                /!NULL-                       ·               ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(v)
+│
+└── • project
+    │ columns: (v int)
+    │
+    └── • limit
+        │ columns: (k int, v int)
+        │ estimated row count: 1 (missing stats)
+        │ count: (1)[int]
+        │
+        └── • filter
+            │ columns: (k int, v int)
+            │ ordering: +v
+            │ estimated row count: 333 (missing stats)
+            │ filter: ((k)[int] != (4)[int])[bool]
+            │
+            └── • scan
+                  columns: (k int, v int)
+                  ordering: +v
+                  estimated row count: 990 (missing stats)
+                  table: opt_test@v
+                  spans: /!NULL-
 
 # Check that the optimization doesn't work when the argument is non-trivial (we
 # can't in general guarantee an ordering on a synthesized column).
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(v+1) FROM opt_test
 ----
-·               distribution         local                       ·              ·
-·               vectorized           true                        ·              ·
-group (scalar)  ·                    ·                           (min int)      ·
- │              estimated row count  1 (missing stats)           ·              ·
- │              aggregate 0          min(column5)                ·              ·
- └── render     ·                    ·                           (column5 int)  ·
-      │         estimated row count  1000 (missing stats)        ·              ·
-      │         render 0             ((v)[int] + (1)[int])[int]  ·              ·
-      └── scan  ·                    ·                           (v int)        ·
-·               estimated row count  1000 (missing stats)        ·              ·
-·               table                opt_test@primary            ·              ·
-·               spans                FULL SCAN                   ·              ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (min int)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: min(column5)
+│
+└── • render
+    │ columns: (column5 int)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: ((v)[int] + (1)[int])[int]
+    │
+    └── • scan
+          columns: (v int)
+          estimated row count: 1000 (missing stats)
+          table: opt_test@primary
+          spans: FULL SCAN
 
 # Verify that we don't use the optimization if there is a GROUP BY.
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test GROUP BY k
 ----
-·               distribution         local                 ·                 ·
-·               vectorized           true                  ·                 ·
-project         ·                    ·                     (min int)         ·
- │              estimated row count  1000 (missing stats)  ·                 ·
- └── group      ·                    ·                     (k int, min int)  ·
-      │         estimated row count  1000 (missing stats)  ·                 ·
-      │         aggregate 0          min(v)                ·                 ·
-      │         group by             k                     ·                 ·
-      │         ordered              +k                    ·                 ·
-      └── scan  ·                    ·                     (k int, v int)    +k
-·               estimated row count  1000 (missing stats)  ·                 ·
-·               table                opt_test@primary      ·                 ·
-·               spans                FULL SCAN             ·                 ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min int)
+│ estimated row count: 1000 (missing stats)
+│
+└── • group
+    │ columns: (k int, min int)
+    │ estimated row count: 1000 (missing stats)
+    │ aggregate 0: min(v)
+    │ group by: k
+    │ ordered: +k
+    │
+    └── • scan
+          columns: (k int, v int)
+          ordering: +k
+          estimated row count: 1000 (missing stats)
+          table: opt_test@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE xy(x STRING, y STRING);
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT (b, a) r FROM ab GROUP BY (b, a)
 ----
-·          distribution         local                                    ·                    ·
-·          vectorized           true                                     ·                    ·
-render     ·                    ·                                        (r tuple{int, int})  ·
- │         estimated row count  1000 (missing stats)                     ·                    ·
- │         render 0             (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
- └── scan  ·                    ·                                        (a int, b int)       ·
-·          estimated row count  1000 (missing stats)                     ·                    ·
-·          table                ab@primary                               ·                    ·
-·          spans                FULL SCAN                                ·                    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r tuple{int, int})
+│ estimated row count: 1000 (missing stats)
+│ render 0: (((b)[int], (a)[int]))[tuple{int, int}]
+│
+└── • scan
+      columns: (a int, b int)
+      estimated row count: 1000 (missing stats)
+      table: ab@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT min(y), (b, a) r FROM ab, xy GROUP BY (x, (a, b))
 ----
-·                             distribution         local                                               ·                                                ·
-·                             vectorized           true                                                ·                                                ·
-render                        ·                    ·                                                   (min string, r tuple{int, int})                  ·
- │                            estimated row count  100000 (missing stats)                              ·                                                ·
- │                            render 0             (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
- │                            render 1             (min)[string]                                       ·                                                ·
- └── group                    ·                    ·                                                   (a int, x string, min string, any_not_null int)  ·
-      │                       estimated row count  100000 (missing stats)                              ·                                                ·
-      │                       aggregate 0          min(y)                                              ·                                                ·
-      │                       aggregate 1          any_not_null(b)                                     ·                                                ·
-      │                       group by             a, x                                                ·                                                ·
-      └── cross join (inner)  ·                    ·                                                   (a int, b int, x string, y string)               ·
-           │                  estimated row count  1000000 (missing stats)                             ·                                                ·
-           ├── scan           ·                    ·                                                   (a int, b int)                                   ·
-           │                  estimated row count  1000 (missing stats)                                ·                                                ·
-           │                  table                ab@primary                                          ·                                                ·
-           │                  spans                FULL SCAN                                           ·                                                ·
-           └── scan           ·                    ·                                                   (x string, y string)                             ·
-·                             estimated row count  1000 (missing stats)                                ·                                                ·
-·                             table                xy@primary                                          ·                                                ·
-·                             spans                FULL SCAN                                           ·                                                ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (min string, r tuple{int, int})
+│ estimated row count: 100000 (missing stats)
+│ render 0: (((any_not_null)[int], (a)[int]))[tuple{int, int}]
+│ render 1: (min)[string]
+│
+└── • group
+    │ columns: (a int, x string, min string, any_not_null int)
+    │ estimated row count: 100000 (missing stats)
+    │ aggregate 0: min(y)
+    │ aggregate 1: any_not_null(b)
+    │ group by: a, x
+    │
+    └── • cross join (inner)
+        │ columns: (a int, b int, x string, y string)
+        │ estimated row count: 1000000 (missing stats)
+        │
+        ├── • scan
+        │     columns: (a int, b int)
+        │     estimated row count: 1000 (missing stats)
+        │     table: ab@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (x string, y string)
+              estimated row count: 1000 (missing stats)
+              table: xy@primary
+              spans: FULL SCAN
 
 # Test that ordering on GROUP BY columns is maintained.
 # TODO(radu): Derive GROUP BY ordering in physicalPropsBuilder.
@@ -999,171 +1255,241 @@ render                        ·                    ·                          
 #·               spans        ALL                ·                 ·
 
 # Regression test for #25533 (crash when propagating filter through GROUP BY).
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
 ----
-·                         distribution         local                                      ·                         ·
-·                         vectorized           true                                       ·                         ·
-render                    ·                    ·                                          (a int)                   ·
- │                        estimated row count  333 (missing stats)                        ·                         ·
- │                        render 0             (1)[int]                                   ·                         ·
- └── distinct             ·                    ·                                          (column7 decimal, v int)  ·
-      │                   estimated row count  333 (missing stats)                        ·                         ·
-      │                   distinct on          column7, v                                 ·                         ·
-      └── filter          ·                    ·                                          (column7 decimal, v int)  ·
-           │              estimated row count  333 (missing stats)                        ·                         ·
-           │              filter               ((column7)[decimal] > (1)[decimal])[bool]  ·                         ·
-           └── render     ·                    ·                                          (column7 decimal, v int)  ·
-                │         estimated row count  1000 (missing stats)                       ·                         ·
-                │         render 0             ((w)[int]::DECIMAL)[decimal]               ·                         ·
-                │         render 1             (v)[int]                                   ·                         ·
-                └── scan  ·                    ·                                          (v int, w int)            ·
-·                         estimated row count  1000 (missing stats)                       ·                         ·
-·                         table                kv@primary                                 ·                         ·
-·                         spans                FULL SCAN                                  ·                         ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a int)
+│ estimated row count: 333 (missing stats)
+│ render 0: (1)[int]
+│
+└── • distinct
+    │ columns: (column7 decimal, v int)
+    │ estimated row count: 333 (missing stats)
+    │ distinct on: column7, v
+    │
+    └── • filter
+        │ columns: (column7 decimal, v int)
+        │ estimated row count: 333 (missing stats)
+        │ filter: ((column7)[decimal] > (1)[decimal])[bool]
+        │
+        └── • render
+            │ columns: (column7 decimal, v int)
+            │ estimated row count: 1000 (missing stats)
+            │ render 0: ((w)[int]::DECIMAL)[decimal]
+            │ render 1: (v)[int]
+            │
+            └── • scan
+                  columns: (v int, w int)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
 
 # Check that GROUP BY picks up column ordinals.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-·                    distribution         local                 ·               ·
-·                    vectorized           true                  ·               ·
-project              ·                    ·                     (m)             ·
- │                   estimated row count  100 (missing stats)   ·               ·
- └── group           ·                    ·                     (column7, min)  ·
-      │              estimated row count  100 (missing stats)   ·               ·
-      │              aggregate 0          min(a)                ·               ·
-      │              group by             column7               ·               ·
-      └── render     ·                    ·                     (column7, a)    ·
-           │         estimated row count  1000 (missing stats)  ·               ·
-           │         render 0             a                     ·               ·
-           │         render 1             a                     ·               ·
-           └── scan  ·                    ·                     (a)             ·
-·                    estimated row count  1000 (missing stats)  ·               ·
-·                    table                foo@primary           ·               ·
-·                    spans                FULL SCAN             ·               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (m)
+│ estimated row count: 100 (missing stats)
+│
+└── • group
+    │ columns: (column7, min)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: min(a)
+    │ group by: column7
+    │
+    └── • render
+        │ columns: (column7, a)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: a
+        │ render 1: a
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: foo@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-·                    distribution         local                 ·               ·
-·                    vectorized           true                  ·               ·
-project              ·                    ·                     (m)             ·
- │                   estimated row count  100 (missing stats)   ·               ·
- └── group           ·                    ·                     (column7, min)  ·
-      │              estimated row count  100 (missing stats)   ·               ·
-      │              aggregate 0          min(a)                ·               ·
-      │              group by             column7               ·               ·
-      └── render     ·                    ·                     (column7, a)    ·
-           │         estimated row count  1000 (missing stats)  ·               ·
-           │         render 0             b                     ·               ·
-           │         render 1             a                     ·               ·
-           └── scan  ·                    ·                     (a, b)          ·
-·                    estimated row count  1000 (missing stats)  ·               ·
-·                    table                foo@primary           ·               ·
-·                    spans                FULL SCAN             ·               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (m)
+│ estimated row count: 100 (missing stats)
+│
+└── • group
+    │ columns: (column7, min)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: min(a)
+    │ group by: column7
+    │
+    └── • render
+        │ columns: (column7, a)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: b
+        │ render 1: a
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1000 (missing stats)
+              table: foo@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)
 ----
-·               distribution         local                 ·            ·
-·               vectorized           true                  ·            ·
-group (scalar)  ·                    ·                     (array_agg)  ·
- │              estimated row count  1 (missing stats)     ·            ·
- │              aggregate 0          array_agg(v)          ·            ·
- └── sort       ·                    ·                     (v)          +v
-      │         estimated row count  1000 (missing stats)  ·            ·
-      │         order                +v                    ·            ·
-      └── scan  ·                    ·                     (v)          ·
-·               estimated row count  1000 (missing stats)  ·            ·
-·               table                kv@primary            ·            ·
-·               spans                FULL SCAN             ·            ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (array_agg)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: array_agg(v)
+│
+└── • sort
+    │ columns: (v)
+    │ ordering: +v
+    │ estimated row count: 1000 (missing stats)
+    │ order: +v
+    │
+    └── • scan
+          columns: (v)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY s
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (k)     ·
- └── sort       ·                    ·                     (k, s)  +s
-      │         estimated row count  1000 (missing stats)  ·       ·
-      │         order                +s                    ·       ·
-      └── scan  ·                    ·                     (k, s)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                kv@primary            ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • sort
+    │ columns: (k, s)
+    │ ordering: +s
+    │ estimated row count: 1000 (missing stats)
+    │ order: +s
+    │
+    └── • scan
+          columns: (k, s)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-group (scalar)  ·                    ·                     (concat_agg)  ·
- │              estimated row count  1 (missing stats)     ·             ·
- │              aggregate 0          concat_agg(s)         ·             ·
- └── scan       ·                    ·                     (k, s)        +k
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                kv@primary            ·             ·
-·               spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (concat_agg)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: concat_agg(s)
+│
+└── • scan
+      columns: (k, s)
+      ordering: +k
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
-·               distribution         local                 ·            ·
-·               vectorized           true                  ·            ·
-group (scalar)  ·                    ·                     (array_agg)  ·
- │              estimated row count  1 (missing stats)     ·            ·
- │              aggregate 0          array_agg(k)          ·            ·
- └── sort       ·                    ·                     (k, s)       +s
-      │         estimated row count  1000 (missing stats)  ·            ·
-      │         order                +s                    ·            ·
-      └── scan  ·                    ·                     (k, s)       ·
-·               estimated row count  1000 (missing stats)  ·            ·
-·               table                kv@primary            ·            ·
-·               spans                FULL SCAN             ·            ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (array_agg)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: array_agg(k)
+│
+└── • sort
+    │ columns: (k, s)
+    │ ordering: +s
+    │ estimated row count: 1000 (missing stats)
+    │ order: +s
+    │
+    └── • scan
+          columns: (k, s)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 ----
-·               distribution         local                   ·                ·
-·               vectorized           true                    ·                ·
-group (scalar)  ·                    ·                       (string_agg)     ·
- │              estimated row count  1 (missing stats)       ·                ·
- │              aggregate 0          string_agg(s, column7)  ·                ·
- └── render     ·                    ·                       (column7, k, s)  +k
-      │         estimated row count  1000 (missing stats)    ·                ·
-      │         render 0             ','                     ·                ·
-      │         render 1             k                       ·                ·
-      │         render 2             s                       ·                ·
-      └── scan  ·                    ·                       (k, s)           +k
-·               estimated row count  1000 (missing stats)    ·                ·
-·               table                kv@primary              ·                ·
-·               spans                FULL SCAN               ·                ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (string_agg)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: string_agg(s, column7)
+│
+└── • render
+    │ columns: (column7, k, s)
+    │ ordering: +k
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: ','
+    │ render 1: k
+    │ render 2: s
+    │
+    └── • scan
+          columns: (k, s)
+          ordering: +k
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
 # Verify that we project away all input columns for count(*).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(*) FROM xyz JOIN kv ON y=v
 ----
-·                            distribution         local                 ·        ·
-·                            vectorized           true                  ·        ·
-group (scalar)               ·                    ·                     (count)  ·
- │                           estimated row count  1 (missing stats)     ·        ·
- │                           aggregate 0          count_rows()          ·        ·
- └── project                 ·                    ·                     ()       ·
-      └── hash join (inner)  ·                    ·                     (y, v)   ·
-           │                 estimated row count  9801 (missing stats)  ·        ·
-           │                 equality             (y) = (v)             ·        ·
-           ├── scan          ·                    ·                     (y)      ·
-           │                 estimated row count  1000 (missing stats)  ·        ·
-           │                 table                xyz@xy                ·        ·
-           │                 spans                FULL SCAN             ·        ·
-           └── scan          ·                    ·                     (v)      ·
-·                            estimated row count  1000 (missing stats)  ·        ·
-·                            table                kv@primary            ·        ·
-·                            spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count_rows()
+│
+└── • project
+    │ columns: ()
+    │
+    └── • hash join (inner)
+        │ columns: (y, v)
+        │ estimated row count: 9801 (missing stats)
+        │ equality: (y) = (v)
+        │
+        ├── • scan
+        │     columns: (y)
+        │     estimated row count: 1000 (missing stats)
+        │     table: xyz@xy
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (v)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 
 # Regression test for #31882: make sure we don't incorrectly advertise an
@@ -1171,37 +1497,48 @@ group (scalar)               ·                    ·                     (count
 statement ok
 CREATE TABLE uvw (u INT, v INT, w INT, INDEX uvw(u, v, w))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u, v, array_agg(w) AS s FROM (SELECT * FROM uvw ORDER BY w) GROUP BY u, v
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-group      ·                    ·                     (u, v, s)  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         aggregate 0          array_agg(w)          ·          ·
- │         group by             u, v                  ·          ·
- │         ordered              +u,+v                 ·          ·
- └── scan  ·                    ·                     (u, v, w)  +u,+v,+w
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                uvw@uvw               ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• group
+│ columns: (u, v, s)
+│ estimated row count: 1000 (missing stats)
+│ aggregate 0: array_agg(w)
+│ group by: u, v
+│ ordered: +u,+v
+│
+└── • scan
+      columns: (u, v, w)
+      ordering: +u,+v,+w
+      estimated row count: 1000 (missing stats)
+      table: uvw@uvw
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
 ----
-·               distribution         local                   ·             ·
-·               vectorized           true                    ·             ·
-group (scalar)  ·                    ·                       (string_agg)  ·
- │              estimated row count  1 (missing stats)       ·             ·
- │              aggregate 0          string_agg(s, column7)  ·             ·
- └── render     ·                    ·                       (column7, s)  ·
-      │         estimated row count  1000 (missing stats)    ·             ·
-      │         render 0             ', '                    ·             ·
-      │         render 1             s                       ·             ·
-      └── scan  ·                    ·                       (s)           ·
-·               estimated row count  1000 (missing stats)    ·             ·
-·               table                kv@primary              ·             ·
-·               spans                FULL SCAN               ·             ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (string_agg)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: string_agg(s, column7)
+│
+└── • render
+    │ columns: (column7, s)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: ', '
+    │ render 1: s
+    │
+    └── • scan
+          columns: (s)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE string_agg_test (
@@ -1210,7 +1547,7 @@ CREATE TABLE string_agg_test (
   employee STRING
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         company_id, string_agg(employee, ',')
@@ -1221,26 +1558,35 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distribution         local                          ·                                ·
-·                    vectorized           true                           ·                                ·
-sort                 ·                    ·                              (company_id, string_agg)         +company_id
- │                   estimated row count  100 (missing stats)            ·                                ·
- │                   order                +company_id                    ·                                ·
- └── group           ·                    ·                              (company_id, string_agg)         ·
-      │              estimated row count  100 (missing stats)            ·                                ·
-      │              aggregate 0          string_agg(employee, column6)  ·                                ·
-      │              group by             company_id                     ·                                ·
-      └── render     ·                    ·                              (column6, company_id, employee)  ·
-           │         estimated row count  1000 (missing stats)           ·                                ·
-           │         render 0             ','                            ·                                ·
-           │         render 1             company_id                     ·                                ·
-           │         render 2             employee                       ·                                ·
-           └── scan  ·                    ·                              (company_id, employee)           ·
-·                    estimated row count  1000 (missing stats)           ·                                ·
-·                    table                string_agg_test@primary        ·                                ·
-·                    spans                FULL SCAN                      ·                                ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (company_id, string_agg)
+│ ordering: +company_id
+│ estimated row count: 100 (missing stats)
+│ order: +company_id
+│
+└── • group
+    │ columns: (company_id, string_agg)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: string_agg(employee, column6)
+    │ group by: company_id
+    │
+    └── • render
+        │ columns: (column6, company_id, employee)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: ','
+        │ render 1: company_id
+        │ render 2: employee
+        │
+        └── • scan
+              columns: (company_id, employee)
+              estimated row count: 1000 (missing stats)
+              table: string_agg_test@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         company_id, string_agg(employee::BYTES, b',')
@@ -1251,26 +1597,35 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distribution         local                         ·                               ·
-·                    vectorized           true                          ·                               ·
-sort                 ·                    ·                             (company_id, string_agg)        +company_id
- │                   estimated row count  100 (missing stats)           ·                               ·
- │                   order                +company_id                   ·                               ·
- └── group           ·                    ·                             (company_id, string_agg)        ·
-      │              estimated row count  100 (missing stats)           ·                               ·
-      │              aggregate 0          string_agg(column6, column7)  ·                               ·
-      │              group by             company_id                    ·                               ·
-      └── render     ·                    ·                             (column6, column7, company_id)  ·
-           │         estimated row count  1000 (missing stats)          ·                               ·
-           │         render 0             employee::BYTES               ·                               ·
-           │         render 1             '\x2c'                        ·                               ·
-           │         render 2             company_id                    ·                               ·
-           └── scan  ·                    ·                             (company_id, employee)          ·
-·                    estimated row count  1000 (missing stats)          ·                               ·
-·                    table                string_agg_test@primary       ·                               ·
-·                    spans                FULL SCAN                     ·                               ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (company_id, string_agg)
+│ ordering: +company_id
+│ estimated row count: 100 (missing stats)
+│ order: +company_id
+│
+└── • group
+    │ columns: (company_id, string_agg)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: string_agg(column6, column7)
+    │ group by: company_id
+    │
+    └── • render
+        │ columns: (column6, column7, company_id)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: employee::BYTES
+        │ render 1: '\x2c'
+        │ render 2: company_id
+        │
+        └── • scan
+              columns: (company_id, employee)
+              estimated row count: 1000 (missing stats)
+              table: string_agg_test@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         company_id, string_agg(employee, NULL)
@@ -1281,26 +1636,35 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distribution         local                          ·                                ·
-·                    vectorized           true                           ·                                ·
-sort                 ·                    ·                              (company_id, string_agg)         +company_id
- │                   estimated row count  100 (missing stats)            ·                                ·
- │                   order                +company_id                    ·                                ·
- └── group           ·                    ·                              (company_id, string_agg)         ·
-      │              estimated row count  100 (missing stats)            ·                                ·
-      │              aggregate 0          string_agg(employee, column6)  ·                                ·
-      │              group by             company_id                     ·                                ·
-      └── render     ·                    ·                              (column6, company_id, employee)  ·
-           │         estimated row count  1000 (missing stats)           ·                                ·
-           │         render 0             NULL                           ·                                ·
-           │         render 1             company_id                     ·                                ·
-           │         render 2             employee                       ·                                ·
-           └── scan  ·                    ·                              (company_id, employee)           ·
-·                    estimated row count  1000 (missing stats)           ·                                ·
-·                    table                string_agg_test@primary        ·                                ·
-·                    spans                FULL SCAN                      ·                                ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (company_id, string_agg)
+│ ordering: +company_id
+│ estimated row count: 100 (missing stats)
+│ order: +company_id
+│
+└── • group
+    │ columns: (company_id, string_agg)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: string_agg(employee, column6)
+    │ group by: company_id
+    │
+    └── • render
+        │ columns: (column6, company_id, employee)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: NULL
+        │ render 1: company_id
+        │ render 2: employee
+        │
+        └── • scan
+              columns: (company_id, employee)
+              estimated row count: 1000 (missing stats)
+              table: string_agg_test@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         company_id, string_agg(employee::BYTES, NULL)
@@ -1311,21 +1675,30 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distribution         local                         ·                               ·
-·                    vectorized           true                          ·                               ·
-sort                 ·                    ·                             (company_id, string_agg)        +company_id
- │                   estimated row count  100 (missing stats)           ·                               ·
- │                   order                +company_id                   ·                               ·
- └── group           ·                    ·                             (company_id, string_agg)        ·
-      │              estimated row count  100 (missing stats)           ·                               ·
-      │              aggregate 0          string_agg(column6, column7)  ·                               ·
-      │              group by             company_id                    ·                               ·
-      └── render     ·                    ·                             (column6, column7, company_id)  ·
-           │         estimated row count  1000 (missing stats)          ·                               ·
-           │         render 0             employee::BYTES               ·                               ·
-           │         render 1             NULL                          ·                               ·
-           │         render 2             company_id                    ·                               ·
-           └── scan  ·                    ·                             (company_id, employee)          ·
-·                    estimated row count  1000 (missing stats)          ·                               ·
-·                    table                string_agg_test@primary       ·                               ·
-·                    spans                FULL SCAN                     ·                               ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (company_id, string_agg)
+│ ordering: +company_id
+│ estimated row count: 100 (missing stats)
+│ order: +company_id
+│
+└── • group
+    │ columns: (company_id, string_agg)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: string_agg(column6, column7)
+    │ group by: company_id
+    │
+    └── • render
+        │ columns: (column6, column7, company_id)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: employee::BYTES
+        │ render 1: NULL
+        │ render 2: company_id
+        │
+        └── • scan
+              columns: (company_id, employee)
+              estimated row count: 1000 (missing stats)
+              table: string_agg_test@primary
+              spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -6,69 +6,81 @@ CREATE TABLE t (x INT[])
 
 # Test some scans of constrained spans on arrays.
 
-query TTT
+query T
 EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         x = ARRAY[1,4,6]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: x = ARRAY[1,4,6]
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         x < ARRAY[1,4,3]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: x < ARRAY[1,4,3]
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         x > ARRAY[1,NULL]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: x > ARRAY[1,NULL]
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +x
- └── filter     ·              ·
-      │         filter         (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          t@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +x
+│
+└── • filter
+    │ filter: (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+    │
+    └── • scan
+          missing stats
+          table: t@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          -x
- └── filter     ·              ·
-      │         filter         (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          t@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: -x
+│
+└── • filter
+    │ filter: (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+    │
+    └── • scan
+          missing stats
+          table: t@primary
+          spans: FULL SCAN
 
 statement ok
 DROP TABLE t
@@ -77,19 +89,22 @@ DROP TABLE t
 statement ok
 CREATE TABLE t (x INT, y INT[], z INT)
 
-query TTT
+query T
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +y
- └── filter     ·              ·
-      │         filter         (x = 2) AND (y < ARRAY[10])
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          t@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +y
+│
+└── • filter
+    │ filter: (x = 2) AND (y < ARRAY[10])
+    │
+    └── • scan
+          missing stats
+          table: t@primary
+          spans: FULL SCAN
 
 # Test span generation on interleaved tables.
 # Add x to parent PRIMARY KEY (x, y) once #50659 is fixed.
@@ -99,38 +114,44 @@ statement ok
 CREATE TABLE parent (x INT, y INT[], PRIMARY KEY (x), FAMILY (x, y));
 CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x), FAMILY (x, y, z)) INTERLEAVE IN PARENT parent (x)
 
-query TTT
+query T
 EXPLAIN SELECT x, y FROM parent WHERE x > 1 AND y > ARRAY[1, NULL]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         y > ARRAY[1,NULL]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          parent@primary
-·          spans          [/2 - ]
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: y > ARRAY[1,NULL]
+│
+└── • scan
+      missing stats
+      table: parent@primary
+      spans: [/2 - ]
 
-query TTT
+query T
 EXPLAIN SELECT y FROM parent WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         y = ARRAY[NULL,NULL]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          parent@primary
-·          spans          [/1 - /1]
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: y = ARRAY[NULL,NULL]
+│
+└── • scan
+      missing stats
+      table: parent@primary
+      spans: [/1 - /1]
 
-query TTT
+query T
 EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         y = ARRAY[NULL,NULL]
- └── scan  ·              ·
-·          missing stats  ·
-·          table          child@primary
-·          spans          [/1 - /1]
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: y = ARRAY[NULL,NULL]
+│
+└── • scan
+      missing stats
+      table: child@primary
+      spans: [/1 - /1]

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -26,7 +26,7 @@ SELECT * FROM ab
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (1, 1)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -47,7 +47,7 @@ dist sender send  r35: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (2, 2), (3, 3)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -71,7 +71,7 @@ BEGIN
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (4, 4), (5, 5)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -95,7 +95,7 @@ ROLLBACK
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -116,7 +116,7 @@ dist sender send  r35: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -140,7 +140,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -177,7 +177,7 @@ SELECT count(*) FROM ab WHERE b=0
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (1, 1)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -198,7 +198,7 @@ dist sender send  r35: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (2, 2), (3, 3)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -222,7 +222,7 @@ BEGIN
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (4, 4), (5, 5)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -246,7 +246,7 @@ ROLLBACK
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -267,7 +267,7 @@ dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -291,7 +291,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -328,7 +328,7 @@ SELECT count(*) FROM ab WHERE b=0
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -353,7 +353,7 @@ BEGIN
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -378,7 +378,7 @@ ROLLBACK
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a, b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -400,7 +400,7 @@ dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a + b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -425,7 +425,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a / b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -463,7 +463,7 @@ SELECT count(*) FROM ab WHERE b=0
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a = 1
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -484,7 +484,7 @@ dist sender send  r35: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (2, 3)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -508,7 +508,7 @@ BEGIN
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (4, 5)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -532,7 +532,7 @@ ROLLBACK
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (6, 7) RETURNING a, b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 true
 
@@ -554,7 +554,7 @@ dist sender send  r35: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (8, 9) RETURNING a + b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -579,7 +579,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (10, 11) RETURNING a / b
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -628,7 +628,7 @@ SELECT * FROM fk_parent JOIN fk_child ON p = b
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO fk_child VALUES (1, 1), (2, 2)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -651,7 +651,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) UPDATE fk_child SET b=b+1 WHERE a < 2
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -675,7 +675,7 @@ dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) DELETE FROM fk_parent WHERE p = 3
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -731,7 +731,7 @@ SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO ab (
     SELECT a*10, b*10 FROM [ INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b ]
   )
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 
@@ -757,7 +757,7 @@ query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) WITH cte AS (INSERT INTO ab VALUES (3, 3), (4, 4) RETURNING a, b)
     INSERT INTO ab (SELECT a*10, b*10 FROM cte)
-] WHERE field = 'auto commit'
+] WHERE info LIKE '%auto commit%'
 ----
 false
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -823,19 +823,23 @@ CREATE TABLE delrng3 (
   FOREIGN KEY (p,q) REFERENCES delrng2(p,q) ON DELETE CASCADE
 );
 
-query TTT
+query T
 EXPLAIN DELETE FROM delrng1 WHERE p = 1
 ----
-·                  distribution  local
-·                  vectorized    false
-root               ·             ·
- ├── delete range  ·             ·
- │                 from          delrng1
- │                 spans         [/1 - /1]
- ├── fk-cascade    ·             ·
- │                 fk            fk_p_ref_delrng1
- └── fk-cascade    ·             ·
-·                  fk            fk_p_ref_delrng1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete range
+│     from: delrng1
+│     spans: [/1 - /1]
+│
+├── • fk-cascade
+│     fk: fk_p_ref_delrng1
+│
+└── • fk-cascade
+      fk: fk_p_ref_delrng1
 
 query T kvtrace(DelRange)
 DELETE FROM delrng1 WHERE p = 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -18,53 +18,67 @@ CREATE TABLE t9 (
 )
 
 # Only column families that are needed to validate check constraints are fetched.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE t9 SET b = b + 1 WHERE a = 5
 ----
-·                    distribution         local              ·                      ·
-·                    vectorized           false              ·                      ·
-update               ·                    ·                  ()                     ·
- │                   estimated row count  0 (missing stats)  ·                      ·
- │                   table                t9                 ·                      ·
- │                   set                  b                  ·                      ·
- │                   auto commit          ·                  ·                      ·
- └── render          ·                    ·                  (a, b, b_new, check1)  ·
-      │              estimated row count  1 (missing stats)  ·                      ·
-      │              render 0             a > b_new          ·                      ·
-      │              render 1             a                  ·                      ·
-      │              render 2             b                  ·                      ·
-      │              render 3             b_new              ·                      ·
-      └── render     ·                    ·                  (b_new, a, b)          ·
-           │         estimated row count  1 (missing stats)  ·                      ·
-           │         render 0             b + 1              ·                      ·
-           │         render 1             a                  ·                      ·
-           │         render 2             b                  ·                      ·
-           └── scan  ·                    ·                  (a, b)                 ·
-·                    estimated row count  1 (missing stats)  ·                      ·
-·                    table                t9@primary         ·                      ·
-·                    spans                /5/0-/5/1/2        ·                      ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: t9
+│ set: b
+│ auto commit
+│
+└── • render
+    │ columns: (a, b, b_new, check1)
+    │ estimated row count: 1 (missing stats)
+    │ render 0: a > b_new
+    │ render 1: a
+    │ render 2: b
+    │ render 3: b_new
+    │
+    └── • render
+        │ columns: (b_new, a, b)
+        │ estimated row count: 1 (missing stats)
+        │ render 0: b + 1
+        │ render 1: a
+        │ render 2: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1 (missing stats)
+              table: t9@primary
+              spans: /5/0-/5/1/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
-·               distribution         local              ·                               ·
-·               vectorized           false              ·                               ·
-update          ·                    ·                  ()                              ·
- │              estimated row count  0 (missing stats)  ·                               ·
- │              table                t9                 ·                               ·
- │              set                  a                  ·                               ·
- │              auto commit          ·                  ·                               ·
- └── render     ·                    ·                  (a, b, c, d, e, a_new, check1)  ·
-      │         estimated row count  1 (missing stats)  ·                               ·
-      │         render 0             b < 2              ·                               ·
-      │         render 1             2                  ·                               ·
-      │         render 2             a                  ·                               ·
-      │         render 3             b                  ·                               ·
-      │         render 4             c                  ·                               ·
-      │         render 5             d                  ·                               ·
-      │         render 6             e                  ·                               ·
-      └── scan  ·                    ·                  (a, b, c, d, e)                 ·
-·               estimated row count  1 (missing stats)  ·                               ·
-·               table                t9@primary         ·                               ·
-·               spans                /5-/5/#            ·                               ·
-·               locking strength     for update         ·                               ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: t9
+│ set: a
+│ auto commit
+│
+└── • render
+    │ columns: (a, b, c, d, e, a_new, check1)
+    │ estimated row count: 1 (missing stats)
+    │ render 0: b < 2
+    │ render 1: 2
+    │ render 2: a
+    │ render 3: b
+    │ render 4: c
+    │ render 5: d
+    │ render 6: e
+    │
+    └── • scan
+          columns: (a, b, c, d, e)
+          estimated row count: 1 (missing stats)
+          table: t9@primary
+          spans: /5-/5/#
+          locking strength: for update

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -92,19 +92,23 @@ output row: [3 9]
 statement ok
 CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-tree       field                description         columns                              ordering
-·          distribution         local               ·                                    ·
-·          vectorized           false               ·                                    ·
-split      ·                    ·                   (key, pretty, split_enforced_until)  ·
- │         estimated row count  10 (missing stats)  ·                                    ·
- └── scan  ·                    ·                   (k1, k2)                             +k1
-·          estimated row count  3 (missing stats)   ·                                    ·
-·          table                s@primary           ·                                    ·
-·          spans                LIMITED SCAN        ·                                    ·
-·          limit                3                   ·                                    ·
+distribution: local
+vectorized: false
+·
+• split
+│ columns: (key, pretty, split_enforced_until)
+│ estimated row count: 10 (missing stats)
+│
+└── • scan
+      columns: (k1, k2)
+      ordering: +k1
+      estimated row count: 3 (missing stats)
+      table: s@primary
+      spans: LIMITED SCAN
+      limit: 3
 
 statement ok
 DROP TABLE t; DROP TABLE other

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -57,141 +57,162 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 ----
 
 # Check that EXPLAIN does not destroy data (#6613)
-query TTT colnames
+query T
 EXPLAIN DELETE FROM unindexed
 ----
-tree          field         description
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          unindexed
-·             spans         FULL SCAN
+distribution: local
+vectorized: false
+·
+• delete range
+  from: unindexed
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
-·                    distribution   local
-·                    vectorized     false
-delete               ·              ·
- │                   from           unindexed
- │                   auto commit    ·
- └── limit           ·              ·
-      │              count          10
-      └── filter     ·              ·
-           │         filter         v = 7
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          unindexed@primary
-·                    spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• delete
+│ from: unindexed
+│ auto commit
+│
+└── • limit
+    │ count: 10
+    │
+    └── • filter
+        │ filter: v = 7
+        │
+        └── • scan
+              missing stats
+              table: unindexed@primary
+              spans: FULL SCAN
 
 # Check DELETE with LIMIT clause (MySQL extension)
-query TTT
+query T
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-·                    distribution   local
-·                    vectorized     false
-delete               ·              ·
- │                   from           unindexed
- │                   auto commit    ·
- └── limit           ·              ·
-      │              count          10
-      └── filter     ·              ·
-           │         filter         v = 5
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          unindexed@primary
-·                    spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• delete
+│ from: unindexed
+│ auto commit
+│
+└── • limit
+    │ count: 10
+    │
+    └── • filter
+        │ filter: v = 5
+        │
+        └── • scan
+              missing stats
+              table: unindexed@primary
+              spans: FULL SCAN
 
 # Check fast DELETE.
-query TTT
+query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          unindexed
-·             spans         [/1 - ]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: unindexed
+  spans: [/1 - ]
 
 # Check fast DELETE with reverse scans (not supported by optimizer).
 query error DELETE statement requires LIMIT when ORDER BY is used
 EXPLAIN DELETE FROM unindexed WHERE true ORDER BY k DESC
 
 # Check that limits don't permit fast deletes.
-query TTT
+query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0 LIMIT 1
 ----
-·          distribution   local
-·          vectorized     false
-delete     ·              ·
- │         from           unindexed
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          unindexed@primary
-·          spans          [/1 - ]
-·          limit          1
+distribution: local
+vectorized: false
+·
+• delete
+│ from: unindexed
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: unindexed@primary
+      spans: [/1 - ]
+      limit: 1
 
-query TTT
+query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-·          distribution   local
-·          vectorized     false
-delete     ·              ·
- │         from           indexed
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          indexed@indexed_value_idx
-·          spans          [/5 - /5]
-·          limit          10
+distribution: local
+vectorized: false
+·
+• delete
+│ from: indexed
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: indexed@indexed_value_idx
+      spans: [/5 - /5]
+      limit: 10
 
-query TTT
+query T
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-·          distribution   local
-·          vectorized     false
-delete     ·              ·
- │         from           indexed
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          indexed@indexed_value_idx
-·          spans          LIMITED SCAN
-·          limit          10
+distribution: local
+vectorized: false
+·
+• delete
+│ from: indexed
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: indexed@indexed_value_idx
+      spans: LIMITED SCAN
+      limit: 10
 
 # TODO(andyk): Prune columns so that index-join is not necessary.
-query TTT
+query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-·          distribution   local
-·          vectorized     false
-delete     ·              ·
- │         from           indexed
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          indexed@indexed_value_idx
-·          spans          [/5 - /5]
-·          limit          10
+distribution: local
+vectorized: false
+·
+• delete
+│ from: indexed
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: indexed@indexed_value_idx
+      spans: [/5 - /5]
+      limit: 10
 
 # Ensure that index hints in DELETE statements force the choice of a specific index
 # as described in #38799.
 statement ok
 CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) DELETE FROM t38799@foo
 ----
-·          distribution         local                 ·       ·
-·          vectorized           false                 ·       ·
-delete     ·                    ·                     ()      ·
- │         estimated row count  0 (missing stats)     ·       ·
- │         from                 t38799                ·       ·
- │         auto commit          ·                     ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t38799@foo            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: false
+·
+• delete
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ from: t38799
+│ auto commit
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t38799@foo
+      spans: FULL SCAN
 
 # Tracing tests for fast delete.
 statement ok
@@ -236,14 +257,15 @@ statement ok
 CREATE TABLE parent (id INT PRIMARY KEY)
 
 # Delete range should be used.
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          parent
-·             spans         [/11 - ]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: parent
+  spans: [/11 - ]
 
 statement ok
 CREATE TABLE child (
@@ -254,30 +276,34 @@ CREATE TABLE child (
 ) INTERLEAVE IN PARENT parent(pid)
 
 # Delete range should be used.
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          parent
-·             spans         [/11 - ]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: parent
+  spans: [/11 - ]
 
 # Delete range should not be used when deleting from the child.
-query TTT
+query T
 EXPLAIN DELETE FROM child WHERE id > 10
 ----
-·               distribution   local
-·               vectorized     false
-delete          ·              ·
- │              from           child
- │              auto commit    ·
- └── filter     ·              ·
-      │         filter         id > 10
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          child@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• delete
+│ from: child
+│ auto commit
+│
+└── • filter
+    │ filter: id > 10
+    │
+    └── • scan
+          missing stats
+          table: child@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE sibling (
@@ -288,14 +314,15 @@ CREATE TABLE sibling (
 ) INTERLEAVE IN PARENT parent(pid)
 
 # Delete range should be used.
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          parent
-·             spans         [/11 - ]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: parent
+  spans: [/11 - ]
 
 statement ok
 CREATE TABLE grandchild (
@@ -307,14 +334,15 @@ CREATE TABLE grandchild (
 ) INTERLEAVE IN PARENT child(gid, pid)
 
 # Delete range should be used.
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          parent
-·             spans         [/11 - ]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: parent
+  spans: [/11 - ]
 
 statement ok
 CREATE TABLE external_ref (
@@ -325,22 +353,27 @@ CREATE TABLE external_ref (
 )
 
 # Delete range should not be used (external ref).
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                distribution   local
-·                vectorized     false
-root             ·              ·
- ├── delete      ·              ·
- │    │          from           parent
- │    └── scan   ·              ·
- │               missing stats  ·
- │               table          parent@primary
- │               spans          [/11 - ]
- ├── fk-cascade  ·              ·
- │               fk             fk_pid_ref_parent
- └── fk-cascade  ·              ·
-·                fk             fk_pid_ref_parent
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • scan
+│         missing stats
+│         table: parent@primary
+│         spans: [/11 - ]
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│
+└── • fk-cascade
+      fk: fk_pid_ref_parent
 
 statement ok
 DROP TABLE external_ref
@@ -356,41 +389,53 @@ CREATE TABLE child_with_index (
 ) INTERLEAVE IN PARENT parent(pid)
 
 # Delete range should not be used (child with secondary index).
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── delete                      ·                   ·
- │    │                          from                parent
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── scan              ·                   ·
- │                               missing stats       ·
- │                               table               parent@primary
- │                               spans               [/11 - ]
- ├── fk-cascade                  ·                   ·
- │                               fk                  fk_pid_ref_parent
- │                               input               buffer 1
- ├── fk-cascade                  ·                   ·
- │                               fk                  fk_pid_ref_parent
- │                               input               buffer 1
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                equality            (id) = (pid)
-                │                left cols are key   ·
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── distinct     ·                   ·
-                     │           distinct on         pid
-                     │           order key           pid
-                     └── scan    ·                   ·
-·                                missing stats       ·
-·                                table               child_with_index@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: parent@primary
+│             spans: [/11 - ]
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│     input: buffer 1
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│     input: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (id) = (pid)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: pid
+                │ order key: pid
+                │
+                └── • scan
+                      missing stats
+                      table: child_with_index@primary
+                      spans: FULL SCAN
 
 statement ok
 DROP TABLE child_with_index
@@ -404,41 +449,53 @@ CREATE TABLE child_without_cascade (
 ) INTERLEAVE IN PARENT parent(pid)
 
 # Delete range should not be used (child without cascading FK).
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── delete                      ·                   ·
- │    │                          from                parent
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── scan              ·                   ·
- │                               missing stats       ·
- │                               table               parent@primary
- │                               spans               [/11 - ]
- ├── fk-cascade                  ·                   ·
- │                               fk                  fk_pid_ref_parent
- │                               input               buffer 1
- ├── fk-cascade                  ·                   ·
- │                               fk                  fk_pid_ref_parent
- │                               input               buffer 1
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join         ·                   ·
-                │                equality            (id) = (pid)
-                │                left cols are key   ·
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── distinct     ·                   ·
-                     │           distinct on         pid
-                     │           order key           pid
-                     └── scan    ·                   ·
-·                                missing stats       ·
-·                                table               child_without_cascade@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: parent@primary
+│             spans: [/11 - ]
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│     input: buffer 1
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│     input: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (id) = (pid)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: pid
+                │ order key: pid
+                │
+                └── • scan
+                      missing stats
+                      table: child_without_cascade@primary
+                      spans: FULL SCAN
 
 statement ok
 DROP TABLE child_without_cascade
@@ -451,22 +508,27 @@ CREATE TABLE child_without_fk (
 ) INTERLEAVE IN PARENT parent(pid)
 
 # Delete range should not be used (child without cascading FK).
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                distribution   local
-·                vectorized     false
-root             ·              ·
- ├── delete      ·              ·
- │    │          from           parent
- │    └── scan   ·              ·
- │               missing stats  ·
- │               table          parent@primary
- │               spans          [/11 - ]
- ├── fk-cascade  ·              ·
- │               fk             fk_pid_ref_parent
- └── fk-cascade  ·              ·
-·                fk             fk_pid_ref_parent
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • scan
+│         missing stats
+│         table: parent@primary
+│         spans: [/11 - ]
+│
+├── • fk-cascade
+│     fk: fk_pid_ref_parent
+│
+└── • fk-cascade
+      fk: fk_pid_ref_parent
 
 statement ok
 DROP TABLE child_without_fk
@@ -485,17 +547,21 @@ CREATE TABLE abc (
 
 
 # Delete range should not be used (FK columns are not in the right order).
-query TTT
+query T
 EXPLAIN DELETE FROM ab WHERE a = 1
 ----
-·                distribution   local
-·                vectorized     false
-root             ·              ·
- ├── delete      ·              ·
- │    │          from           ab
- │    └── scan   ·              ·
- │               missing stats  ·
- │               table          ab@primary
- │               spans          [/1 - /1]
- └── fk-cascade  ·              ·
-·                fk             fk_b_ref_ab
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: ab
+│   │
+│   └── • scan
+│         missing stats
+│         table: ab@primary
+│         spans: [/1 - /1]
+│
+└── • fk-cascade
+      fk: fk_b_ref_ab

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -6,113 +6,157 @@ CREATE TABLE uniontest (
   v INT
 )
 
-query TTT
+query T
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-·          distribution   full
-·          vectorized     true
-union      ·              ·
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          uniontest@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          uniontest@primary
-·          spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• union
+│
+├── • scan
+│     missing stats
+│     table: uniontest@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: uniontest@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-·          distribution   full
-·          vectorized     true
-union all  ·              ·
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          uniontest@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          uniontest@primary
-·          spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• union all
+│
+├── • scan
+│     missing stats
+│     table: uniontest@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: uniontest@primary
+      spans: FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
-query TTT
+query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-·                   distribution  local
-·                   vectorized    false
-union               ·             ·
- ├── virtual table  ·             ·
- │                  table         node_build_info@primary
- └── values         ·             ·
-·                   size          1 column, 1 row
+distribution: local
+vectorized: false
+·
+• union
+│
+├── • virtual table
+│     table: node_build_info@primary
+│
+└── • values
+      size: 1 column, 1 row
 
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc ORDER BY c) ORDER BY a
 ----
-·                    distribution         full                  ·       ·
-·                    vectorized           true                  ·       ·
-sort                 ·                    ·                     (a)     +a
- │                   estimated row count  100 (missing stats)   ·       ·
- │                   order                +a                    ·       ·
- └── intersect       ·                    ·                     (a)     ·
-      │              estimated row count  100 (missing stats)   ·       ·
-      ├── project    ·                    ·                     (a)     ·
-      │    └── scan  ·                    ·                     (a, b)  ·
-      │              estimated row count  1000 (missing stats)  ·       ·
-      │              table                abc@primary           ·       ·
-      │              spans                FULL SCAN             ·       ·
-      └── project    ·                    ·                     (a)     ·
-           └── scan  ·                    ·                     (a, c)  ·
-·                    estimated row count  1000 (missing stats)  ·       ·
-·                    table                abc@primary           ·       ·
-·                    spans                FULL SCAN             ·       ·
+distribution: full
+vectorized: true
+·
+• sort
+│ columns: (a)
+│ ordering: +a
+│ estimated row count: 100 (missing stats)
+│ order: +a
+│
+└── • intersect
+    │ columns: (a)
+    │ estimated row count: 100 (missing stats)
+    │
+    ├── • project
+    │   │ columns: (a)
+    │   │
+    │   └── • scan
+    │         columns: (a, b)
+    │         estimated row count: 1000 (missing stats)
+    │         table: abc@primary
+    │         spans: FULL SCAN
+    │
+    └── • project
+        │ columns: (a)
+        │
+        └── • scan
+              columns: (a, c)
+              estimated row count: 1000 (missing stats)
+              table: abc@primary
+              spans: FULL SCAN
 
 # Regression test for #32723.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
-·                      distribution         full             ·                         ·
-·                      vectorized           true             ·                         ·
-project                ·                    ·                (a)                       ·
- └── except all        ·                    ·                (a, a)                    ·
-      │                estimated row count  1                ·                         ·
-      ├── project      ·                    ·                (a, a)                    ·
-      │    └── values  ·                    ·                (a)                       ·
-      │                size                 1 column, 1 row  ·                         ·
-      │                row 0, expr 0        ''               ·                         ·
-      └── project      ·                    ·                ("?column?", "?column?")  ·
-           └── values  ·                    ·                ("?column?")              ·
-·                      size                 1 column, 1 row  ·                         ·
-·                      row 0, expr 0        ''               ·                         ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│
+└── • except all
+    │ columns: (a, a)
+    │ estimated row count: 1
+    │
+    ├── • project
+    │   │ columns: (a, a)
+    │   │
+    │   └── • values
+    │         columns: (a)
+    │         size: 1 column, 1 row
+    │         row 0, expr 0: ''
+    │
+    └── • project
+        │ columns: ("?column?", "?column?")
+        │
+        └── • values
+              columns: ("?column?")
+              size: 1 column, 1 row
+              row 0, expr 0: ''
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
-·                      distribution         full              ·                                     ·
-·                      vectorized           true              ·                                     ·
-render                 ·                    ·                 ("?column?", "?column?", "?column?")  ·
- │                     estimated row count  1                 ·                                     ·
- │                     render 0             "?column?"        ·                                     ·
- │                     render 1             "?column?"        ·                                     ·
- │                     render 2             "?column?"        ·                                     ·
- └── except            ·                    ·                 ("?column?", "?column?", "?column?")  ·
-      │                estimated row count  1                 ·                                     ·
-      ├── project      ·                    ·                 ("?column?", "?column?", "?column?")  ·
-      │    └── values  ·                    ·                 ("?column?", "?column?")              ·
-      │                size                 2 columns, 1 row  ·                                     ·
-      │                row 0, expr 0        ''                ·                                     ·
-      │                row 0, expr 1        'x'               ·                                     ·
-      └── values       ·                    ·                 (column1, column2, column3)           ·
-·                      size                 3 columns, 1 row  ·                                     ·
-·                      row 0, expr 0        ''                ·                                     ·
-·                      row 0, expr 1        ''                ·                                     ·
-·                      row 0, expr 2        'x'               ·                                     ·
+distribution: full
+vectorized: true
+·
+• render
+│ columns: ("?column?", "?column?", "?column?")
+│ estimated row count: 1
+│ render 0: "?column?"
+│ render 1: "?column?"
+│ render 2: "?column?"
+│
+└── • except
+    │ columns: ("?column?", "?column?", "?column?")
+    │ estimated row count: 1
+    │
+    ├── • project
+    │   │ columns: ("?column?", "?column?", "?column?")
+    │   │
+    │   └── • values
+    │         columns: ("?column?", "?column?")
+    │         size: 2 columns, 1 row
+    │         row 0, expr 0: ''
+    │         row 0, expr 1: 'x'
+    │
+    └── • values
+          columns: (column1, column2, column3)
+          size: 3 columns, 1 row
+          row 0, expr 0: ''
+          row 0, expr 1: ''
+          row 0, expr 2: 'x'
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -8,143 +8,177 @@ CREATE TABLE xyz (
   INDEX foo (z, y)
 )
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-·          distribution   local
-·          vectorized     true
-distinct   ·              ·
- │         distinct on    y, z
- │         order key      y, z
- └── scan  ·              ·
-·          missing stats  ·
-·          table          xyz@foo
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: y, z
+│ order key: y, z
+│
+└── • scan
+      missing stats
+      table: xyz@foo
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-·          distribution   local
-·          vectorized     true
-distinct   ·              ·
- │         distinct on    y, z
- │         order key      y, z
- └── scan  ·              ·
-·          missing stats  ·
-·          table          xyz@foo
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: y, z
+│ order key: y, z
+│
+└── • scan
+      missing stats
+      table: xyz@foo
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +y
- └── distinct   ·              ·
-      │         distinct on    y, z
-      │         order key      y, z
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          xyz@foo
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +y
+│
+└── • distinct
+    │ distinct on: y, z
+    │ order key: y, z
+    │
+    └── • scan
+          missing stats
+          table: xyz@foo
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +y,+z
- └── distinct   ·              ·
-      │         distinct on    y, z
-      │         order key      y, z
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          xyz@foo
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +y,+z
+│
+└── • distinct
+    │ distinct on: y, z
+    │ order key: y, z
+    │
+    └── • scan
+          missing stats
+          table: xyz@foo
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y + z AS r FROM xyz ORDER BY y + z
 ----
-·                    distribution   local
-·                    vectorized     true
-distinct             ·              ·
- │                   distinct on    r
- │                   order key      r
- └── sort            ·              ·
-      │              order          +r
-      └── render     ·              ·
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          xyz@primary
-·                    spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: r
+│ order key: r
+│
+└── • sort
+    │ order: +r
+    │
+    └── • render
+        │
+        └── • scan
+              missing stats
+              table: xyz@primary
+              spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
 ----
-·          distribution   local
-·          vectorized     true
-distinct   ·              ·
- │         distinct on    y, z
- │         order key      y, z
- └── scan  ·              ·
-·          missing stats  ·
-·          table          xyz@foo
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: y, z
+│ order key: y, z
+│
+└── • scan
+      missing stats
+      table: xyz@foo
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +y
- └── distinct   ·              ·
-      │         distinct on    y
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          xyz@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +y
+│
+└── • distinct
+    │ distinct on: y
+    │
+    └── • scan
+          missing stats
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (x)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                xyz@primary           ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x)
+  estimated row count: 1000 (missing stats)
+  table: xyz@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (x, y, z)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                xyz@primary           ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y, z)
+  estimated row count: 1000 (missing stats)
+  table: xyz@primary
+  spans: FULL SCAN
 
 # Test the case when the DistinctOn operator is projecting away a column.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-·                    distribution         local                 ·       ·
-·                    vectorized           true                  ·       ·
-distinct             ·                    ·                     (z)     ·
- │                   estimated row count  98 (missing stats)    ·       ·
- │                   distinct on          z                     ·       ·
- │                   order key            z                     ·       ·
- └── project         ·                    ·                     (z)     +z
-      └── filter     ·                    ·                     (y, z)  +z
-           │         estimated row count  333 (missing stats)   ·       ·
-           │         filter               y > 1                 ·       ·
-           └── scan  ·                    ·                     (y, z)  +z
-·                    estimated row count  1000 (missing stats)  ·       ·
-·                    table                xyz@foo               ·       ·
-·                    spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (z)
+│ estimated row count: 98 (missing stats)
+│ distinct on: z
+│ order key: z
+│
+└── • project
+    │ columns: (z)
+    │ ordering: +z
+    │
+    └── • filter
+        │ columns: (y, z)
+        │ ordering: +z
+        │ estimated row count: 333 (missing stats)
+        │ filter: y > 1
+        │
+        └── • scan
+              columns: (y, z)
+              ordering: +z
+              estimated row count: 1000 (missing stats)
+              table: xyz@foo
+              spans: FULL SCAN
 
 statement ok
 CREATE TABLE abcd (
@@ -156,108 +190,137 @@ CREATE TABLE abcd (
   UNIQUE INDEX (d, b)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT 1 AS z, d, b FROM abcd ORDER BY d, b
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-render     ·                    ·                     (z, d, b)  +d,+b
- │         estimated row count  1000 (missing stats)  ·          ·
- │         render 0             1                     ·          ·
- │         render 1             b                     ·          ·
- │         render 2             d                     ·          ·
- └── scan  ·                    ·                     (b, d)     +d,+b
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                abcd@abcd_d_b_key     ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (z, d, b)
+│ ordering: +d,+b
+│ estimated row count: 1000 (missing stats)
+│ render 0: 1
+│ render 1: b
+│ render 2: d
+│
+└── • scan
+      columns: (b, d)
+      ordering: +d,+b
+      estimated row count: 1000 (missing stats)
+      table: abcd@abcd_d_b_key
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-distinct   ·                    ·                     (a, b)  ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         distinct on          a, b                  ·       ·
- │         order key            a, b                  ·       ·
- └── scan  ·                    ·                     (a, b)  +a,+b
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                abcd@primary          ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (a, b)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: a, b
+│ order key: a, b
+│
+└── • scan
+      columns: (a, b)
+      ordering: +a,+b
+      estimated row count: 1000 (missing stats)
+      table: abcd@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (a, b, c)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                abcd@primary          ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c)
+  estimated row count: 1000 (missing stats)
+  table: abcd@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
 ----
-·     distribution         local                 ·             ·
-·     vectorized           true                  ·             ·
-scan  ·                    ·                     (a, b, c, d)  ·
-·     estimated row count  1000 (missing stats)  ·             ·
-·     table                abcd@primary          ·             ·
-·     spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c, d)
+  estimated row count: 1000 (missing stats)
+  table: abcd@primary
+  spans: FULL SCAN
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-distinct   ·                    ·                     (v)  ·
- │         estimated row count  991 (missing stats)   ·    ·
- │         distinct on          v                     ·    ·
- │         order key            v                     ·    ·
- └── scan  ·                    ·                     (v)  +v
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                kv@idx                ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (v)
+│ estimated row count: 991 (missing stats)
+│ distinct on: v
+│ order key: v
+│
+└── • scan
+      columns: (v)
+      ordering: +v
+      estimated row count: 1000 (missing stats)
+      table: kv@idx
+      spans: FULL SCAN
 
 # Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-distinct   ·                    ·                     (v)  ·
- │         estimated row count  991 (missing stats)   ·    ·
- │         distinct on          v                     ·    ·
- │         order key            v                     ·    ·
- └── scan  ·                    ·                     (v)  +v
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                kv@idx                ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (v)
+│ estimated row count: 991 (missing stats)
+│ distinct on: v
+│ order key: v
+│
+└── • scan
+      columns: (v)
+      ordering: +v
+      estimated row count: 1000 (missing stats)
+      table: kv@idx
+      spans: FULL SCAN
 
 # Here we can infer that v is not-NULL so eliding the node is correct.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-·     distribution         local                ·    ·
-·     vectorized           true                 ·    ·
-scan  ·                    ·                    (v)  ·
-·     estimated row count  330 (missing stats)  ·    ·
-·     table                kv@idx               ·    ·
-·     spans                /1-                  ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (v)
+  estimated row count: 330 (missing stats)
+  table: kv@idx
+  spans: /1-
 
 statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 
 # In this case it is correct to elide the distinct node.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (v)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                kv2@idx               ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (v)
+  estimated row count: 1000 (missing stats)
+  table: kv2@idx
+  spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -24,494 +24,672 @@ CREATE TABLE abc (
 
 # 3/3 columns
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-distinct   ·                    ·                     (x, y, z)  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         distinct on          x, y, z               ·          ·
- └── scan  ·                    ·                     (x, y, z)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                xyz@primary           ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (x, y, z)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y, z
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (x)        ·
- └── distinct   ·                    ·                     (x, y, z)  ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         distinct on          x, y, z               ·          ·
-      └── scan  ·                    ·                     (x, y, z)  ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                xyz@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x)
+│
+└── • distinct
+    │ columns: (x, y, z)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: x, y, z
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (a, c, b)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                abc@primary           ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, c, b)
+  estimated row count: 1000 (missing stats)
+  table: abc@primary
+  spans: FULL SCAN
 
 # Distinct node should be elided since we have a strong key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                abc@primary           ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: abc@primary
+  spans: FULL SCAN
 
 # Distinct node should be elided since we have a strong key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-sort       ·                    ·                     (b)  +b
- │         estimated row count  1000 (missing stats)  ·    ·
- │         order                +b                    ·    ·
- └── scan  ·                    ·                     (b)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                abc@primary           ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (b)
+│ ordering: +b
+│ estimated row count: 1000 (missing stats)
+│ order: +b
+│
+└── • scan
+      columns: (b)
+      estimated row count: 1000 (missing stats)
+      table: abc@primary
+      spans: FULL SCAN
 
 
 # 2/3 columns
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-distinct   ·                    ·                     (y, x)  ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         distinct on          x, y                  ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xyz@primary           ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (y, x)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (x)     ·
- └── distinct   ·                    ·                     (x, y)  ·
-      │         estimated row count  1000 (missing stats)  ·       ·
-      │         distinct on          x, y                  ·       ·
-      └── scan  ·                    ·                     (x, y)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                xyz@primary           ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x)
+│
+└── • distinct
+    │ columns: (x, y)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: x, y
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-distinct   ·                    ·                     (x, y)  ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         distinct on          x, y                  ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xyz@primary           ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (x, y)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
-·          distribution         local                 ·         ·
-·          vectorized           true                  ·         ·
-distinct   ·                    ·                     (pk1, x)  +pk1
- │         estimated row count  1000 (missing stats)  ·         ·
- │         distinct on          x, pk1                ·         ·
- │         order key            pk1                   ·         ·
- └── scan  ·                    ·                     (x, pk1)  +pk1
-·          estimated row count  1000 (missing stats)  ·         ·
-·          table                xyz@primary           ·         ·
-·          spans                FULL SCAN             ·         ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (pk1, x)
+│ ordering: +pk1
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, pk1
+│ order key: pk1
+│
+└── • scan
+      columns: (x, pk1)
+      ordering: +pk1
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (a, b)     ·
- └── distinct   ·                    ·                     (a, b, c)  ·
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         distinct on          a, c                  ·          ·
-      │         order key            a                     ·          ·
-      └── scan  ·                    ·                     (a, b, c)  +a
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                abc@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • distinct
+    │ columns: (a, b, c)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: a, c
+    │ order key: a
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: abc@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-distinct   ·                    ·                     (b, c, a)  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         distinct on          a, c                  ·          ·
- │         order key            a                     ·          ·
- └── scan  ·                    ·                     (a, b, c)  +a
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                abc@primary           ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (b, c, a)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: a, c
+│ order key: a
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a
+      estimated row count: 1000 (missing stats)
+      table: abc@primary
+      spans: FULL SCAN
 
 
 # 1/3 columns
 
 # Check that distinct propagates the smaller, tighter key (pk1) as opposed to
 # the original key (pk1, pk2).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
 ----
-·          distribution         local                 ·           ·
-·          vectorized           true                  ·           ·
-distinct   ·                    ·                     (pk1, pk2)  ·
- │         estimated row count  100 (missing stats)   ·           ·
- │         distinct on          pk1                   ·           ·
- │         order key            pk1                   ·           ·
- └── scan  ·                    ·                     (pk1, pk2)  +pk1
-·          estimated row count  1000 (missing stats)  ·           ·
-·          table                xyz@primary           ·           ·
-·          spans                FULL SCAN             ·           ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (pk1, pk2)
+│ estimated row count: 100 (missing stats)
+│ distinct on: pk1
+│ order key: pk1
+│
+└── • scan
+      columns: (pk1, pk2)
+      ordering: +pk1
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 # Ensure the distinctNode advertises an a+ ordering.
 # TODO(radu): set the ordering in the render node to fix this.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-·                    distribution         local                 ·          ·
-·                    vectorized           true                  ·          ·
-project              ·                    ·                     (a, c)     +a
- │                   estimated row count  100 (missing stats)   ·          ·
- └── distinct        ·                    ·                     (a, b, c)  +a
-      │              distinct on          a                     ·          ·
-      │              order key            a                     ·          ·
-      └── sort       ·                    ·                     (a, b, c)  +a,-c,+b
-           │         estimated row count  1000 (missing stats)  ·          ·
-           │         order                +a,-c,+b              ·          ·
-           │         already ordered      +a                    ·          ·
-           └── scan  ·                    ·                     (a, b, c)  +a
-·                    estimated row count  1000 (missing stats)  ·          ·
-·                    table                abc@primary           ·          ·
-·                    spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, c)
+│ ordering: +a
+│ estimated row count: 100 (missing stats)
+│
+└── • distinct
+    │ columns: (a, b, c)
+    │ ordering: +a
+    │ distinct on: a
+    │ order key: a
+    │
+    └── • sort
+        │ columns: (a, b, c)
+        │ ordering: +a,-c,+b
+        │ estimated row count: 1000 (missing stats)
+        │ order: +a,-c,+b
+        │ already ordered: +a
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a
+              estimated row count: 1000 (missing stats)
+              table: abc@primary
+              spans: FULL SCAN
 
 #################
 # With ORDER BY #
 #################
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-·               distribution         local                 ·    ·
-·               vectorized           true                  ·    ·
-sort            ·                    ·                     (x)  -x
- │              estimated row count  100 (missing stats)   ·    ·
- │              order                -x                    ·    ·
- └── distinct   ·                    ·                     (x)  ·
-      │         estimated row count  100 (missing stats)   ·    ·
-      │         distinct on          x                     ·    ·
-      └── scan  ·                    ·                     (x)  ·
-·               estimated row count  1000 (missing stats)  ·    ·
-·               table                xyz@primary           ·    ·
-·               spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x)
+│ ordering: -x
+│ estimated row count: 100 (missing stats)
+│ order: -x
+│
+└── • distinct
+    │ columns: (x)
+    │ estimated row count: 100 (missing stats)
+    │ distinct on: x
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-distinct        ·                    ·                     (y, z, x)  +z
- │              estimated row count  1000 (missing stats)  ·          ·
- │              distinct on          x, z                  ·          ·
- │              order key            z                     ·          ·
- └── sort       ·                    ·                     (x, y, z)  +z
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         order                +z                    ·          ·
-      └── scan  ·                    ·                     (x, y, z)  ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                xyz@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (y, z, x)
+│ ordering: +z
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, z
+│ order key: z
+│
+└── • sort
+    │ columns: (x, y, z)
+    │ ordering: +z
+    │ estimated row count: 1000 (missing stats)
+    │ order: +z
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-distinct        ·                    ·                     (y, z, x)  +x
- │              estimated row count  100 (missing stats)   ·          ·
- │              distinct on          x                     ·          ·
- │              order key            x                     ·          ·
- └── sort       ·                    ·                     (x, y, z)  +x,-z,-y
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         order                +x,-z,-y              ·          ·
-      └── scan  ·                    ·                     (x, y, z)  ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                xyz@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (y, z, x)
+│ ordering: +x
+│ estimated row count: 100 (missing stats)
+│ distinct on: x
+│ order key: x
+│
+└── • sort
+    │ columns: (x, y, z)
+    │ ordering: +x,-z,-y
+    │ estimated row count: 1000 (missing stats)
+    │ order: +x,-z,-y
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
 #####################
 # With aggregations #
 #####################
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
-·               distribution         local                 ·      ·
-·               vectorized           true                  ·      ·
-group (scalar)  ·                    ·                     (max)  ·
- │              estimated row count  1 (missing stats)     ·      ·
- │              aggregate 0          max(x)                ·      ·
- └── scan       ·                    ·                     (x)    ·
-·               estimated row count  1000 (missing stats)  ·      ·
-·               table                xyz@primary           ·      ·
-·               spans                FULL SCAN             ·      ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: max(x)
+│
+└── • scan
+      columns: (x)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
-·               distribution         local              ·      ·
-·               vectorized           true               ·      ·
-group (scalar)  ·                    ·                  (max)  ·
- │              estimated row count  1 (missing stats)  ·      ·
- │              aggregate 0          any_not_null(a)    ·      ·
- └── revscan    ·                    ·                  (a)    ·
-·               estimated row count  1 (missing stats)  ·      ·
-·               table                abc@primary        ·      ·
-·               spans                LIMITED SCAN       ·      ·
-·               limit                1                  ·      ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: any_not_null(a)
+│
+└── • revscan
+      columns: (a)
+      estimated row count: 1 (missing stats)
+      table: abc@primary
+      spans: LIMITED SCAN
+      limit: 1
 
 #################
 # With GROUP BY #
 #################
 
 # We can elide the DISTINCT ON since its key is equivalent to the group key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
-·               distribution         local                 ·         ·
-·               vectorized           true                  ·         ·
-project         ·                    ·                     (min)     ·
- └── group      ·                    ·                     (y, min)  ·
-      │         estimated row count  100 (missing stats)   ·         ·
-      │         aggregate 0          min(x)                ·         ·
-      │         group by             y                     ·         ·
-      └── scan  ·                    ·                     (x, y)    ·
-·               estimated row count  1000 (missing stats)  ·         ·
-·               table                xyz@primary           ·         ·
-·               spans                FULL SCAN             ·         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min)
+│
+└── • group
+    │ columns: (y, min)
+    │ estimated row count: 100 (missing stats)
+    │ aggregate 0: min(x)
+    │ group by: y
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
 ----
-·                         distribution         local                 ·         ·
-·                         vectorized           true                  ·         ·
-project                   ·                    ·                     (min)     ·
- │                        estimated row count  1 (missing stats)     ·         ·
- └── limit                ·                    ·                     (y, min)  ·
-      │                   estimated row count  1 (missing stats)     ·         ·
-      │                   count                1                     ·         ·
-      └── filter          ·                    ·                     (y, min)  ·
-           │              estimated row count  1 (missing stats)     ·         ·
-           │              filter               min = 1               ·         ·
-           └── group      ·                    ·                     (y, min)  ·
-                │         estimated row count  100 (missing stats)   ·         ·
-                │         aggregate 0          min(x)                ·         ·
-                │         group by             y                     ·         ·
-                └── scan  ·                    ·                     (x, y)    ·
-·                         estimated row count  1000 (missing stats)  ·         ·
-·                         table                xyz@primary           ·         ·
-·                         spans                FULL SCAN             ·         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (min)
+│ estimated row count: 1 (missing stats)
+│
+└── • limit
+    │ columns: (y, min)
+    │ estimated row count: 1 (missing stats)
+    │ count: 1
+    │
+    └── • filter
+        │ columns: (y, min)
+        │ estimated row count: 1 (missing stats)
+        │ filter: min = 1
+        │
+        └── • group
+            │ columns: (y, min)
+            │ estimated row count: 100 (missing stats)
+            │ aggregate 0: min(x)
+            │ group by: y
+            │
+            └── • scan
+                  columns: (x, y)
+                  estimated row count: 1000 (missing stats)
+                  table: xyz@primary
+                  spans: FULL SCAN
 
 #########################
 # With window functions #
 #########################
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-·                    distribution         local                                                                  ·                ·
-·                    vectorized           true                                                                   ·                ·
-project              ·                    ·                                                                      (y)              ·
- └── distinct        ·                    ·                                                                      (y, row_number)  ·
-      │              estimated row count  1000 (missing stats)                                                   ·                ·
-      │              distinct on          row_number                                                             ·                ·
-      └── window     ·                    ·                                                                      (y, row_number)  ·
-           │         estimated row count  1000 (missing stats)                                                   ·                ·
-           │         window 0             row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
-           └── scan  ·                    ·                                                                      (y)              ·
-·                    estimated row count  1000 (missing stats)                                                   ·                ·
-·                    table                xyz@primary                                                            ·                ·
-·                    spans                FULL SCAN                                                              ·                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y)
+│
+└── • distinct
+    │ columns: (y, row_number)
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: row_number
+    │
+    └── • window
+        │ columns: (y, row_number)
+        │ estimated row count: 1000 (missing stats)
+        │ window 0: row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        │
+        └── • scan
+              columns: (y)
+              estimated row count: 1000 (missing stats)
+              table: xyz@primary
+              spans: FULL SCAN
 
 ###########################
 # With ordinal references #
 ###########################
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-distinct   ·                    ·                     (x, y, z)  ·
- │         estimated row count  100 (missing stats)   ·          ·
- │         distinct on          x                     ·          ·
- └── scan  ·                    ·                     (x, y, z)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                xyz@primary           ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (x, y, z)
+│ estimated row count: 100 (missing stats)
+│ distinct on: x
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 # Distinct node elided because of strong key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (a, b, c)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                abc@primary           ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c)
+  estimated row count: 1000 (missing stats)
+  table: abc@primary
+  spans: FULL SCAN
 
 #########################
 # With alias references #
 #########################
 
 # This should priortize alias (use 'x' as the key).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-distinct   ·                    ·                     (y, x)  ·
- │         estimated row count  100 (missing stats)   ·       ·
- │         distinct on          x                     ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xyz@primary           ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (y, x)
+│ estimated row count: 100 (missing stats)
+│ distinct on: x
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 # Ignores the alias.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-distinct   ·                    ·                     (y)  ·
- │         estimated row count  100 (missing stats)   ·    ·
- │         distinct on          x                     ·    ·
- └── scan  ·                    ·                     (x)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                xyz@primary           ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (y)
+│ estimated row count: 100 (missing stats)
+│ distinct on: x
+│
+└── • scan
+      columns: (x)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 ##################################
 # With nested parentheses/tuples #
 ##################################
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-distinct   ·                    ·                     (x, y)  ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         distinct on          x, y                  ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xyz@primary           ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• distinct
+│ columns: (x, y)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 ################################
 # Hybrid PK and non-PK queries #
 ################################
 
 # Distinct elided because of strong key presence.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-sort       ·                    ·                     (x, y, z)  +x,+y
- │         estimated row count  1000 (missing stats)  ·          ·
- │         order                +x,+y                 ·          ·
- └── scan  ·                    ·                     (x, y, z)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                xyz@primary           ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, y, z)
+│ ordering: +x,+y
+│ estimated row count: 1000 (missing stats)
+│ order: +x,+y
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
-·                    distribution         local                 ·               ·
-·                    vectorized           true                  ·               ·
-project              ·                    ·                     (pk1)           ·
- └── distinct        ·                    ·                     (x, y, z, pk1)  +x
-      │              estimated row count  1000 (missing stats)  ·               ·
-      │              distinct on          x, y, z               ·               ·
-      │              order key            x                     ·               ·
-      └── sort       ·                    ·                     (x, y, z, pk1)  +x
-           │         estimated row count  1000 (missing stats)  ·               ·
-           │         order                +x                    ·               ·
-           └── scan  ·                    ·                     (x, y, z, pk1)  ·
-·                    estimated row count  1000 (missing stats)  ·               ·
-·                    table                xyz@primary           ·               ·
-·                    spans                FULL SCAN             ·               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (pk1)
+│
+└── • distinct
+    │ columns: (x, y, z, pk1)
+    │ ordering: +x
+    │ estimated row count: 1000 (missing stats)
+    │ distinct on: x, y, z
+    │ order key: x
+    │
+    └── • sort
+        │ columns: (x, y, z, pk1)
+        │ ordering: +x
+        │ estimated row count: 1000 (missing stats)
+        │ order: +x
+        │
+        └── • scan
+              columns: (x, y, z, pk1)
+              estimated row count: 1000 (missing stats)
+              table: xyz@primary
+              spans: FULL SCAN
 
 # Regression tests for #34112: distinct on constant column.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y
 ----
-·                    distribution         local                 ·       ·
-·                    vectorized           true                  ·       ·
-limit                ·                    ·                     (x, y)  ·
- │                   estimated row count  1 (missing stats)     ·       ·
- │                   count                1                     ·       ·
- └── sort            ·                    ·                     (x, y)  +y
-      │              estimated row count  10 (missing stats)    ·       ·
-      │              order                +y                    ·       ·
-      └── filter     ·                    ·                     (x, y)  ·
-           │         estimated row count  10 (missing stats)    ·       ·
-           │         filter               x = 1                 ·       ·
-           └── scan  ·                    ·                     (x, y)  ·
-·                    estimated row count  1000 (missing stats)  ·       ·
-·                    table                xyz@primary           ·       ·
-·                    spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (x, y)
+│ estimated row count: 1 (missing stats)
+│ count: 1
+│
+└── • sort
+    │ columns: (x, y)
+    │ ordering: +y
+    │ estimated row count: 10 (missing stats)
+    │ order: +y
+    │
+    └── • filter
+        │ columns: (x, y)
+        │ estimated row count: 10 (missing stats)
+        │ filter: x = 1
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 1000 (missing stats)
+              table: xyz@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y)
 ----
-·                              distribution         local                 ·        ·
-·                              vectorized           true                  ·        ·
-group (scalar)                 ·                    ·                     (count)  ·
- │                             estimated row count  1 (missing stats)     ·        ·
- │                             aggregate 0          count_rows()          ·        ·
- └── project                   ·                    ·                     ()       ·
-      └── limit                ·                    ·                     (x, y)   ·
-           │                   estimated row count  1 (missing stats)     ·        ·
-           │                   count                1                     ·        ·
-           └── sort            ·                    ·                     (x, y)   +y
-                │              estimated row count  10 (missing stats)    ·        ·
-                │              order                +y                    ·        ·
-                └── filter     ·                    ·                     (x, y)   ·
-                     │         estimated row count  10 (missing stats)    ·        ·
-                     │         filter               x = 1                 ·        ·
-                     └── scan  ·                    ·                     (x, y)   ·
-·                              estimated row count  1000 (missing stats)  ·        ·
-·                              table                xyz@primary           ·        ·
-·                              spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (count)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: count_rows()
+│
+└── • project
+    │ columns: ()
+    │
+    └── • limit
+        │ columns: (x, y)
+        │ estimated row count: 1 (missing stats)
+        │ count: 1
+        │
+        └── • sort
+            │ columns: (x, y)
+            │ ordering: +y
+            │ estimated row count: 10 (missing stats)
+            │ order: +y
+            │
+            └── • filter
+                │ columns: (x, y)
+                │ estimated row count: 10 (missing stats)
+                │ filter: x = 1
+                │
+                └── • scan
+                      columns: (x, y)
+                      estimated row count: 1000 (missing stats)
+                      table: xyz@primary
+                      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -350,21 +350,26 @@ group-by
  └── aggregations
       └── count-rows [as=count_rows:5]
 
-query TTTTT
+query T
 EXPLAIN (verbose) SELECT b, count(*), corr(a, b) FROM data2 WHERE a=1 GROUP BY b
 ----
-·          distribution         full                ·                 ·
-·          vectorized           true                ·                 ·
-group      ·                    ·                   (b, count, corr)  ·
- │         estimated row count  10 (missing stats)  ·                 ·
- │         aggregate 0          count_rows()        ·                 ·
- │         aggregate 1          corr(a, b)          ·                 ·
- │         group by             b                   ·                 ·
- │         ordered              +b                  ·                 ·
- └── scan  ·                    ·                   (a, b)            +b
-·          estimated row count  10 (missing stats)  ·                 ·
-·          table                data2@primary       ·                 ·
-·          spans                /1-/2               ·                 ·
+distribution: full
+vectorized: true
+·
+• group
+│ columns: (b, count, corr)
+│ estimated row count: 10 (missing stats)
+│ aggregate 0: count_rows()
+│ aggregate 1: corr(a, b)
+│ group by: b
+│ ordered: +b
+│
+└── • scan
+      columns: (a, b)
+      ordering: +b
+      estimated row count: 10 (missing stats)
+      table: data2@primary
+      spans: /1-/2
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b];

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -64,18 +64,22 @@ NULL             /NULL/NULL/NULL  {5}       5
 /"2"/"3"/"4"     /"3"/"4"/"5"     {4}       4
 /"3"/"4"/"5"     NULL             {5}       5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
-·          distribution         full                  ·          ·
-·          vectorized           true                  ·          ·
-distinct   ·                    ·                     (x, y, z)  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         distinct on          x, y, z               ·          ·
- └── scan  ·                    ·                     (x, y, z)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                xyz@primary           ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: full
+vectorized: true
+·
+• distinct
+│ columns: (x, y, z)
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y, z
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
@@ -83,22 +87,30 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
 https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lU1v4jAQhu_7K6w5tZKj4HxQyIlVy0pILHSBw0oVh5RYbSSaZO1E4kP891WSCgotHhdH3Ajx43ntZzTZgvy3hACm_WH_fkYKsSS_JuPf5Kn_93H4czAiNw-D6Wz6Z3hL3peUz4PR_YyMR-RmRcmaks0tef9Rw6v1Zg4UkjTio_CNSwiegAEFByi4QMEDCj7MKWQiXXApU1Eu2VbAIFpB0KIQJ1mRl3_PKSxSwSHYQh7nSw4BzMLnJZ_wMOLCbgGFiOdhvKzKrNabXibit1CsgcI0CxMZEMsuK4-LPCA9h_Zc2vNgvqOQFvmhiMzDFw4B21H9IA-xzONkkdv-cYoeo1WhkyoH8HlNXkP5epY65HHO5jnsViSpiLjg0dF-1S5nE7OWVuRDELfZIKPUSjOb-Scrv67tHdVm-t3BNLrDdizbu7A_kCj7225fqT9Yc_3BjPrD0Xfk6DjyrOoOL3GERNmf-O5KjpzmHDlGjlx9R66Oo7ZV3eEljpAo-xN3ruTIbc6Ra-TI03fk6Ti6sy40hATZn7d7JUNec4a8xr6EX5SZcJmlieRa37lWGZRHL7w-lUwLseCPIl1UZerHccVVf0Rc5vVbVj8MkvpVGfAjzE5h9hF2jmD2PbhtAndNYGaUm_lq2lHet6uGXbWsttqWp6R9NeybqFbDiGo1jKhWw5hqhEZUt01U3ynhjlpWx0SWGkZkqWFElhrGZCE0IqtrIoshUxQbo2Zz1GyQmk1Sw1FqNkuZ0TBlyDT1EGmfxum3pKlpTJqaxqSpaVQagmPSPg1VpbT57sf_AAAA__-kuPbl
 
 # Ensure that ordering propagates past local DISTINCT processors.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
-·               distribution         full                  ·          ·
-·               vectorized           true                  ·          ·
-distinct        ·                    ·                     (x, y, z)  +x
- │              estimated row count  1000 (missing stats)  ·          ·
- │              distinct on          x, y, z               ·          ·
- │              order key            x                     ·          ·
- └── sort       ·                    ·                     (x, y, z)  +x
-      │         estimated row count  1000 (missing stats)  ·          ·
-      │         order                +x                    ·          ·
-      └── scan  ·                    ·                     (x, y, z)  ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                xyz@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: full
+vectorized: true
+·
+• distinct
+│ columns: (x, y, z)
+│ ordering: +x
+│ estimated row count: 1000 (missing stats)
+│ distinct on: x, y, z
+│ order key: x
+│
+└── • sort
+    │ columns: (x, y, z)
+    │ ordering: +x
+    │ estimated row count: 1000 (missing stats)
+    │ order: +x
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
@@ -107,22 +119,30 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzElk9v4jwQh-_vp7Dm1Oo1Cn
 
 # Ensure that even with more ordering columns, ordering propagates past local
 # DISTINCT processors.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-·               distribution         full                  ·       ·
-·               vectorized           true                  ·       ·
-distinct        ·                    ·                     (x, y)  +y
- │              estimated row count  100 (missing stats)   ·       ·
- │              distinct on          y                     ·       ·
- │              order key            y                     ·       ·
- └── sort       ·                    ·                     (x, y)  +y,+x
-      │         estimated row count  1000 (missing stats)  ·       ·
-      │         order                +y,+x                 ·       ·
-      └── scan  ·                    ·                     (x, y)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                xyz@primary           ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: full
+vectorized: true
+·
+• distinct
+│ columns: (x, y)
+│ ordering: +y
+│ estimated row count: 100 (missing stats)
+│ distinct on: y
+│ order key: y
+│
+└── • sort
+    │ columns: (x, y)
+    │ ordering: +y,+x
+    │ estimated row count: 1000 (missing stats)
+    │ order: +y,+x
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
@@ -130,35 +150,46 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY
 https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lk1v2kAQhu_9Fas5Jcois2vzEZ9oEyohpZACh1YRBwevEiSC3V0j4UT898o2kgMOMzZGHP3xeGbnfTTyB5h_S3Bh0n_o303ZWi_Zz_HoF3vq_3l8-D4Ysqv7wWQ6-f1wzXavJNeD4d2UjYbsKr5mG87ijNnE72w0vu-P2Y-_LOZsMwMOq8BXQ-9NGXCfQAAHCRxs4OAAhxbMOIQ6mCtjAp288pECA38DbpPDYhWuo-T2jMM80ArcD4gW0VKBC1PveanGyvOVtprAwVeRt1imZTbxey_UizdPx8BhEnor47KGlVQerSOX9STv2TDbcgjWUV7BRN6LAldsefkuJoGOlLZa-w305A3viZujJWSVEvcLEy1W88gSzcMqyYG0r7Tyk0MdlMu_8ByzV8-8FujZNm_JPtpS_p0gq3XsrGjvhQmhved9OTX6-rqnYdAIQkvuD_NY-dZeeVFeSVFCSUs2LOcUKYk-dlK260hJlMiDFReTUpxdysKETpJSlrdClrHCaaTRVbaC6GNnRaeOFUSJfLLyYlbIs1tRmNBJVtjlrbDLWNFupNFVtoLoY2dFt44VRIl8svbFrLDPbkVhQidZ4ZS3wiljRadxihNEFzsnbus4QZTI5-pczAnn7E4UJlT7p-aLcmNlwmBlVKn_lWbSsPJfVHZIE6z1XD3qYJ6WyS5HKZfe8JWJsqciuxisskdJg59hgcISh-UhLD7D9h4sqsHdOrCQteh2HVo2cdpGB-7gsIOnRWTdQuk2DrdRuIPDnTqi4DAhCg5TohA0IQpOU6J064hyi--EJrEUiJVC7ZTCUqkSN0ETeRM0FTiFE4kTOBW5KKyWKpkLfLUIh0gNXy6iReCF7VIpdJymQsdpMnQCp0LHcTJ0fLNSoReWzH5qXSI1fMuIWwIv7JlKoeM0FTpOk6ETOBU6jlOhS3zDHoY-2377HwAA__8VCBZB
 
 # Distinct processors elided becaue of strong key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ----
-·     distribution         full                  ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (a, b, c)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                abc@primary           ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: full
+vectorized: true
+·
+• scan
+  columns: (a, b, c)
+  estimated row count: 1000 (missing stats)
+  table: abc@primary
+  spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJykk0-L2zAQxe_9FOKddkHG8Z_04FPLNgWD62yTFAobHxRr2Aa8livJ0BLy3YvlpfnTtCjNZfCT5vn9GEY7mO8NMixnxexhxXrdsI-L-Sf2NPv6WLzPS3b3IV-ulp-Le_baMui8fFixecnuBGcbzup79voxmsWmrsDRKkmleCGD7AkROGJwJOBIwTFFxdFpVZMxSg8tO2fI5Q9kE45t2_V2OK44aqUJ2Q52axtChpXYNLQgIUmHw38lWbFtXIzY1O86vX0R-ic4lp1oTcbC8ktRHEoQrhGt8bvGa6Dac6jeHjKNFc-ELNrzv3AdcPpWaUma5AlKtb9AXqpAdeH0rPFydHwSHfmPJPYZyR8jCI7FVVOJ_dGSa9DiY7RRJK6m3miJP1rqh3bGERyLcI2pN1rqjzbxQAvOlpyJVrKIKfuN9H9s9wWiBZlOtYa8lncybD_JZxqfilG9rulRq9rFjHLufO5AkrHjbTSKvHVXDvDYHP3T_PbEPDk3x7ckJ7eY01vM06vM1f7NrwAAAP__dnDXkQ==
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-·               distribution         full                  ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (a, b)     +a,+b
- │              estimated row count  1000 (missing stats)  ·          ·
- └── distinct   ·                    ·                     (a, b, c)  +a,+b
-      │         distinct on          a, b                  ·          ·
-      │         order key            a, b                  ·          ·
-      └── scan  ·                    ·                     (a, b, c)  +a,+b,+c
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                abc@primary           ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ ordering: +a,+b
+│ estimated row count: 1000 (missing stats)
+│
+└── • distinct
+    │ columns: (a, b, c)
+    │ ordering: +a,+b
+    │ distinct on: a, b
+    │ order key: a, b
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a,+b,+c
+          estimated row count: 1000 (missing stats)
+          table: abc@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -29,25 +29,35 @@ NULL       /1       {1}       1
 /9         NULL     {5}       5
 
 # ensure merge joins are planned when there's orderings.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-·                        distribution         full                  ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b)        ·
- │                       estimated row count  100 (missing stats)   ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, b)  ·
-      │                  estimated row count  100 (missing stats)   ·             ·
-      │                  equality             (a, b) = (a, b)       ·             ·
-      │                  merge ordering       +"(a=a)",+"(b=b)"     ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a,+b
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                data@primary          ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      └── scan           ·                    ·                     (a, b)        +a,+b
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                data@primary          ·             ·
-·                        spans                FULL SCAN             ·             ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ estimated row count: 100 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, b)
+    │ estimated row count: 100 (missing stats)
+    │ equality: (a, b) = (a, b)
+    │ merge ordering: +"(a=a)",+"(b=b)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a,+b
+    │     estimated row count: 1000 (missing stats)
+    │     table: data@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b)
+          ordering: +a,+b
+          estimated row count: 1000 (missing stats)
+          table: data@primary
+          spans: FULL SCAN
 
 # TODO(radu): enable these tests when joins pass through orderings on equality
 # columns.
@@ -110,25 +120,34 @@ project                  ·                    ·                     (a, b)    
 # https://cockroachdb.github.io/distsqlplan/decode.html#eJzElk9v2kwQxu_vp4jm9FbZCu_a_LNUiWsqNanS3ioODt6CJcKitZEaRXz3ChyEbMM-ni6yjwR-3tmZ3-TxO21Mqh-TV51T_IskCVIkKCRBEQka0lzQ1pqFznNjDz8pgYf0D8WBoGyz3RWHP88FLYzVFL9TkRVrTTH9TF7W-lknqbaDgASlukiy9fGYrc1eE_s2S5MiIUFPuyK-m0kxUzTfCzK74uOp54e9vN2tknxVfcwJmQvKi2SpKZZ78W8FDlsUGIpZVCvwfLLinPzD2ELbgQzq97kXM3Xv24TwainnRxmbaqvTq-e3_uWF233Tdqm_mmxzuGKtsWv9u_j_g_70xWbL1fljxQThbnfkf8cLlT-az2Y7UNWxXCthWClBtndN9rIMjAJHt10GcPJpGWQHyyD7XYZRF8ug2g9a9WIio8DxbU0EJ59MVB2YqPo1cdyFiWH7QYe9mMgocHJbE8HJJxPDDkwM-zVx0oWJUftBR72YyChwelsTwcknE6MOTIz6NXHa9avqhYKedb41m1y3egMNDlfS6VKXDcvNzi70d2sWx2PKj09H7vjmk-q8KL8Nyw8Pm_KrQ4Ht4YkPLJUXPfKhVeCmZZ0OKnQFDuqwYjRc8eCJD1xrOJce-dC1hjfo0NnwyD2tyD0t6R7X0Gc_3DDYDzeM9gPQYD_cNNqPkbPjY3fDxz774YbBfrhhtB-ABvvhptF-THz2Y-pjuBsGhrthZDiggeFuGiZAI0AqHZfgn4psJAhHckADywGNNEc48BzgSHTZyBGO6bKRIxzVAQ1cBzSSHeHAdoBD3d0ZKodAd06INmfOSVEuDXVn5SgXh7q7kxTpzolSLo10Z4UpG0e6s-K0ibvzVE6B7pxEbc6cE6lcGurOClUujnRX7lSt6z7f__c3AAD__68_ThQ=
 
 # ORDER BY on a different ordering should require a terminal SORT NODE.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-·                       distribution         full                  ·             ·
-·                       vectorized           true                  ·             ·
-sort                    ·                    ·                     (a, b, c, d)  +b,+a
- │                      estimated row count  100 (missing stats)   ·             ·
- │                      order                +b,+a                 ·             ·
- └── hash join (inner)  ·                    ·                     (a, b, c, d)  ·
-      │                 estimated row count  100 (missing stats)   ·             ·
-      │                 equality             (a, b) = (c, d)       ·             ·
-      ├── scan          ·                    ·                     (a, b)        ·
-      │                 estimated row count  1000 (missing stats)  ·             ·
-      │                 table                data@primary          ·             ·
-      │                 spans                FULL SCAN             ·             ·
-      └── scan          ·                    ·                     (c, d)        ·
-·                       estimated row count  1000 (missing stats)  ·             ·
-·                       table                data@primary          ·             ·
-·                       spans                FULL SCAN             ·             ·
+distribution: full
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d)
+│ ordering: +b,+a
+│ estimated row count: 100 (missing stats)
+│ order: +b,+a
+│
+└── • hash join (inner)
+    │ columns: (a, b, c, d)
+    │ estimated row count: 100 (missing stats)
+    │ equality: (a, b) = (c, d)
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     estimated row count: 1000 (missing stats)
+    │     table: data@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (c, d)
+          estimated row count: 1000 (missing stats)
+          table: data@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -185,45 +185,58 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 # Merge joins #
 ###############
 
-query TTT
+query T
 EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ----
-·           distribution       full
-·           vectorized         true
-merge join  ·                  ·
- │          equality           (pid1) = (pid1)
- │          left cols are key  ·
- ├── scan   ·                  ·
- │          missing stats      ·
- │          table              parent1@primary
- │          spans              FULL SCAN
- └── scan   ·                  ·
-·           missing stats      ·
-·           table              child1@primary
-·           spans              FULL SCAN
+distribution: full
+vectorized: true
+·
+• merge join
+│ equality: (pid1) = (pid1)
+│ left cols are key
+│
+├── • scan
+│     missing stats
+│     table: parent1@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: child1@primary
+      spans: FULL SCAN
 
 # Select over two ranges for parent/child with split at children key.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
-·                        distribution         full                 ·                             ·
-·                        vectorized           true                 ·                             ·
-project                  ·                    ·                    (pid1, pa1, cid1, ca1)        ·
- │                       estimated row count  30 (missing stats)   ·                             ·
- └── merge join (inner)  ·                    ·                    (pid1, pa1, pid1, cid1, ca1)  ·
-      │                  estimated row count  30 (missing stats)   ·                             ·
-      │                  equality             (pid1) = (pid1)      ·                             ·
-      │                  left cols are key    ·                    ·                             ·
-      │                  merge ordering       +"(pid1=pid1)"       ·                             ·
-      ├── scan           ·                    ·                    (pid1, pa1)                   +pid1
-      │                  estimated row count  3 (missing stats)    ·                             ·
-      │                  table                parent1@primary      ·                             ·
-      │                  spans                /3-/5/#              ·                             ·
-      │                  parallel             ·                    ·                             ·
-      └── scan           ·                    ·                    (pid1, cid1, ca1)             +pid1
-·                        estimated row count  30 (missing stats)   ·                             ·
-·                        table                child1@primary       ·                             ·
-·                        spans                /3/#/55/1-/5/#/55/2  ·                             ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, pa1, cid1, ca1)
+│ estimated row count: 30 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, pa1, pid1, cid1, ca1)
+    │ estimated row count: 30 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ left cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, pa1)
+    │     ordering: +pid1
+    │     estimated row count: 3 (missing stats)
+    │     table: parent1@primary
+    │     spans: /3-/5/#
+    │     parallel
+    │
+    └── • scan
+          columns: (pid1, cid1, ca1)
+          ordering: +pid1
+          estimated row count: 30 (missing stats)
+          table: child1@primary
+          spans: /3/#/55/1-/5/#/55/2
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
@@ -231,27 +244,37 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1)
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzEVN1q20wQvf-eYpnc2F_WrFY_LggMCo3bKjhyaru0kOpCkaa2QNGquxI0BL97kddgyTiK3bj0TrMzZ-bMmYOeQf3MwIX5eDJ-vyCVzMiH2fSW3I-_3U2u_ID0rv35Yv550ifbkv91QRFJzEtObqZ-QOJVmiWcfJn7wUfSK9KE98nXT-PZWAfke2UYFo6I1SdXwXXzMR4Rpx8ChVwkGESPqMC9Bw4UTKBgQUihkCJGpYSsU8-bQj_5Ba5BIc2LqtTPZVpmCC5UuZAJSkyAQoJllGZ1PlyHFGIhEdxdaSAGomDDvUIKoiq3bUMKqoyWCK69po3RvDH6QONF9JDhDKMEJTNa7WErm1fI9DGST0BhXkS5cgmzBsxmF8xxGGe2DW0iu94PT2QVqVW7q8dhs-GWLP9Tsma7rT7rIa5bouejbL5Iedfn0GHB45f14KOqDmx_i3KJNyLNUTK7jcnwR9nz-GV_JNPlSn8ChWlVusTj1DOpZ1PPgZcsY7VWMo-_Aj_WMg3xB8xhF2c0zQl0rSNNs8-2Dswzmsb8J6Zx_qZpjO4rzFAVIld41B_MqDfBZIlaHyUqGeOdFPFmjA6nG9zmIUFV6uw7Hfi5TtUEm2C-D-ZNsNUC89PAw26wecJk8zTwsBtsdQpmdNO23yJYN_gVwZy3CNYNfkWw4UmChev_fgcAAP__kmG_Pw==
 
 # Swap parent1 and child1 tables.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
-·                        distribution         full                 ·                             ·
-·                        vectorized           true                 ·                             ·
-project                  ·                    ·                    (pid1, cid1, ca1, pa1)        ·
- │                       estimated row count  30 (missing stats)   ·                             ·
- └── merge join (inner)  ·                    ·                    (pid1, cid1, ca1, pid1, pa1)  ·
-      │                  estimated row count  30 (missing stats)   ·                             ·
-      │                  equality             (pid1) = (pid1)      ·                             ·
-      │                  right cols are key   ·                    ·                             ·
-      │                  merge ordering       +"(pid1=pid1)"       ·                             ·
-      ├── scan           ·                    ·                    (pid1, cid1, ca1)             +pid1
-      │                  estimated row count  30 (missing stats)   ·                             ·
-      │                  table                child1@primary       ·                             ·
-      │                  spans                /3/#/55/1-/5/#/55/2  ·                             ·
-      └── scan           ·                    ·                    (pid1, pa1)                   +pid1
-·                        estimated row count  3 (missing stats)    ·                             ·
-·                        table                parent1@primary      ·                             ·
-·                        spans                /3-/5/#              ·                             ·
-·                        parallel             ·                    ·                             ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, cid1, ca1, pa1)
+│ estimated row count: 30 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, cid1, ca1, pid1, pa1)
+    │ estimated row count: 30 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ right cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, cid1, ca1)
+    │     ordering: +pid1
+    │     estimated row count: 30 (missing stats)
+    │     table: child1@primary
+    │     spans: /3/#/55/1-/5/#/55/2
+    │
+    └── • scan
+          columns: (pid1, pa1)
+          ordering: +pid1
+          estimated row count: 3 (missing stats)
+          table: parent1@primary
+          spans: /3-/5/#
+          parallel
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
@@ -261,25 +284,34 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzEVE1r20AQvfdXLNOL3ayRVh
 # Select over two ranges for parent/child with split at grandchild key.
 # Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
 # have 3 rows.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1
 ----
-·                   distribution         full                   ·                             ·
-·                   vectorized           true                   ·                             ·
-merge join (inner)  ·                    ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
- │                  estimated row count  30 (missing stats)     ·                             ·
- │                  equality             (pid1) = (pid1)        ·                             ·
- │                  left cols are key    ·                      ·                             ·
- │                  merge ordering       +"(pid1=pid1)"         ·                             ·
- ├── scan           ·                    ·                      (pid1, pa1)                   +pid1
- │                  estimated row count  3 (missing stats)      ·                             ·
- │                  table                parent1@primary        ·                             ·
- │                  spans                /29-/31/#              ·                             ·
- │                  parallel             ·                      ·                             ·
- └── scan           ·                    ·                      (pid1, cid1, ca1)             +pid1
-·                   estimated row count  30 (missing stats)     ·                             ·
-·                   table                child1@primary         ·                             ·
-·                   spans                /29/#/55/1-/31/#/55/2  ·                             ·
+distribution: full
+vectorized: true
+·
+• merge join (inner)
+│ columns: (pid1, pa1, pid1, cid1, ca1)
+│ ordering: +pid1
+│ estimated row count: 30 (missing stats)
+│ equality: (pid1) = (pid1)
+│ left cols are key
+│ merge ordering: +"(pid1=pid1)"
+│
+├── • scan
+│     columns: (pid1, pa1)
+│     ordering: +pid1
+│     estimated row count: 3 (missing stats)
+│     table: parent1@primary
+│     spans: /29-/31/#
+│     parallel
+│
+└── • scan
+      columns: (pid1, cid1, ca1)
+      ordering: +pid1
+      estimated row count: 30 (missing stats)
+      table: child1@primary
+      spans: /29/#/55/1-/31/#/55/2
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
@@ -293,26 +325,38 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8UtFum0AQfO9XnDYvcXPpcY
 # joins).
 # TODO(richardwu): we can remove nodes reading from just one table for INNER
 # joins or LEFT/RIGHT joins.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1
 ----
-·                        distribution         full                 ·                                   ·
-·                        vectorized           true                 ·                                   ·
-project                  ·                    ·                    (pid1, pa1, cid2, cid3, ca2)        +pid1
- │                       estimated row count  333 (missing stats)  ·                                   ·
- └── merge join (inner)  ·                    ·                    (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
-      │                  estimated row count  333 (missing stats)  ·                                   ·
-      │                  equality             (pid1) = (pid1)      ·                                   ·
-      │                  left cols are key    ·                    ·                                   ·
-      │                  merge ordering       +"(pid1=pid1)"       ·                                   ·
-      ├── scan           ·                    ·                    (pid1, pa1)                         +pid1
-      │                  estimated row count  333 (missing stats)  ·                                   ·
-      │                  table                parent1@primary      ·                                   ·
-      │                  spans                /12-                 ·                                   ·
-      └── scan           ·                    ·                    (pid1, cid2, cid3, ca2)             +pid1
-·                        estimated row count  333 (missing stats)  ·                                   ·
-·                        table                child2@primary       ·                                   ·
-·                        spans                /12/#/56/1-          ·                                   ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, pa1, cid2, cid3, ca2)
+│ ordering: +pid1
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, pa1, pid1, cid2, cid3, ca2)
+    │ ordering: +pid1
+    │ estimated row count: 333 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ left cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, pa1)
+    │     ordering: +pid1
+    │     estimated row count: 333 (missing stats)
+    │     table: parent1@primary
+    │     spans: /12-
+    │
+    └── • scan
+          columns: (pid1, cid2, cid3, ca2)
+          ordering: +pid1
+          estimated row count: 333 (missing stats)
+          table: child2@primary
+          spans: /12/#/56/1-
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
@@ -320,27 +364,39 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1)
 https://cockroachdb.github.io/distsqlplan/decode.html#eJy8ll1vuzYUxu_3Kayzm3Z_R2Dz0gSpEtuabanapEs6bVOXCxq8BCkFZoi0qsp3n4B0WV7wgVnhLg78sB-f38XzAdlfa_BgNnwYfv9MNnJNfphOHsnL8Lenh29HY3J1N5o9z35-uCa7V76pXkgDKeKckfvJaEwWq2gdcvLLbDT-kVylUciuya8_DadDUvwmf2xM0xK3hHEymd4Np-S738sHc6AQJ6EYB28iA-8FGFDgQMECCjZQcGBOIZXJQmRZIotXPkpgFP4NnkkhitNNXvw9p7BIpADvA_IoXwvw4Dl4XYupCEIhDRMohCIPonW5ze7sfiqjt0C-A4VZGsSZRwzGewbjxteG4xjMcDgJ4pBwkuQrITOYbykkm3y3536r13eyCrLV4SY-g_l2TiHLg6UAj23p_zv74PCz1VWfOTo3P4_tmj2DlyHcYsV3i77BDF4lYlUirUC8NtD-O4kMhRTh8Xe-FBs3euvM3TwKuRT3SRQLabCjwa7Fn_mVz75c38pouap-AoXJJveIz6jPqW9T36G-exR9H8vSi3XmwOOkl6QGcw5er9vePtieNdeENVd8r3fPYPanJ469WxSeMPtS5reI5DQ0n3263kkcXhunQ-_Zhb3nzafEG4tXN5uewdxL6dYiiNtUt25y8NocHXrGL-yZ1Xw8VmPP3J7B-v_OqL9blDPqX8qzFkFumnrWTQ5em6NDz6wLe2Y3H4_d2LO62fQOutiljGsRqd_UuK4T8dpEHbpnd9ghz5xlKrI0iTPRqB6aRRoRLkV1R1mykQvxJJNFuU21nJRcWU1CkeXVU14tRnH1qDhgc9jVgQc6MNM6N3PUNGtxZbwd7OrAAx2YaZ376MpOaH5Mm_-lLfV9W0qYHd6ZeUzbOoKrYURwNYwIroYxwREaEdzREVwNI4KrYURwNYwJjtCI4K6O4Dc6iqphRFE1jCiqhjFFERpRtK-jqBpGFFXDiKJqGFMUoRFFBzqKMq2egNCIpAiNWIrQmKYYjnUFvbKg1xb06oJmX9ArDEyrMbCTytDKVjWN2aqmMVvVNGorgmO2tilLpzNr05ba0pitrfpSaxyz9aQ8KG2db7_6JwAA__9-zsYU
 
 # These rows are all on the same node 1 (gateway).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1
 ----
-·                        distribution         full                                                                                   ·                                   ·
-·                        vectorized           true                                                                                   ·                                   ·
-project                  ·                    ·                                                                                      (pid1, pa1, cid2, cid3, ca2)        +pid1
- │                       estimated row count  40 (missing stats)                                                                     ·                                   ·
- └── merge join (inner)  ·                    ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
-      │                  estimated row count  40 (missing stats)                                                                     ·                                   ·
-      │                  equality             (pid1) = (pid1)                                                                        ·                                   ·
-      │                  left cols are key    ·                                                                                      ·                                   ·
-      │                  merge ordering       +"(pid1=pid1)"                                                                         ·                                   ·
-      ├── scan           ·                    ·                                                                                      (pid1, pa1)                         +pid1
-      │                  estimated row count  4 (missing stats)                                                                      ·                                   ·
-      │                  table                parent1@primary                                                                        ·                                   ·
-      │                  spans                /1-/1/# /11-/11/# /21-/21/# /31-/31/#                                                  ·                                   ·
-      │                  parallel             ·                                                                                      ·                                   ·
-      └── scan           ·                    ·                                                                                      (pid1, cid2, cid3, ca2)             +pid1
-·                        estimated row count  40 (missing stats)                                                                     ·                                   ·
-·                        table                child2@primary                                                                         ·                                   ·
-·                        spans                /1/#/56/1-/1/#/56/2 /11/#/56/1-/11/#/56/2 /21/#/56/1-/21/#/56/2 /31/#/56/1-/31/#/56/2  ·                                   ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, pa1, cid2, cid3, ca2)
+│ ordering: +pid1
+│ estimated row count: 40 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, pa1, pid1, cid2, cid3, ca2)
+    │ ordering: +pid1
+    │ estimated row count: 40 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ left cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, pa1)
+    │     ordering: +pid1
+    │     estimated row count: 4 (missing stats)
+    │     table: parent1@primary
+    │     spans: /1-/1/# /11-/11/# /21-/21/# /31-/31/#
+    │     parallel
+    │
+    └── • scan
+          columns: (pid1, cid2, cid3, ca2)
+          ordering: +pid1
+          estimated row count: 40 (missing stats)
+          table: child2@primary
+          spans: /1/#/56/1-/1/#/56/2 /11/#/56/1-/11/#/56/2 /21/#/56/1-/21/#/56/2 /31/#/56/1-/31/#/56/2
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
@@ -349,7 +405,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJycktFv0zAQxt_5K063lxaMUr
 
 # Parent-grandchild.
 # We add the pa1 > 0 condition so a lookup join is not considered to be a better plan.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
     pid1 >= 11 AND pid1 <= 13
@@ -357,26 +413,39 @@ EXPLAIN (VERBOSE)
     OR pid1 >= 31 AND pid1 <= 33
     OR pa1 > 0
 ----
-·                        distribution         full                                                                                                                    ·                                           ·
-·                        vectorized           true                                                                                                                    ·                                           ·
-project                  ·                    ·                                                                                                                       (pid1, pa1, cid2, cid3, gcid2, gca2)        ·
- │                       estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
- └── merge join (inner)  ·                    ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
-      │                  estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-      │                  equality             (pid1) = (pid1)                                                                                                         ·                                           ·
-      │                  left cols are key    ·                                                                                                                       ·                                           ·
-      │                  merge ordering       +"(pid1=pid1)"                                                                                                          ·                                           ·
-      ├── filter         ·                    ·                                                                                                                       (pid1, pa1)                                 +pid1
-      │    │             estimated row count  333 (missing stats)                                                                                                     ·                                           ·
-      │    │             filter               ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
-      │    └── scan      ·                    ·                                                                                                                       (pid1, pa1)                                 +pid1
-      │                  estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-      │                  table                parent1@primary                                                                                                         ·                                           ·
-      │                  spans                FULL SCAN                                                                                                               ·                                           ·
-      └── scan           ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2)             +pid1
-·                        estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-·                        table                grandchild2@primary                                                                                                     ·                                           ·
-·                        spans                FULL SCAN                                                                                                               ·                                           ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, pa1, cid2, cid3, gcid2, gca2)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ left cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • filter
+    │   │ columns: (pid1, pa1)
+    │   │ ordering: +pid1
+    │   │ estimated row count: 333 (missing stats)
+    │   │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
+    │   │
+    │   └── • scan
+    │         columns: (pid1, pa1)
+    │         ordering: +pid1
+    │         estimated row count: 1000 (missing stats)
+    │         table: parent1@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          columns: (pid1, cid2, cid3, gcid2, gca2)
+          ordering: +pid1
+          estimated row count: 1000 (missing stats)
+          table: grandchild2@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -389,7 +458,7 @@ SELECT url FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzsl19v4kYUxd_7KUa3L9AdZI_HdsBSJK-6bMsqC1tI1UpbHrx4CpZY2x0bqaso370yhoQ4zlzPTtK88Gbj-5s_95wjXW6g-GcLASzGV-Ofr8lObsn7-ewj-Tz-89PV28mU9N5NFteL36765FDyU12QR1KkJSMfZpMpWcsojVebZBs75PfFZPoL6eVJzPrkj1_H8zHp9Xr7d_LXzra5uCSM9cnb6Tty8uvqkjDe75PZnDSLR23FDuu3VvPWpTk_VufRsZbY_SVQSLNYTKOvooDgMzCg4AAFDhRcoODBkkIus5UoikxWJTd7YBL_C4FNIUnzXVn9vKSwyqSA4AbKpNwKCOA6-rIVcxHFQlo2UIhFGSXb_TaH5oW5TL5G8htQWORRWgRkYDnWj5bnW8xynfp5aDHLIVEaE06yciNkARTeJ9tSyGDf2fC0r0EQTKbXw0MPwtPmHj8dunaKjZ7EnLsVWzj-9HacN7jQuWv78Qssbylku_LQwvvOfflGNlGxedizkMHydkmhKKO1gIDd0u-Twnu47Il1v1cOk2s4T17jfp1MxkKKuLnOm2rjTlUtHfko5Fp8yJJUSIs13LkVf5e9kL3pX8pkvakfgcJsVwYkZDR0aOjS0KOhT8OLxu3vb8Y73GyXtp269cDTbJDlFvMale17uw_2Zt3NwTrm9AlfDCy3evaq391zZtWZ1ZDF18isvjTPl1_2OvllL59fp7tYTtcMnQgysPw71fz6uVLNP2dInSENWS50MqQtzfNlyHmdDDkvnyHeXSzeNUPt2gys4Tk56uRoiDHUSU5HQZ4vL_x18sJfPi9ud4ncrnkZDixmHyXy7MNLpRGzz5FRR0ZDj5FOZLpr8nypcV8nNe7_-0-r5ThzUeRZWohO_6Ps6kIiXou6TUW2kyvxSWar_Tb162zP7WffWBRl_dWpXyZp_ak6YHfYN4FHJjAzOjfz1DTTaJmjB_sm8MgEZkbnbrTsEe00afuU5up-cyXMHvbMbtKuicHVMGJwNYwYXA1jBkdoxOCeicHVMGJwNYwYXA1jBkdoxOC-icEvTCyqhhGLqmHEomoYsyhCIxYdmlhUDSMWVcOIRdUwZlGERiw6MrEoM5oTEBoxKUIjLkVozKYYjs0KZsOC2bRgNi4YzgtmAwMzmhjYo5FBy61qGnOrmsbcqqZRtyI45ladYemxZjrTki6NuVVrXtLGMbc-Gh6Ubl3e_vBfAAAA__8sedd5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
     pid1 >= 11 AND pid1 <= 13
@@ -397,26 +466,39 @@ EXPLAIN (VERBOSE)
     OR pid1 >= 31 AND pid1 <= 33
     OR pa1 > 0
 ----
-·                        distribution         full                                                                                                                    ·                                           ·
-·                        vectorized           true                                                                                                                    ·                                           ·
-project                  ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pa1)        ·
- │                       estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
- └── merge join (inner)  ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
-      │                  estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-      │                  equality             (pid1) = (pid1)                                                                                                         ·                                           ·
-      │                  right cols are key   ·                                                                                                                       ·                                           ·
-      │                  merge ordering       +"(pid1=pid1)"                                                                                                          ·                                           ·
-      ├── scan           ·                    ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2)             +pid1
-      │                  estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-      │                  table                grandchild2@primary                                                                                                     ·                                           ·
-      │                  spans                FULL SCAN                                                                                                               ·                                           ·
-      └── filter         ·                    ·                                                                                                                       (pid1, pa1)                                 +pid1
-           │             estimated row count  333 (missing stats)                                                                                                     ·                                           ·
-           │             filter               ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
-           └── scan      ·                    ·                                                                                                                       (pid1, pa1)                                 +pid1
-·                        estimated row count  1000 (missing stats)                                                                                                    ·                                           ·
-·                        table                parent1@primary                                                                                                         ·                                           ·
-·                        spans                FULL SCAN                                                                                                               ·                                           ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, cid2, cid3, gcid2, gca2, pa1)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ right cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, cid2, cid3, gcid2, gca2)
+    │     ordering: +pid1
+    │     estimated row count: 1000 (missing stats)
+    │     table: grandchild2@primary
+    │     spans: FULL SCAN
+    │
+    └── • filter
+        │ columns: (pid1, pa1)
+        │ ordering: +pid1
+        │ estimated row count: 333 (missing stats)
+        │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
+        │
+        └── • scan
+              columns: (pid1, pa1)
+              ordering: +pid1
+              estimated row count: 1000 (missing stats)
+              table: parent1@primary
+              spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -429,28 +511,32 @@ SELECT url FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzsl0Fv2zYUx-_7FMTbxV5pSCQlxxYQQMWabi5Su7MzbEDng2pxtgBX0igZWBHkuw-y7MRRFD6xhJdLbpLFH8lH_v7A8y0U_2whgMXV9dXPN2SntuT9fPaRfL7689P128mU9N5NFjeL36775DDkp3rAWkVpvNok25iTD7PJlOSRkmnJyO-LyfQX0suTmPXJH79eza9Ir9fbv5O_dq4r5CVhrE_eTt-Rk19Xl4SJfp_M5qQ5eNw2mLN-62jROrUQx9F5dBxL3P4SKKRZLKfRV1lA8BkYUOBAQQAFDyj4sKSQq2wliyJT1ZDbPTCJ_4XApZCk-a6sfl5SWGVKQnALZVJuJQRwE33ZyrmMYqkcFyjEsoyS7X6Zk8MLc5V8jdQ3oLDIo7QIyMDhzo-OP3SY4_H6eeQwh5MojYkgWbmRqoDlHYVsVx6Wf1j1yzeyiYrN4_VCBsu7JYWijNYSAnZHv68M__G0hyv_3hIovE-2pVTBXpDwVI8gCCbTm9HhKsNTR46fDpd_io2fxfj9jC2ceH45IRpcyO_tOX6xugr-7FU8zJOpWCoZN-d5Uy3caVTLrX6Uai0_ZEkqlcMadm7l32UvZG_6lypZb-pHoDDblQEJGQ05DQUNPRr6NLxoVP9QmehQ2S5t23XrhqfZIMsd5jdGtq_tPVqbdRecGeT0GccHjlc9-9Xv3rkya1DSsGNmzct5zW8zv-xl8svOn1_eXThukqETuQbO8N7AYf1cGTg8V4YMSrromiHjcl4z1MwQf5kM8fNnSHQXTphkqN2zgTM6V3IMChl1TU7HIl7z0syLeJm8iPPnxeuumWeSl9HAYe5RN989vFS-MfdckTGoZdw1Mt3reE1NMzXey6TG-3__abVsZy6LPEsL2el_lFsVJOO1rI-pyHZqJT-pbLVfpn6d7bl97xvLoqy_8vplktafqg12h4c28NgGZlb7Zr6eZgZHxs3goQ08toGZ1b4bR_aE5k3aPaWF_ryFFmaPz8xt0p6N4HoYEVwPI4LrYUxwhEYE920E18OI4HoYEVwPY4IjNCL40EbwCxtF9TCiqB5GFNXDmKIIjSg6slFUDyOK6mFEUT2MKYrQiKJjG0WZVZ-A0IikCI1YitCYphiO9Qp2zYJdt2DXLlj2C3YNA7PqGNiTlsHIVj2N2aqnMVv1NGorgmO2mjRLT-_MpFsypTFbjfolYxyz9UnzoLV1effDfwEAAP__sfHXag==
 
-query TTT
+query T
 EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   pid1 >= 11 AND pid1 <= 13
   OR pid1 >= 19 AND pid1 <= 21
   OR pid1 >= 31 AND pid1 <= 33
   OR pa1 > 0
 ----
-·               distribution        full
-·               vectorized          true
-merge join      ·                   ·
- │              equality            (pid1) = (pid1)
- │              right cols are key  ·
- ├── scan       ·                   ·
- │              missing stats       ·
- │              table               grandchild2@primary
- │              spans               FULL SCAN
- └── filter     ·                   ·
-      │         filter              ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
-      └── scan  ·                   ·
-·               missing stats       ·
-·               table               parent1@primary
-·               spans               FULL SCAN
+distribution: full
+vectorized: true
+·
+• merge join
+│ equality: (pid1) = (pid1)
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: grandchild2@primary
+│     spans: FULL SCAN
+│
+└── • filter
+    │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
+    │
+    └── • scan
+          missing stats
+          table: parent1@primary
+          spans: FULL SCAN
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
@@ -469,7 +555,7 @@ SELECT url FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzkl9-O4jYUh-_7FNbpDemYJs6_gUgjZdVlVVazsGVGaqUtF1niQiQ2oU6QuhrNu1chMCSB9YnXOxqkuQuOv9jH_n7S4QHyf9cQwN3odvTbPdmKNXk3m34gn0Z_fbx9M56Q3tvx3f3dH7cG2U_5pZqwWCXr2Cbvp-MJWYoojfcD0wnp9arnXzdJzMhN_fVuyCBvJm_JYdIiie3WpHLIOJnlnM5yDPLn76PZiPSaa_69tSyH3xCv-ZHju8UNuTYMMp0dN7vbxwFk9plNHkjmGgd22aDc4Z5aNuZ7zDDmQCHNYj6JvvAcgk_AgIINFByg4AIFD-YUNiJb8DzPRDnlYQeM4_8gsCgk6WZblMNzCotMcAgeoEiKNYcA7qPPaz7jUcyFaQGFmBdRst4tU-0_3IjkSyS-AoW7TZTmAembtvmz6fkmM127eh6YzLRJlMbEIVmx4iKH-SOFbFvsVz4u-PkrWUX5qrlUyGho09CB-eOcQl5ESw4Be6TfV4fX_Hjt4r-3GArvknXBRVDaEtYkCYJgPLkf7O8urClyeLO_7bAuSIuq6_GEHTi3pkiLc2uaPHE_4ODtbx788WuZiLngcftrVzS0r2joXJXbUJp95k4_cLHk77Mk5cJkLTnX_J-iV_uCcSOS5ao5BBSm2yIghyJp6NLQo6FPw2saDmg4bB3W8QicDkewTc-VdbaSSdbPNibzWjPPr-021mbdvWfd8vsN4_umWz575bj7vFlWqMlXyLJ6Ya851-wycs1eMNd2dw_tjtmqqdY3_Scf_eq59NF_3mwp1HStki3lwl5ztuzLyJb9gtlyunvodMzWeev65uB5E6VQyUAlUR3Lec05ci4jR84L5sjtbp_bMUeDvsmsg3yetf9R2ses542SQjFDlSh1r-g1p8m9jDS5F_JP7sw-ZzzfZGnOO_1Ps8pKebzk1Xnm2VYs-EeRLXbLVD-nO27XbMc8L6q3dvVjnFavyg12h30deKgDM619M09OM4Ujs9VgXwce6sBMa9-tIzuh7TZt1WlHft6OFGbNM7PatKsjuBxGBJfDiOByGBMcoRHBPR3B5TAiuBxGBJfDmOAIjQju6wh-raOoHEYUlcOIonIYUxShEUUHOorKYURROYwoKocxRREaUXSooyjT6hMQGpEUoRFLERrTFMOxXkGvWdDrFvTaBc1-Qa9hYFodAztpGZRsldOYrXIas1VOo7YiOGarSrN0emcq3ZIqjdmq1C8p45itJ82D1Nb540__BwAA__-TjQ6E
 
-query TTT
+query T
 EXPLAIN
   SELECT * FROM child2 JOIN grandchild2 ON
     child2.pid1=grandchild2.pid1
@@ -480,21 +566,25 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-·               distribution       full
-·               vectorized         true
-merge join      ·                  ·
- │              equality           (pid1, cid2, cid3) = (pid1, cid2, cid3)
- │              left cols are key  ·
- ├── scan       ·                  ·
- │              missing stats      ·
- │              table              child2@primary
- │              spans              FULL SCAN
- └── filter     ·                  ·
-      │         filter             (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
-      └── scan  ·                  ·
-·               missing stats      ·
-·               table              grandchild2@primary
-·               spans              FULL SCAN
+distribution: full
+vectorized: true
+·
+• merge join
+│ equality: (pid1, cid2, cid3) = (pid1, cid2, cid3)
+│ left cols are key
+│
+├── • scan
+│     missing stats
+│     table: child2@primary
+│     spans: FULL SCAN
+│
+└── • filter
+    │ filter: (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
+    │
+    └── • scan
+          missing stats
+          table: grandchild2@primary
+          spans: FULL SCAN
 
 # Aggregation over parent and child keys.
 query T
@@ -574,117 +664,157 @@ NULL       /0       {5}       5
 
 ### Begin OUTER queries
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)
 ----
-·                             distribution         full                  ·                                   ·
-·                             vectorized           true                  ·                                   ·
-render                        ·                    ·                     (pid1, pa1, cid1, cid2, ca1)        ·
- │                            estimated row count  1000 (missing stats)  ·                                   ·
- │                            render 0             COALESCE(pid1, pid1)  ·                                   ·
- │                            render 1             pa1                   ·                                   ·
- │                            render 2             cid1                  ·                                   ·
- │                            render 3             cid2                  ·                                   ·
- │                            render 4             ca1                   ·                                   ·
- └── merge join (full outer)  ·                    ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
-      │                       estimated row count  1000 (missing stats)  ·                                   ·
-      │                       equality             (pid1) = (pid1)       ·                                   ·
-      │                       left cols are key    ·                     ·                                   ·
-      │                       merge ordering       +"(pid1=pid1)"        ·                                   ·
-      ├── scan                ·                    ·                     (pid1, pa1)                         +pid1
-      │                       estimated row count  1000 (missing stats)  ·                                   ·
-      │                       table                outer_p1@primary      ·                                   ·
-      │                       spans                FULL SCAN             ·                                   ·
-      └── scan                ·                    ·                     (pid1, cid1, cid2, ca1)             +pid1
-·                             estimated row count  1000 (missing stats)  ·                                   ·
-·                             table                outer_c1@primary      ·                                   ·
-·                             spans                FULL SCAN             ·                                   ·
+distribution: full
+vectorized: true
+·
+• render
+│ columns: (pid1, pa1, cid1, cid2, ca1)
+│ estimated row count: 1000 (missing stats)
+│ render 0: COALESCE(pid1, pid1)
+│ render 1: pa1
+│ render 2: cid1
+│ render 3: cid2
+│ render 4: ca1
+│
+└── • merge join (full outer)
+    │ columns: (pid1, pa1, pid1, cid1, cid2, ca1)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ left cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, pa1)
+    │     ordering: +pid1
+    │     estimated row count: 1000 (missing stats)
+    │     table: outer_p1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (pid1, cid1, cid2, ca1)
+          ordering: +pid1
+          estimated row count: 1000 (missing stats)
+          table: outer_c1@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMllFr4kwUhu-_XzGcK_06kszE2BpYSOnaxWK1qxYWiiypmdWATbKTCFuK_32J6dKt1TmTHRXvajLPzHvmPKTnBbKfC_Bg1Ol1rsZkKRfkeji4JQ-db3e9y26f1D53R-PR116dvC75v1yQLHMhv6eMXN_3euRm0O2_Ppoycj_q9r-QWhqFrD4BCnESin7wJDLwHoABBQ4UHKDQBAouTCikMpmKLEtkseRlDXTDX-DZFKI4XebF4wmFaSIFeC-QR_lCgAfj4HEhhiIIhbSKfUORB9FifcyffH4qo6dAPgOFURrEmUcsu2G5JIhDwkiSz4WEyYoW61_Pedv-8ZnMg2z-fmOfwWQ1oZDlwUyAx1b03_K2tuWdHjwv35n3bZ9EhkKKcHOfs-JgrVVbSr8VciZukiguWrXRq_FzKrxSpMH9uDNc6wQUFuJHXvPZWf2TjGbz8k-gMBRxKKRHrgaXvc7oqlPzGfWdOiU-p8RvUuK7lPitjWt6uwJH4wqW8bbytlbWTxpJajF3Y-X2s5vvzmb6unBtvd2GxewD-V0h8Lm23_sNzHcGPqLg_IQE5_o9c7QlY3bDYof6ilZIfKFt2Z4T852Jj6iZc0KaOfpNa-pr5jYsfqiPWYXEbX3N9puY70x8RM2aJ6RZU79ptq5mDetQilVI6-oqts-0fGfaI-pln5BeyAA_FFmaxJnQmvXsonIRzkR5n1mylFNxJ5Pp-pjy52DNreeUUGR5-Za55a9uXL4rEurT3ARumcBtE5ghuVmVK-PVaG4Ct0zgtgnMkNx8k7b_ph31fTtKmL2v2t6km0aCq2lEFDWMCK6GEcGRopHcrpHgahoRRQ0jgqthRHCkaCR3y0TwcyNF1TTSajWMKKqGEUWRopHcF0aKqmmk1WoYUVQNI4oiRSO52yaKMrM5AcGxf7hGkwJCI5pihWPRDYcFs2nBbFwwmxfMBgZmNDGwDyNDNVvVONZyNY3ZqqYxW5HCseiVhqWPTasyLVWlMVurzEtVadTWD8OD0tbJ6r_fAQAA__8cdcZP
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)
 ----
-·                             distribution         full                                          ·                                                       ·
-·                             vectorized           true                                          ·                                                       ·
-render                        ·                    ·                                             (pid1, cid1, cid2, gcid1, gca1, ca1)                    ·
- │                            estimated row count  1999 (missing stats)                          ·                                                       ·
- │                            render 0             COALESCE(pid1, pid1)                          ·                                                       ·
- │                            render 1             COALESCE(cid1, cid1)                          ·                                                       ·
- │                            render 2             COALESCE(cid2, cid2)                          ·                                                       ·
- │                            render 3             gcid1                                         ·                                                       ·
- │                            render 4             gca1                                          ·                                                       ·
- │                            render 5             ca1                                           ·                                                       ·
- └── merge join (full outer)  ·                    ·                                             (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
-      │                       estimated row count  1999 (missing stats)                          ·                                                       ·
-      │                       equality             (pid1, cid1, cid2) = (pid1, cid1, cid2)       ·                                                       ·
-      │                       right cols are key   ·                                             ·                                                       ·
-      │                       merge ordering       +"(pid1=pid1)",+"(cid1=cid1)",+"(cid2=cid2)"  ·                                                       ·
-      ├── scan                ·                    ·                                             (pid1, cid1, cid2, gcid1, gca1)                         +pid1,+cid1,+cid2
-      │                       estimated row count  1000 (missing stats)                          ·                                                       ·
-      │                       table                outer_gc1@primary                             ·                                                       ·
-      │                       spans                FULL SCAN                                     ·                                                       ·
-      └── scan                ·                    ·                                             (pid1, cid1, cid2, ca1)                                 +pid1,+cid1,+cid2
-·                             estimated row count  1000 (missing stats)                          ·                                                       ·
-·                             table                outer_c1@primary                              ·                                                       ·
-·                             spans                FULL SCAN                                     ·                                                       ·
+distribution: full
+vectorized: true
+·
+• render
+│ columns: (pid1, cid1, cid2, gcid1, gca1, ca1)
+│ estimated row count: 1999 (missing stats)
+│ render 0: COALESCE(pid1, pid1)
+│ render 1: COALESCE(cid1, cid1)
+│ render 2: COALESCE(cid2, cid2)
+│ render 3: gcid1
+│ render 4: gca1
+│ render 5: ca1
+│
+└── • merge join (full outer)
+    │ columns: (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)
+    │ estimated row count: 1999 (missing stats)
+    │ equality: (pid1, cid1, cid2) = (pid1, cid1, cid2)
+    │ right cols are key
+    │ merge ordering: +"(pid1=pid1)",+"(cid1=cid1)",+"(cid2=cid2)"
+    │
+    ├── • scan
+    │     columns: (pid1, cid1, cid2, gcid1, gca1)
+    │     ordering: +pid1,+cid1,+cid2
+    │     estimated row count: 1000 (missing stats)
+    │     table: outer_gc1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (pid1, cid1, cid2, ca1)
+          ordering: +pid1,+cid1,+cid2
+          estimated row count: 1000 (missing stats)
+          table: outer_c1@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzUl1Fv2joUx9_vp7DOE9waJXYILZGulKqXXlFR6AUqTarQlBIPkGiSOUFaVfHdp0C3Fgo-9jyGeJlEyM_--5yf2ekL5F_nEMCg1WldDclCzsl1v3dLHlqf7jqX7S6p_NseDAf_d6rk9ZW_1y-ki0LIz5MxI9f3nQ656bW7r8_GjNwP2t3_SCWbxYyS8Y9_eXUEFJI0Ft3oSeQQPAADChwoeEChDhR8GFHIZDoWeZ7K8pWXFdCOv0HgUpgl2aIoH48ojFMpIHiBYlbMBQQwjB7noi-iWEinXDcWRTSbr7b5GTbM5Owpks9AYZBFSR4Qx605PomSmDCSFlMhYbSkJfC60dv6j89kGuXTzZVDRkNOQw9GyxGFvIgmAgK2pL8Wu7Er9p9KzfemflstlbGQIt5e7YyG_IyG3lkZw-jtHQW5FXIibtJZUvZxq5HD50wEa-N698NWf-UdUJiLL0Xl3crVf-RsMt18BBT6IomFDMhV77LTGly1KmUhGlX67gGn4fnGA4-GF1VKwjoloU9J2Nwq9VsBPY0CLpJdRdlZh25aSzOH-Vtv7t67vrE301eO698Uv-Yw96BXxSD3ufZVOURsvjf2Ee8KP9m7wvX77un7ytyaww77224Q_EJb2IPk5ntzH9FY72SN9fQbXzcw1q85_LA_sQbBm_rGHiI335v7iMbWT9bYun7jXW1ja85hbTUI7eva-vsz872Zj2iqe7KmIn8w9UWepUkutOZit6yTiCdi3Y08XcixuJPpeLXN-mNvxa3GuFjkxfpb5q8_tZP1d2VCfZrbwA0buGkDMyQ3MykZN6O5DdywgZs2MENy823afU976np7SphtntrdputWgqtpRBQ1jAiuhhHBkUMjuX0rwdU0IooaRgRXw4jgyKGR3A0bwc-tFFXTSKvVMKKoGkYURQ6N5L6wUlRNI61Ww4iiahhRFDk0krtpoyizmxMQHPsP12pSQGhEU-zgWHTLYcFuWrAbF-zmBbuBgVlNDOzDyGBmqxrHWq6mMVvVNGYrcnAsutGw9LFpJtOSKY3ZajIvmdKorR-GB6Wto-Vf3wMAAP__mJcbjw==
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40
 ----
-·                             distribution         full                  ·                                   ·
-·                             vectorized           true                  ·                                   ·
-project                       ·                    ·                     (pid1, cid1, cid2, ca1, pa1)        ·
- │                            estimated row count  400 (missing stats)   ·                                   ·
- └── merge join (left outer)  ·                    ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
-      │                       estimated row count  400 (missing stats)   ·                                   ·
-      │                       equality             (pid1) = (pid1)       ·                                   ·
-      │                       right cols are key   ·                     ·                                   ·
-      │                       merge ordering       +"(pid1=pid1)"        ·                                   ·
-      ├── scan                ·                    ·                     (pid1, cid1, cid2, ca1)             +pid1
-      │                       estimated row count  400 (missing stats)   ·                                   ·
-      │                       table                outer_c1@primary      ·                                   ·
-      │                       spans                /0/#/60/1-/39/#/60/2  ·                                   ·
-      └── scan                ·                    ·                     (pid1, pa1)                         +pid1
-·                             estimated row count  40 (missing stats)    ·                                   ·
-·                             table                outer_p1@primary      ·                                   ·
-·                             spans                /0-/39/#              ·                                   ·
-·                             parallel             ·                     ·                                   ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, cid1, cid2, ca1, pa1)
+│ estimated row count: 400 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (pid1, cid1, cid2, ca1, pid1, pa1)
+    │ estimated row count: 400 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ right cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, cid1, cid2, ca1)
+    │     ordering: +pid1
+    │     estimated row count: 400 (missing stats)
+    │     table: outer_c1@primary
+    │     spans: /0/#/60/1-/39/#/60/2
+    │
+    └── • scan
+          columns: (pid1, pa1)
+          ordering: +pid1
+          estimated row count: 40 (missing stats)
+          table: outer_p1@primary
+          spans: /0-/39/#
+          parallel
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlVFv2jAQx9_3KazbS1mNYidAS6RKqVa6UVHogGqTumhKyQ0i0SRzEmlVxXefIJ1aULDNTNu9kdg_3__MT7kHyH7NwYVRp9f5OCaFmJPz4eCS3HS-XfVOu31ycNYdjUdfejXyuOVDuSEpchQ_Jpz0OudjcjHo9h9fpZxcj7r9T-QgjUJeI18_d4ad8oF8Lxhz8ISwGjntnz1_OSENVvOBQpyE2A_uMAP3BjhQsIGCAxQa4FNIRTLBLEvEcvlhtbkb_gaXUYjitMiXr30Kk0QguA-QR_kcwYVxcDvHIQYhCosBhRDzIJqvSvztw0tFdBeIe6AwSoM4c4nFrPdWi1m8bjVJEIeEkySfoQB_QZfYY7mnKrf3ZBZks_XzPQ7-wqeQ5cEUweUL-m-xG1Wx08rY-8xrb837dE4iQhQYbp5zuCystaui9UsUU7xIohiFdbzOjO9TdEvtBtfjznAlH1CY48_8wOOHtRMRTWflT6AwKHKXeJx6NvUc6jWo19q4kaduHY1ui7iqk8om-kk9SS1ub-ysrt1Yq831zeDaQjfrFmcvpPIOgZvaKu83sL018Ou53H4jl239v8fW9omzusVf6tu4Q-KWtlB7TmxvTfx6RnH2Rko5-n-Qo69Us27ZL_WN2iHxkb5S-01sb038ikrx_2DiVmQcYpYmcYZa85Qtu8RwiuXdZUkhJnglksmqTPk4WHGrWRBilperdvnQjculZUB9uGUCt01grsjNd2ja3g1umcBtE5grctubNHtOO_Ibc6QwX6fZJt0wkUwOKySTwwrJ5LBKsqaJZHJYIZkcVkgmh1WStUwkOzLRRA4rNJHDCk3ksEqTYxNN5LBCEzms0EQOqzRpm2jCjWaWglaIoqAVpiho5dgym1tmg8tscpmNLr7b7PIX7_4EAAD__yaJcIw=
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20
 ----
-·                             distribution         full                  ·                                           ·
-·                             vectorized           true                  ·                                           ·
-project                       ·                    ·                     (pid1, pa1, cid1, cid2, gcid1, gca1)        ·
- │                            estimated row count  200 (missing stats)   ·                                           ·
- └── merge join (left outer)  ·                    ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
-      │                       estimated row count  200 (missing stats)   ·                                           ·
-      │                       equality             (pid1) = (pid1)       ·                                           ·
-      │                       right cols are key   ·                     ·                                           ·
-      │                       merge ordering       +"(pid1=pid1)"        ·                                           ·
-      ├── scan                ·                    ·                     (pid1, cid1, cid2, gcid1, gca1)             +pid1
-      │                       estimated row count  200 (missing stats)   ·                                           ·
-      │                       table                outer_gc1@primary     ·                                           ·
-      │                       spans                /1/#/60/1-/20/#/60/2  ·                                           ·
-      └── scan                ·                    ·                     (pid1, pa1)                                 +pid1
-·                             estimated row count  20 (missing stats)    ·                                           ·
-·                             table                outer_p1@primary      ·                                           ·
-·                             spans                /1-/20/#              ·                                           ·
-·                             parallel             ·                     ·                                           ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pid1, pa1, cid1, cid2, gcid1, gca1)
+│ estimated row count: 200 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)
+    │ estimated row count: 200 (missing stats)
+    │ equality: (pid1) = (pid1)
+    │ right cols are key
+    │ merge ordering: +"(pid1=pid1)"
+    │
+    ├── • scan
+    │     columns: (pid1, cid1, cid2, gcid1, gca1)
+    │     ordering: +pid1
+    │     estimated row count: 200 (missing stats)
+    │     table: outer_gc1@primary
+    │     spans: /1/#/60/1-/20/#/60/2
+    │
+    └── • scan
+          columns: (pid1, pa1)
+          ordering: +pid1
+          estimated row count: 20 (missing stats)
+          table: outer_p1@primary
+          spans: /1-/20/#
+          parallel
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -77,33 +77,49 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr 
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVFr2zwUhu-_XyHOVQsqsWwnaQwFf2wdS-mSrunFoPjCjbXG4FiuJENCyH8ftgOpE0-ypySXtvRI5zwv6GxAfCTgwez-8f7LC8p5gr49T3-g1_tfT4__jyfo6ut49jL7-XiNdltWGAnJq11pvpRMfOQhp-hhOp7sfkiOphO0RndoVS1GAWBIWUQn4ZIK8F6BAAYbMDiAwQUMfQgwZJzNqRCMF1s2JTCOVuBZGOI0y2XxO8AwZ5yCtwEZy4SCBy_hW0KfaRhR3rMAQ0RlGCflNZ8K9DMeL0O-BgyzLEyFh24g2GJgudwdvT_xbY0WoVjUz_JtCLYBBiHDdwoe2eJ_K5E0lSh5Q30927KsjkWSWpH2X4vcn5OnjEeU06h2UlCQui0NnX4PxeKBxSnlvUG9tIT-lle-fX3H4_eFvPLJNWCY5tJDPsG-e9DnvgfHoIeGAifshmU9Qg67bbzbrd1N2odstw25zPim5542aXLZpIfnSNpub9tpbdstbQ9Oa9u-rO3bc9h22tt2W9selLZvT2vbuazt0Tlsu-1t91vbLjx3nWkq0e5lRRPr3POi4f5nKjKWCtpqGlhFBzR6p5URwXI-p0-czctrqs9pyZUvcESFrFbt6mOcVktFge3hvgk8NIFHJjAhapp0MGZ3g_sm8NAEHpnAB8aOaPuQtj7Tjlq3o4RJ3bd1SLsmYalhTVhqWBOWGtaEpYZ1YfVNwhqY6FbDGt1qWKNbDWt0q2Gd7qGJ7lsT3WpYo1sNa3SrYY1uNazTPTLRTboMy-M3tMu07ErrHv8u87IrrXNOjqaHUnqw_e9PAAAA__-O9umd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-·                        distribution         full                  ·            ·
-·                        vectorized           true                  ·            ·
-project                  ·                    ·                     (x, str)     ·
- │                       estimated row count  333 (missing stats)   ·            ·
- └── merge join (inner)  ·                    ·                     (x, y, str)  ·
-      │                  estimated row count  333 (missing stats)   ·            ·
-      │                  equality             (x) = (y)             ·            ·
-      │                  left cols are key    ·                     ·            ·
-      │                  right cols are key   ·                     ·            ·
-      │                  merge ordering       +"(x=y)"              ·            ·
-      ├── filter         ·                    ·                     (x)          +x
-      │    │             estimated row count  333 (missing stats)   ·            ·
-      │    │             filter               (x % 2) = 0           ·            ·
-      │    └── scan      ·                    ·                     (x)          +x
-      │                  estimated row count  1000 (missing stats)  ·            ·
-      │                  table                numtosquare@primary   ·            ·
-      │                  spans                FULL SCAN             ·            ·
-      └── filter         ·                    ·                     (y, str)     +y
-           │             estimated row count  333 (missing stats)   ·            ·
-           │             filter               (y % 2) = 0           ·            ·
-           └── scan      ·                    ·                     (y, str)     +y
-·                        estimated row count  1000 (missing stats)  ·            ·
-·                        table                numtostr@primary      ·            ·
-·                        spans                FULL SCAN             ·            ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (x, str)
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (x, y, str)
+    │ estimated row count: 333 (missing stats)
+    │ equality: (x) = (y)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(x=y)"
+    │
+    ├── • filter
+    │   │ columns: (x)
+    │   │ ordering: +x
+    │   │ estimated row count: 333 (missing stats)
+    │   │ filter: (x % 2) = 0
+    │   │
+    │   └── • scan
+    │         columns: (x)
+    │         ordering: +x
+    │         estimated row count: 1000 (missing stats)
+    │         table: numtosquare@primary
+    │         spans: FULL SCAN
+    │
+    └── • filter
+        │ columns: (y, str)
+        │ ordering: +y
+        │ estimated row count: 333 (missing stats)
+        │ filter: (y % 2) = 0
+        │
+        └── • scan
+              columns: (y, str)
+              ordering: +y
+              estimated row count: 1000 (missing stats)
+              table: numtostr@primary
+              spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]
@@ -152,15 +168,17 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr WHERE y < 1000 OR y > 
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkEEPk0AQhe_-isl4aZNtWGp6YE_VFiMJLRVI1FQOK0wqCbC4uySShv9ugKqtidXjvnnf2zdzRfOtQoGJH_q7FDpdwds4OsDZ_3gKXwdHWOyDJE3eh0u4WfrZ0HS1VcZq-PDOj31Y9PC54_xVDi7nfAlR_Esi8G7S3o_hzSfoYe8nOwiDQ5DCJkOGjSroKGsyKM7oIsMNZgxbrXIyRulRvk6moPiOgjMsm7azo5wxzJUmFFe0pa0IBR7VSrXOmFKQlWU12QaGqrO_IWPlhVCsB3YX7D4PTuWXimKSBWmHP8Tjz2tsW13WUvfIMGllYwSsHM_znJcgmwJcUPYraWQYdVbAduwYlnVpYYN_a-g-NPzH6jGZVjWG_mt3PmQMqbjQfF6jOp3TSat8-mZ-RhM3CQUZO0_X8yNo5tFY8B52n8L8DzgbXvwIAAD__-xGysw=
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
-·     distribution         full                  ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (x)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                numtosquare@primary   ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: full
+vectorized: true
+·
+• scan
+  columns: (x)
+  estimated row count: 1000 (missing stats)
+  table: numtosquare@primary
+  spans: FULL SCAN
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.
@@ -169,44 +187,60 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToS
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyMT01L80AYvL-_YplT-7pi43FPFa0QqG1tchDKHtbsQwkku-l-QCTkv0uyinoQPC3zsTPzDPCXBgLFZru5L1l0DXs87p_YafNy2N7lO7Z4yIuyeN4u2YelT4bFJ-Tslv2fnp5dsSyJJrbB-ktUjpYSHMZq2qmWPMQJGSRH52xF3ls3UcNsyHUPseKoTRfDREuOyjqCGBDq0BAESvXa0JGUJnezAoemoOpmjv3Wue5c3Sr3Bo6iU8YLdg2OfQyCrTPIkcPG8FXigzoTRDbyvw85ku-s8fRjw2_Jq1FykD5TOtbb6Co6OFvNNQnu538zocmHpGYJ5CZJoxz_vQcAAP__tjyKSg==
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res
 ----
-·               distribution         full                  ·              ·
-·               vectorized           true                  ·              ·
-sort            ·                    ·                     (y, str, res)  +res
- │              estimated row count  1000 (missing stats)  ·              ·
- │              order                +res                  ·              ·
- └── render     ·                    ·                     (res, y, str)  ·
-      │         estimated row count  1000 (missing stats)  ·              ·
-      │         render 0             repeat('test', y)     ·              ·
-      │         render 1             y                     ·              ·
-      │         render 2             str                   ·              ·
-      └── scan  ·                    ·                     (y, str)       ·
-·               estimated row count  1000 (missing stats)  ·              ·
-·               table                numtostr@primary      ·              ·
-·               spans                FULL SCAN             ·              ·
+distribution: full
+vectorized: true
+·
+• sort
+│ columns: (y, str, res)
+│ ordering: +res
+│ estimated row count: 1000 (missing stats)
+│ order: +res
+│
+└── • render
+    │ columns: (res, y, str)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: repeat('test', y)
+    │ render 1: y
+    │ render 2: str
+    │
+    └── • scan
+          columns: (y, str)
+          estimated row count: 1000 (missing stats)
+          table: numtostr@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
 ----
-·                    distribution         full                  ·              ·
-·                    vectorized           true                  ·              ·
-limit                ·                    ·                     (y, str, res)  ·
- │                   estimated row count  10 (missing stats)    ·              ·
- │                   count                10                    ·              ·
- └── sort            ·                    ·                     (res, y, str)  +res
-      │              estimated row count  1000 (missing stats)  ·              ·
-      │              order                +res                  ·              ·
-      └── render     ·                    ·                     (res, y, str)  ·
-           │         estimated row count  1000 (missing stats)  ·              ·
-           │         render 0             repeat('test', y)     ·              ·
-           │         render 1             y                     ·              ·
-           │         render 2             str                   ·              ·
-           └── scan  ·                    ·                     (y, str)       ·
-·                    estimated row count  1000 (missing stats)  ·              ·
-·                    table                numtostr@primary      ·              ·
-·                    spans                FULL SCAN             ·              ·
+distribution: full
+vectorized: true
+·
+• limit
+│ columns: (y, str, res)
+│ estimated row count: 10 (missing stats)
+│ count: 10
+│
+└── • sort
+    │ columns: (res, y, str)
+    │ ordering: +res
+    │ estimated row count: 1000 (missing stats)
+    │ order: +res
+    │
+    └── • render
+        │ columns: (res, y, str)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: repeat('test', y)
+        │ render 1: y
+        │ render 2: str
+        │
+        └── • scan
+              columns: (y, str)
+              estimated row count: 1000 (missing stats)
+              table: numtostr@primary
+              spans: FULL SCAN
 
 # Regression test for #20481.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
@@ -30,17 +30,21 @@ NULL       /2       {1}       1
 /6         /7       {4}       4
 /7         NULL     {5}       5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY
 ----
-·           distribution         local                 ·                        ·
-·           vectorized           true                  ·                        ·
-ordinality  ·                    ·                     (x, y, z, "ordinality")  ·
- │          estimated row count  1000 (missing stats)  ·                        ·
- └── scan   ·                    ·                     (x, y, z)                ·
-·           estimated row count  1000 (missing stats)  ·                        ·
-·           table                xyz@primary           ·                        ·
-·           spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• ordinality
+│ columns: (x, y, z, "ordinality")
+│ estimated row count: 1000 (missing stats)
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1000 (missing stats)
+      table: xyz@primary
+      spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -133,69 +133,69 @@ NULL       /0         {1}       1
 
 # Secondary index should not be tightened.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE b <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE b <= 3] WHERE info LIKE '%spans%'
 ----
--/4
+  spans: -/4
 
 # Partial predicate on primary key should not be tightened.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3] WHERE info LIKE '%spans%'
 ----
--/4
+  spans: -/4
 
 # Tighten end key if span contains full primary key.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3 AND b <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3 AND b <= 3] WHERE info LIKE '%spans%'
 ----
--/3/3/#
+      spans: -/3/3/#
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3 AND b < 4] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 3 AND b < 4] WHERE info LIKE '%spans%'
 ----
--/3/3/#
+      spans: -/3/3/#
 
 # Mixed bounds.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a >= 2 AND b <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a >= 2 AND b <= 3] WHERE info LIKE '%spans%'
 ----
-/2-
+      spans: /2-
 
 # Edge cases.
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 0 AND b <= 0] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= 0 AND b <= 0] WHERE info LIKE '%spans%'
 ----
--/0/0/#
+      spans: -/0/0/#
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= -1 AND b <= -1] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a <= -1 AND b <= -1] WHERE info LIKE '%spans%'
 ----
--/-1/-1/#
+      spans: -/-1/-1/#
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808] WHERE info LIKE '%spans%'
 ----
-/1-/1/-9223372036854775808/#
+  spans: /1-/1/-9223372036854775808/#
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807] WHERE info LIKE '%spans%'
 ----
-/1-/1/9223372036854775807/#
+  spans: /1-/1/9223372036854775807/#
 
 # Table c1 (interleaved table)
 
 # Partial primary key does not tighten.
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM c1 WHERE a <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM c1 WHERE a <= 3] WHERE info LIKE '%spans%'
 ----
--/4
+  spans: -/4
 
 # Tighten span on fully primary key.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM c1 WHERE a <= 3 AND b <= 3] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM c1 WHERE a <= 3 AND b <= 3] WHERE info LIKE '%spans%'
 ----
--/3/3/#/54/1/#
+      spans: -/3/3/#/54/1/#
 
 # Table p2 with interleaved index.
 
@@ -203,16 +203,16 @@ SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM c1 WHERE a <= 3 AND b <
 
 # Lower bound (i >= 2)
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2 WHERE i >= 2] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2 WHERE i >= 2] WHERE info LIKE '%spans%'
 ----
-/2-
+  spans: /2-
 
 # Upper bound (i <= 5)
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2 WHERE i <= 5] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2 WHERE i <= 5] WHERE info LIKE '%spans%'
 ----
--/5/#
+  spans: -/5/#
 
 # From the interleaved index: no tightening at all.
 
@@ -220,53 +220,53 @@ SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2 WHERE i <= 5] WHERE 
 
 # Note 53/2 refers to the 2nd index (after primary index) of table p2.
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2] WHERE info LIKE '%spans%'
 ----
-/1/#/55/2/2-
+      spans: /1/#/55/2/2-
 
 # Upper bound (i <= 6 AND d <= 5)
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5] WHERE info LIKE '%spans%'
 ----
--/6/#/55/2/6
+      spans: -/6/#/55/2/6
 
 # IS NULL
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL] WHERE info LIKE '%spans%'
 ----
-/1/#/55/2/NULL-
+      spans: /1/#/55/2/NULL-
 
 # IS NOT NULL
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL] WHERE info LIKE '%spans%'
 ----
-/1/#/55/2/!NULL-
+      spans: /1/#/55/2/!NULL-
 
 # String table
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM bytes_t WHERE a = 'a'] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM bytes_t WHERE a = 'a'] WHERE info LIKE '%spans%'
 ----
-/"a"-/"a"/#
+  spans: /"a"-/"a"/#
 
 # No tightening.
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM bytes_t WHERE a < 'aa'] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM bytes_t WHERE a < 'aa'] WHERE info LIKE '%spans%'
 ----
--/"aa"
+  spans: -/"aa"
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM decimal_t WHERE a = 1.00] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM decimal_t WHERE a = 1.00] WHERE info LIKE '%spans%'
 ----
-/1-/1/#
+  spans: /1-/1/#
 
 # No tightening.
 
 query T
-SELECT description FROM [EXPLAIN (VERBOSE) SELECT * FROM decimal_t WHERE a < 2] WHERE field = 'spans'
+SELECT info FROM [EXPLAIN (VERBOSE) SELECT * FROM decimal_t WHERE a < 2] WHERE info LIKE '%spans%'
 ----
--/2
+  spans: -/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1,63 +1,67 @@
 # LogicTest: local
 
-query TTT colnames
+query T
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-tree    field         description
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
-query TTT colnames
+query T
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
-tree    field         description
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
-query TTT colnames
+query T
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
 ----
-tree       field          description
-·          distribution   local
-·          vectorized     true
-render     ·              ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          jobs@jobs_status_created_idx
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • scan
+      missing stats
+      table: jobs@jobs_status_created_idx
+      spans: FULL SCAN
 
-query TTTTT colnames
+query T
 EXPLAIN (PLAN, VERBOSE) SELECT 1 a
 ----
-tree    field          description      columns  ordering
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (a)      ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  1                ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a)
+  size: 1 column, 1 row
+  row 0, expr 0: 1
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE,PLAN) SELECT 1 a
 ----
-tree    field          description      columns  ordering
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (a)      ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  1                ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a)
+  size: 1 column, 1 row
+  row 0, expr 0: 1
 
 
-query TTTTT colnames
+query T
 EXPLAIN (TYPES) SELECT 1 a
 ----
-tree    field          description      columns  ordering
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (a int)  ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  (1)[int]         ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a int)
+  size: 1 column, 1 row
+  row 0, expr 0: (1)[int]
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (PLAN,PLAN) SELECT 1
@@ -82,375 +86,478 @@ EXPLAIN (TYPES) SELECT $1
 
 
 # Ensure that all relevant statement types can be explained
-query TTT
+query T
 EXPLAIN CREATE DATABASE foo
 ----
-·                distribution  local
-·                vectorized    false
-create database  ·             ·
+distribution: local
+vectorized: false
+·
+• create database
 
-query TTT
+query T
 EXPLAIN CREATE TABLE foo (x INT)
 ----
-·             distribution  local
-·             vectorized    false
-create table  ·             ·
+distribution: local
+vectorized: false
+·
+• create table
 
 statement ok
 CREATE TABLE foo (x INT)
 
-query TTT
+query T
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
-·             distribution  local
-·             vectorized    false
-create index  ·             ·
+distribution: local
+vectorized: false
+·
+• create index
 
 statement ok
 CREATE DATABASE foo
 
-query TTT
+query T
 EXPLAIN DROP DATABASE foo
 ----
-·              distribution  local
-·              vectorized    false
-drop database  ·             ·
+distribution: local
+vectorized: false
+·
+• drop database
 
 # explain SHOW JOBS - beware to test this before the CREATE INDEX
 # below, otherwise the result becomes non-deterministic.
 # Migrations with backfill will affect the number of rows.
-query TTT
-SELECT * FROM [EXPLAIN SHOW JOBS] WHERE field != 'size' AND field != 'filter'
+query T
+SELECT * FROM [EXPLAIN SHOW JOBS] WHERE info NOT LIKE '%size%' AND info NOT LIKE '%filter%'
 ----
-·                             distribution  local
-·                             vectorized    false
-sort                          ·             ·
- │                            order         -column18,-started
- └── render                   ·             ·
-      └── filter              ·             ·
-           └── virtual table  ·             ·
-·                             table         jobs@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: -column18,-started
+│
+└── • render
+    │
+        │
+        └── • virtual table
+              table: jobs@primary
 
 statement ok
 CREATE INDEX a ON foo(x)
 
-query TTT
+query T
 EXPLAIN DROP INDEX foo@a
 ----
-·           distribution  local
-·           vectorized    false
-drop index  ·             ·
+distribution: local
+vectorized: false
+·
+• drop index
 
-query TTT
+query T
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
-·            distribution  local
-·            vectorized    false
-alter table  ·             ·
+distribution: local
+vectorized: false
+·
+• alter table
 
-query TTT
-SELECT tree, field, description FROM [EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)]
+query T
+EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)
 ----
-·            distribution         local
-·            vectorized           false
-split        ·                    ·
- │           estimated row count  10 (missing stats)
- └── values  ·                    ·
-·            size                 1 column, 1 row
-·            row 0, expr 0        42
+distribution: local
+vectorized: false
+·
+• split
+│ columns: (key, pretty, split_enforced_until)
+│ estimated row count: 10 (missing stats)
+│
+└── • values
+      columns: (column1)
+      size: 1 column, 1 row
+      row 0, expr 0: 42
 
-query TTT
+query T
 EXPLAIN DROP TABLE foo
 ----
-·           distribution  local
-·           vectorized    false
-drop table  ·             ·
+distribution: local
+vectorized: false
+·
+• drop table
 
-query TTT
+query T
 EXPLAIN SHOW DATABASES
 ----
-·                   distribution  local
-·                   vectorized    false
-sort                ·             ·
- │                  order         +name
- └── virtual table  ·             ·
-·                   table         databases@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +name
+│
+└── • virtual table
+      table: databases@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW TABLES] WHERE info NOT LIKE '%size%'
 ----
-·                                                      distribution  local
-·                                                      vectorized    false
-sort                                                   ·             ·
- │                                                     order         +nspname,+relname
- └── render                                            ·             ·
-      └── hash join (left outer)                       ·             ·
-           │                                           equality      (column59) = (table_id)
-           ├── render                                  ·             ·
-           │    └── hash join (right outer)            ·             ·
-           │         │                                 equality      (oid) = (relowner)
-           │         ├── virtual table                 ·             ·
-           │         │                                 table         pg_roles@primary
-           │         └── hash join                     ·             ·
-           │              │                            equality      (oid) = (relnamespace)
-           │              ├── filter                   ·             ·
-           │              │    │                       filter        nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-           │              │    └── virtual table       ·             ·
-           │              │                            table         pg_namespace@primary
-           │              └── hash join (left outer)   ·             ·
-           │                   │                       equality      (oid) = (objoid)
-           │                   ├── filter              ·             ·
-           │                   │    │                  filter        relkind IN ('S', 'm', 'r', 'v')
-           │                   │    └── virtual table  ·             ·
-           │                   │                       table         pg_class@primary
-           │                   └── filter              ·             ·
-           │                        │                  filter        objsubid = 0
-           │                        └── virtual table  ·             ·
-           │                                           table         pg_description@primary
-           └── virtual table                           ·             ·
-·                                                      table         table_row_statistics@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +nspname,+relname
+│
+└── • render
+    │
+    └── • hash join (left outer)
+        │ equality: (column59) = (table_id)
+        │
+        ├── • render
+        │   │
+        │   └── • hash join (right outer)
+        │       │ equality: (oid) = (relowner)
+        │       │
+        │       ├── • virtual table
+        │       │     table: pg_roles@primary
+        │       │
+        │       └── • hash join
+        │           │ equality: (oid) = (relnamespace)
+        │           │
+        │           ├── • filter
+        │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+        │           │   │
+        │           │   └── • virtual table
+        │           │         table: pg_namespace@primary
+        │           │
+        │           └── • hash join (left outer)
+        │               │ equality: (oid) = (objoid)
+        │               │
+        │               ├── • filter
+        │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
+        │               │   │
+        │               │   └── • virtual table
+        │               │         table: pg_class@primary
+        │               │
+        │               └── • filter
+        │                   │ filter: objsubid = 0
+        │                   │
+        │                   └── • virtual table
+        │                         table: pg_description@primary
+        │
+        └── • virtual table
+              table: table_row_statistics@primary
 
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE info NOT LIKE '%size%'
 ----
-·                                                      distribution  local
-·                                                      vectorized    false
-sort                                                   ·             ·
- │                                                     order         +nspname,+relname
- └── render                                            ·             ·
-      └── hash join (left outer)                       ·             ·
-           │                                           equality      (column59) = (table_id)
-           ├── render                                  ·             ·
-           │    └── hash join (right outer)            ·             ·
-           │         │                                 equality      (oid) = (relowner)
-           │         ├── virtual table                 ·             ·
-           │         │                                 table         pg_roles@primary
-           │         └── hash join                     ·             ·
-           │              │                            equality      (oid) = (relnamespace)
-           │              ├── filter                   ·             ·
-           │              │    │                       filter        nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-           │              │    └── virtual table       ·             ·
-           │              │                            table         pg_namespace@primary
-           │              └── hash join (left outer)   ·             ·
-           │                   │                       equality      (oid) = (objoid)
-           │                   ├── filter              ·             ·
-           │                   │    │                  filter        relkind IN ('S', 'm', 'r', 'v')
-           │                   │    └── virtual table  ·             ·
-           │                   │                       table         pg_class@primary
-           │                   └── filter              ·             ·
-           │                        │                  filter        objsubid = 0
-           │                        └── virtual table  ·             ·
-           │                                           table         pg_description@primary
-           └── virtual table                           ·             ·
-·                                                      table         table_row_statistics@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +nspname,+relname
+│
+└── • render
+    │
+    └── • hash join (left outer)
+        │ equality: (column59) = (table_id)
+        │
+        ├── • render
+        │   │
+        │   └── • hash join (right outer)
+        │       │ equality: (oid) = (relowner)
+        │       │
+        │       ├── • virtual table
+        │       │     table: pg_roles@primary
+        │       │
+        │       └── • hash join
+        │           │ equality: (oid) = (relnamespace)
+        │           │
+        │           ├── • filter
+        │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+        │           │   │
+        │           │   └── • virtual table
+        │           │         table: pg_namespace@primary
+        │           │
+        │           └── • hash join (left outer)
+        │               │ equality: (oid) = (objoid)
+        │               │
+        │               ├── • filter
+        │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
+        │               │   │
+        │               │   └── • virtual table
+        │               │         table: pg_class@primary
+        │               │
+        │               └── • filter
+        │                   │ filter: objsubid = 0
+        │                   │
+        │                   └── • virtual table
+        │                         table: pg_description@primary
+        │
+        └── • virtual table
+              table: table_row_statistics@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'database'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'database'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW SCHEMAS] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW SCHEMAS] WHERE info NOT LIKE '%size%'
 ----
-·                                  distribution  local
-·                                  vectorized    false
-sort                               ·             ·
- │                                 order         +nspname
- └── hash join (right outer)       ·             ·
-      │                            equality      (oid) = (nspowner)
-      ├── virtual table            ·             ·
-      │                            table         pg_roles@primary
-      └── hash join                ·             ·
-           │                       equality      (nspname) = (schema_name)
-           ├── virtual table       ·             ·
-           │                       table         pg_namespace@primary
-           └── filter              ·             ·
-                │                  filter        catalog_name = 'test'
-                └── virtual table  ·             ·
-·                                  table         schemata@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +nspname
+│
+└── • hash join (right outer)
+    │ equality: (oid) = (nspowner)
+    │
+    ├── • virtual table
+    │     table: pg_roles@primary
+    │
+    └── • hash join
+        │ equality: (nspname) = (schema_name)
+        │
+        ├── • virtual table
+        │     table: pg_namespace@primary
+        │
+        └── • filter
+            │ filter: catalog_name = 'test'
+            │
+            └── • virtual table
+                  table: schemata@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'timezone'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'timezone'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'default_transaction_isolation'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'default_transaction_isolation'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'default_transaction_priority'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'default_transaction_priority'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'transaction_isolation'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'transaction_isolation'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE info NOT LIKE '%size%'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        variable = 'transaction_priority'
- └── virtual table  ·             ·
-·                   table         session_variables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'transaction_priority'
+│
+└── • virtual table
+      table: session_variables@primary
 
-query TTT
+query T
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-·                                       distribution  local
-·                                       vectorized    false
-render                                  ·             ·
- └── group                              ·             ·
-      │                                 group by      column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
-      │                                 ordered       +ordinal_position
-      └── sort                          ·             ·
-           │                            order         +ordinal_position
-           └── hash join (left outer)   ·             ·
-                │                       equality      (column_name) = (column_name)
-                ├── filter              ·             ·
-                │    │                  filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-                │    └── virtual table  ·             ·
-                │                       table         columns@primary
-                └── filter              ·             ·
-                     │                  filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-                     └── virtual table  ·             ·
-·                                       table         statistics@primary
+distribution: local
+vectorized: false
+·
+• render
+│
+└── • group
+    │ group by: column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
+    │ ordered: +ordinal_position
+    │
+    └── • sort
+        │ order: +ordinal_position
+        │
+        └── • hash join (left outer)
+            │ equality: (column_name) = (column_name)
+            │
+            ├── • filter
+            │   │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+            │   │
+            │   └── • virtual table
+            │         table: columns@primary
+            │
+            └── • filter
+                │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+                │
+                └── • virtual table
+                      table: statistics@primary
 
-query TTT
-SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE field != 'size'
+query T
+SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE info NOT LIKE '%size%'
 ----
-·                        distribution  local
-·                        vectorized    false
-sort                     ·             ·
- │                       order         +grantee,+privilege_type
- └── filter              ·             ·
-      │                  filter        (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
-      └── virtual table  ·             ·
-·                        table         table_privileges@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +grantee,+privilege_type
+│
+└── • filter
+    │ filter: (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
+    │
+    └── • virtual table
+          table: table_privileges@primary
 
-query TTT
+query T
 EXPLAIN SHOW INDEX FROM foo
 ----
-·                        distribution  local
-·                        vectorized    false
-render                   ·             ·
- └── filter              ·             ·
-      │                  filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-      └── virtual table  ·             ·
-·                        table         statistics@primary
+distribution: local
+vectorized: false
+·
+• render
+│
+└── • filter
+    │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+    │
+    └── • virtual table
+          table: statistics@primary
 
-query TTT
+query T
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-·                                         distribution  local
-·                                         vectorized    false
-sort                                      ·             ·
- │                                        order         +conname
- └── render                               ·             ·
-      └── hash join                       ·             ·
-           │                              equality      (relnamespace) = (oid)
-           ├── virtual table lookup join  ·             ·
-           │    │                         table         pg_constraint@pg_constraint_conrelid_idx
-           │    │                         equality      (oid) = (conrelid)
-           │    └── filter                ·             ·
-           │         │                    filter        relname = 'foo'
-           │         └── virtual table    ·             ·
-           │                              table         pg_class@primary
-           └── filter                     ·             ·
-                │                         filter        nspname = 'public'
-                └── virtual table         ·             ·
-·                                         table         pg_namespace@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +conname
+│
+└── • render
+    │
+    └── • hash join
+        │ equality: (relnamespace) = (oid)
+        │
+        ├── • virtual table lookup join
+        │   │ table: pg_constraint@pg_constraint_conrelid_idx
+        │   │ equality: (oid) = (conrelid)
+        │   │
+        │   └── • filter
+        │       │ filter: relname = 'foo'
+        │       │
+        │       └── • virtual table
+        │             table: pg_class@primary
+        │
+        └── • filter
+            │ filter: nspname = 'public'
+            │
+            └── • virtual table
+                  table: pg_namespace@primary
 
-query TTT
+query T
 EXPLAIN SHOW USERS
 ----
-·                                                                distribution       local
-·                                                                vectorized         true
-sort                                                             ·                  ·
- │                                                               order              +username
- └── render                                                      ·                  ·
-      └── group                                                  ·                  ·
-           │                                                     group by           username
-           └── sort                                              ·                  ·
-                │                                                order              +role
-                └── hash join (left outer)                       ·                  ·
-                     │                                           equality           (username) = (member)
-                     │                                           left cols are key  ·
-                     ├── group                                   ·                  ·
-                     │    │                                      group by           username
-                     │    └── window                             ·                  ·
-                     │         └── render                        ·                  ·
-                     │              └── merge join (left outer)  ·                  ·
-                     │                   │                       equality           (username) = (username)
-                     │                   │                       left cols are key  ·
-                     │                   ├── scan                ·                  ·
-                     │                   │                       missing stats      ·
-                     │                   │                       table              users@primary
-                     │                   │                       spans              FULL SCAN
-                     │                   └── scan                ·                  ·
-                     │                                           missing stats      ·
-                     │                                           table              role_options@primary
-                     │                                           spans              FULL SCAN
-                     └── scan                                    ·                  ·
-·                                                                missing stats      ·
-·                                                                table              role_members@role_members_role_idx
-·                                                                spans              FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +username
+│
+└── • render
+    │
+    └── • group
+        │ group by: username
+        │
+        └── • sort
+            │ order: +role
+            │
+            └── • hash join (left outer)
+                │ equality: (username) = (member)
+                │ left cols are key
+                │
+                ├── • group
+                │   │ group by: username
+                │   │
+                │   └── • window
+                │       │
+                │       └── • render
+                │           │
+                │           └── • merge join (left outer)
+                │               │ equality: (username) = (username)
+                │               │ left cols are key
+                │               │
+                │               ├── • scan
+                │               │     missing stats
+                │               │     table: users@primary
+                │               │     spans: FULL SCAN
+                │               │
+                │               └── • scan
+                │                     missing stats
+                │                     table: role_options@primary
+                │                     spans: FULL SCAN
+                │
+                └── • scan
+                      missing stats
+                      table: role_members@role_members_role_idx
+                      spans: FULL SCAN
 
 # EXPLAIN selecting from a sequence.
 statement ok
 CREATE SEQUENCE select_test
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM select_test
 ----
-tree             field                description  columns                           ordering
-·                distribution         local        ·                                 ·
-·                vectorized           false        ·                                 ·
-sequence select  ·                    ·            (last_value, log_cnt, is_called)  ·
-·                estimated row count  1            ·                                 ·
+distribution: local
+vectorized: false
+·
+• sequence select
+  columns: (last_value, log_cnt, is_called)
+  estimated row count: 1
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT @1 FROM select_test
 ----
-tree                  field                description  columns                           ordering
-·                     distribution         local        ·                                 ·
-·                     vectorized           false        ·                                 ·
-render                ·                    ·            ("?column?")                      ·
- │                    estimated row count  1            ·                                 ·
- │                    render 0             last_value   ·                                 ·
- └── sequence select  ·                    ·            (last_value, log_cnt, is_called)  ·
-·                     estimated row count  1            ·                                 ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1
+│ render 0: last_value
+│
+└── • sequence select
+      columns: (last_value, log_cnt, is_called)
+      estimated row count: 1
 
 statement ok
 CREATE TABLE t (
@@ -459,352 +566,435 @@ CREATE TABLE t (
   FAMILY "primary" (k, v)
 )
 
-query TTT
+query T
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-·                 distribution  local
-·                 vectorized    false
-insert fast path  ·             ·
-·                 into          t(k, v)
-·                 auto commit   ·
-·                 size          2 columns, 1 row
-
-query I
-SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
-----
-0
+distribution: local
+vectorized: false
+·
+• insert fast path
+  into: t(k, v)
+  auto commit
+  size: 2 columns, 1 row
 
 statement ok
 INSERT INTO t VALUES (1, 2)
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (k, v)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, v)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/1 - /1] [/3 - /3]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/1 - /1] [/3 - /3]
 
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY)
 
-query TTT
+query T
 EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
 ----
-·            distribution           local
-·            vectorized             true
-lookup join  ·                      ·
- │           table                  t2@primary
- │           equality               (k) = (x)
- │           equality cols are key  ·
- └── scan    ·                      ·
-·            missing stats          ·
-·            table                  t@primary
-·            spans                  FULL SCAN
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: t2@primary
+│ equality: (k) = (x)
+│ equality cols are key
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (k, v)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               (k % 2) = 0           ·       ·
- └── scan  ·                    ·                     (k, v)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k, v)
+│ estimated row count: 333 (missing stats)
+│ filter: (k % 2) = 0
+│
+└── • scan
+      columns: (k, v)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distribution  local
-·       vectorized    false
-values  ·             ·
-·       size          3 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• values
+  size: 3 columns, 2 rows
 
-query TTT
+query T
 EXPLAIN VALUES (1)
 ----
-·       distribution  local
-·       vectorized    false
-values  ·             ·
-·       size          1 column, 1 row
+distribution: local
+vectorized: false
+·
+• values
+  size: 1 column, 1 row
 
-query TTT
-SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1]
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
-·                distribution         local
-·                vectorized           true
-limit            ·                    ·
- │               estimated row count  1 (missing stats)
- │               offset               1
- └── ordinality  ·                    ·
-      │          estimated row count  2 (missing stats)
-      └── scan   ·                    ·
-·                estimated row count  2 (missing stats)
-·                table                t@primary
-·                spans                LIMITED SCAN
-·                limit                2
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, v, "ordinality")
+│ estimated row count: 1 (missing stats)
+│ offset: 1
+│
+└── • ordinality
+    │ columns: (k, v, "ordinality")
+    │ estimated row count: 2 (missing stats)
+    │
+    └── • scan
+          columns: (k, v)
+          estimated row count: 2 (missing stats)
+          table: t@primary
+          spans: LIMITED SCAN
+          limit: 2
 
-query TTT
+query T
 EXPLAIN SELECT DISTINCT v FROM t
 ----
-·          distribution   local
-·          vectorized     true
-distinct   ·              ·
- │         distinct on    v
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: v
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
-SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
+query T
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1
 ----
-·                    distribution         local
-·                    vectorized           true
-limit                ·                    ·
- │                   estimated row count  1 (missing stats)
- │                   offset               1
- └── limit           ·                    ·
-      │              estimated row count  2 (missing stats)
-      │              count                2
-      └── distinct   ·                    ·
-           │         estimated row count  100 (missing stats)
-           │         distinct on          v
-           └── scan  ·                    ·
-·                    estimated row count  1000 (missing stats)
-·                    table                t@primary
-·                    spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (v)
+│ estimated row count: 1 (missing stats)
+│ offset: 1
+│
+└── • limit
+    │ columns: (v)
+    │ estimated row count: 2 (missing stats)
+    │ count: 2
+    │
+    └── • distinct
+        │ columns: (v)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: v
+        │
+        └── • scan
+              columns: (v)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-·                distribution         local               ·           ·
-·                vectorized           true                ·           ·
-sort             ·                    ·                   (a, b)      +b
- │               estimated row count  10 (missing stats)  ·           ·
- │               order                +b                  ·           ·
- └── index join  ·                    ·                   (a, b)      ·
-      │          estimated row count  10 (missing stats)  ·           ·
-      │          table                tc@primary          ·           ·
-      │          key columns          rowid               ·           ·
-      └── scan   ·                    ·                   (a, rowid)  ·
-·                estimated row count  10 (missing stats)  ·           ·
-·                table                tc@c                ·           ·
-·                spans                /10-/11             ·           ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b)
+│ ordering: +b
+│ estimated row count: 10 (missing stats)
+│ order: +b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 10 (missing stats)
+    │ table: tc@primary
+    │ key columns: rowid
+    │
+    └── • scan
+          columns: (a, rowid)
+          estimated row count: 10 (missing stats)
+          table: tc@c
+          spans: /10-/11
 
-query TTTTT colnames
+query T
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-tree              field                description        columns  ordering
-·                 distribution         local              ·        ·
-·                 vectorized           false              ·        ·
-insert fast path  ·                    ·                  ()       ·
-·                 estimated row count  0 (missing stats)  ·        ·
-·                 into                 t(k, v)            ·        ·
-·                 auto commit          ·                  ·        ·
-·                 size                 2 columns, 1 row   ·        ·
-·                 row 0, expr 0        (1)[int]           ·        ·
-·                 row 0, expr 1        (2)[int]           ·        ·
+distribution: local
+vectorized: false
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: t(k, v)
+  auto commit
+  size: 2 columns, 1 row
+  row 0, expr 0: (1)[int]
+  row 0, expr 1: (2)[int]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT 42 AS a
 ----
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (a int)  ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  (42)[int]        ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a int)
+  size: 1 column, 1 row
+  row 0, expr 0: (42)[int]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-·     distribution         local                 ·               ·
-·     vectorized           true                  ·               ·
-scan  ·                    ·                     (k int, v int)  ·
-·     estimated row count  1000 (missing stats)  ·               ·
-·     table                t@primary             ·               ·
-·     spans                FULL SCAN             ·               ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k int, v int)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ----
-·     distribution         local                 ·        ·
-·     vectorized           true                  ·        ·
-scan  ·                    ·                     (k int)  ·
-·     estimated row count  1000 (missing stats)  ·        ·
-·     table                t@primary             ·        ·
-·     spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k int)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-·          distribution         local                          ·               ·
-·          vectorized           true                           ·               ·
-filter     ·                    ·                              (k int, v int)  ·
- │         estimated row count  333 (missing stats)            ·               ·
- │         filter               ((v)[int] > (123)[int])[bool]  ·               ·
- └── scan  ·                    ·                              (k int, v int)  ·
-·          estimated row count  1000 (missing stats)           ·               ·
-·          table                t@primary                      ·               ·
-·          spans                FULL SCAN                      ·               ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k int, v int)
+│ estimated row count: 333 (missing stats)
+│ filter: ((v)[int] > (123)[int])[bool]
+│
+└── • scan
+      columns: (k int, v int)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distribution   local              ·                                        ·
-·       vectorized     false              ·                                        ·
-values  ·              ·                  (column1 int, column2 int, column3 int)  ·
-·       size           3 columns, 2 rows  ·                                        ·
-·       row 0, expr 0  (1)[int]           ·                                        ·
-·       row 0, expr 1  (2)[int]           ·                                        ·
-·       row 0, expr 2  (3)[int]           ·                                        ·
-·       row 1, expr 0  (4)[int]           ·                                        ·
-·       row 1, expr 1  (5)[int]           ·                                        ·
-·       row 1, expr 2  (6)[int]           ·                                        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (column1 int, column2 int, column3 int)
+  size: 3 columns, 2 rows
+  row 0, expr 0: (1)[int]
+  row 0, expr 1: (2)[int]
+  row 0, expr 2: (3)[int]
+  row 1, expr 0: (4)[int]
+  row 1, expr 1: (5)[int]
+  row 1, expr 2: (6)[int]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND count(k)>1
 ----
-·            distribution         local                           ·                   ·
-·            vectorized           true                            ·                   ·
-render       ·                    ·                               (z int, v int)      ·
- │           estimated row count  0                               ·                   ·
- │           render 0             ((count)[int] * (2)[int])[int]  ·                   ·
- │           render 1             (v)[int]                        ·                   ·
- └── norows  ·                    ·                               (v int, count int)  ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (z int, v int)
+│ estimated row count: 0
+│ render 0: ((count)[int] * (2)[int])[int]
+│ render 1: (v)[int]
+│
+└── • norows
+      columns: (v int, count int)
 
-query TTTTT
+query T
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-·                    distribution         local                        ·               ·
-·                    vectorized           false                        ·               ·
-delete               ·                    ·                            ()              ·
- │                   estimated row count  0 (missing stats)            ·               ·
- │                   from                 t                            ·               ·
- │                   auto commit          ·                            ·               ·
- └── project         ·                    ·                            (k int)         ·
-      └── filter     ·                    ·                            (k int, v int)  ·
-           │         estimated row count  333 (missing stats)          ·               ·
-           │         filter               ((v)[int] > (1)[int])[bool]  ·               ·
-           └── scan  ·                    ·                            (k int, v int)  ·
-·                    estimated row count  1000 (missing stats)         ·               ·
-·                    table                t@primary                    ·               ·
-·                    spans                FULL SCAN                    ·               ·
+distribution: local
+vectorized: false
+·
+• delete
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ from: t
+│ auto commit
+│
+└── • project
+    │ columns: (k int)
+    │
+    └── • filter
+        │ columns: (k int, v int)
+        │ estimated row count: 333 (missing stats)
+        │ filter: ((v)[int] > (1)[int])[bool]
+        │
+        └── • scan
+              columns: (k int, v int)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-·                    distribution         local                          ·                          ·
-·                    vectorized           false                          ·                          ·
-update               ·                    ·                              ()                         ·
- │                   estimated row count  0 (missing stats)              ·                          ·
- │                   table                t                              ·                          ·
- │                   set                  v                              ·                          ·
- │                   auto commit          ·                              ·                          ·
- └── render          ·                    ·                              (k int, v int, v_new int)  ·
-      │              estimated row count  333 (missing stats)            ·                          ·
-      │              render 0             ((k)[int] + (1)[int])[int]     ·                          ·
-      │              render 1             (k)[int]                       ·                          ·
-      │              render 2             (v)[int]                       ·                          ·
-      └── filter     ·                    ·                              (k int, v int)             ·
-           │         estimated row count  333 (missing stats)            ·                          ·
-           │         filter               ((v)[int] > (123)[int])[bool]  ·                          ·
-           └── scan  ·                    ·                              (k int, v int)             ·
-·                    estimated row count  1000 (missing stats)           ·                          ·
-·                    table                t@primary                      ·                          ·
-·                    spans                FULL SCAN                      ·                          ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: t
+│ set: v
+│ auto commit
+│
+└── • render
+    │ columns: (k int, v int, v_new int)
+    │ estimated row count: 333 (missing stats)
+    │ render 0: ((k)[int] + (1)[int])[int]
+    │ render 1: (k)[int]
+    │ render 2: (v)[int]
+    │
+    └── • filter
+        │ columns: (k int, v int)
+        │ estimated row count: 333 (missing stats)
+        │ filter: ((v)[int] > (123)[int])[bool]
+        │
+        └── • scan
+              columns: (k int, v int)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-·            distribution         local            ·              ·
-·            vectorized           false            ·              ·
-union        ·                    ·                (column1 int)  ·
- │           estimated row count  2                ·              ·
- ├── values  ·                    ·                (column1 int)  ·
- │           size                 1 column, 1 row  ·              ·
- │           row 0, expr 0        (1)[int]         ·              ·
- └── values  ·                    ·                (column1 int)  ·
-·            size                 1 column, 1 row  ·              ·
-·            row 0, expr 0        (2)[int]         ·              ·
+distribution: local
+vectorized: false
+·
+• union
+│ columns: (column1 int)
+│ estimated row count: 2
+│
+├── • values
+│     columns: (column1 int)
+│     size: 1 column, 1 row
+│     row 0, expr 0: (1)[int]
+│
+└── • values
+      columns: (column1 int)
+      size: 1 column, 1 row
+      row 0, expr 0: (2)[int]
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-·     distribution         local                 ·        ·
-·     vectorized           true                  ·        ·
-scan  ·                    ·                     (k int)  ·
-·     estimated row count  1000 (missing stats)  ·        ·
-·     table                t@primary             ·        ·
-·     spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k int)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-·          distribution         local                 ·        ·
-·          vectorized           true                  ·        ·
-sort       ·                    ·                     (v int)  +v
- │         estimated row count  1000 (missing stats)  ·        ·
- │         order                +v                    ·        ·
- └── scan  ·                    ·                     (v int)  ·
-·          estimated row count  1000 (missing stats)  ·        ·
-·          table                t@primary             ·        ·
-·          spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (v int)
+│ ordering: +v
+│ estimated row count: 1000 (missing stats)
+│ order: +v
+│
+└── • scan
+      columns: (v int)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-·     distribution         local              ·        ·
-·     vectorized           true               ·        ·
-scan  ·                    ·                  (v int)  ·
-·     estimated row count  1 (missing stats)  ·        ·
-·     table                t@primary          ·        ·
-·     spans                LIMITED SCAN       ·        ·
-·     limit                1                  ·        ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (v int)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: LIMITED SCAN
+  limit: 1
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-·          distribution         local                                                                      ·               ·
-·          vectorized           true                                                                       ·               ·
-filter     ·                    ·                                                                          (x int, y int)  ·
- │         estimated row count  311 (missing stats)                                                        ·               ·
- │         filter               ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
- └── scan  ·                    ·                                                                          (x int, y int)  ·
-·          estimated row count  1000 (missing stats)                                                       ·               ·
-·          table                tt@primary                                                                 ·               ·
-·          spans                FULL SCAN                                                                  ·               ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x int, y int)
+│ estimated row count: 311 (missing stats)
+│ filter: ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
+│
+└── • scan
+      columns: (x int, y int)
+      estimated row count: 1000 (missing stats)
+      table: tt@primary
+      spans: FULL SCAN
 
 # TODO(radu): we don't support placeholders with no values.
 #query TTTTT
@@ -814,24 +1004,28 @@ filter     ·                    ·                                             
 # │             render 0  (($1)[int] + (2)[int])[int]  ·        ·
 # └── emptyrow  ·         ·                            ()       ·
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (a int)  ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  (1)[int]         ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a int)
+  size: 1 column, 1 row
+  row 0, expr 0: (1)[int]
 
 # Check array subscripts (#13811)
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
-·       distribution   local            ·        ·
-·       vectorized     false            ·        ·
-values  ·              ·                (x int)  ·
-·       size           1 column, 1 row  ·        ·
-·       row 0, expr 0  (1)[int]         ·        ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (x int)
+  size: 1 column, 1 row
+  row 0, expr 0: (1)[int]
 
 query T
 EXPLAIN (OPT) SELECT 1 AS r
@@ -1086,69 +1280,79 @@ sort
                 ├── variable: a:1 [type=int]
                 └── variable: b:2 [type=int]
 
-query TTT colnames
+query T
 EXPLAIN SELECT string_agg(x, y) FROM (VALUES ('foo', 'foo'), ('bar', 'bar')) t(x, y)
 ----
-tree            field         description
-·               distribution  local
-·               vectorized    false
-group (scalar)  ·             ·
- └── values     ·             ·
-·               size          2 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• group (scalar)
+│
+└── • values
+      size: 2 columns, 2 rows
 
-query TTT
+query T
 EXPLAIN SELECT corr(a, b) FROM tc;
 ----
-·               distribution   local
-·               vectorized     true
-group (scalar)  ·              ·
- └── scan       ·              ·
-·               missing stats  ·
-·               table          tc@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • scan
+      missing stats
+      table: tc@primary
+      spans: FULL SCAN
 
 # Verify that subqueries are handled correctly, namely that we can have
 # subqueries outside of the EXPLAINed query.
-query ITTT
+query IT
 WITH
   a AS MATERIALIZED (SELECT max(k) FROM t WHERE k > (SELECT v FROM t WHERE v = k + 1)),
   b AS MATERIALIZED (EXPLAIN SELECT k, v FROM t)
 SELECT * FROM a, b
 ----
-NULL  ·     distribution   local
-NULL  ·     vectorized     true
-NULL  scan  ·              ·
-NULL  ·     missing stats  ·
-NULL  ·     table          t@primary
-NULL  ·     spans          FULL SCAN
+NULL  distribution: local
+NULL  vectorized: true
+NULL  ·
+NULL  • scan
+NULL    missing stats
+NULL    table: t@primary
+NULL    spans: FULL SCAN
 
 # Tests with EXPLAIN inside EXPLAIN.
-query TTT
+query T
 EXPLAIN EXPLAIN SELECT 1
 ----
-·        distribution  local
-·        vectorized    false
-explain  ·             ·
+distribution: local
+vectorized: false
+·
+• explain
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) EXPLAIN ANALYZE SELECT 1
 ----
-·             distribution         local               ·                       ·
-·             vectorized           false               ·                       ·
-project       ·                    ·                   (automatic, url)        ·
- └── explain  ·                    ·                   (automatic, url, json)  ·
-·             estimated row count  10 (missing stats)  ·                       ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (automatic, url)
+│
+└── • explain
+      columns: (automatic, url, json)
+      estimated row count: 10 (missing stats)
 
 # Test a case with many spans.
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE k IN (10, 20, 30, 40, 50, 60, 70, 80)
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/10 - /10] [/20 - /20] [/30 - /30] [/40 - /40] … (4 more)
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/10 - /10] [/20 - /20] [/30 - /30] [/40 - /40] … (4 more)
 
 
 # UPSERT and INSERT ON CONFLICT include arbiters.
@@ -1161,45 +1365,56 @@ CREATE TABLE u (
   FAMILY "primary" (k, v)
 )
 
-query TTT
+query T
 EXPLAIN UPSERT INTO u VALUES (1, 1)
 ----
-·                             distribution      local
-·                             vectorized        false
-upsert                        ·                 ·
- │                            into              u(k, v)
- │                            auto commit       ·
- │                            arbiter indexes   primary
- └── cross join (left outer)  ·                 ·
-      ├── values              ·                 ·
-      │                       size              2 columns, 1 row
-      └── scan                ·                 ·
-·                             missing stats     ·
-·                             table             u@primary
-·                             spans             [/1 - /1]
-·                             locking strength  for update
+distribution: local
+vectorized: false
+·
+• upsert
+│ into: u(k, v)
+│ auto commit
+│ arbiter indexes: primary
+│
+└── • cross join (left outer)
+    │
+    ├── • values
+    │     size: 2 columns, 1 row
+    │
+    └── • scan
+          missing stats
+          table: u@primary
+          spans: [/1 - /1]
+          locking strength: for update
 
-query TTT
+query T
 EXPLAIN INSERT INTO u VALUES (1, 1) ON CONFLICT DO NOTHING
 ----
-·                                            distribution           local
-·                                            vectorized             false
-insert                                       ·                      ·
- │                                           into                   u(k, v)
- │                                           auto commit            ·
- │                                           arbiter indexes        primary, u_v_key
- └── filter                                  ·                      ·
-      │                                      filter                 k IS NULL
-      └── lookup join (left outer)           ·                      ·
-           │                                 table                  u@u_v_key
-           │                                 equality               (column2) = (v)
-           │                                 equality cols are key  ·
-           └── filter                        ·                      ·
-                │                            filter                 k IS NULL
-                └── cross join (left outer)  ·                      ·
-                     ├── values              ·                      ·
-                     │                       size                   2 columns, 1 row
-                     └── scan                ·                      ·
-·                                            missing stats          ·
-·                                            table                  u@primary
-·                                            spans                  [/1 - /1]
+distribution: local
+vectorized: false
+·
+• insert
+│ into: u(k, v)
+│ auto commit
+│ arbiter indexes: primary, u_v_key
+│
+└── • filter
+    │ filter: k IS NULL
+    │
+    └── • lookup join (left outer)
+        │ table: u@u_v_key
+        │ equality: (column2) = (v)
+        │ equality cols are key
+        │
+        └── • filter
+            │ filter: k IS NULL
+            │
+            └── • cross join (left outer)
+                │
+                ├── • values
+                │     size: 2 columns, 1 row
+                │
+                └── • scan
+                      missing stats
+                      table: u@primary
+                      spans: [/1 - /1]

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -12,84 +12,110 @@ CREATE TABLE parent (p INT PRIMARY KEY, other INT UNIQUE, FAMILY (p, other))
 statement ok
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMILY (c, p), INDEX (p))
 
-query TTT
+query T
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                                  distribution           local
-·                                  vectorized             false
-root                               ·                      ·
- ├── insert                        ·                      ·
- │    │                            into                   child(c, p)
- │    └── buffer                   ·                      ·
- │         │                       label                  buffer 1
- │         └── values              ·                      ·
- │                                 size                   2 columns, 2 rows
- └── fk-check                      ·                      ·
-      └── error if rows            ·                      ·
-           └── lookup join (anti)  ·                      ·
-                │                  table                  parent@primary
-                │                  equality               (column2) = (p)
-                │                  equality cols are key  ·
-                └── scan buffer    ·                      ·
-·                                  label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: child(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 2 columns, 2 rows
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@primary
+            │ equality: (column2) = (p)
+            │ equality cols are key
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 # Use data from a different table as input.
 statement ok
 CREATE TABLE xy (x INT, y INT)
 
-query TTT
+query T
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── insert                      ·                   ·
- │    │                          into                child(c, p)
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── scan              ·                   ·
- │                               missing stats       ·
- │                               table               xy@primary
- │                               spans               FULL SCAN
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (y) = (p)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               parent@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: child(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: xy@primary
+│             spans: FULL SCAN
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (y) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@primary
+                  spans: FULL SCAN
 
 statement ok
 CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p), INDEX (p));
 
 # Because the input column can be NULL (in which case it requires no FK match),
 # we have to add an extra filter.
-query TTT
+query T
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
-·                                     distribution           local
-·                                     vectorized             false
-root                                  ·                      ·
- ├── insert                           ·                      ·
- │    │                               into                   child_nullable(c, p)
- │    └── buffer                      ·                      ·
- │         │                          label                  buffer 1
- │         └── values                 ·                      ·
- │                                    size                   2 columns, 2 rows
- └── fk-check                         ·                      ·
-      └── error if rows               ·                      ·
-           └── lookup join (anti)     ·                      ·
-                │                     table                  parent@primary
-                │                     equality               (column2) = (p)
-                │                     equality cols are key  ·
-                └── filter            ·                      ·
-                     │                filter                 column2 IS NOT NULL
-                     └── scan buffer  ·                      ·
-·                                     label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: child_nullable(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 2 columns, 2 rows
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@primary
+            │ equality: (column2) = (p)
+            │ equality cols are key
+            │
+            └── • filter
+                │ filter: column2 IS NOT NULL
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 # Tests with multicolumn FKs.
 statement ok
@@ -103,28 +129,37 @@ CREATE TABLE multi_col_child  (
 )
 
 # Only p and q are nullable.
-query TTT
+query T
 EXPLAIN INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
 ----
-·                                     distribution           local
-·                                     vectorized             false
-root                                  ·                      ·
- ├── insert                           ·                      ·
- │    │                               into                   multi_col_child(c, p, q, r)
- │    └── buffer                      ·                      ·
- │         │                          label                  buffer 1
- │         └── values                 ·                      ·
- │                                    size                   4 columns, 2 rows
- └── fk-check                         ·                      ·
-      └── error if rows               ·                      ·
-           └── lookup join (anti)     ·                      ·
-                │                     table                  multi_col_parent@primary
-                │                     equality               (column2, column3, column4) = (p,q,r)
-                │                     equality cols are key  ·
-                └── filter            ·                      ·
-                     │                filter                 (column2 IS NOT NULL) AND (column3 IS NOT NULL)
-                     └── scan buffer  ·                      ·
-·                                     label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: multi_col_child(c, p, q, r)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 4 columns, 2 rows
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: multi_col_parent@primary
+            │ equality: (column2, column3, column4) = (p,q,r)
+            │ equality cols are key
+            │
+            └── • filter
+                │ filter: (column2 IS NOT NULL) AND (column3 IS NOT NULL)
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 statement ok
 CREATE TABLE multi_ref_parent_a (a INT PRIMARY KEY, other INT)
@@ -142,120 +177,164 @@ CREATE TABLE multi_ref_child (
   CONSTRAINT fk2 FOREIGN KEY (b,c) REFERENCES multi_ref_parent_bc(b,c)
 )
 
-query TTT
+query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL), (2, 3, 4, 5)
 ----
-·                                     distribution           local
-·                                     vectorized             false
-root                                  ·                      ·
- ├── insert                           ·                      ·
- │    │                               into                   multi_ref_child(k, a, b, c)
- │    └── buffer                      ·                      ·
- │         │                          label                  buffer 1
- │         └── values                 ·                      ·
- │                                    size                   4 columns, 2 rows
- ├── fk-check                         ·                      ·
- │    └── error if rows               ·                      ·
- │         └── lookup join (anti)     ·                      ·
- │              │                     table                  multi_ref_parent_a@primary
- │              │                     equality               (column2) = (a)
- │              │                     equality cols are key  ·
- │              └── filter            ·                      ·
- │                   │                filter                 column2 IS NOT NULL
- │                   └── scan buffer  ·                      ·
- │                                    label                  buffer 1
- └── fk-check                         ·                      ·
-      └── error if rows               ·                      ·
-           └── lookup join (anti)     ·                      ·
-                │                     table                  multi_ref_parent_bc@primary
-                │                     equality               (column3, column4) = (b,c)
-                │                     equality cols are key  ·
-                └── filter            ·                      ·
-                     │                filter                 (column3 IS NOT NULL) AND (column4 IS NOT NULL)
-                     └── scan buffer  ·                      ·
-·                                     label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: multi_ref_child(k, a, b, c)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 4 columns, 2 rows
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (anti)
+│           │ table: multi_ref_parent_a@primary
+│           │ equality: (column2) = (a)
+│           │ equality cols are key
+│           │
+│           └── • filter
+│               │ filter: column2 IS NOT NULL
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: multi_ref_parent_bc@primary
+            │ equality: (column3, column4) = (b,c)
+            │ equality cols are key
+            │
+            └── • filter
+                │ filter: (column3 IS NOT NULL) AND (column4 IS NOT NULL)
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 # FK check can be omitted when we are inserting only NULLs.
-query TTT
+query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
 ----
-·            distribution  local
-·            vectorized    false
-insert       ·             ·
- │           into          multi_ref_child(k, a, b, c)
- │           auto commit   ·
- └── values  ·             ·
-·            size          4 columns, 1 row
+distribution: local
+vectorized: false
+·
+• insert
+│ into: multi_ref_child(k, a, b, c)
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
 
 # -- Tests with DELETE --
 
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                  distribution   local
-·                                  vectorized     false
-root                               ·              ·
- ├── delete                        ·              ·
- │    │                            from           parent
- │    └── buffer                   ·              ·
- │         │                       label          buffer 1
- │         └── scan                ·              ·
- │                                 missing stats  ·
- │                                 table          parent@primary
- │                                 spans          [/3 - /3]
- ├── fk-check                      ·              ·
- │    └── error if rows            ·              ·
- │         └── lookup join (semi)  ·              ·
- │              │                  table          child@child_p_idx
- │              │                  equality       (p) = (p)
- │              └── scan buffer    ·              ·
- │                                 label          buffer 1
- └── fk-check                      ·              ·
-      └── error if rows            ·              ·
-           └── lookup join (semi)  ·              ·
-                │                  table          child_nullable@child_nullable_p_idx
-                │                  equality       (p) = (p)
-                └── scan buffer    ·              ·
-·                                  label          buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: parent@primary
+│             spans: [/3 - /3]
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: child@child_p_idx
+│           │ equality: (p) = (p)
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: child_nullable@child_nullable_p_idx
+            │ equality: (p) = (p)
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other), INDEX (p))
 
-query TTT
+query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                  distribution   local
-·                                  vectorized     false
-root                               ·              ·
- ├── delete                        ·              ·
- │    │                            from           parent
- │    └── buffer                   ·              ·
- │         │                       label          buffer 1
- │         └── scan                ·              ·
- │                                 missing stats  ·
- │                                 table          parent@primary
- │                                 spans          [/3 - /3]
- ├── fk-check                      ·              ·
- │    └── error if rows            ·              ·
- │         └── lookup join (semi)  ·              ·
- │              │                  table          child@child_p_idx
- │              │                  equality       (p) = (p)
- │              └── scan buffer    ·              ·
- │                                 label          buffer 1
- ├── fk-check                      ·              ·
- │    └── error if rows            ·              ·
- │         └── lookup join (semi)  ·              ·
- │              │                  table          child_nullable@child_nullable_p_idx
- │              │                  equality       (p) = (p)
- │              └── scan buffer    ·              ·
- │                                 label          buffer 1
- └── fk-check                      ·              ·
-      └── error if rows            ·              ·
-           └── lookup join (semi)  ·              ·
-                │                  table          child2@child2_p_idx
-                │                  equality       (other) = (p)
-                └── scan buffer    ·              ·
-·                                  label          buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: parent@primary
+│             spans: [/3 - /3]
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: child@child_p_idx
+│           │ equality: (p) = (p)
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: child_nullable@child_nullable_p_idx
+│           │ equality: (p) = (p)
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: child2@child2_p_idx
+            │ equality: (other) = (p)
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 CREATE TABLE doubleparent (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
@@ -269,445 +348,595 @@ CREATE TABLE doublechild (
   INDEX (p1, p2)
 )
 
-query TTT
+query T
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
-·                                  distribution   local
-·                                  vectorized     false
-root                               ·              ·
- ├── delete                        ·              ·
- │    │                            from           doubleparent
- │    └── buffer                   ·              ·
- │         │                       label          buffer 1
- │         └── scan                ·              ·
- │                                 missing stats  ·
- │                                 table          doubleparent@primary
- │                                 spans          [/10 - /10]
- └── fk-check                      ·              ·
-      └── error if rows            ·              ·
-           └── lookup join (semi)  ·              ·
-                │                  table          doublechild@doublechild_p1_p2_idx
-                │                  equality       (p1, p2) = (p1,p2)
-                └── scan buffer    ·              ·
-·                                  label          buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: doubleparent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: doubleparent@primary
+│             spans: [/10 - /10]
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: doublechild@doublechild_p1_p2_idx
+            │ equality: (p1, p2) = (p1,p2)
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 # -- Tests with UPDATE --
 
-query TTT
+query T
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── update                      ·                   ·
- │    │                          table               child
- │    │                          set                 p
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── render            ·                   ·
- │              └── scan         ·                   ·
- │                               missing stats       ·
- │                               table               child@primary
- │                               spans               FULL SCAN
- │                               locking strength    for update
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (p_new) = (p)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               parent@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
-·                                  distribution           local
-·                                  vectorized             false
-root                               ·                      ·
- ├── update                        ·                      ·
- │    │                            table                  child
- │    │                            set                    p
- │    └── buffer                   ·                      ·
- │         │                       label                  buffer 1
- │         └── render              ·                      ·
- │              └── scan           ·                      ·
- │                                 missing stats          ·
- │                                 table                  child@primary
- │                                 spans                  [/10 - /10]
- │                                 locking strength       for update
- └── fk-check                      ·                      ·
-      └── error if rows            ·                      ·
-           └── lookup join (anti)  ·                      ·
-                │                  table                  parent@primary
-                │                  equality               (p_new) = (p)
-                │                  equality cols are key  ·
-                └── scan buffer    ·                      ·
-·                                  label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: [/10 - /10]
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@primary
+            │ equality: (p_new) = (p)
+            │ equality cols are key
+            │
+            └── • scan buffer
+                  label: buffer 1
 
-query TTT
+query T
 EXPLAIN UPDATE parent SET p = p+1
 ----
-·                                     distribution        local
-·                                     vectorized          false
-root                                  ·                   ·
- ├── update                           ·                   ·
- │    │                               table               parent
- │    │                               set                 p
- │    └── buffer                      ·                   ·
- │         │                          label               buffer 1
- │         └── render                 ·                   ·
- │              └── scan              ·                   ·
- │                                    missing stats       ·
- │                                    table               parent@primary
- │                                    spans               FULL SCAN
- │                                    locking strength    for update
- ├── fk-check                         ·                   ·
- │    └── error if rows               ·                   ·
- │         └── hash join              ·                   ·
- │              │                     equality            (p) = (p)
- │              │                     left cols are key   ·
- │              │                     right cols are key  ·
- │              ├── except            ·                   ·
- │              │    ├── scan buffer  ·                   ·
- │              │    │                label               buffer 1
- │              │    └── scan buffer  ·                   ·
- │              │                     label               buffer 1
- │              └── distinct          ·                   ·
- │                   │                distinct on         p
- │                   │                order key           p
- │                   └── scan         ·                   ·
- │                                    missing stats       ·
- │                                    table               child@child_p_idx
- │                                    spans               FULL SCAN
- └── fk-check                         ·                   ·
-      └── error if rows               ·                   ·
-           └── hash join              ·                   ·
-                │                     equality            (p) = (p)
-                │                     left cols are key   ·
-                │                     right cols are key  ·
-                ├── except            ·                   ·
-                │    ├── scan buffer  ·                   ·
-                │    │                label               buffer 1
-                │    └── scan buffer  ·                   ·
-                │                     label               buffer 1
-                └── distinct          ·                   ·
-                     │                distinct on         p
-                     │                order key           p
-                     └── scan         ·                   ·
-·                                     missing stats       ·
-·                                     table               child_nullable@child_nullable_p_idx
-·                                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: parent
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: parent@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join
+│           │ equality: (p) = (p)
+│           │ left cols are key
+│           │ right cols are key
+│           │
+│           ├── • except
+│           │   │
+│           │   ├── • scan buffer
+│           │   │     label: buffer 1
+│           │   │
+│           │   └── • scan buffer
+│           │         label: buffer 1
+│           │
+│           └── • distinct
+│               │ distinct on: p
+│               │ order key: p
+│               │
+│               └── • scan
+│                     missing stats
+│                     table: child@child_p_idx
+│                     spans: FULL SCAN
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (p) = (p)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: p
+                │ order key: p
+                │
+                └── • scan
+                      missing stats
+                      table: child_nullable@child_nullable_p_idx
+                      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
-·                                     distribution      local
-·                                     vectorized        false
-root                                  ·                 ·
- ├── update                           ·                 ·
- │    │                               table             parent
- │    │                               set               p
- │    └── buffer                      ·                 ·
- │         │                          label             buffer 1
- │         └── render                 ·                 ·
- │              └── scan              ·                 ·
- │                                    missing stats     ·
- │                                    table             parent@parent_other_key
- │                                    spans             [/10 - /10]
- │                                    locking strength  for update
- ├── fk-check                         ·                 ·
- │    └── error if rows               ·                 ·
- │         └── lookup join (semi)     ·                 ·
- │              │                     table             child@child_p_idx
- │              │                     equality          (p) = (p)
- │              └── except            ·                 ·
- │                   ├── scan buffer  ·                 ·
- │                   │                label             buffer 1
- │                   └── scan buffer  ·                 ·
- │                                    label             buffer 1
- └── fk-check                         ·                 ·
-      └── error if rows               ·                 ·
-           └── lookup join (semi)     ·                 ·
-                │                     table             child_nullable@child_nullable_p_idx
-                │                     equality          (p) = (p)
-                └── except            ·                 ·
-                     ├── scan buffer  ·                 ·
-                     │                label             buffer 1
-                     └── scan buffer  ·                 ·
-·                                     label             buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: parent
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: parent@parent_other_key
+│                 spans: [/10 - /10]
+│                 locking strength: for update
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: child@child_p_idx
+│           │ equality: (p) = (p)
+│           │
+│           └── • except
+│               │
+│               ├── • scan buffer
+│               │     label: buffer 1
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: child_nullable@child_nullable_p_idx
+            │ equality: (p) = (p)
+            │
+            └── • except
+                │
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 statement ok
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 
-query TTT
+query T
 EXPLAIN UPDATE child SET c = 4
 ----
-·                                     distribution        local
-·                                     vectorized          false
-root                                  ·                   ·
- ├── update                           ·                   ·
- │    │                               table               child
- │    │                               set                 c
- │    └── buffer                      ·                   ·
- │         │                          label               buffer 1
- │         └── render                 ·                   ·
- │              └── scan              ·                   ·
- │                                    missing stats       ·
- │                                    table               child@primary
- │                                    spans               FULL SCAN
- │                                    locking strength    for update
- └── fk-check                         ·                   ·
-      └── error if rows               ·                   ·
-           └── hash join              ·                   ·
-                │                     equality            (c) = (c)
-                │                     left cols are key   ·
-                │                     right cols are key  ·
-                ├── except            ·                   ·
-                │    ├── scan buffer  ·                   ·
-                │    │                label               buffer 1
-                │    └── scan buffer  ·                   ·
-                │                     label               buffer 1
-                └── distinct          ·                   ·
-                     │                distinct on         c
-                     └── scan         ·                   ·
-·                                     missing stats       ·
-·                                     table               grandchild@primary
-·                                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: c
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (c) = (c)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: c
+                │
+                └── • scan
+                      missing stats
+                      table: grandchild@primary
+                      spans: FULL SCAN
 
 # This update shouldn't emit checks for c, since it's unchanged.
-query TTT
+query T
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── update                      ·                   ·
- │    │                          table               child
- │    │                          set                 p
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── render            ·                   ·
- │              └── scan         ·                   ·
- │                               missing stats       ·
- │                               table               child@primary
- │                               spans               FULL SCAN
- │                               locking strength    for update
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (p_new) = (p)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               parent@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE child SET p = p
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── update                      ·                   ·
- │    │                          table               child
- │    │                          set                 p
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── scan              ·                   ·
- │                               missing stats       ·
- │                               table               child@primary
- │                               spans               FULL SCAN
- │                               locking strength    for update
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (p) = (p)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               parent@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: child@primary
+│             spans: FULL SCAN
+│             locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (p) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
-·                                     distribution        local
-·                                     vectorized          false
-root                                  ·                   ·
- ├── update                           ·                   ·
- │    │                               table               child
- │    │                               set                 c, p
- │    └── buffer                      ·                   ·
- │         │                          label               buffer 1
- │         └── render                 ·                   ·
- │              └── scan              ·                   ·
- │                                    missing stats       ·
- │                                    table               child@primary
- │                                    spans               FULL SCAN
- │                                    locking strength    for update
- ├── fk-check                         ·                   ·
- │    └── error if rows               ·                   ·
- │         └── hash join (anti)       ·                   ·
- │              │                     equality            (p_new) = (p)
- │              │                     right cols are key  ·
- │              ├── scan buffer       ·                   ·
- │              │                     label               buffer 1
- │              └── scan              ·                   ·
- │                                    missing stats       ·
- │                                    table               parent@primary
- │                                    spans               FULL SCAN
- └── fk-check                         ·                   ·
-      └── error if rows               ·                   ·
-           └── hash join              ·                   ·
-                │                     equality            (c) = (c)
-                │                     left cols are key   ·
-                │                     right cols are key  ·
-                ├── except            ·                   ·
-                │    ├── scan buffer  ·                   ·
-                │    │                label               buffer 1
-                │    └── scan buffer  ·                   ·
-                │                     label               buffer 1
-                └── distinct          ·                   ·
-                     │                distinct on         c
-                     └── scan         ·                   ·
-·                                     missing stats       ·
-·                                     table               grandchild@primary
-·                                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: c, p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+├── • fk-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (anti)
+│           │ equality: (p_new) = (p)
+│           │ right cols are key
+│           │
+│           ├── • scan buffer
+│           │     label: buffer 1
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: parent@primary
+│                 spans: FULL SCAN
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (c) = (c)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: c
+                │
+                └── • scan
+                      missing stats
+                      table: grandchild@primary
+                      spans: FULL SCAN
 
 # Multiple grandchild tables
 statement ok
 CREATE TABLE grandchild2 (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 
-query TTT
+query T
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── update                      ·                   ·
- │    │                          table               child
- │    │                          set                 p
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── render            ·                   ·
- │              └── scan         ·                   ·
- │                               missing stats       ·
- │                               table               child@primary
- │                               spans               FULL SCAN
- │                               locking strength    for update
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (p_new) = (p)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               parent@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: child
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: parent@primary
+                  spans: FULL SCAN
 
 statement ok
 CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
 
-query TTT
+query T
 EXPLAIN UPDATE self SET y = 3
 ----
-·                                distribution        local
-·                                vectorized          false
-root                             ·                   ·
- ├── update                      ·                   ·
- │    │                          table               self
- │    │                          set                 y
- │    └── buffer                 ·                   ·
- │         │                     label               buffer 1
- │         └── render            ·                   ·
- │              └── scan         ·                   ·
- │                               missing stats       ·
- │                               table               self@primary
- │                               spans               FULL SCAN
- │                               locking strength    for update
- └── fk-check                    ·                   ·
-      └── error if rows          ·                   ·
-           └── hash join (anti)  ·                   ·
-                │                equality            (y_new) = (x)
-                │                right cols are key  ·
-                ├── scan buffer  ·                   ·
-                │                label               buffer 1
-                └── scan         ·                   ·
-·                                missing stats       ·
-·                                table               self@primary
-·                                spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: self
+│   │ set: y
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: self@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (y_new) = (x)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: self@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE self SET x = 3
 ----
-·                                     distribution        local
-·                                     vectorized          false
-root                                  ·                   ·
- ├── update                           ·                   ·
- │    │                               table               self
- │    │                               set                 x
- │    └── buffer                      ·                   ·
- │         │                          label               buffer 1
- │         └── render                 ·                   ·
- │              └── scan              ·                   ·
- │                                    missing stats       ·
- │                                    table               self@primary
- │                                    spans               FULL SCAN
- │                                    locking strength    for update
- └── fk-check                         ·                   ·
-      └── error if rows               ·                   ·
-           └── hash join              ·                   ·
-                │                     equality            (x) = (y)
-                │                     left cols are key   ·
-                │                     right cols are key  ·
-                ├── except            ·                   ·
-                │    ├── scan buffer  ·                   ·
-                │    │                label               buffer 1
-                │    └── scan buffer  ·                   ·
-                │                     label               buffer 1
-                └── distinct          ·                   ·
-                     │                distinct on         y
-                     └── scan         ·                   ·
-·                                     missing stats       ·
-·                                     table               self@primary
-·                                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: self
+│   │ set: x
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: self@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join
+            │ equality: (x) = (y)
+            │ left cols are key
+            │ right cols are key
+            │
+            ├── • except
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • distinct
+                │ distinct on: y
+                │
+                └── • scan
+                      missing stats
+                      table: self@primary
+                      spans: FULL SCAN
 
 # Tests for the insert fast path.
 statement ok
 SET enable_insert_fast_path = true
 
 # Simple insert with VALUES should use the fast path.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                 distribution         local              ·   ·
-·                 vectorized           false              ·   ·
-insert fast path  ·                    ·                  ()  ·
-·                 estimated row count  0 (missing stats)  ·   ·
-·                 into                 child(c, p)        ·   ·
-·                 auto commit          ·                  ·   ·
-·                 FK check             parent@primary     ·   ·
-·                 size                 2 columns, 2 rows  ·   ·
-·                 row 0, expr 0        1                  ·   ·
-·                 row 0, expr 1        1                  ·   ·
-·                 row 1, expr 0        2                  ·   ·
-·                 row 1, expr 1        2                  ·   ·
+distribution: local
+vectorized: false
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: child(c, p)
+  auto commit
+  FK check: parent@primary
+  size: 2 columns, 2 rows
+  row 0, expr 0: 1
+  row 0, expr 1: 1
+  row 1, expr 0: 2
+  row 1, expr 1: 2
 
 # We shouldn't use the fast path if the VALUES columns are not in order.
 query B 
 SELECT count(*) > 0 FROM [
   EXPLAIN INSERT INTO child (SELECT b, a FROM (VALUES (1,2)) AS v(a,b))
-] WHERE tree LIKE '%insert-fast-path'
+] WHERE info LIKE '%insert-fast-path'
 ----
 false
 
@@ -716,7 +945,7 @@ query B
 SELECT count(*) > 0 FROM [
   EXPLAIN WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING p)
   INSERT INTO parent VALUES (2, 3)
-] WHERE tree LIKE '%insert-fast-path'
+] WHERE info LIKE '%insert-fast-path'
 ----
 false
 
@@ -724,7 +953,7 @@ false
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN INSERT INTO self VALUES (1, 1)
-] WHERE tree LIKE '%insert-fast-path'
+] WHERE info LIKE '%insert-fast-path'
 ----
 false
 
@@ -743,7 +972,7 @@ ALTER TABLE parent INJECT STATISTICS '[
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2), (3,3), (4,4)
-] WHERE tree LIKE '%insert-fast-path'
+] WHERE info LIKE '%insert-fast-path'
 ----
 false
 
@@ -766,16 +995,17 @@ CREATE TABLE nonunique_idx_child (
   CONSTRAINT "fk" FOREIGN KEY (ref1, ref2) REFERENCES nonunique_idx_parent (k1, k2)
 )
 
-query TTT
+query T
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
-·                 distribution  local
-·                 vectorized    false
-insert fast path  ·             ·
-·                 into          nonunique_idx_child(k, ref1, ref2)
-·                 auto commit   ·
-·                 FK check      nonunique_idx_parent@nonunique_idx_parent_k2_idx
-·                 size          3 columns, 1 row
+distribution: local
+vectorized: false
+·
+• insert fast path
+  into: nonunique_idx_child(k, ref1, ref2)
+  auto commit
+  FK check: nonunique_idx_parent@nonunique_idx_parent_k2_idx
+  size: 3 columns, 1 row
 
 # Regression test for #46397: upserter was looking at the incorrect ordinal for
 # the check because of an extra input column used by the FK check.
@@ -810,40 +1040,56 @@ CREATE TABLE cascadechild (
   p INT NOT NULL REFERENCES cascadeparent(p) ON DELETE CASCADE
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
 ----
-·                  distribution         local                   ·   ·
-·                  vectorized           false                   ·   ·
-root               ·                    ·                       ()  ·
- ├── delete range  ·                    ·                       ()  ·
- │                 estimated row count  0 (missing stats)       ·   ·
- │                 from                 cascadeparent           ·   ·
- │                 spans                /2-                     ·   ·
- └── fk-cascade    ·                    ·                       ·   ·
-·                  fk                   fk_p_ref_cascadeparent  ·   ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: ()
+│
+├── • delete range
+│     columns: ()
+│     estimated row count: 0 (missing stats)
+│     from: cascadeparent
+│     spans: /2-
+│
+└── • fk-cascade
+      fk: fk_p_ref_cascadeparent
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1 AND data > 0
 ----
-·                         distribution         local                   ·          ·
-·                         vectorized           false                   ·          ·
-root                      ·                    ·                       ()         ·
- ├── delete               ·                    ·                       ()         ·
- │    │                   estimated row count  0 (missing stats)       ·          ·
- │    │                   from                 cascadeparent           ·          ·
- │    └── buffer          ·                    ·                       (p, data)  ·
- │         │              label                buffer 1                ·          ·
- │         └── filter     ·                    ·                       (p, data)  ·
- │              │         estimated row count  311 (missing stats)     ·          ·
- │              │         filter               data > 0                ·          ·
- │              └── scan  ·                    ·                       (p, data)  ·
- │                        estimated row count  333 (missing stats)     ·          ·
- │                        table                cascadeparent@primary   ·          ·
- │                        spans                /2-                     ·          ·
- └── fk-cascade           ·                    ·                       ·          ·
-·                         fk                   fk_p_ref_cascadeparent  ·          ·
-·                         input                buffer 1                ·          ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: ()
+│
+├── • delete
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ from: cascadeparent
+│   │
+│   └── • buffer
+│       │ columns: (p, data)
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ columns: (p, data)
+│           │ estimated row count: 311 (missing stats)
+│           │ filter: data > 0
+│           │
+│           └── • scan
+│                 columns: (p, data)
+│                 estimated row count: 333 (missing stats)
+│                 table: cascadeparent@primary
+│                 spans: /2-
+│
+└── • fk-cascade
+      fk: fk_p_ref_cascadeparent
+      input: buffer 1
 
 statement ok
 CREATE TABLE a (
@@ -865,7 +1111,7 @@ statement ok
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) NOT VALID
 
 # Verify that the optimizer doesn't use an unvalidated constraint to simplify plans.
-query TTT colnames
+query T
 EXPLAIN SELECT
   s.a_z, s.a_y, s.a_x
 FROM
@@ -874,30 +1120,34 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree                          field               description
-·                             distribution        local
-·                             vectorized          true
-filter                        ·                   ·
- │                            filter              z IS NULL
- └── merge join (left outer)  ·                   ·
-      │                       equality            (a_z, a_y, a_x) = (z, y, x)
-      │                       right cols are key  ·
-      ├── filter              ·                   ·
-      │    │                  filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
-      │    └── scan           ·                   ·
-      │                       missing stats       ·
-      │                       table               b@idx
-      │                       spans               (/NULL - ]
-      └── scan                ·                   ·
-·                             missing stats       ·
-·                             table               a@primary
-·                             spans               FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: z IS NULL
+│
+└── • merge join (left outer)
+    │ equality: (a_z, a_y, a_x) = (z, y, x)
+    │ right cols are key
+    │
+    ├── • filter
+    │   │ filter: (a_y IS NOT NULL) AND (a_x IS NOT NULL)
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: b@idx
+    │         spans: (/NULL - ]
+    │
+    └── • scan
+          missing stats
+          table: a@primary
+          spans: FULL SCAN
 
 statement ok
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 # Now the plan should be simplified.
-query TTT colnames
+query T
 EXPLAIN SELECT
   s.a_z, s.a_y, s.a_x
 FROM
@@ -906,10 +1156,10 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree    field         description
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
 # Verify that prefer_lookup_joins_for_fks works as expected.
 statement ok
@@ -938,211 +1188,282 @@ ALTER TABLE c INJECT STATISTICS '[
 
 # These queries should not be using lookup joins (we're inserting more rows
 # than exist in the tables).
-query TTT
+query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
 ----
-·                                distribution         local
-·                                vectorized           false
-root                             ·                    ·
- ├── insert                      ·                    ·
- │    │                          into                 c(c, p)
- │    └── buffer                 ·                    ·
- │         │                     label                buffer 1
- │         └── values            ·                    ·
- │                               size                 2 columns, 3 rows
- └── fk-check                    ·                    ·
-      └── error if rows          ·                    ·
-           └── hash join (anti)  ·                    ·
-                │                equality             (column2) = (p)
-                │                right cols are key   ·
-                ├── scan buffer  ·                    ·
-                │                label                buffer 1
-                └── scan         ·                    ·
-·                                estimated row count  1
-·                                table                p@primary
-·                                spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: c(c, p)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 2 columns, 3 rows
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (column2) = (p)
+            │ right cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  estimated row count: 1
+                  table: p@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
-·                                     distribution         local
-·                                     vectorized           false
-root                                  ·                    ·
- ├── update                           ·                    ·
- │    │                               table                c
- │    │                               set                  p
- │    └── buffer                      ·                    ·
- │         │                          label                buffer 1
- │         └── render                 ·                    ·
- │              └── scan              ·                    ·
- │                                    estimated row count  1
- │                                    table                c@primary
- │                                    spans                [/1 - ]
- │                                    locking strength     for update
- └── fk-check                         ·                    ·
-      └── error if rows               ·                    ·
-           └── hash join (anti)       ·                    ·
-                │                     equality             (p_new) = (p)
-                │                     right cols are key   ·
-                ├── filter            ·                    ·
-                │    │                filter               p_new IS NOT NULL
-                │    └── scan buffer  ·                    ·
-                │                     label                buffer 1
-                └── scan              ·                    ·
-·                                     estimated row count  1
-·                                     table                p@primary
-·                                     spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: c
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 estimated row count: 1
+│                 table: c@primary
+│                 spans: [/1 - ]
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (anti)
+            │ equality: (p_new) = (p)
+            │ right cols are key
+            │
+            ├── • filter
+            │   │ filter: p_new IS NOT NULL
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • scan
+                  estimated row count: 1
+                  table: p@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
 ----
-·                                     distribution         local
-·                                     vectorized           false
-root                                  ·                    ·
- ├── update                           ·                    ·
- │    │                               table                p
- │    │                               set                  p
- │    └── buffer                      ·                    ·
- │         │                          label                buffer 1
- │         └── render                 ·                    ·
- │              └── scan              ·                    ·
- │                                    estimated row count  1
- │                                    table                p@primary
- │                                    spans                [/1 - ]
- │                                    locking strength     for update
- └── fk-check                         ·                    ·
-      └── error if rows               ·                    ·
-           └── hash join (semi)       ·                    ·
-                │                     equality             (p) = (p)
-                │                     left cols are key    ·
-                ├── except            ·                    ·
-                │    ├── scan buffer  ·                    ·
-                │    │                label                buffer 1
-                │    └── scan buffer  ·                    ·
-                │                     label                buffer 1
-                └── scan              ·                    ·
-·                                     estimated row count  1
-·                                     table                c@primary
-·                                     spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: p
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 estimated row count: 1
+│                 table: p@primary
+│                 spans: [/1 - ]
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (p) = (p)
+            │ left cols are key
+            │
+            ├── • except
+            │   │
+            │   ├── • scan buffer
+            │   │     label: buffer 1
+            │   │
+            │   └── • scan buffer
+            │         label: buffer 1
+            │
+            └── • scan
+                  estimated row count: 1
+                  table: c@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
-·                                distribution         local
-·                                vectorized           false
-root                             ·                    ·
- ├── delete                      ·                    ·
- │    │                          from                 p
- │    └── buffer                 ·                    ·
- │         │                     label                buffer 1
- │         └── scan              ·                    ·
- │                               estimated row count  1
- │                               table                p@primary
- │                               spans                [/1 - ]
- └── fk-check                    ·                    ·
-      └── error if rows          ·                    ·
-           └── hash join (semi)  ·                    ·
-                │                equality             (p) = (p)
-                │                left cols are key    ·
-                ├── scan buffer  ·                    ·
-                │                label                buffer 1
-                └── scan         ·                    ·
-·                                estimated row count  1
-·                                table                c@primary
-·                                spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             estimated row count: 1
+│             table: p@primary
+│             spans: [/1 - ]
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (p) = (p)
+            │ left cols are key
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  estimated row count: 1
+                  table: c@primary
+                  spans: FULL SCAN
 
 statement ok
 SET prefer_lookup_joins_for_fks = true
 
 # Now we should be using lookup joins.
-query TTT
+query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
 ----
-·                 distribution  local
-·                 vectorized    false
-insert fast path  ·             ·
-·                 into          c(c, p)
-·                 auto commit   ·
-·                 FK check      p@primary
-·                 size          2 columns, 3 rows
+distribution: local
+vectorized: false
+·
+• insert fast path
+  into: c(c, p)
+  auto commit
+  FK check: p@primary
+  size: 2 columns, 3 rows
 
-query TTT
+query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
-·                                     distribution           local
-·                                     vectorized             false
-root                                  ·                      ·
- ├── update                           ·                      ·
- │    │                               table                  c
- │    │                               set                    p
- │    └── buffer                      ·                      ·
- │         │                          label                  buffer 1
- │         └── render                 ·                      ·
- │              └── scan              ·                      ·
- │                                    estimated row count    1
- │                                    table                  c@primary
- │                                    spans                  [/1 - ]
- │                                    locking strength       for update
- └── fk-check                         ·                      ·
-      └── error if rows               ·                      ·
-           └── lookup join (anti)     ·                      ·
-                │                     table                  p@primary
-                │                     equality               (p_new) = (p)
-                │                     equality cols are key  ·
-                └── filter            ·                      ·
-                     │                filter                 p_new IS NOT NULL
-                     └── scan buffer  ·                      ·
-·                                     label                  buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: c
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 estimated row count: 1
+│                 table: c@primary
+│                 spans: [/1 - ]
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: p@primary
+            │ equality: (p_new) = (p)
+            │ equality cols are key
+            │
+            └── • filter
+                │ filter: p_new IS NOT NULL
+                │
+                └── • scan buffer
+                      label: buffer 1
 
-query TTT
+query T
 EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
 ----
-·                                     distribution         local
-·                                     vectorized           false
-root                                  ·                    ·
- ├── update                           ·                    ·
- │    │                               table                p
- │    │                               set                  p
- │    └── buffer                      ·                    ·
- │         │                          label                buffer 1
- │         └── render                 ·                    ·
- │              └── scan              ·                    ·
- │                                    estimated row count  1
- │                                    table                p@primary
- │                                    spans                [/1 - ]
- │                                    locking strength     for update
- └── fk-check                         ·                    ·
-      └── error if rows               ·                    ·
-           └── lookup join (semi)     ·                    ·
-                │                     table                c@c_p_idx
-                │                     equality             (p) = (p)
-                └── except            ·                    ·
-                     ├── scan buffer  ·                    ·
-                     │                label                buffer 1
-                     └── scan buffer  ·                    ·
-·                                     label                buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • update
+│   │ table: p
+│   │ set: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 estimated row count: 1
+│                 table: p@primary
+│                 spans: [/1 - ]
+│                 locking strength: for update
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: c@c_p_idx
+            │ equality: (p) = (p)
+            │
+            └── • except
+                │
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
 
-query TTT
+query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
-·                                  distribution         local
-·                                  vectorized           false
-root                               ·                    ·
- ├── delete                        ·                    ·
- │    │                            from                 p
- │    └── buffer                   ·                    ·
- │         │                       label                buffer 1
- │         └── scan                ·                    ·
- │                                 estimated row count  1
- │                                 table                p@primary
- │                                 spans                [/1 - ]
- └── fk-check                      ·                    ·
-      └── error if rows            ·                    ·
-           └── lookup join (semi)  ·                    ·
-                │                  table                c@c_p_idx
-                │                  equality             (p) = (p)
-                └── scan buffer    ·                    ·
-·                                  label                buffer 1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • delete
+│   │ from: p
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             estimated row count: 1
+│             table: p@primary
+│             spans: [/1 - ]
+│
+└── • fk-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: c@c_p_idx
+            │ equality: (p) = (p)
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 SET prefer_lookup_joins_for_fks = false

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -6,53 +6,69 @@ SET experimental_enable_hash_sharded_indexes = true;
 statement ok
 CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=11)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
 ----
-·                      distribution         local                                          ·                           ·
-·                      vectorized           false                                          ·                           ·
-insert                 ·                    ·                                              ()                          ·
- │                     estimated row count  0 (missing stats)                              ·                           ·
- │                     into                 sharded_primary(crdb_internal_a_shard_11, a)   ·                           ·
- │                     auto commit          ·                                              ·                           ·
- └── render            ·                    ·                                              (column6, column1, check1)  ·
-      │                estimated row count  2                                              ·                           ·
-      │                render 0             column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)  ·                           ·
-      │                render 1             column1                                        ·                           ·
-      │                render 2             column6                                        ·                           ·
-      └── render       ·                    ·                                              (column6, column1)          ·
-           │           estimated row count  2                                              ·                           ·
-           │           render 0             mod(fnv32(COALESCE(column1::STRING, '')), 11)  ·                           ·
-           │           render 1             column1                                        ·                           ·
-           └── values  ·                    ·                                              (column1)                   ·
-·                      size                 1 column, 2 rows                               ·                           ·
-·                      row 0, expr 0        1                                              ·                           ·
-·                      row 1, expr 0        2                                              ·                           ·
+distribution: local
+vectorized: false
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: sharded_primary(crdb_internal_a_shard_11, a)
+│ auto commit
+│
+└── • render
+    │ columns: (column6, column1, check1)
+    │ estimated row count: 2
+    │ render 0: column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    │ render 1: column1
+    │ render 2: column6
+    │
+    └── • render
+        │ columns: (column6, column1)
+        │ estimated row count: 2
+        │ render 0: mod(fnv32(COALESCE(column1::STRING, '')), 11)
+        │ render 1: column1
+        │
+        └── • values
+              columns: (column1)
+              size: 1 column, 2 rows
+              row 0, expr 0: 1
+              row 1, expr 0: 2
 
 statement ok
 CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=12)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
 ----
-·                      distribution         local                                                  ·                                    ·
-·                      vectorized           false                                                  ·                                    ·
-insert                 ·                    ·                                                      ()                                   ·
- │                     estimated row count  0 (missing stats)                                      ·                                    ·
- │                     into                 sharded_secondary(a, crdb_internal_a_shard_12, rowid)  ·                                    ·
- │                     auto commit          ·                                                      ·                                    ·
- └── render            ·                    ·                                                      (column1, column8, column7, check1)  ·
-      │                estimated row count  2                                                      ·                                    ·
-      │                render 0             column8 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)      ·                                    ·
-      │                render 1             column1                                                ·                                    ·
-      │                render 2             column7                                                ·                                    ·
-      │                render 3             column8                                                ·                                    ·
-      └── render       ·                    ·                                                      (column8, column7, column1)          ·
-           │           estimated row count  2                                                      ·                                    ·
-           │           render 0             mod(fnv32(COALESCE(column1::STRING, '')), 12)          ·                                    ·
-           │           render 1             unique_rowid()                                         ·                                    ·
-           │           render 2             column1                                                ·                                    ·
-           └── values  ·                    ·                                                      (column1)                            ·
-·                      size                 1 column, 2 rows                                       ·                                    ·
-·                      row 0, expr 0        1                                                      ·                                    ·
-·                      row 1, expr 0        2                                                      ·                                    ·
+distribution: local
+vectorized: false
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: sharded_secondary(a, crdb_internal_a_shard_12, rowid)
+│ auto commit
+│
+└── • render
+    │ columns: (column1, column8, column7, check1)
+    │ estimated row count: 2
+    │ render 0: column8 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    │ render 1: column1
+    │ render 2: column7
+    │ render 3: column8
+    │
+    └── • render
+        │ columns: (column8, column7, column1)
+        │ estimated row count: 2
+        │ render 0: mod(fnv32(COALESCE(column1::STRING, '')), 12)
+        │ render 1: unique_rowid()
+        │ render 2: column1
+        │
+        └── • values
+              columns: (column1)
+              size: 1 column, 2 rows
+              row 0, expr 0: 1
+              row 1, expr 0: 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -1,23 +1,27 @@
 # LogicTest: local
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
-·              distribution         local                 ·                                                                                        ·
-·              vectorized           false                 ·                                                                                        ·
-virtual table  ·                    ·                     (catalog_name, schema_name, default_character_set_name, sql_path, crdb_is_user_defined)  ·
-·              estimated row count  1000 (missing stats)  ·                                                                                        ·
-·              table                schemata@primary      ·                                                                                        ·
+distribution: local
+vectorized: false
+·
+• virtual table
+  columns: (catalog_name, schema_name, default_character_set_name, sql_path, crdb_is_user_defined)
+  estimated row count: 1000 (missing stats)
+  table: schemata@primary
 
-query TTT
+query T
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        table_name = 'foo'
- └── virtual table  ·             ·
-·                   table         tables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: table_name = 'foo'
+│
+└── • virtual table
+      table: tables@primary
 
 statement error use of crdb_internal_vtable_pk column not allowed
 SELECT crdb_internal_vtable_pk FROM system.information_schema.schemata

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -302,152 +302,199 @@ statement ok
 CREATE TABLE select_t (x INT, v INT)
 
 # Check that INSERT supports ORDER BY (MySQL extension)
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 10
-]
 ----
-·                         distribution         local
-·                         vectorized           false
-insert                    ·                    ·
- │                        estimated row count  0 (missing stats)
- │                        into                 insert_t(x, v, rowid)
- │                        auto commit          ·
- └── render               ·                    ·
-      │                   estimated row count  10 (missing stats)
-      │                   render 0             unique_rowid()
-      │                   render 1             x
-      │                   render 2             v
-      └── limit           ·                    ·
-           │              estimated row count  10 (missing stats)
-           │              count                10
-           └── sort       ·                    ·
-                │         estimated row count  1000 (missing stats)
-                │         order                -v
-                └── scan  ·                    ·
-·                         estimated row count  1000 (missing stats)
-·                         table                select_t@primary
-·                         spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │ columns: (x, v, column11)
+    │ estimated row count: 10 (missing stats)
+    │ render 0: unique_rowid()
+    │ render 1: x
+    │ render 2: v
+    │
+    └── • limit
+        │ columns: (x, v)
+        │ estimated row count: 10 (missing stats)
+        │ count: 10
+        │
+        └── • sort
+            │ columns: (x, v)
+            │ ordering: -v
+            │ estimated row count: 1000 (missing stats)
+            │ order: -v
+            │
+            └── • scan
+                  columns: (x, v)
+                  estimated row count: 1000 (missing stats)
+                  table: select_t@primary
+                  spans: FULL SCAN
 
 # Check that INSERT supports LIMIT (MySQL extension)
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
-]
 ----
-·               distribution         local
-·               vectorized           false
-insert          ·                    ·
- │              estimated row count  0 (missing stats)
- │              into                 insert_t(x, v, rowid)
- │              auto commit          ·
- └── render     ·                    ·
-      │         estimated row count  1 (missing stats)
-      │         render 0             unique_rowid()
-      │         render 1             x
-      │         render 2             v
-      └── scan  ·                    ·
-·               estimated row count  1 (missing stats)
-·               table                select_t@primary
-·               spans                LIMITED SCAN
-·               limit                1
+distribution: local
+vectorized: false
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │ columns: (x, v, column11)
+    │ estimated row count: 1 (missing stats)
+    │ render 0: unique_rowid()
+    │ render 1: x
+    │ render 2: v
+    │
+    └── • scan
+          columns: (x, v)
+          estimated row count: 1 (missing stats)
+          table: select_t@primary
+          spans: LIMITED SCAN
+          limit: 1
 
 # Check the grouping of LIMIT and ORDER BY
-query TTT
+query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-·                      distribution  local
-·                      vectorized    false
-insert                 ·             ·
- │                     into          insert_t(x, v, rowid)
- │                     auto commit   ·
- └── render            ·             ·
-      └── limit        ·             ·
-           │           count         1
-           └── values  ·             ·
-·                      size          2 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• insert
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • values
+              size: 2 columns, 2 rows
 
-query TTT
+query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-·                           distribution  local
-·                           vectorized    false
-insert                      ·             ·
- │                          into          insert_t(x, v, rowid)
- │                          auto commit   ·
- └── render                 ·             ·
-      └── limit             ·             ·
-           │                count         1
-           └── sort         ·             ·
-                │           order         +column2
-                └── values  ·             ·
-·                           size          2 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• insert
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • sort
+            │ order: +column2
+            │
+            └── • values
+                  size: 2 columns, 2 rows
 
-query TTT
+query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-·                           distribution  local
-·                           vectorized    false
-insert                      ·             ·
- │                          into          insert_t(x, v, rowid)
- │                          auto commit   ·
- └── render                 ·             ·
-      └── limit             ·             ·
-           │                count         1
-           └── sort         ·             ·
-                │           order         +column2
-                └── values  ·             ·
-·                           size          2 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• insert
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • sort
+            │ order: +column2
+            │
+            └── • values
+                  size: 2 columns, 2 rows
 
-query TTT
+query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
-·                           distribution  local
-·                           vectorized    false
-insert                      ·             ·
- │                          into          insert_t(x, v, rowid)
- │                          auto commit   ·
- └── render                 ·             ·
-      └── limit             ·             ·
-           │                count         1
-           └── sort         ·             ·
-                │           order         +column2
-                └── values  ·             ·
-·                           size          2 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• insert
+│ into: insert_t(x, v, rowid)
+│ auto commit
+│
+└── • render
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • sort
+            │ order: +column2
+            │
+            └── • values
+                  size: 2 columns, 2 rows
 
 # ORDER BY expression that's not inserted into table.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETURNING x+v
 ----
-·                                   distribution         local                   ·                               ·
-·                                   vectorized           false                   ·                               ·
-render                              ·                    ·                       ("?column?")                    ·
- │                                  estimated row count  10 (missing stats)      ·                               ·
- │                                  render 0             x + v                   ·                               ·
- └── insert                         ·                    ·                       (x, v, rowid)                   ·
-      │                             estimated row count  10 (missing stats)      ·                               ·
-      │                             into                 insert_t(x, v, rowid)   ·                               ·
-      └── render                    ·                    ·                       (length, "?column?", column13)  ·
-           │                        estimated row count  10 (missing stats)      ·                               ·
-           │                        render 0             unique_rowid()          ·                               ·
-           │                        render 1             length                  ·                               ·
-           │                        render 2             "?column?"              ·                               ·
-           └── limit                ·                    ·                       (length, "?column?", column12)  ·
-                │                   estimated row count  10 (missing stats)      ·                               ·
-                │                   count                10                      ·                               ·
-                └── sort            ·                    ·                       (length, "?column?", column12)  +column12
-                     │              estimated row count  1000 (missing stats)    ·                               ·
-                     │              order                +column12               ·                               ·
-                     └── render     ·                    ·                       (length, "?column?", column12)  ·
-                          │         estimated row count  1000 (missing stats)    ·                               ·
-                          │         render 0             length(k)               ·                               ·
-                          │         render 1             2                       ·                               ·
-                          │         render 2             k::STRING || v::STRING  ·                               ·
-                          └── scan  ·                    ·                       (k, v)                          ·
-·                                   estimated row count  1000 (missing stats)    ·                               ·
-·                                   table                kv@primary              ·                               ·
-·                                   spans                FULL SCAN               ·                               ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 10 (missing stats)
+│ render 0: x + v
+│
+└── • insert
+    │ columns: (x, v, rowid)
+    │ estimated row count: 10 (missing stats)
+    │ into: insert_t(x, v, rowid)
+    │
+    └── • render
+        │ columns: (length, "?column?", column13)
+        │ estimated row count: 10 (missing stats)
+        │ render 0: unique_rowid()
+        │ render 1: length
+        │ render 2: "?column?"
+        │
+        └── • limit
+            │ columns: (length, "?column?", column12)
+            │ estimated row count: 10 (missing stats)
+            │ count: 10
+            │
+            └── • sort
+                │ columns: (length, "?column?", column12)
+                │ ordering: +column12
+                │ estimated row count: 1000 (missing stats)
+                │ order: +column12
+                │
+                └── • render
+                    │ columns: (length, "?column?", column12)
+                    │ estimated row count: 1000 (missing stats)
+                    │ render 0: length(k)
+                    │ render 1: 2
+                    │ render 2: k::STRING || v::STRING
+                    │
+                    └── • scan
+                          columns: (k, v)
+                          estimated row count: 1000 (missing stats)
+                          table: kv@primary
+                          spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Insert rows into table during schema changes.
@@ -460,20 +507,24 @@ statement ok
 BEGIN; ALTER TABLE mutation DROP COLUMN y
 
 # Ensure that default value is still inserted into y, since y is write-only.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
-·                      distribution         local                  ·           ·
-·                      vectorized           false                  ·           ·
-project                ·                    ·                      (x)         ·
- │                     estimated row count  1                      ·           ·
- └── insert fast path  ·                    ·                      (x, rowid)  ·
-·                      estimated row count  1                      ·           ·
-·                      into                 mutation(x, rowid, y)  ·           ·
-·                      size                 3 columns, 1 row       ·           ·
-·                      row 0, expr 0        2                      ·           ·
-·                      row 0, expr 1        unique_rowid()         ·           ·
-·                      row 0, expr 2        10                     ·           ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (x)
+│ estimated row count: 1
+│
+└── • insert fast path
+      columns: (x, rowid)
+      estimated row count: 1
+      into: mutation(x, rowid, y)
+      size: 3 columns, 1 row
+      row 0, expr 0: 2
+      row 0, expr 1: unique_rowid()
+      row 0, expr 2: 10
 
 statement ok
 ROLLBACK
@@ -482,18 +533,20 @@ statement ok
 BEGIN; ALTER TABLE mutation ADD COLUMN z INT AS (x + y) STORED
 
 # Ensure that value is *not* inserted into z, since z is delete-only.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
-·                 distribution         local                  ·   ·
-·                 vectorized           false                  ·   ·
-insert fast path  ·                    ·                      ()  ·
-·                 estimated row count  0 (missing stats)      ·   ·
-·                 into                 mutation(x, y, rowid)  ·   ·
-·                 size                 3 columns, 1 row       ·   ·
-·                 row 0, expr 0        2                      ·   ·
-·                 row 0, expr 1        2                      ·   ·
-·                 row 0, expr 2        unique_rowid()         ·   ·
+distribution: local
+vectorized: false
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: mutation(x, y, rowid)
+  size: 3 columns, 1 row
+  row 0, expr 0: 2
+  row 0, expr 1: 2
+  row 0, expr 2: unique_rowid()
 
 statement ok
 ROLLBACK
@@ -507,39 +560,57 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-·                                   distribution         local                                                ·                    ·
-·                                   vectorized           false                                                ·                    ·
-root                                ·                    ·                                                    (z)                  ·
- ├── sort                           ·                    ·                                                    (z)                  +z
- │    │                             estimated row count  1000 (missing stats)                                 ·                    ·
- │    │                             order                +z                                                   ·                    ·
- │    └── scan buffer               ·                    ·                                                    (z)                  ·
- │                                  estimated row count  1000 (missing stats)                                 ·                    ·
- │                                  label                buffer 1                                             ·                    ·
- └── subquery                       ·                    ·                                                    ·                    ·
-      │                             id                   @S1                                                  ·                    ·
-      │                             original sql         INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                    ·
-      │                             exec mode            all rows                                             ·                    ·
-      └── buffer                    ·                    ·                                                    (z)                  ·
-           │                        label                buffer 1                                             ·                    ·
-           └── project              ·                    ·                                                    (z)                  ·
-                │                   estimated row count  1000 (missing stats)                                 ·                    ·
-                └── insert          ·                    ·                                                    (z, rowid)           ·
-                     │              estimated row count  1000 (missing stats)                                 ·                    ·
-                     │              into                 xyz(x, y, z, rowid)                                  ·                    ·
-                     └── render     ·                    ·                                                    (a, b, c, column13)  ·
-                          │         estimated row count  1000 (missing stats)                                 ·                    ·
-                          │         render 0             unique_rowid()                                       ·                    ·
-                          │         render 1             a                                                    ·                    ·
-                          │         render 2             b                                                    ·                    ·
-                          │         render 3             c                                                    ·                    ·
-                          └── scan  ·                    ·                                                    (a, b, c)            ·
-·                                   estimated row count  1000 (missing stats)                                 ·                    ·
-·                                   table                abc@primary                                          ·                    ·
-·                                   spans                FULL SCAN                                            ·                    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (z)
+│
+├── • sort
+│   │ columns: (z)
+│   │ ordering: +z
+│   │ estimated row count: 1000 (missing stats)
+│   │ order: +z
+│   │
+│   └── • scan buffer
+│         columns: (z)
+│         estimated row count: 1000 (missing stats)
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (z)
+        │ label: buffer 1
+        │
+        └── • project
+            │ columns: (z)
+            │ estimated row count: 1000 (missing stats)
+            │
+            └── • insert
+                │ columns: (z, rowid)
+                │ estimated row count: 1000 (missing stats)
+                │ into: xyz(x, y, z, rowid)
+                │
+                └── • render
+                    │ columns: (a, b, c, column13)
+                    │ estimated row count: 1000 (missing stats)
+                    │ render 0: unique_rowid()
+                    │ render 1: a
+                    │ render 2: b
+                    │ render 3: c
+                    │
+                    └── • scan
+                          columns: (a, b, c)
+                          estimated row count: 1000 (missing stats)
+                          table: abc@primary
+                          spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -36,47 +36,48 @@ CREATE TABLE level4 (
   CONSTRAINT fk3 FOREIGN KEY (k1, k2, k3) REFERENCES level3
 ) INTERLEAVE IN PARENT level3 (k1, k2, k3)
 
-query TTT
+query T
 EXPLAIN SELECT * FROM level4
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          level4@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: level4@primary
+  spans: FULL SCAN
 
 # The span below ends at the end of the first index of table 53, and is not
 # constraining the value of k2 or k3. This is confusing on first glance because
 # the second interleave in the hierarchy doesn't contain any new primary key
 # columns on top of the first interleave.
 query T
-SELECT description FROM [
+SELECT info FROM [
   EXPLAIN (VERBOSE) SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
-] WHERE field = 'spans'
+] WHERE info LIKE '%spans%'
 ----
-/2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+  spans: /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
 
 query T
-SELECT description FROM [
+SELECT info FROM [
   EXPLAIN (VERBOSE) SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
-] WHERE field = 'spans'
+] WHERE info LIKE '%spans%'
 ----
-/2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+  spans: /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
 
 query T
-SELECT description FROM [
+SELECT info FROM [
   EXPLAIN (VERBOSE) SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
-] WHERE field = 'spans'
+] WHERE info LIKE '%spans%'
 ----
-/2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+  spans: /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
 
 query T
-SELECT description FROM [
+SELECT info FROM [
   EXPLAIN (VERBOSE) SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
-] WHERE field = 'spans'
+] WHERE info LIKE '%spans%'
 ----
-/2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+  spans: /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
 
 # ------------------------------------------------------------------------------
 # Trace of interleaved fetches from interesting interleaved hierarchy.
@@ -378,24 +379,30 @@ INSERT INTO table0 SELECT i FROM generate_series(1, 10) AS i;
 INSERT INTO table1 SELECT (i-1)//10+1, i FROM generate_series(1, 100) AS i;
 INSERT INTO table2 SELECT (i-1)//100+1, (i-1)//10+1, i FROM generate_series(1, 1000) AS i;
 
-query TTT
+query T
 EXPLAIN SELECT count(*) FROM table1 INNER MERGE JOIN table2 USING(c0, c1) WHERE c1 >= 25 AND c1 < 75
 ----
-·                    distribution       local
-·                    vectorized         true
-group (scalar)       ·                  ·
- └── merge join      ·                  ·
-      │              equality           (c0, c1) = (c0, c1)
-      │              left cols are key  ·
-      ├── filter     ·                  ·
-      │    │         filter             (c1 >= 25) AND (c1 < 75)
-      │    └── scan  ·                  ·
-      │              missing stats      ·
-      │              table              table1@primary
-      │              spans              FULL SCAN
-      └── filter     ·                  ·
-           │         filter             (c1 >= 25) AND (c1 < 75)
-           └── scan  ·                  ·
-·                    missing stats      ·
-·                    table              table2@primary
-·                    spans              FULL SCAN
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • merge join
+    │ equality: (c0, c1) = (c0, c1)
+    │ left cols are key
+    │
+    ├── • filter
+    │   │ filter: (c1 >= 25) AND (c1 < 75)
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: table1@primary
+    │         spans: FULL SCAN
+    │
+    └── • filter
+        │ filter: (c1 >= 25) AND (c1 < 75)
+        │
+        └── • scan
+              missing stats
+              table: table2@primary
+              spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -163,468 +163,582 @@ Put /Table/55/1/0/0 -> /TUPLE/
 Del /Table/55/2/1/0/0
 InitPut /Table/55/2/15/0/0 -> /BYTES/
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
-·           distribution         local                        ·       ·
-·           vectorized           true                         ·       ·
-index join  ·                    ·                            (a, b)  ·
- │          estimated row count  110 (missing stats)          ·       ·
- │          table                d@primary                    ·       ·
- │          key columns          a                            ·       ·
- └── scan   ·                    ·                            (a)     ·
-·           estimated row count  110 (missing stats)          ·       ·
-·           table                d@foo_inv                    ·       ·
-·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
-·           distribution         local                                    ·       ·
-·           vectorized           true                                     ·       ·
-index join  ·                    ·                                        (a, b)  ·
- │          estimated row count  110 (missing stats)                      ·       ·
- │          table                d@primary                                ·       ·
- │          key columns          a                                        ·       ·
- └── scan   ·                    ·                                        (a)     ·
-·           estimated row count  110 (missing stats)                      ·       ·
-·           table                d@foo_inv                                ·       ·
-·           spans                /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
-·           distribution         local                                            ·       ·
-·           vectorized           true                                             ·       ·
-index join  ·                    ·                                                (a, b)  ·
- │          estimated row count  110 (missing stats)                              ·       ·
- │          table                d@primary                                        ·       ·
- │          key columns          a                                                ·       ·
- └── scan   ·                    ·                                                (a)     ·
-·           estimated row count  110 (missing stats)                              ·       ·
-·           table                d@foo_inv                                        ·       ·
-·           spans                /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
-·           distribution         local                         ·       ·
-·           vectorized           true                          ·       ·
-index join  ·                    ·                             (a, b)  ·
- │          estimated row count  110 (missing stats)           ·       ·
- │          table                d@primary                     ·       ·
- │          key columns          a                             ·       ·
- └── scan   ·                    ·                             (a)     ·
-·           estimated row count  110 (missing stats)           ·       ·
-·           table                d@foo_inv                     ·       ·
-·           spans                /"a"/"b"/True-/"a"/"b"/False  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"/True-/"a"/"b"/False
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
-·           distribution         local                    ·       ·
-·           vectorized           true                     ·       ·
-index join  ·                    ·                        (a, b)  ·
- │          estimated row count  110 (missing stats)      ·       ·
- │          table                d@primary                ·       ·
- │          key columns          a                        ·       ·
- └── scan   ·                    ·                        (a)     ·
-·           estimated row count  110 (missing stats)      ·       ·
-·           table                d@foo_inv                ·       ·
-·           spans                /Arr/1-/Arr/1/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /Arr/1-/Arr/1/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
-·           distribution         local                                            ·       ·
-·           vectorized           true                                             ·       ·
-index join  ·                    ·                                                (a, b)  ·
- │          estimated row count  110 (missing stats)                              ·       ·
- │          table                d@primary                                        ·       ·
- │          key columns          a                                                ·       ·
- └── scan   ·                    ·                                                (a)     ·
-·           estimated row count  110 (missing stats)                              ·       ·
-·           table                d@foo_inv                                        ·       ·
-·           spans                /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  110 (missing stats)   ·       ·
- │         filter               b @> '[]'             ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                d@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ filter: b @> '[]'
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: d@primary
+      spans: FULL SCAN
 
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  110 (missing stats)   ·       ·
- │         filter               b @> '{}'             ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                d@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ filter: b @> '{}'
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: d@primary
+      spans: FULL SCAN
 
 
 # TODO(mgartner): It should not be required to force the index scan. It is
 # required until the statistics builder treats b->'a' = '"b"' similarly to the
 # containment operator, @>.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d@foo_inv where b->'a' = '"b"'
 ----
-·           distribution         local                        ·       ·
-·           vectorized           true                         ·       ·
-index join  ·                    ·                            (a, b)  ·
- │          estimated row count  333 (missing stats)          ·       ·
- │          table                d@primary                    ·       ·
- │          key columns          a                            ·       ·
- └── scan   ·                    ·                            (a)     ·
-·           estimated row count  110 (missing stats)          ·       ·
-·           table                d@foo_inv                    ·       ·
-·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 
 # TODO(mgartner): Add support for building inverted index constraints for chained JSON
 # fetch operators.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
-·          distribution         local                    ·       ·
-·          vectorized           true                     ·       ·
-filter     ·                    ·                        (a, b)  ·
- │         estimated row count  333 (missing stats)      ·       ·
- │         filter               ((b->'a')->'c') = '"b"'  ·       ·
- └── scan  ·                    ·                        (a, b)  ·
-·          estimated row count  1000 (missing stats)     ·       ·
-·          table                d@primary                ·       ·
-·          spans                FULL SCAN                ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: ((b->'a')->'c') = '"b"'
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: d@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
 ----
-·       distribution  local  ·       ·
-·       vectorized    true   ·       ·
-norows  ·             ·      (a, b)  ·
+distribution: local
+vectorized: true
+·
+• norows
+  columns: (a, b)
 
 # TODO(mgartner): It should not be required to force the index scan. It is
 # required until the statistics builder treats b->'a' = '"b"' similarly to the
 # containment operator, @>.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d@foo_inv where '"b"' = b->'a'
 ----
-·           distribution         local                        ·       ·
-·           vectorized           true                         ·       ·
-index join  ·                    ·                            (a, b)  ·
- │          estimated row count  333 (missing stats)          ·       ·
- │          table                d@primary                    ·       ·
- │          key columns          a                            ·       ·
- └── scan   ·                    ·                            (a)     ·
-·           estimated row count  110 (missing stats)          ·       ·
-·           table                d@foo_inv                    ·       ·
-·           spans                /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ table: d@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 
 # Make sure that querying for NULL equality doesn't use the inverted index.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  10 (missing stats)    ·       ·
- │         filter               b IS NULL             ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                d@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 10 (missing stats)
+│ filter: b IS NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: d@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         b @> '{"a": []}'
- └── scan  ·              ·
-·          missing stats  ·
-·          table          d@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: b @> '{"a": []}'
+│
+└── • scan
+      missing stats
+      table: d@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         b @> '{"a": {}}'
- └── scan  ·              ·
-·          missing stats  ·
-·          table          d@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: b @> '{"a": {}}'
+│
+└── • scan
+      missing stats
+      table: d@primary
+      spans: FULL SCAN
 
 # Multi-path contains queries. Should create zigzag joins.
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                    distribution           local                               ·       ·
-·                    vectorized             true                                ·       ·
-lookup join (inner)  ·                      ·                                   (a, b)  ·
- │                   estimated row count    12 (missing stats)                  ·       ·
- │                   table                  d@primary                           ·       ·
- │                   equality               (a) = (a)                           ·       ·
- │                   equality cols are key  ·                                   ·       ·
- │                   pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag join     ·                      ·                                   (a)     ·
-·                    estimated row count    12 (missing stats)                  ·       ·
-·                    left table             d@foo_inv                           ·       ·
-·                    left columns           (a)                                 ·       ·
-·                    left fixed values      1 column                            ·       ·
-·                    right table            d@foo_inv                           ·       ·
-·                    right columns          ()                                  ·       ·
-·                    right fixed values     1 column                            ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '{"a": {"b": "c"}, "f": "g"}'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                    distribution           local                                         ·       ·
-·                    vectorized             true                                          ·       ·
-lookup join (inner)  ·                      ·                                             (a, b)  ·
- │                   estimated row count    1 (missing stats)                             ·       ·
- │                   table                  d@primary                                     ·       ·
- │                   equality               (a) = (a)                                     ·       ·
- │                   equality cols are key  ·                                             ·       ·
- │                   pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag join     ·                      ·                                             (a)     ·
-·                    estimated row count    12 (missing stats)                            ·       ·
-·                    left table             d@foo_inv                                     ·       ·
-·                    left columns           (a)                                           ·       ·
-·                    left fixed values      1 column                                      ·       ·
-·                    right table            d@foo_inv                                     ·       ·
-·                    right columns          ()                                            ·       ·
-·                    right fixed values     1 column                                      ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 1 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                    distribution           local                              ·       ·
-·                    vectorized             true                               ·       ·
-lookup join (inner)  ·                      ·                                  (a, b)  ·
- │                   estimated row count    12 (missing stats)                 ·       ·
- │                   table                  d@primary                          ·       ·
- │                   equality               (a) = (a)                          ·       ·
- │                   equality cols are key  ·                                  ·       ·
- │                   pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag join     ·                      ·                                  (a)     ·
-·                    estimated row count    12 (missing stats)                 ·       ·
-·                    left table             d@foo_inv                          ·       ·
-·                    left columns           (a)                                ·       ·
-·                    left fixed values      1 column                           ·       ·
-·                    right table            d@foo_inv                          ·       ·
-·                    right columns          ()                                 ·       ·
-·                    right fixed values     1 column                           ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '[{"a": {"b": [[2]]}}, "d"]'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
 statement ok
 SET enable_zigzag_join = true
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                    distribution           local                               ·       ·
-·                    vectorized             true                                ·       ·
-lookup join (inner)  ·                      ·                                   (a, b)  ·
- │                   estimated row count    12 (missing stats)                  ·       ·
- │                   table                  d@primary                           ·       ·
- │                   equality               (a) = (a)                           ·       ·
- │                   equality cols are key  ·                                   ·       ·
- │                   pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag join     ·                      ·                                   (a)     ·
-·                    estimated row count    12 (missing stats)                  ·       ·
-·                    left table             d@foo_inv                           ·       ·
-·                    left columns           (a)                                 ·       ·
-·                    left fixed values      1 column                            ·       ·
-·                    right table            d@foo_inv                           ·       ·
-·                    right columns          ()                                  ·       ·
-·                    right fixed values     1 column                            ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '{"a": {"b": "c"}, "f": "g"}'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                    distribution           local                                         ·       ·
-·                    vectorized             true                                          ·       ·
-lookup join (inner)  ·                      ·                                             (a, b)  ·
- │                   estimated row count    1 (missing stats)                             ·       ·
- │                   table                  d@primary                                     ·       ·
- │                   equality               (a) = (a)                                     ·       ·
- │                   equality cols are key  ·                                             ·       ·
- │                   pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag join     ·                      ·                                             (a)     ·
-·                    estimated row count    12 (missing stats)                            ·       ·
-·                    left table             d@foo_inv                                     ·       ·
-·                    left columns           (a)                                           ·       ·
-·                    left fixed values      1 column                                      ·       ·
-·                    right table            d@foo_inv                                     ·       ·
-·                    right columns          ()                                            ·       ·
-·                    right fixed values     1 column                                      ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 1 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                    distribution           local                              ·       ·
-·                    vectorized             true                               ·       ·
-lookup join (inner)  ·                      ·                                  (a, b)  ·
- │                   estimated row count    12 (missing stats)                 ·       ·
- │                   table                  d@primary                          ·       ·
- │                   equality               (a) = (a)                          ·       ·
- │                   equality cols are key  ·                                  ·       ·
- │                   pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag join     ·                      ·                                  (a)     ·
-·                    estimated row count    12 (missing stats)                 ·       ·
-·                    left table             d@foo_inv                          ·       ·
-·                    left columns           (a)                                ·       ·
-·                    left fixed values      1 column                           ·       ·
-·                    right table            d@foo_inv                          ·       ·
-·                    right columns          ()                                 ·       ·
-·                    right fixed values     1 column                           ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> '[{"a": {"b": [[2]]}}, "d"]'
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: d@foo_inv
+      left columns: (a)
+      left fixed values: 1 column
+      right table: d@foo_inv
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-·                distribution         local                     ·       ·
-·                vectorized           true                      ·       ·
-filter           ·                    ·                         (a, b)  ·
- │               estimated row count  12 (missing stats)        ·       ·
- │               filter               b @> '{"a": {}, "b": 2}'  ·       ·
- └── index join  ·                    ·                         (a, b)  ·
-      │          estimated row count  110 (missing stats)       ·       ·
-      │          table                d@primary                 ·       ·
-      │          key columns          a                         ·       ·
-      └── scan   ·                    ·                         (a)     ·
-·                estimated row count  110 (missing stats)       ·       ·
-·                table                d@foo_inv                 ·       ·
-·                spans                /"b"/2-/"b"/2/PrefixEnd   ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ filter: b @> '{"a": {}, "b": 2}'
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 110 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 110 (missing stats)
+          table: d@foo_inv
+          spans: /"b"/2-/"b"/2/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ----
-·          distribution         local                      ·       ·
-·          vectorized           true                       ·       ·
-filter     ·                    ·                          (a, b)  ·
- │         estimated row count  12 (missing stats)         ·       ·
- │         filter               b @> '{"a": {}, "b": {}}'  ·       ·
- └── scan  ·                    ·                          (a, b)  ·
-·          estimated row count  1000 (missing stats)       ·       ·
-·          table                d@primary                  ·       ·
-·          spans                FULL SCAN                  ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ filter: b @> '{"a": {}, "b": {}}'
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: d@primary
+      spans: FULL SCAN
 
 subtest array
 
 # Tests for array inverted indexes.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1]
 ----
-·           distribution         local                ·       ·
-·           vectorized           true                 ·       ·
-index join  ·                    ·                    (a, b)  ·
- │          estimated row count  110 (missing stats)  ·       ·
- │          table                e@primary            ·       ·
- │          key columns          a                    ·       ·
- └── scan   ·                    ·                    (a)     ·
-·           estimated row count  110 (missing stats)  ·       ·
-·           table                e@e_b_idx            ·       ·
-·           spans                /1-/2                ·       ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: e@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 110 (missing stats)
+      table: e@e_b_idx
+      spans: /1-/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  330 (missing stats)   ·       ·
- │         filter               b @> ARRAY[]          ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                e@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 330 (missing stats)
+│ filter: b @> ARRAY[]
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: e@primary
+      spans: FULL SCAN
 
 # Test that searching for a NULL element using the inverted index.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
 ----
-·            distribution         local                ·       ·
-·            vectorized           true                 ·       ·
-index join   ·                    ·                    (a, b)  ·
- │           estimated row count  110 (missing stats)  ·       ·
- │           table                e@primary            ·       ·
- │           key columns          a                    ·       ·
- └── norows  ·                    ·                    (a)     ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 110 (missing stats)
+│ table: e@primary
+│ key columns: a
+│
+└── • norows
+      columns: (a)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> NULL
 ----
-·       distribution  local  ·       ·
-·       vectorized    true   ·       ·
-norows  ·             ·      (a, b)  ·
+distribution: local
+vectorized: true
+·
+• norows
+  columns: (a, b)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (a, b)  ·
- │         estimated row count  10 (missing stats)    ·       ·
- │         filter               b IS NULL             ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                e@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 10 (missing stats)
+│ filter: b IS NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: e@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ----
-·                    distribution           local               ·       ·
-·                    vectorized             true                ·       ·
-lookup join (inner)  ·                      ·                   (a, b)  ·
- │                   estimated row count    12 (missing stats)  ·       ·
- │                   table                  e@primary           ·       ·
- │                   equality               (a) = (a)           ·       ·
- │                   equality cols are key  ·                   ·       ·
- │                   pred                   b @> ARRAY[1,2]     ·       ·
- └── zigzag join     ·                      ·                   (a)     ·
-·                    estimated row count    12 (missing stats)  ·       ·
-·                    left table             e@e_b_idx           ·       ·
-·                    left columns           (a)                 ·       ·
-·                    left fixed values      1 column            ·       ·
-·                    right table            e@e_b_idx           ·       ·
-·                    right columns          ()                  ·       ·
-·                    right fixed values     1 column            ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: e@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> ARRAY[1,2]
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: e@e_b_idx
+      left columns: (a)
+      left fixed values: 1 column
+      right table: e@e_b_idx
+      right columns: ()
+      right fixed values: 1 column
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ----
-·                    distribution           local                                ·       ·
-·                    vectorized             true                                 ·       ·
-lookup join (inner)  ·                      ·                                    (a, b)  ·
- │                   estimated row count    12 (missing stats)                   ·       ·
- │                   table                  e@primary                            ·       ·
- │                   equality               (a) = (a)                            ·       ·
- │                   equality cols are key  ·                                    ·       ·
- │                   pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
- └── zigzag join     ·                      ·                                    (a)     ·
-·                    estimated row count    12 (missing stats)                   ·       ·
-·                    left table             e@e_b_idx                            ·       ·
-·                    left columns           (a)                                  ·       ·
-·                    left fixed values      1 column                             ·       ·
-·                    right table            e@e_b_idx                            ·       ·
-·                    right columns          ()                                   ·       ·
-·                    right fixed values     1 column                             ·       ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: e@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: (b @> ARRAY[1]) AND (b @> ARRAY[2])
+│
+└── • zigzag join
+      columns: (a)
+      estimated row count: 12 (missing stats)
+      left table: e@e_b_idx
+      left columns: (a)
+      left fixed values: 1 column
+      right table: e@e_b_idx
+      right columns: ()
+      right fixed values: 1 column
 
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.
@@ -647,29 +761,41 @@ CREATE TABLE geo_table(
   INVERTED INDEX geom_index(geom)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM geo_table WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
-·                                    distribution         local                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ·                       ·
-·                                    vectorized           false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ·                       ·
-project                              ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k)                     ·
- │                                   estimated row count  110 (missing stats)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ·                       ·
- └── filter                          ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k, geom)               ·
-      │                              estimated row count  110 (missing stats)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ·                       ·
-      │                              filter               st_intersects('010100000000000000000008400000000000000840', geom)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ·                       ·
-      └── index join                 ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k, geom)               ·
-           │                         estimated row count  111 (missing stats)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ·                       ·
-           │                         table                geo_table@primary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ·                       ·
-           │                         key columns          k                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ·                       ·
-           └── project               ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k)                     ·
-                │                    estimated row count  111 (missing stats)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ·                       ·
-                └── inverted filter  ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k, geom_inverted_key)  ·
-                     │               inverted column      geom_inverted_key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ·                       ·
-                     │               num spans            31                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ·                       ·
-                     └── scan        ·                    ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    (k, geom_inverted_key)  ·
-·                                    estimated row count  111 (missing stats)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ·                       ·
-·                                    table                geo_table@geom_index                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ·                       ·
-·                                    spans                /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x01"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x02" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x04"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x05" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x10"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x11" /"B\xfd\x10\x00\x00\x00\x00\x00\x00@"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00A" /"B\xfd\x10\x00\x00\x00\x00\x00\x01\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x01\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x04\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x04\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x10\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x10\x01" /"B\xfd\x10\x00\x00\x00\x00\x00@\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00@\x01" /"B\xfd\x10\x00\x00\x00\x00\x01\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x01\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x04\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x04\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x10\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x10\x00\x01" /"B\xfd\x10\x00\x00\x00\x00@\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00@\x00\x01" /"B\xfd\x10\x00\x00\x00\x01\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x01\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x04\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x04\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x10\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x10\x00\x00\x01" /"B\xfd\x10\x00\x00\x00@\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00@\x00\x00\x01" /"B\xfd\x10\x00\x00\x01\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x01\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x04\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x04\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x10\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x10\x00\x00\x00\x01" /"B\xfd\x10\x00\x00@\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00@\x00\x00\x00\x01" /"B\xfd\x10\x00\x01\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x01\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x04\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x04\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x10\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x10\x00\x00\x00\x00\x01" /"B\xfd\x10\x00@\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00@\x00\x00\x00\x00\x01" /"B\xfd\x10\x01\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x01\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x04\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x04\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x10\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x10\x00\x00\x00\x00\x00\x01" /"B\xfd\x10@\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10@\x00\x00\x00\x00\x00\x01" /"B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x11\x00\x00\x00\x00\x00\x00\x01" /"B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x14\x00\x00\x00\x00\x00\x00\x01"  ·                       ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (k)
+│ estimated row count: 110 (missing stats)
+│
+└── • filter
+    │ columns: (k, geom)
+    │ estimated row count: 110 (missing stats)
+    │ filter: st_intersects('010100000000000000000008400000000000000840', geom)
+    │
+    └── • index join
+        │ columns: (k, geom)
+        │ estimated row count: 111 (missing stats)
+        │ table: geo_table@primary
+        │ key columns: k
+        │
+        └── • project
+            │ columns: (k)
+            │ estimated row count: 111 (missing stats)
+            │
+            └── • inverted filter
+                │ columns: (k, geom_inverted_key)
+                │ inverted column: geom_inverted_key
+                │ num spans: 31
+                │
+                └── • scan
+                      columns: (k, geom_inverted_key)
+                      estimated row count: 111 (missing stats)
+                      table: geo_table@geom_index
+                      spans: /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x01"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x02" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x04"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x05" /"B\xfd\x10\x00\x00\x00\x00\x00\x00\x10"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x11" /"B\xfd\x10\x00\x00\x00\x00\x00\x00@"-/"B\xfd\x10\x00\x00\x00\x00\x00\x00A" /"B\xfd\x10\x00\x00\x00\x00\x00\x01\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x01\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x04\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x04\x01" /"B\xfd\x10\x00\x00\x00\x00\x00\x10\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00\x10\x01" /"B\xfd\x10\x00\x00\x00\x00\x00@\x00"-/"B\xfd\x10\x00\x00\x00\x00\x00@\x01" /"B\xfd\x10\x00\x00\x00\x00\x01\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x01\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x04\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x04\x00\x01" /"B\xfd\x10\x00\x00\x00\x00\x10\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00\x10\x00\x01" /"B\xfd\x10\x00\x00\x00\x00@\x00\x00"-/"B\xfd\x10\x00\x00\x00\x00@\x00\x01" /"B\xfd\x10\x00\x00\x00\x01\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x01\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x04\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x04\x00\x00\x01" /"B\xfd\x10\x00\x00\x00\x10\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00\x10\x00\x00\x01" /"B\xfd\x10\x00\x00\x00@\x00\x00\x00"-/"B\xfd\x10\x00\x00\x00@\x00\x00\x01" /"B\xfd\x10\x00\x00\x01\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x01\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x04\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x04\x00\x00\x00\x01" /"B\xfd\x10\x00\x00\x10\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00\x10\x00\x00\x00\x01" /"B\xfd\x10\x00\x00@\x00\x00\x00\x00"-/"B\xfd\x10\x00\x00@\x00\x00\x00\x01" /"B\xfd\x10\x00\x01\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x01\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x04\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x04\x00\x00\x00\x00\x01" /"B\xfd\x10\x00\x10\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00\x10\x00\x00\x00\x00\x01" /"B\xfd\x10\x00@\x00\x00\x00\x00\x00"-/"B\xfd\x10\x00@\x00\x00\x00\x00\x01" /"B\xfd\x10\x01\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x01\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x04\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x04\x00\x00\x00\x00\x00\x01" /"B\xfd\x10\x10\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10\x10\x00\x00\x00\x00\x00\x01" /"B\xfd\x10@\x00\x00\x00\x00\x00\x00"-/"B\xfd\x10@\x00\x00\x00\x00\x00\x01" /"B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x11\x00\x00\x00\x00\x00\x00\x01" /"B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"-/"B\xfd\x14\x00\x00\x00\x00\x00\x00\x01"
 
 statement ok
 CREATE TABLE geo_table2(
@@ -711,43 +837,57 @@ inner-join (lookup geo_table)
  └── filters
       └── st_intersects(geo_table2.geom:2, geo_table.geom:6) [outer=(2,6), immutable, constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM geo_table2 JOIN geo_table@geom_index
 ON ST_Intersects(geo_table2.geom, geo_table.geom)
 ----
-·                                distribution           local                                   ·                                ·
-·                                vectorized             true                                    ·                                ·
-lookup join (inner)              ·                      ·                                       (k, geom, k, geom)               ·
- │                               estimated row count    9801 (missing stats)                    ·                                ·
- │                               table                  geo_table@primary                       ·                                ·
- │                               equality               (k) = (k)                               ·                                ·
- │                               equality cols are key  ·                                       ·                                ·
- │                               pred                   st_intersects(geom, geom)               ·                                ·
- └── project                     ·                      ·                                       (k, geom, k)                     ·
-      │                          estimated row count    10000 (missing stats)                   ·                                ·
-      └── inverted join (inner)  ·                      ·                                       (k, geom, k, geom_inverted_key)  ·
-           │                     table                  geo_table@geom_index                    ·                                ·
-           │                     inverted expr          st_intersects(geom, geom_inverted_key)  ·                                ·
-           └── scan              ·                      ·                                       (k, geom)                        ·
-·                                estimated row count    1000 (missing stats)                    ·                                ·
-·                                table                  geo_table2@primary                      ·                                ·
-·                                spans                  FULL SCAN                               ·                                ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (k, geom, k, geom)
+│ estimated row count: 9801 (missing stats)
+│ table: geo_table@primary
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: st_intersects(geom, geom)
+│
+└── • project
+    │ columns: (k, geom, k)
+    │ estimated row count: 10000 (missing stats)
+    │
+    └── • inverted join (inner)
+        │ columns: (k, geom, k, geom_inverted_key)
+        │ table: geo_table@geom_index
+        │ inverted expr: st_intersects(geom, geom_inverted_key)
+        │
+        └── • scan
+              columns: (k, geom)
+              estimated row count: 1000 (missing stats)
+              table: geo_table2@primary
+              spans: FULL SCAN
 
 # Do not use the index when using a _ prefixed builtin.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM geo_table WHERE _ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
-·               distribution         local                                                               ·          ·
-·               vectorized           true                                                                ·          ·
-project         ·                    ·                                                                   (k)        ·
- │              estimated row count  330 (missing stats)                                                 ·          ·
- └── filter     ·                    ·                                                                   (k, geom)  ·
-      │         estimated row count  330 (missing stats)                                                 ·          ·
-      │         filter               _st_intersects('010100000000000000000008400000000000000840', geom)  ·          ·
-      └── scan  ·                    ·                                                                   (k, geom)  ·
-·               estimated row count  1000 (missing stats)                                                ·          ·
-·               table                geo_table@primary                                                   ·          ·
-·               spans                FULL SCAN                                                           ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│ estimated row count: 330 (missing stats)
+│
+└── • filter
+    │ columns: (k, geom)
+    │ estimated row count: 330 (missing stats)
+    │ filter: _st_intersects('010100000000000000000008400000000000000840', geom)
+    │
+    └── • scan
+          columns: (k, geom)
+          estimated row count: 1000 (missing stats)
+          table: geo_table@primary
+          spans: FULL SCAN
 
 query T
 EXPLAIN (OPT, VERBOSE) SELECT * FROM geo_table2 LEFT JOIN geo_table@geom_index

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -8,88 +8,104 @@ CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51
 
 ## Simple test cases for inner, left, right, and outer joins
 
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-·          distribution   local
-·          vectorized     true
-hash join  ·              ·
- │         equality       (x) = (x)
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          onecolumn@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          twocolumn@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (x) = (x)
+│
+├── • scan
+│     missing stats
+│     table: onecolumn@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: twocolumn@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-·          distribution   local
-·          vectorized     true
-hash join  ·              ·
- │         equality       (x) = (y)
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          twocolumn@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          twocolumn@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (x) = (y)
+│
+├── • scan
+│     missing stats
+│     table: twocolumn@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: twocolumn@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-·               distribution   local
-·               vectorized     true
-cross join      ·              ·
- ├── scan       ·              ·
- │              missing stats  ·
- │              table          twocolumn@primary
- │              spans          FULL SCAN
- └── filter     ·              ·
-      │         filter         x = 44
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          twocolumn@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• cross join
+│
+├── • scan
+│     missing stats
+│     table: twocolumn@primary
+│     spans: FULL SCAN
+│
+└── • filter
+    │ filter: x = 44
+    │
+    └── • scan
+          missing stats
+          table: twocolumn@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-·          distribution   local
-·          vectorized     true
-hash join  ·              ·
- │         equality       (x) = (y)
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          onecolumn@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          twocolumn@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (x) = (y)
+│
+├── • scan
+│     missing stats
+│     table: onecolumn@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: twocolumn@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-·          distribution   local
-·          vectorized     true
-hash join  ·              ·
- │         equality       (x) = (y)
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          onecolumn@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          twocolumn@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (x) = (y)
+│
+├── • scan
+│     missing stats
+│     table: onecolumn@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: twocolumn@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM
   onecolumn
   CROSS JOIN twocolumn
@@ -97,171 +113,232 @@ EXPLAIN SELECT * FROM
   JOIN twocolumn AS c (d, e) ON a.b = c.d AND c.d = onecolumn.x
 LIMIT 1
 ----
-·                    distribution   local
-·                    vectorized     true
-limit                ·              ·
- │                   count          1
- └── hash join       ·              ·
-      │              equality       (x) = (x)
-      ├── hash join  ·              ·
-      │    │         equality       (x) = (x)
-      │    ├── scan  ·              ·
-      │    │         missing stats  ·
-      │    │         table          onecolumn@primary
-      │    │         spans          FULL SCAN
-      │    └── scan  ·              ·
-      │              missing stats  ·
-      │              table          twocolumn@primary
-      │              spans          FULL SCAN
-      └── hash join  ·              ·
-           │         equality       (x) = (x)
-           ├── scan  ·              ·
-           │         missing stats  ·
-           │         table          onecolumn@primary
-           │         spans          FULL SCAN
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          twocolumn@primary
-·                    spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 1
+│
+└── • hash join
+    │ equality: (x) = (x)
+    │
+    ├── • hash join
+    │   │ equality: (x) = (x)
+    │   │
+    │   ├── • scan
+    │   │     missing stats
+    │   │     table: onecolumn@primary
+    │   │     spans: FULL SCAN
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: twocolumn@primary
+    │         spans: FULL SCAN
+    │
+    └── • hash join
+        │ equality: (x) = (x)
+        │
+        ├── • scan
+        │     missing stats
+        │     table: onecolumn@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: twocolumn@primary
+              spans: FULL SCAN
 
 # The following queries verify that only the necessary columns are scanned.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-·                   distribution         local                    ·       ·
-·                   vectorized           true                     ·       ·
-cross join (inner)  ·                    ·                        (x, y)  ·
- │                  estimated row count  1000000 (missing stats)  ·       ·
- ├── scan           ·                    ·                        (x)     ·
- │                  estimated row count  1000 (missing stats)     ·       ·
- │                  table                twocolumn@primary        ·       ·
- │                  spans                FULL SCAN                ·       ·
- └── scan           ·                    ·                        (y)     ·
-·                   estimated row count  1000 (missing stats)     ·       ·
-·                   table                twocolumn@primary        ·       ·
-·                   spans                FULL SCAN                ·       ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (x, y)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (x)
+│     estimated row count: 1000 (missing stats)
+│     table: twocolumn@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (y)
+      estimated row count: 1000 (missing stats)
+      table: twocolumn@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-·                       distribution         local                 ·          ·
-·                       vectorized           true                  ·          ·
-project                 ·                    ·                     (y)        ·
- │                      estimated row count  9801 (missing stats)  ·          ·
- └── hash join (inner)  ·                    ·                     (x, x, y)  ·
-      │                 estimated row count  9801 (missing stats)  ·          ·
-      │                 equality             (x) = (x)             ·          ·
-      ├── scan          ·                    ·                     (x)        ·
-      │                 estimated row count  1000 (missing stats)  ·          ·
-      │                 table                twocolumn@primary     ·          ·
-      │                 spans                FULL SCAN             ·          ·
-      └── scan          ·                    ·                     (x, y)     ·
-·                       estimated row count  1000 (missing stats)  ·          ·
-·                       table                twocolumn@primary     ·          ·
-·                       spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y)
+│ estimated row count: 9801 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (x, x, y)
+    │ estimated row count: 9801 (missing stats)
+    │ equality: (x) = (x)
+    │
+    ├── • scan
+    │     columns: (x)
+    │     estimated row count: 1000 (missing stats)
+    │     table: twocolumn@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: twocolumn@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-·                       distribution         local                 ·          ·
-·                       vectorized           true                  ·          ·
-project                 ·                    ·                     (y)        ·
- │                      estimated row count  9801 (missing stats)  ·          ·
- └── hash join (inner)  ·                    ·                     (x, x, y)  ·
-      │                 estimated row count  9801 (missing stats)  ·          ·
-      │                 equality             (x) = (x)             ·          ·
-      ├── scan          ·                    ·                     (x)        ·
-      │                 estimated row count  1000 (missing stats)  ·          ·
-      │                 table                twocolumn@primary     ·          ·
-      │                 spans                FULL SCAN             ·          ·
-      └── scan          ·                    ·                     (x, y)     ·
-·                       estimated row count  1000 (missing stats)  ·          ·
-·                       table                twocolumn@primary     ·          ·
-·                       spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y)
+│ estimated row count: 9801 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (x, x, y)
+    │ estimated row count: 9801 (missing stats)
+    │ equality: (x) = (x)
+    │
+    ├── • scan
+    │     columns: (x)
+    │     estimated row count: 1000 (missing stats)
+    │     table: twocolumn@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: twocolumn@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-·                        distribution         local                   ·       ·
-·                        vectorized           true                    ·       ·
-project                  ·                    ·                       (x)     ·
- │                       estimated row count  326700 (missing stats)  ·       ·
- └── cross join (inner)  ·                    ·                       (x, y)  ·
-      │                  estimated row count  326700 (missing stats)  ·       ·
-      │                  pred                 x < y                   ·       ·
-      ├── scan           ·                    ·                       (x)     ·
-      │                  estimated row count  1000 (missing stats)    ·       ·
-      │                  table                twocolumn@primary       ·       ·
-      │                  spans                FULL SCAN               ·       ·
-      └── scan           ·                    ·                       (y)     ·
-·                        estimated row count  1000 (missing stats)    ·       ·
-·                        table                twocolumn@primary       ·       ·
-·                        spans                FULL SCAN               ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x)
+│ estimated row count: 326700 (missing stats)
+│
+└── • cross join (inner)
+    │ columns: (x, y)
+    │ estimated row count: 326700 (missing stats)
+    │ pred: x < y
+    │
+    ├── • scan
+    │     columns: (x)
+    │     estimated row count: 1000 (missing stats)
+    │     table: twocolumn@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (y)
+          estimated row count: 1000 (missing stats)
+          table: twocolumn@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
 ----
-·                            distribution         local                  ·                   ·
-·                            vectorized           true                   ·                   ·
-render                       ·                    ·                      (x, two, plus1)     ·
- │                           estimated row count  10000 (missing stats)  ·                   ·
- │                           render 0             COALESCE(x, x)         ·                   ·
- │                           render 1             two                    ·                   ·
- │                           render 2             plus1                  ·                   ·
- └── hash join (full outer)  ·                    ·                      (two, x, plus1, x)  ·
-      │                      estimated row count  10000 (missing stats)  ·                   ·
-      │                      equality             (x) = (x)              ·                   ·
-      ├── render             ·                    ·                      (two, x)            ·
-      │    │                 estimated row count  1000 (missing stats)   ·                   ·
-      │    │                 render 0             2                      ·                   ·
-      │    │                 render 1             x                      ·                   ·
-      │    └── scan          ·                    ·                      (x)                 ·
-      │                      estimated row count  1000 (missing stats)   ·                   ·
-      │                      table                onecolumn@primary      ·                   ·
-      │                      spans                FULL SCAN              ·                   ·
-      └── render             ·                    ·                      (plus1, x)          ·
-           │                 estimated row count  1000 (missing stats)   ·                   ·
-           │                 render 0             y + 1                  ·                   ·
-           │                 render 1             x                      ·                   ·
-           └── scan          ·                    ·                      (x, y)              ·
-·                            estimated row count  1000 (missing stats)   ·                   ·
-·                            table                twocolumn@primary      ·                   ·
-·                            spans                FULL SCAN              ·                   ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (x, two, plus1)
+│ estimated row count: 10000 (missing stats)
+│ render 0: COALESCE(x, x)
+│ render 1: two
+│ render 2: plus1
+│
+└── • hash join (full outer)
+    │ columns: (two, x, plus1, x)
+    │ estimated row count: 10000 (missing stats)
+    │ equality: (x) = (x)
+    │
+    ├── • render
+    │   │ columns: (two, x)
+    │   │ estimated row count: 1000 (missing stats)
+    │   │ render 0: 2
+    │   │ render 1: x
+    │   │
+    │   └── • scan
+    │         columns: (x)
+    │         estimated row count: 1000 (missing stats)
+    │         table: onecolumn@primary
+    │         spans: FULL SCAN
+    │
+    └── • render
+        │ columns: (plus1, x)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: y + 1
+        │ render 1: x
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 1000 (missing stats)
+              table: twocolumn@primary
+              spans: FULL SCAN
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-·                            distribution         local                  ·                                     ·
-·                            vectorized           false                  ·                                     ·
-sort                         ·                    ·                      (k, u, w)                             +u
- │                           estimated row count  2                      ·                                     ·
- │                           order                +column1               ·                                     ·
- └── project                 ·                    ·                      (column1, column2, column2)           ·
-      │                      estimated row count  2                      ·                                     ·
-      └── hash join (inner)  ·                    ·                      (column1, column2, column1, column2)  ·
-           │                 estimated row count  2                      ·                                     ·
-           │                 equality             (column2) = (column1)  ·                                     ·
-           ├── values        ·                    ·                      (column1, column2)                    ·
-           │                 size                 2 columns, 2 rows      ·                                     ·
-           │                 row 0, expr 0        9                      ·                                     ·
-           │                 row 0, expr 1        1                      ·                                     ·
-           │                 row 1, expr 0        8                      ·                                     ·
-           │                 row 1, expr 1        2                      ·                                     ·
-           └── values        ·                    ·                      (column1, column2)                    ·
-·                            size                 2 columns, 2 rows      ·                                     ·
-·                            row 0, expr 0        1                      ·                                     ·
-·                            row 0, expr 1        1                      ·                                     ·
-·                            row 1, expr 0        2                      ·                                     ·
-·                            row 1, expr 1        2                      ·                                     ·
+distribution: local
+vectorized: false
+·
+• sort
+│ columns: (k, u, w)
+│ ordering: +u
+│ estimated row count: 2
+│ order: +column1
+│
+└── • project
+    │ columns: (column1, column2, column2)
+    │ estimated row count: 2
+    │
+    └── • hash join (inner)
+        │ columns: (column1, column2, column1, column2)
+        │ estimated row count: 2
+        │ equality: (column2) = (column1)
+        │
+        ├── • values
+        │     columns: (column1, column2)
+        │     size: 2 columns, 2 rows
+        │     row 0, expr 0: 9
+        │     row 0, expr 1: 1
+        │     row 1, expr 0: 8
+        │     row 1, expr 1: 2
+        │
+        └── • values
+              columns: (column1, column2)
+              size: 2 columns, 2 rows
+              row 0, expr 0: 1
+              row 0, expr 1: 1
+              row 1, expr 0: 2
+              row 1, expr 1: 2
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
 CREATE TABLE customers(id INT PRIMARY KEY NOT NULL); CREATE TABLE orders(id INT, cust INT REFERENCES customers(id))
 
-query ITTT
-SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
+query T
+EXPLAIN (VERBOSE) SELECT
        NULL::text  AS pktable_cat,
        pkn.nspname AS pktable_schem,
        pkc.relname AS pktable_name,
@@ -323,115 +400,166 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
            pkc.relname,
            con.conname,
            pos.n
-  ] WHERE node_type <> 'values' AND field <> 'size'
 ----
-0   ·                                  distribution         local
-0   ·                                  vectorized           false
-0   project                            ·                    ·
-1   sort                               ·                    ·
-1   ·                                  estimated row count  110908 (missing stats)
-1   ·                                  order                +nspname,+relname,+conname,+generate_series
-2   render                             ·                    ·
-2   ·                                  estimated row count  110908 (missing stats)
-2   ·                                  render 0             CAST(NULL AS STRING)
-2   ·                                  render 1             CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-2   ·                                  render 2             CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-2   ·                                  render 3             CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
-2   ·                                  render 4             nspname
-2   ·                                  render 5             relname
-2   ·                                  render 6             attname
-2   ·                                  render 7             nspname
-2   ·                                  render 8             relname
-2   ·                                  render 9             attname
-2   ·                                  render 10            conname
-2   ·                                  render 11            generate_series
-2   ·                                  render 12            relname
-3   hash join (inner)                  ·                    ·
-3   ·                                  estimated row count  110908 (missing stats)
-3   ·                                  equality             (oid) = (objid)
-4   hash join (inner)                  ·                    ·
-4   ·                                  estimated row count  114302 (missing stats)
-4   ·                                  equality             (relnamespace) = (oid)
-5   hash join (inner)                  ·                    ·
-5   ·                                  estimated row count  11557 (missing stats)
-5   ·                                  equality             (attrelid) = (oid)
-5   ·                                  pred                 attnum = confkey[generate_series]
-6   hash join (inner)                  ·                    ·
-6   ·                                  estimated row count  3502 (missing stats)
-6   ·                                  equality             (attrelid) = (confrelid)
-7   virtual table                      ·                    ·
-7   ·                                  estimated row count  1000 (missing stats)
-7   ·                                  table                pg_attribute@primary
-7   cross join (inner)                 ·                    ·
-7   ·                                  estimated row count  354 (missing stats)
-7   ·                                  pred                 attnum = conkey[generate_series]
-8   hash join (inner)                  ·                    ·
-8   ·                                  estimated row count  107 (missing stats)
-8   ·                                  equality             (relnamespace) = (oid)
-9   virtual table lookup join (inner)  ·                    ·
-9   ·                                  estimated row count  105 (missing stats)
-9   ·                                  table                pg_attribute@pg_attribute_attrelid_idx
-9   ·                                  equality             (oid) = (attrelid)
-10  virtual table lookup join (inner)  ·                    ·
-10  ·                                  estimated row count  10 (missing stats)
-10  ·                                  table                pg_constraint@pg_constraint_conrelid_idx
-10  ·                                  equality             (oid) = (conrelid)
-10  ·                                  pred                 contype = 'f'
-11  filter                             ·                    ·
-11  ·                                  estimated row count  10 (missing stats)
-11  ·                                  filter               relname = 'orders'
-12  virtual table                      ·                    ·
-12  ·                                  estimated row count  1000 (missing stats)
-12  ·                                  table                pg_class@primary
-9   filter                             ·                    ·
-9   ·                                  estimated row count  10 (missing stats)
-9   ·                                  filter               nspname = 'public'
-10  virtual table                      ·                    ·
-10  ·                                  estimated row count  1000 (missing stats)
-10  ·                                  table                pg_namespace@primary
-8   project set                        ·                    ·
-8   ·                                  estimated row count  10
-8   ·                                  render 0             generate_series(1, 32)
-9   emptyrow                           ·                    ·
-6   virtual table                      ·                    ·
-6   ·                                  estimated row count  1000 (missing stats)
-6   ·                                  table                pg_class@primary
-5   virtual table                      ·                    ·
-5   ·                                  estimated row count  1000 (missing stats)
-5   ·                                  table                pg_namespace@primary
-4   hash join (inner)                  ·                    ·
-4   ·                                  estimated row count  99 (missing stats)
-4   ·                                  equality             (refobjid) = (oid)
-5   virtual table                      ·                    ·
-5   ·                                  estimated row count  1000 (missing stats)
-5   ·                                  table                pg_depend@primary
-5   filter                             ·                    ·
-5   ·                                  estimated row count  10 (missing stats)
-5   ·                                  filter               relkind = 'i'
-6   virtual table                      ·                    ·
-6   ·                                  estimated row count  1000 (missing stats)
-6   ·                                  table                pg_class@primary
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (pktable_cat, pktable_schem, pktable_name, pkcolumn_name, fktable_cat, fktable_schem, fktable_name, fkcolumn_name, key_seq, update_rule, delete_rule, fk_name, pk_name, deferrability)
+│
+└── • sort
+    │ columns: (pktable_cat, update_rule, delete_rule, deferrability, nspname, relname, attname, nspname, relname, attname, conname, generate_series, relname)
+    │ ordering: +nspname,+relname,+conname,+generate_series
+    │ estimated row count: 110908 (missing stats)
+    │ order: +nspname,+relname,+conname,+generate_series
+    │
+    └── • render
+        │ columns: (pktable_cat, update_rule, delete_rule, deferrability, nspname, relname, attname, nspname, relname, attname, conname, generate_series, relname)
+        │ estimated row count: 110908 (missing stats)
+        │ render 0: CAST(NULL AS STRING)
+        │ render 1: CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+        │ render 2: CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+        │ render 3: CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
+        │ render 4: nspname
+        │ render 5: relname
+        │ render 6: attname
+        │ render 7: nspname
+        │ render 8: relname
+        │ render 9: attname
+        │ render 10: conname
+        │ render 11: generate_series
+        │ render 12: relname
+        │
+        └── • hash join (inner)
+            │ columns: (attrelid, attname, attnum, oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname, generate_series, oid, relname, relnamespace, oid, nspname, objid, refobjid, oid, relname, relkind)
+            │ estimated row count: 110908 (missing stats)
+            │ equality: (oid) = (objid)
+            │
+            ├── • hash join (inner)
+            │   │ columns: (attrelid, attname, attnum, oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname, generate_series, oid, relname, relnamespace, oid, nspname)
+            │   │ estimated row count: 114302 (missing stats)
+            │   │ equality: (relnamespace) = (oid)
+            │   │
+            │   ├── • hash join (inner)
+            │   │   │ columns: (attrelid, attname, attnum, oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname, generate_series, oid, relname, relnamespace)
+            │   │   │ estimated row count: 11557 (missing stats)
+            │   │   │ equality: (attrelid) = (oid)
+            │   │   │ pred: attnum = confkey[generate_series]
+            │   │   │
+            │   │   ├── • hash join (inner)
+            │   │   │   │ columns: (attrelid, attname, attnum, oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname, generate_series)
+            │   │   │   │ estimated row count: 3502 (missing stats)
+            │   │   │   │ equality: (attrelid) = (confrelid)
+            │   │   │   │
+            │   │   │   ├── • virtual table
+            │   │   │   │     columns: (attrelid, attname, attnum)
+            │   │   │   │     estimated row count: 1000 (missing stats)
+            │   │   │   │     table: pg_attribute@primary
+            │   │   │   │
+            │   │   │   └── • cross join (inner)
+            │   │   │       │ columns: (oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname, generate_series)
+            │   │   │       │ estimated row count: 354 (missing stats)
+            │   │   │       │ pred: attnum = conkey[generate_series]
+            │   │   │       │
+            │   │   │       ├── • hash join (inner)
+            │   │   │       │   │ columns: (oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum, oid, nspname)
+            │   │   │       │   │ estimated row count: 107 (missing stats)
+            │   │   │       │   │ equality: (relnamespace) = (oid)
+            │   │   │       │   │
+            │   │   │       │   ├── • virtual table lookup join (inner)
+            │   │   │       │   │   │ columns: (oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, attrelid, attname, attnum)
+            │   │   │       │   │   │ estimated row count: 105 (missing stats)
+            │   │   │       │   │   │ table: pg_attribute@pg_attribute_attrelid_idx
+            │   │   │       │   │   │ equality: (oid) = (attrelid)
+            │   │   │       │   │   │
+            │   │   │       │   │   └── • virtual table lookup join (inner)
+            │   │   │       │   │       │ columns: (oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey)
+            │   │   │       │   │       │ estimated row count: 10 (missing stats)
+            │   │   │       │   │       │ table: pg_constraint@pg_constraint_conrelid_idx
+            │   │   │       │   │       │ equality: (oid) = (conrelid)
+            │   │   │       │   │       │ pred: contype = 'f'
+            │   │   │       │   │       │
+            │   │   │       │   │       └── • filter
+            │   │   │       │   │           │ columns: (oid, relname, relnamespace)
+            │   │   │       │   │           │ estimated row count: 10 (missing stats)
+            │   │   │       │   │           │ filter: relname = 'orders'
+            │   │   │       │   │           │
+            │   │   │       │   │           └── • virtual table
+            │   │   │       │   │                 columns: (oid, relname, relnamespace)
+            │   │   │       │   │                 estimated row count: 1000 (missing stats)
+            │   │   │       │   │                 table: pg_class@primary
+            │   │   │       │   │
+            │   │   │       │   └── • filter
+            │   │   │       │       │ columns: (oid, nspname)
+            │   │   │       │       │ estimated row count: 10 (missing stats)
+            │   │   │       │       │ filter: nspname = 'public'
+            │   │   │       │       │
+            │   │   │       │       └── • virtual table
+            │   │   │       │             columns: (oid, nspname)
+            │   │   │       │             estimated row count: 1000 (missing stats)
+            │   │   │       │             table: pg_namespace@primary
+            │   │   │       │
+            │   │   │       └── • project set
+            │   │   │           │ columns: (generate_series)
+            │   │   │           │ estimated row count: 10
+            │   │   │           │ render 0: generate_series(1, 32)
+            │   │   │           │
+            │   │   │           └── • emptyrow
+            │   │   │                 columns: ()
+            │   │   │
+            │   │   └── • virtual table
+            │   │         columns: (oid, relname, relnamespace)
+            │   │         estimated row count: 1000 (missing stats)
+            │   │         table: pg_class@primary
+            │   │
+            │   └── • virtual table
+            │         columns: (oid, nspname)
+            │         estimated row count: 1000 (missing stats)
+            │         table: pg_namespace@primary
+            │
+            └── • hash join (inner)
+                │ columns: (objid, refobjid, oid, relname, relkind)
+                │ estimated row count: 99 (missing stats)
+                │ equality: (refobjid) = (oid)
+                │
+                ├── • virtual table
+                │     columns: (objid, refobjid)
+                │     estimated row count: 1000 (missing stats)
+                │     table: pg_depend@primary
+                │
+                └── • filter
+                    │ columns: (oid, relname, relkind)
+                    │ estimated row count: 10 (missing stats)
+                    │ filter: relkind = 'i'
+                    │
+                    └── • virtual table
+                          columns: (oid, relname, relkind)
+                          estimated row count: 1000 (missing stats)
+                          table: pg_class@primary
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok
 CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id), INDEX (cust))
 
-query TTT
+query T
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          equality            (cust) = (id)
- │          right cols are key  ·
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               cards@cards_cust_idx
- │          spans               FULL SCAN
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               customers@primary
-·           spans               FULL SCAN
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (cust) = (id)
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: cards@cards_cust_idx
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: customers@primary
+      spans: FULL SCAN
 
 # Tests for filter propagation through joins.
 
@@ -442,219 +570,290 @@ statement ok
 CREATE TABLE pairs (a INT, b INT)
 
 # The filter expression becomes an equality constraint.
-query TTT
+query T
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-·          distribution        local
-·          vectorized          true
-hash join  ·                   ·
- │         equality            (b) = (n)
- │         right cols are key  ·
- ├── scan  ·                   ·
- │         missing stats       ·
- │         table               pairs@primary
- │         spans               FULL SCAN
- └── scan  ·                   ·
-·          missing stats       ·
-·          table               square@primary
-·          spans               FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (b) = (n)
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: pairs@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: square@primary
+      spans: FULL SCAN
 
 # The filter expression becomes an ON predicate.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-·                       distribution         local                 ·                        ·
-·                       vectorized           true                  ·                        ·
-project                 ·                    ·                     (a, b, n, sq)            ·
- │                      estimated row count  990 (missing stats)   ·                        ·
- └── hash join (inner)  ·                    ·                     (column10, a, b, n, sq)  ·
-      │                 estimated row count  990 (missing stats)   ·                        ·
-      │                 equality             (column10) = (sq)     ·                        ·
-      ├── render        ·                    ·                     (column10, a, b)         ·
-      │    │            estimated row count  1000 (missing stats)  ·                        ·
-      │    │            render 0             a + b                 ·                        ·
-      │    │            render 1             a                     ·                        ·
-      │    │            render 2             b                     ·                        ·
-      │    └── scan     ·                    ·                     (a, b)                   ·
-      │                 estimated row count  1000 (missing stats)  ·                        ·
-      │                 table                pairs@primary         ·                        ·
-      │                 spans                FULL SCAN             ·                        ·
-      └── scan          ·                    ·                     (n, sq)                  ·
-·                       estimated row count  1000 (missing stats)  ·                        ·
-·                       table                square@primary        ·                        ·
-·                       spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, n, sq)
+│ estimated row count: 990 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (column10, a, b, n, sq)
+    │ estimated row count: 990 (missing stats)
+    │ equality: (column10) = (sq)
+    │
+    ├── • render
+    │   │ columns: (column10, a, b)
+    │   │ estimated row count: 1000 (missing stats)
+    │   │ render 0: a + b
+    │   │ render 1: a
+    │   │ render 2: b
+    │   │
+    │   └── • scan
+    │         columns: (a, b)
+    │         estimated row count: 1000 (missing stats)
+    │         table: pairs@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          columns: (n, sq)
+          estimated row count: 1000 (missing stats)
+          table: square@primary
+          spans: FULL SCAN
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a * b / 2 AS div, n, sq FROM pairs, square) WHERE div = sq
 ----
-·                                  distribution         local                    ·                   ·
-·                                  vectorized           true                     ·                   ·
-project                            ·                    ·                        (a, b, n, sq)       ·
- │                                 estimated row count  990 (missing stats)      ·                   ·
- └── filter                        ·                    ·                        (div, a, b, n, sq)  ·
-      │                            estimated row count  990 (missing stats)      ·                   ·
-      │                            filter               div = sq                 ·                   ·
-      └── render                   ·                    ·                        (div, a, b, n, sq)  ·
-           │                       estimated row count  1000000 (missing stats)  ·                   ·
-           │                       render 0             (a * b) / 2              ·                   ·
-           │                       render 1             a                        ·                   ·
-           │                       render 2             b                        ·                   ·
-           │                       render 3             n                        ·                   ·
-           │                       render 4             sq                       ·                   ·
-           └── cross join (inner)  ·                    ·                        (a, b, n, sq)       ·
-                │                  estimated row count  1000000 (missing stats)  ·                   ·
-                ├── scan           ·                    ·                        (a, b)              ·
-                │                  estimated row count  1000 (missing stats)     ·                   ·
-                │                  table                pairs@primary            ·                   ·
-                │                  spans                FULL SCAN                ·                   ·
-                └── scan           ·                    ·                        (n, sq)             ·
-·                                  estimated row count  1000 (missing stats)     ·                   ·
-·                                  table                square@primary           ·                   ·
-·                                  spans                FULL SCAN                ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, n, sq)
+│ estimated row count: 990 (missing stats)
+│
+└── • filter
+    │ columns: (div, a, b, n, sq)
+    │ estimated row count: 990 (missing stats)
+    │ filter: div = sq
+    │
+    └── • render
+        │ columns: (div, a, b, n, sq)
+        │ estimated row count: 1000000 (missing stats)
+        │ render 0: (a * b) / 2
+        │ render 1: a
+        │ render 2: b
+        │ render 3: n
+        │ render 4: sq
+        │
+        └── • cross join (inner)
+            │ columns: (a, b, n, sq)
+            │ estimated row count: 1000000 (missing stats)
+            │
+            ├── • scan
+            │     columns: (a, b)
+            │     estimated row count: 1000 (missing stats)
+            │     table: pairs@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  columns: (n, sq)
+                  estimated row count: 1000 (missing stats)
+                  table: square@primary
+                  spans: FULL SCAN
 
 # The filter expression must stay on top of the outer join.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-·                            distribution         local                 ·                        ·
-·                            vectorized           true                  ·                        ·
-project                      ·                    ·                     (a, b, n, sq)            ·
- │                           estimated row count  1000 (missing stats)  ·                        ·
- └── hash join (full outer)  ·                    ·                     (column10, a, b, n, sq)  ·
-      │                      estimated row count  1000 (missing stats)  ·                        ·
-      │                      equality             (column10) = (sq)     ·                        ·
-      ├── render             ·                    ·                     (column10, a, b)         ·
-      │    │                 estimated row count  1000 (missing stats)  ·                        ·
-      │    │                 render 0             a + b                 ·                        ·
-      │    │                 render 1             a                     ·                        ·
-      │    │                 render 2             b                     ·                        ·
-      │    └── scan          ·                    ·                     (a, b)                   ·
-      │                      estimated row count  1000 (missing stats)  ·                        ·
-      │                      table                pairs@primary         ·                        ·
-      │                      spans                FULL SCAN             ·                        ·
-      └── scan               ·                    ·                     (n, sq)                  ·
-·                            estimated row count  1000 (missing stats)  ·                        ·
-·                            table                square@primary        ·                        ·
-·                            spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, n, sq)
+│ estimated row count: 1000 (missing stats)
+│
+└── • hash join (full outer)
+    │ columns: (column10, a, b, n, sq)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (column10) = (sq)
+    │
+    ├── • render
+    │   │ columns: (column10, a, b)
+    │   │ estimated row count: 1000 (missing stats)
+    │   │ render 0: a + b
+    │   │ render 1: a
+    │   │ render 2: b
+    │   │
+    │   └── • scan
+    │         columns: (a, b)
+    │         estimated row count: 1000 (missing stats)
+    │         table: pairs@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          columns: (n, sq)
+          estimated row count: 1000 (missing stats)
+          table: square@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-·                                 distribution         local                 ·                        ·
-·                                 vectorized           true                  ·                        ·
-project                           ·                    ·                     (a, b, n, sq)            ·
- │                                estimated row count  333 (missing stats)   ·                        ·
- └── filter                       ·                    ·                     (column10, a, b, n, sq)  ·
-      │                           estimated row count  333 (missing stats)   ·                        ·
-      │                           filter               (b % 2) != (sq % 2)   ·                        ·
-      └── hash join (full outer)  ·                    ·                     (column10, a, b, n, sq)  ·
-           │                      estimated row count  1000 (missing stats)  ·                        ·
-           │                      equality             (column10) = (sq)     ·                        ·
-           ├── render             ·                    ·                     (column10, a, b)         ·
-           │    │                 estimated row count  1000 (missing stats)  ·                        ·
-           │    │                 render 0             a + b                 ·                        ·
-           │    │                 render 1             a                     ·                        ·
-           │    │                 render 2             b                     ·                        ·
-           │    └── scan          ·                    ·                     (a, b)                   ·
-           │                      estimated row count  1000 (missing stats)  ·                        ·
-           │                      table                pairs@primary         ·                        ·
-           │                      spans                FULL SCAN             ·                        ·
-           └── scan               ·                    ·                     (n, sq)                  ·
-·                                 estimated row count  1000 (missing stats)  ·                        ·
-·                                 table                square@primary        ·                        ·
-·                                 spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, n, sq)
+│ estimated row count: 333 (missing stats)
+│
+└── • filter
+    │ columns: (column10, a, b, n, sq)
+    │ estimated row count: 333 (missing stats)
+    │ filter: (b % 2) != (sq % 2)
+    │
+    └── • hash join (full outer)
+        │ columns: (column10, a, b, n, sq)
+        │ estimated row count: 1000 (missing stats)
+        │ equality: (column10) = (sq)
+        │
+        ├── • render
+        │   │ columns: (column10, a, b)
+        │   │ estimated row count: 1000 (missing stats)
+        │   │ render 0: a + b
+        │   │ render 1: a
+        │   │ render 2: b
+        │   │
+        │   └── • scan
+        │         columns: (a, b)
+        │         estimated row count: 1000 (missing stats)
+        │         table: pairs@primary
+        │         spans: FULL SCAN
+        │
+        └── • scan
+              columns: (n, sq)
+              estimated row count: 1000 (missing stats)
+              table: square@primary
+              spans: FULL SCAN
 
 # Filter propagation through outer joins.
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs LEFT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
-]
 ----
-·                            distribution         local
-·                            vectorized           true
-filter                       ·                    ·
- │                           estimated row count  115 (missing stats)
- │                           filter               ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash join (left outer)  ·                    ·
-      │                      estimated row count  1037 (missing stats)
-      │                      equality             (b) = (sq)
-      │                      pred                 a > 1
-      ├── filter             ·                    ·
-      │    │                 estimated row count  333 (missing stats)
-      │    │                 filter               b > 1
-      │    └── scan          ·                    ·
-      │                      estimated row count  1000 (missing stats)
-      │                      table                pairs@primary
-      │                      spans                FULL SCAN
-      └── filter             ·                    ·
-           │                 estimated row count  311 (missing stats)
-           │                 filter               sq > 1
-           └── scan          ·                    ·
-·                            estimated row count  333 (missing stats)
-·                            table                square@primary
-·                            spans                -/5/#
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, n, sq)
+│ estimated row count: 115 (missing stats)
+│ filter: ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+│
+└── • hash join (left outer)
+    │ columns: (a, b, n, sq)
+    │ estimated row count: 1037 (missing stats)
+    │ equality: (b) = (sq)
+    │ pred: a > 1
+    │
+    ├── • filter
+    │   │ columns: (a, b)
+    │   │ estimated row count: 333 (missing stats)
+    │   │ filter: b > 1
+    │   │
+    │   └── • scan
+    │         columns: (a, b)
+    │         estimated row count: 1000 (missing stats)
+    │         table: pairs@primary
+    │         spans: FULL SCAN
+    │
+    └── • filter
+        │ columns: (n, sq)
+        │ estimated row count: 311 (missing stats)
+        │ filter: sq > 1
+        │
+        └── • scan
+              columns: (n, sq)
+              estimated row count: 333 (missing stats)
+              table: square@primary
+              spans: -/5/#
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs RIGHT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
-]
 ----
-·                            distribution         local
-·                            vectorized           true
-filter                       ·                    ·
- │                           estimated row count  42 (missing stats)
- │                           filter               ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
- └── hash join (left outer)  ·                    ·
-      │                      estimated row count  377 (missing stats)
-      │                      equality             (sq) = (b)
-      │                      pred                 n < 6
-      ├── scan               ·                    ·
-      │                      estimated row count  333 (missing stats)
-      │                      table                square@primary
-      │                      spans                /2-
-      └── filter             ·                    ·
-           │                 estimated row count  333 (missing stats)
-           │                 filter               a > 1
-           └── scan          ·                    ·
-·                            estimated row count  1000 (missing stats)
-·                            table                pairs@primary
-·                            spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, n, sq)
+│ estimated row count: 42 (missing stats)
+│ filter: ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+│
+└── • hash join (left outer)
+    │ columns: (n, sq, a, b)
+    │ estimated row count: 377 (missing stats)
+    │ equality: (sq) = (b)
+    │ pred: n < 6
+    │
+    ├── • scan
+    │     columns: (n, sq)
+    │     estimated row count: 333 (missing stats)
+    │     table: square@primary
+    │     spans: /2-
+    │
+    └── • filter
+        │ columns: (a, b)
+        │ estimated row count: 333 (missing stats)
+        │ filter: a > 1
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1000 (missing stats)
+              table: pairs@primary
+              spans: FULL SCAN
 
 # The simpler plan for an inner join, to compare.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
-]
 ----
-·                  distribution         local
-·                  vectorized           true
-hash join (inner)  ·                    ·
- │                 estimated row count  6 (missing stats)
- │                 equality             (b) = (sq)
- ├── filter        ·                    ·
- │    │            estimated row count  111 (missing stats)
- │    │            filter               ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
- │    └── scan     ·                    ·
- │                 estimated row count  1000 (missing stats)
- │                 table                pairs@primary
- │                 spans                FULL SCAN
- └── scan          ·                    ·
-·                  estimated row count  4 (missing stats)
-·                  table                square@primary
-·                  spans                /2-/5/#
-·                  parallel             ·
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (a, b, n, sq)
+│ estimated row count: 6 (missing stats)
+│ equality: (b) = (sq)
+│
+├── • filter
+│   │ columns: (a, b)
+│   │ estimated row count: 111 (missing stats)
+│   │ filter: ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+│   │
+│   └── • scan
+│         columns: (a, b)
+│         estimated row count: 1000 (missing stats)
+│         table: pairs@primary
+│         spans: FULL SCAN
+│
+└── • scan
+      columns: (n, sq)
+      estimated row count: 4 (missing stats)
+      table: square@primary
+      spans: /2-/5/#
+      parallel
 
 
 statement ok
@@ -663,24 +862,32 @@ CREATE TABLE t1 (col1 INT, x INT, col2 INT, y INT)
 statement ok
 CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-·                       distribution         local                 ·             ·
-·                       vectorized           true                  ·             ·
-project                 ·                    ·                     (x)           ·
- │                      estimated row count  96 (missing stats)    ·             ·
- └── hash join (inner)  ·                    ·                     (x, y, y, x)  ·
-      │                 estimated row count  96 (missing stats)    ·             ·
-      │                 equality             (x, y) = (x, y)       ·             ·
-      ├── scan          ·                    ·                     (x, y)        ·
-      │                 estimated row count  1000 (missing stats)  ·             ·
-      │                 table                t1@primary            ·             ·
-      │                 spans                FULL SCAN             ·             ·
-      └── scan          ·                    ·                     (y, x)        ·
-·                       estimated row count  1000 (missing stats)  ·             ·
-·                       table                t2@primary            ·             ·
-·                       spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x)
+│ estimated row count: 96 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (x, y, y, x)
+    │ estimated row count: 96 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │
+    ├── • scan
+    │     columns: (x, y)
+    │     estimated row count: 1000 (missing stats)
+    │     table: t1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (y, x)
+          estimated row count: 1000 (missing stats)
+          table: t2@primary
+          spans: FULL SCAN
 
 # Tests for merge join ordering information.
 statement ok
@@ -695,87 +902,119 @@ CREATE TABLE pkBAC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,c))
 statement ok
 CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-·                  distribution         local                  ·                         ·
-·                  vectorized           true                   ·                         ·
-hash join (inner)  ·                    ·                      (a, b, c, d, a, b, c, d)  ·
- │                 estimated row count  1 (missing stats)      ·                         ·
- │                 equality             (a, b, c) = (a, b, c)  ·                         ·
- │                 left cols are key    ·                      ·                         ·
- │                 right cols are key   ·                      ·                         ·
- ├── scan          ·                    ·                      (a, b, c, d)              ·
- │                 estimated row count  1000 (missing stats)   ·                         ·
- │                 table                pkba@primary           ·                         ·
- │                 spans                FULL SCAN              ·                         ·
- └── scan          ·                    ·                      (a, b, c, d)              ·
-·                  estimated row count  1000 (missing stats)   ·                         ·
-·                  table                pkbc@primary           ·                         ·
-·                  spans                FULL SCAN              ·                         ·
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 1 (missing stats)
+│ equality: (a, b, c) = (a, b, c)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     estimated row count: 1000 (missing stats)
+│     table: pkba@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: pkbc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-·                       distribution         local                        ·                         ·
-·                       vectorized           true                         ·                         ·
-project                 ·                    ·                            (a, b, c, d)              ·
- │                      estimated row count  0 (missing stats)            ·                         ·
- └── hash join (inner)  ·                    ·                            (a, b, c, d, a, b, c, d)  ·
-      │                 estimated row count  0 (missing stats)            ·                         ·
-      │                 equality             (a, b, c, d) = (a, b, c, d)  ·                         ·
-      │                 left cols are key    ·                            ·                         ·
-      │                 right cols are key   ·                            ·                         ·
-      ├── scan          ·                    ·                            (a, b, c, d)              ·
-      │                 estimated row count  1000 (missing stats)         ·                         ·
-      │                 table                pkba@primary                 ·                         ·
-      │                 spans                FULL SCAN                    ·                         ·
-      └── scan          ·                    ·                            (a, b, c, d)              ·
-·                       estimated row count  1000 (missing stats)         ·                         ·
-·                       table                pkbad@primary                ·                         ·
-·                       spans                FULL SCAN                    ·                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d)
+│ estimated row count: 0 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 0 (missing stats)
+    │ equality: (a, b, c, d) = (a, b, c, d)
+    │ left cols are key
+    │ right cols are key
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     estimated row count: 1000 (missing stats)
+    │     table: pkba@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: pkbad@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-·                        distribution         local                       ·                         ·
-·                        vectorized           true                        ·                         ·
-project                  ·                    ·                           (a, b, c, d, d)           ·
- │                       estimated row count  1 (missing stats)           ·                         ·
- └── merge join (inner)  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
-      │                  estimated row count  1 (missing stats)           ·                         ·
-      │                  equality             (b, a, c) = (b, a, c)       ·                         ·
-      │                  left cols are key    ·                           ·                         ·
-      │                  right cols are key   ·                           ·                         ·
-      │                  merge ordering       +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
-      ├── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
-      │                  estimated row count  1000 (missing stats)        ·                         ·
-      │                  table                pkbac@primary               ·                         ·
-      │                  spans                FULL SCAN                   ·                         ·
-      └── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
-·                        estimated row count  1000 (missing stats)        ·                         ·
-·                        table                pkbac@primary               ·                         ·
-·                        spans                FULL SCAN                   ·                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, d)
+│ estimated row count: 1 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (b, a, c) = (b, a, c)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(b=b)",+"(a=a)",+"(c=c)"
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     ordering: +b,+a,+c
+    │     estimated row count: 1000 (missing stats)
+    │     table: pkbac@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          ordering: +b,+a,+c
+          estimated row count: 1000 (missing stats)
+          table: pkbac@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-·                   distribution         local                       ·                         ·
-·                   vectorized           true                        ·                         ·
-merge join (inner)  ·                    ·                           (a, b, c, d, a, b, c, d)  ·
- │                  estimated row count  1 (missing stats)           ·                         ·
- │                  equality             (b, a, c) = (b, a, d)       ·                         ·
- │                  left cols are key    ·                           ·                         ·
- │                  right cols are key   ·                           ·                         ·
- │                  merge ordering       +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
- ├── scan           ·                    ·                           (a, b, c, d)              +b,+a,+c
- │                  estimated row count  1000 (missing stats)        ·                         ·
- │                  table                pkbac@primary               ·                         ·
- │                  spans                FULL SCAN                   ·                         ·
- └── scan           ·                    ·                           (a, b, c, d)              +b,+a,+d
-·                   estimated row count  1000 (missing stats)        ·                         ·
-·                   table                pkbad@primary               ·                         ·
-·                   spans                FULL SCAN                   ·                         ·
+distribution: local
+vectorized: true
+·
+• merge join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 1 (missing stats)
+│ equality: (b, a, c) = (b, a, d)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(b=b)",+"(a=a)",+"(c=d)"
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     ordering: +b,+a,+c
+│     estimated row count: 1000 (missing stats)
+│     table: pkbac@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      ordering: +b,+a,+d
+      estimated row count: 1000 (missing stats)
+      table: pkbad@primary
+      spans: FULL SCAN
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -784,110 +1023,150 @@ CREATE TABLE str1 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 statement ok
 CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-·                       distribution         local                 ·          ·
-·                       vectorized           true                  ·          ·
-project                 ·                    ·                     (s, s, s)  ·
- └── hash join (inner)  ·                    ·                     (s, s)     ·
-      │                 estimated row count  9801 (missing stats)  ·          ·
-      │                 equality             (s) = (s)             ·          ·
-      ├── scan          ·                    ·                     (s)        ·
-      │                 estimated row count  1000 (missing stats)  ·          ·
-      │                 table                str1@primary          ·          ·
-      │                 spans                FULL SCAN             ·          ·
-      └── scan          ·                    ·                     (s)        ·
-·                       estimated row count  1000 (missing stats)  ·          ·
-·                       table                str2@primary          ·          ·
-·                       spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (s, s, s)
+│
+└── • hash join (inner)
+    │ columns: (s, s)
+    │ estimated row count: 9801 (missing stats)
+    │ equality: (s) = (s)
+    │
+    ├── • scan
+    │     columns: (s)
+    │     estimated row count: 1000 (missing stats)
+    │     table: str1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (s)
+          estimated row count: 1000 (missing stats)
+          table: str2@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-·                            distribution         local                  ·          ·
-·                            vectorized           true                   ·          ·
-project                      ·                    ·                      (s, s, s)  ·
- └── hash join (left outer)  ·                    ·                      (s, s)     ·
-      │                      estimated row count  10000 (missing stats)  ·          ·
-      │                      equality             (s) = (s)              ·          ·
-      ├── scan               ·                    ·                      (s)        ·
-      │                      estimated row count  1000 (missing stats)   ·          ·
-      │                      table                str1@primary           ·          ·
-      │                      spans                FULL SCAN              ·          ·
-      └── scan               ·                    ·                      (s)        ·
-·                            estimated row count  1000 (missing stats)   ·          ·
-·                            table                str2@primary           ·          ·
-·                            spans                FULL SCAN              ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (s, s, s)
+│
+└── • hash join (left outer)
+    │ columns: (s, s)
+    │ estimated row count: 10000 (missing stats)
+    │ equality: (s) = (s)
+    │
+    ├── • scan
+    │     columns: (s)
+    │     estimated row count: 1000 (missing stats)
+    │     table: str1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (s)
+          estimated row count: 1000 (missing stats)
+          table: str2@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-·                            distribution         local                  ·          ·
-·                            vectorized           true                   ·          ·
-render                       ·                    ·                      (s, s, s)  ·
- │                           estimated row count  10000 (missing stats)  ·          ·
- │                           render 0             COALESCE(s, s)         ·          ·
- │                           render 1             s                      ·          ·
- │                           render 2             s                      ·          ·
- └── hash join (left outer)  ·                    ·                      (s, s)     ·
-      │                      estimated row count  10000 (missing stats)  ·          ·
-      │                      equality             (s) = (s)              ·          ·
-      ├── scan               ·                    ·                      (s)        ·
-      │                      estimated row count  1000 (missing stats)   ·          ·
-      │                      table                str2@primary           ·          ·
-      │                      spans                FULL SCAN              ·          ·
-      └── scan               ·                    ·                      (s)        ·
-·                            estimated row count  1000 (missing stats)   ·          ·
-·                            table                str1@primary           ·          ·
-·                            spans                FULL SCAN              ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (s, s, s)
+│ estimated row count: 10000 (missing stats)
+│ render 0: COALESCE(s, s)
+│ render 1: s
+│ render 2: s
+│
+└── • hash join (left outer)
+    │ columns: (s, s)
+    │ estimated row count: 10000 (missing stats)
+    │ equality: (s) = (s)
+    │
+    ├── • scan
+    │     columns: (s)
+    │     estimated row count: 1000 (missing stats)
+    │     table: str2@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (s)
+          estimated row count: 1000 (missing stats)
+          table: str1@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-·                            distribution         local                  ·          ·
-·                            vectorized           true                   ·          ·
-render                       ·                    ·                      (s, s, s)  ·
- │                           estimated row count  10000 (missing stats)  ·          ·
- │                           render 0             COALESCE(s, s)         ·          ·
- │                           render 1             s                      ·          ·
- │                           render 2             s                      ·          ·
- └── hash join (full outer)  ·                    ·                      (s, s)     ·
-      │                      estimated row count  10000 (missing stats)  ·          ·
-      │                      equality             (s) = (s)              ·          ·
-      ├── scan               ·                    ·                      (s)        ·
-      │                      estimated row count  1000 (missing stats)   ·          ·
-      │                      table                str1@primary           ·          ·
-      │                      spans                FULL SCAN              ·          ·
-      └── scan               ·                    ·                      (s)        ·
-·                            estimated row count  1000 (missing stats)   ·          ·
-·                            table                str2@primary           ·          ·
-·                            spans                FULL SCAN              ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (s, s, s)
+│ estimated row count: 10000 (missing stats)
+│ render 0: COALESCE(s, s)
+│ render 1: s
+│ render 2: s
+│
+└── • hash join (full outer)
+    │ columns: (s, s)
+    │ estimated row count: 10000 (missing stats)
+    │ equality: (s) = (s)
+    │
+    ├── • scan
+    │     columns: (s)
+    │     estimated row count: 1000 (missing stats)
+    │     table: str1@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (s)
+          estimated row count: 1000 (missing stats)
+          table: str2@primary
+          spans: FULL SCAN
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-·                            distribution         local                 ·             ·
-·                            vectorized           true                  ·             ·
-render                       ·                    ·                     (a, s)        ·
- │                           estimated row count  1000 (missing stats)  ·             ·
- │                           render 0             COALESCE(s, s)        ·             ·
- │                           render 1             a                     ·             ·
- └── hash join (left outer)  ·                    ·                     (a, s, a, s)  ·
-      │                      estimated row count  1000 (missing stats)  ·             ·
-      │                      equality             (a, s) = (a, s)       ·             ·
-      │                      left cols are key    ·                     ·             ·
-      │                      right cols are key   ·                     ·             ·
-      ├── scan               ·                    ·                     (a, s)        ·
-      │                      estimated row count  1000 (missing stats)  ·             ·
-      │                      table                str2@primary          ·             ·
-      │                      spans                FULL SCAN             ·             ·
-      └── scan               ·                    ·                     (a, s)        ·
-·                            estimated row count  1000 (missing stats)  ·             ·
-·                            table                str1@primary          ·             ·
-·                            spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, s)
+│ estimated row count: 1000 (missing stats)
+│ render 0: COALESCE(s, s)
+│ render 1: a
+│
+└── • hash join (left outer)
+    │ columns: (a, s, a, s)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a, s) = (a, s)
+    │ left cols are key
+    │ right cols are key
+    │
+    ├── • scan
+    │     columns: (a, s)
+    │     estimated row count: 1000 (missing stats)
+    │     table: str2@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, s)
+          estimated row count: 1000 (missing stats)
+          table: str1@primary
+          spans: FULL SCAN
 
 
 statement ok
@@ -896,292 +1175,424 @@ CREATE TABLE xyu (x INT, y INT, u INT, PRIMARY KEY(x,y,u))
 statement ok
 CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                        distribution         local                ·                   ·
-·                        vectorized           true                 ·                   ·
-project                  ·                    ·                    (x, y, u, v)        ·
- │                       estimated row count  34 (missing stats)   ·                   ·
- └── merge join (inner)  ·                    ·                    (x, y, u, x, y, v)  ·
-      │                  estimated row count  34 (missing stats)   ·                   ·
-      │                  equality             (x, y) = (x, y)      ·                   ·
-      │                  merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan           ·                    ·                    (x, y, u)           +x,+y
-      │                  estimated row count  333 (missing stats)  ·                   ·
-      │                  table                xyu@primary          ·                   ·
-      │                  spans                /3-                  ·                   ·
-      └── scan           ·                    ·                    (x, y, v)           +x,+y
-·                        estimated row count  333 (missing stats)  ·                   ·
-·                        table                xyv@primary          ·                   ·
-·                        spans                /3-                  ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 34 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (x, y, u, x, y, v)
+    │ estimated row count: 34 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, u)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyu@primary
+    │     spans: /3-
+    │
+    └── • scan
+          columns: (x, y, v)
+          ordering: +x,+y
+          estimated row count: 333 (missing stats)
+          table: xyv@primary
+          spans: /3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                             distribution         local                ·                   ·
-·                             vectorized           true                 ·                   ·
-project                       ·                    ·                    (x, y, u, v)        ·
- │                            estimated row count  333 (missing stats)  ·                   ·
- └── merge join (left outer)  ·                    ·                    (x, y, u, x, y, v)  ·
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       equality             (x, y) = (x, y)      ·                   ·
-      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan                ·                    ·                    (x, y, u)           +x,+y
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       table                xyu@primary          ·                   ·
-      │                       spans                /3-                  ·                   ·
-      └── scan                ·                    ·                    (x, y, v)           +x,+y
-·                             estimated row count  333 (missing stats)  ·                   ·
-·                             table                xyv@primary          ·                   ·
-·                             spans                /3-                  ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (x, y, u, x, y, v)
+    │ estimated row count: 333 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, u)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyu@primary
+    │     spans: /3-
+    │
+    └── • scan
+          columns: (x, y, v)
+          ordering: +x,+y
+          estimated row count: 333 (missing stats)
+          table: xyv@primary
+          spans: /3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                             distribution         local                ·                   ·
-·                             vectorized           true                 ·                   ·
-project                       ·                    ·                    (x, y, u, v)        ·
- │                            estimated row count  333 (missing stats)  ·                   ·
- └── merge join (left outer)  ·                    ·                    (x, y, v, x, y, u)  ·
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       equality             (x, y) = (x, y)      ·                   ·
-      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan                ·                    ·                    (x, y, v)           +x,+y
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       table                xyv@primary          ·                   ·
-      │                       spans                /3-                  ·                   ·
-      └── scan                ·                    ·                    (x, y, u)           +x,+y
-·                             estimated row count  333 (missing stats)  ·                   ·
-·                             table                xyu@primary          ·                   ·
-·                             spans                /3-                  ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (x, y, v, x, y, u)
+    │ estimated row count: 333 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, v)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyv@primary
+    │     spans: /3-
+    │
+    └── • scan
+          columns: (x, y, u)
+          ordering: +x,+y
+          estimated row count: 333 (missing stats)
+          table: xyu@primary
+          spans: /3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                                  distribution         local                 ·                   ·
-·                                  vectorized           true                  ·                   ·
-filter                             ·                    ·                     (x, y, u, v)        ·
- │                                 estimated row count  633 (missing stats)   ·                   ·
- │                                 filter               x > 2                 ·                   ·
- └── render                        ·                    ·                     (x, y, u, v)        ·
-      │                            estimated row count  1900 (missing stats)  ·                   ·
-      │                            render 0             COALESCE(x, x)        ·                   ·
-      │                            render 1             COALESCE(y, y)        ·                   ·
-      │                            render 2             u                     ·                   ·
-      │                            render 3             v                     ·                   ·
-      └── merge join (full outer)  ·                    ·                     (x, y, u, x, y, v)  ·
-           │                       estimated row count  1900 (missing stats)  ·                   ·
-           │                       equality             (x, y) = (x, y)       ·                   ·
-           │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-           ├── scan                ·                    ·                     (x, y, u)           +x,+y
-           │                       estimated row count  1000 (missing stats)  ·                   ·
-           │                       table                xyu@primary           ·                   ·
-           │                       spans                FULL SCAN             ·                   ·
-           └── scan                ·                    ·                     (x, y, v)           +x,+y
-·                                  estimated row count  1000 (missing stats)  ·                   ·
-·                                  table                xyv@primary           ·                   ·
-·                                  spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y, u, v)
+│ estimated row count: 633 (missing stats)
+│ filter: x > 2
+│
+└── • render
+    │ columns: (x, y, u, v)
+    │ estimated row count: 1900 (missing stats)
+    │ render 0: COALESCE(x, x)
+    │ render 1: COALESCE(y, y)
+    │ render 2: u
+    │ render 3: v
+    │
+    └── • merge join (full outer)
+        │ columns: (x, y, u, x, y, v)
+        │ estimated row count: 1900 (missing stats)
+        │ equality: (x, y) = (x, y)
+        │ merge ordering: +"(x=x)",+"(y=y)"
+        │
+        ├── • scan
+        │     columns: (x, y, u)
+        │     ordering: +x,+y
+        │     estimated row count: 1000 (missing stats)
+        │     table: xyu@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (x, y, v)
+              ordering: +x,+y
+              estimated row count: 1000 (missing stats)
+              table: xyv@primary
+              spans: FULL SCAN
 
 # Verify that we transfer constraints between the two sides.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-·                   distribution         local              ·                   ·
-·                   vectorized           true               ·                   ·
-merge join (inner)  ·                    ·                  (x, y, u, x, y, v)  ·
- │                  estimated row count  9 (missing stats)  ·                   ·
- │                  equality             (x, y) = (x, y)    ·                   ·
- │                  merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan           ·                    ·                  (x, y, u)           +y
- │                  estimated row count  9 (missing stats)  ·                   ·
- │                  table                xyu@primary        ·                   ·
- │                  spans                /1-/1/10           ·                   ·
- └── scan           ·                    ·                  (x, y, v)           +y
-·                   estimated row count  9 (missing stats)  ·                   ·
-·                   table                xyv@primary        ·                   ·
-·                   spans                /1-/1/10           ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (inner)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 9 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, u)
+│     ordering: +y
+│     estimated row count: 9 (missing stats)
+│     table: xyu@primary
+│     spans: /1-/1/10
+│
+└── • scan
+      columns: (x, y, v)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyv@primary
+      spans: /1-/1/10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                   distribution         local              ·                   ·
-·                   vectorized           true               ·                   ·
-merge join (inner)  ·                    ·                  (x, y, u, x, y, v)  ·
- │                  estimated row count  9 (missing stats)  ·                   ·
- │                  equality             (x, y) = (x, y)    ·                   ·
- │                  merge ordering       +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan           ·                    ·                  (x, y, u)           +y
- │                  estimated row count  9 (missing stats)  ·                   ·
- │                  table                xyu@primary        ·                   ·
- │                  spans                /1-/1/10           ·                   ·
- └── scan           ·                    ·                  (x, y, v)           +y
-·                   estimated row count  9 (missing stats)  ·                   ·
-·                   table                xyv@primary        ·                   ·
-·                   spans                /1-/1/10           ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (inner)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 9 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, u)
+│     ordering: +y
+│     estimated row count: 9 (missing stats)
+│     table: xyu@primary
+│     spans: /1-/1/10
+│
+└── • scan
+      columns: (x, y, v)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyv@primary
+      spans: /1-/1/10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                        distribution         local                 ·                   ·
-·                        vectorized           true                  ·                   ·
-merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       equality             (x, y) = (x, y)       ·                   ·
- │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan                ·                    ·                     (x, y, u)           +x,+y
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       table                xyu@primary           ·                   ·
- │                       spans                FULL SCAN             ·                   ·
- └── scan                ·                    ·                     (x, y, v)           +y
-·                        estimated row count  9 (missing stats)     ·                   ·
-·                        table                xyv@primary           ·                   ·
-·                        spans                /1-/1/10              ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, u)
+│     ordering: +x,+y
+│     estimated row count: 1000 (missing stats)
+│     table: xyu@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, v)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyv@primary
+      spans: /1-/1/10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                        distribution         local                 ·                   ·
-·                        vectorized           true                  ·                   ·
-merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       equality             (x, y) = (x, y)       ·                   ·
- │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan                ·                    ·                     (x, y, v)           +x,+y
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       table                xyv@primary           ·                   ·
- │                       spans                FULL SCAN             ·                   ·
- └── scan                ·                    ·                     (x, y, u)           +y
-·                        estimated row count  9 (missing stats)     ·                   ·
-·                        table                xyu@primary           ·                   ·
-·                        spans                /1-/1/10              ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, v)
+│     ordering: +x,+y
+│     estimated row count: 1000 (missing stats)
+│     table: xyv@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, u)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyu@primary
+      spans: /1-/1/10
 
 
 # Test OUTER joins that are run in the distSQL merge joiner
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                             distribution         local                ·                   ·
-·                             vectorized           true                 ·                   ·
-project                       ·                    ·                    (x, y, u, v)        ·
- │                            estimated row count  333 (missing stats)  ·                   ·
- └── merge join (left outer)  ·                    ·                    (x, y, u, x, y, v)  ·
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       equality             (x, y) = (x, y)      ·                   ·
-      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan                ·                    ·                    (x, y, u)           +x,+y
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       table                xyu@primary          ·                   ·
-      │                       spans                /3-                  ·                   ·
-      └── scan                ·                    ·                    (x, y, v)           +x,+y
-·                             estimated row count  333 (missing stats)  ·                   ·
-·                             table                xyv@primary          ·                   ·
-·                             spans                /3-                  ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (x, y, u, x, y, v)
+    │ estimated row count: 333 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, u)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyu@primary
+    │     spans: /3-
+    │
+    └── • scan
+          columns: (x, y, v)
+          ordering: +x,+y
+          estimated row count: 333 (missing stats)
+          table: xyv@primary
+          spans: /3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                             distribution         local                ·                   ·
-·                             vectorized           true                 ·                   ·
-project                       ·                    ·                    (x, y, u, v)        ·
- │                            estimated row count  333 (missing stats)  ·                   ·
- └── merge join (left outer)  ·                    ·                    (x, y, v, x, y, u)  ·
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       equality             (x, y) = (x, y)      ·                   ·
-      │                       merge ordering       +"(x=x)",+"(y=y)"    ·                   ·
-      ├── scan                ·                    ·                    (x, y, v)           +x,+y
-      │                       estimated row count  333 (missing stats)  ·                   ·
-      │                       table                xyv@primary          ·                   ·
-      │                       spans                /3-                  ·                   ·
-      └── scan                ·                    ·                    (x, y, u)           +x,+y
-·                             estimated row count  333 (missing stats)  ·                   ·
-·                             table                xyu@primary          ·                   ·
-·                             spans                /3-                  ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 333 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (x, y, v, x, y, u)
+    │ estimated row count: 333 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, v)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyv@primary
+    │     spans: /3-
+    │
+    └── • scan
+          columns: (x, y, u)
+          ordering: +x,+y
+          estimated row count: 333 (missing stats)
+          table: xyu@primary
+          spans: /3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                                  distribution         local                 ·                   ·
-·                                  vectorized           true                  ·                   ·
-filter                             ·                    ·                     (x, y, u, v)        ·
- │                                 estimated row count  633 (missing stats)   ·                   ·
- │                                 filter               x > 2                 ·                   ·
- └── render                        ·                    ·                     (x, y, u, v)        ·
-      │                            estimated row count  1900 (missing stats)  ·                   ·
-      │                            render 0             COALESCE(x, x)        ·                   ·
-      │                            render 1             COALESCE(y, y)        ·                   ·
-      │                            render 2             u                     ·                   ·
-      │                            render 3             v                     ·                   ·
-      └── merge join (full outer)  ·                    ·                     (x, y, u, x, y, v)  ·
-           │                       estimated row count  1900 (missing stats)  ·                   ·
-           │                       equality             (x, y) = (x, y)       ·                   ·
-           │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-           ├── scan                ·                    ·                     (x, y, u)           +x,+y
-           │                       estimated row count  1000 (missing stats)  ·                   ·
-           │                       table                xyu@primary           ·                   ·
-           │                       spans                FULL SCAN             ·                   ·
-           └── scan                ·                    ·                     (x, y, v)           +x,+y
-·                                  estimated row count  1000 (missing stats)  ·                   ·
-·                                  table                xyv@primary           ·                   ·
-·                                  spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y, u, v)
+│ estimated row count: 633 (missing stats)
+│ filter: x > 2
+│
+└── • render
+    │ columns: (x, y, u, v)
+    │ estimated row count: 1900 (missing stats)
+    │ render 0: COALESCE(x, x)
+    │ render 1: COALESCE(y, y)
+    │ render 2: u
+    │ render 3: v
+    │
+    └── • merge join (full outer)
+        │ columns: (x, y, u, x, y, v)
+        │ estimated row count: 1900 (missing stats)
+        │ equality: (x, y) = (x, y)
+        │ merge ordering: +"(x=x)",+"(y=y)"
+        │
+        ├── • scan
+        │     columns: (x, y, u)
+        │     ordering: +x,+y
+        │     estimated row count: 1000 (missing stats)
+        │     table: xyu@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (x, y, v)
+              ordering: +x,+y
+              estimated row count: 1000 (missing stats)
+              table: xyv@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                        distribution         local                 ·                   ·
-·                        vectorized           true                  ·                   ·
-merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       equality             (x, y) = (x, y)       ·                   ·
- │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan                ·                    ·                     (x, y, u)           +x,+y
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       table                xyu@primary           ·                   ·
- │                       spans                FULL SCAN             ·                   ·
- └── scan                ·                    ·                     (x, y, v)           +y
-·                        estimated row count  9 (missing stats)     ·                   ·
-·                        table                xyv@primary           ·                   ·
-·                        spans                /1-/1/10              ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, u)
+│     ordering: +x,+y
+│     estimated row count: 1000 (missing stats)
+│     table: xyu@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, v)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyv@primary
+      spans: /1-/1/10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                        distribution         local                 ·                   ·
-·                        vectorized           true                  ·                   ·
-merge join (left outer)  ·                    ·                     (x, y, u, x, y, v)  ·
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       equality             (x, y) = (x, y)       ·                   ·
- │                       merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
- ├── scan                ·                    ·                     (x, y, v)           +x,+y
- │                       estimated row count  1000 (missing stats)  ·                   ·
- │                       table                xyv@primary           ·                   ·
- │                       spans                FULL SCAN             ·                   ·
- └── scan                ·                    ·                     (x, y, u)           +y
-·                        estimated row count  9 (missing stats)     ·                   ·
-·                        table                xyu@primary           ·                   ·
-·                        spans                /1-/1/10              ·                   ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (x, y, u, x, y, v)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x, y) = (x, y)
+│ merge ordering: +"(x=x)",+"(y=y)"
+│
+├── • scan
+│     columns: (x, y, v)
+│     ordering: +x,+y
+│     estimated row count: 1000 (missing stats)
+│     table: xyv@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, u)
+      ordering: +y
+      estimated row count: 9 (missing stats)
+      table: xyu@primary
+      spans: /1-/1/10
 
 # Regression test for #20472: break up tuple inequalities.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-·                        distribution         local                 ·                   ·
-·                        vectorized           true                  ·                   ·
-project                  ·                    ·                     (x, y, u, v)        ·
- │                       estimated row count  33 (missing stats)    ·                   ·
- └── merge join (inner)  ·                    ·                     (x, y, u, x, y, v)  ·
-      │                  estimated row count  33 (missing stats)    ·                   ·
-      │                  equality             (x, y) = (x, y)       ·                   ·
-      │                  merge ordering       +"(x=x)",+"(y=y)"     ·                   ·
-      ├── scan           ·                    ·                     (x, y, u)           +x,+y
-      │                  estimated row count  333 (missing stats)   ·                   ·
-      │                  table                xyu@primary           ·                   ·
-      │                  spans                /1/2/4-               ·                   ·
-      └── scan           ·                    ·                     (x, y, v)           +x,+y
-·                        estimated row count  1000 (missing stats)  ·                   ·
-·                        table                xyv@primary           ·                   ·
-·                        spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, y, u, v)
+│ estimated row count: 33 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (x, y, u, x, y, v)
+    │ estimated row count: 33 (missing stats)
+    │ equality: (x, y) = (x, y)
+    │ merge ordering: +"(x=x)",+"(y=y)"
+    │
+    ├── • scan
+    │     columns: (x, y, u)
+    │     ordering: +x,+y
+    │     estimated row count: 333 (missing stats)
+    │     table: xyu@primary
+    │     spans: /1/2/4-
+    │
+    └── • scan
+          columns: (x, y, v)
+          ordering: +x,+y
+          estimated row count: 1000 (missing stats)
+          table: xyv@primary
+          spans: FULL SCAN
 
 
 # Regression test for #20765/27431.
@@ -1194,89 +1605,117 @@ CREATE TABLE l (a INT PRIMARY KEY, b1 INT, FAMILY (a))
 statement ok
 CREATE TABLE r (a INT PRIMARY KEY, b2 INT, FAMILY (a))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                             distribution         local              ·               ·
-·                             vectorized           true               ·               ·
-project                       ·                    ·                  (a, b1, b2)     ·
- │                            estimated row count  1 (missing stats)  ·               ·
- └── merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
-      │                       estimated row count  1 (missing stats)  ·               ·
-      │                       equality             (a) = (a)          ·               ·
-      │                       left cols are key    ·                  ·               ·
-      │                       right cols are key   ·                  ·               ·
-      │                       merge ordering       +"(a=a)"           ·               ·
-      ├── scan                ·                    ·                  (a, b1)         ·
-      │                       estimated row count  1 (missing stats)  ·               ·
-      │                       table                l@primary          ·               ·
-      │                       spans                /3-/3/#            ·               ·
-      └── scan                ·                    ·                  (a, b2)         ·
-·                             estimated row count  1 (missing stats)  ·               ·
-·                             table                r@primary          ·               ·
-·                             spans                /3-/3/#            ·               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b1, b2)
+│ estimated row count: 1 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (a, b1, a, b2)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b1)
+    │     estimated row count: 1 (missing stats)
+    │     table: l@primary
+    │     spans: /3-/3/#
+    │
+    └── • scan
+          columns: (a, b2)
+          estimated row count: 1 (missing stats)
+          table: r@primary
+          spans: /3-/3/#
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-·                        distribution         local              ·               ·
-·                        vectorized           true               ·               ·
-merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
- │                       estimated row count  1 (missing stats)  ·               ·
- │                       equality             (a) = (a)          ·               ·
- │                       left cols are key    ·                  ·               ·
- │                       right cols are key   ·                  ·               ·
- │                       merge ordering       +"(a=a)"           ·               ·
- ├── scan                ·                    ·                  (a, b1)         ·
- │                       estimated row count  1 (missing stats)  ·               ·
- │                       table                l@primary          ·               ·
- │                       spans                /3-/3/#            ·               ·
- └── scan                ·                    ·                  (a, b2)         ·
-·                        estimated row count  1 (missing stats)  ·               ·
-·                        table                r@primary          ·               ·
-·                        spans                /3-/3/#            ·               ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (a, b1, a, b2)
+│ estimated row count: 1 (missing stats)
+│ equality: (a) = (a)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(a=a)"
+│
+├── • scan
+│     columns: (a, b1)
+│     estimated row count: 1 (missing stats)
+│     table: l@primary
+│     spans: /3-/3/#
+│
+└── • scan
+      columns: (a, b2)
+      estimated row count: 1 (missing stats)
+      table: r@primary
+      spans: /3-/3/#
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                             distribution         local              ·               ·
-·                             vectorized           true               ·               ·
-project                       ·                    ·                  (a, b1, b2)     ·
- │                            estimated row count  1 (missing stats)  ·               ·
- └── merge join (left outer)  ·                    ·                  (a, b2, a, b1)  ·
-      │                       estimated row count  1 (missing stats)  ·               ·
-      │                       equality             (a) = (a)          ·               ·
-      │                       left cols are key    ·                  ·               ·
-      │                       right cols are key   ·                  ·               ·
-      │                       merge ordering       +"(a=a)"           ·               ·
-      ├── scan                ·                    ·                  (a, b2)         ·
-      │                       estimated row count  1 (missing stats)  ·               ·
-      │                       table                r@primary          ·               ·
-      │                       spans                /3-/3/#            ·               ·
-      └── scan                ·                    ·                  (a, b1)         ·
-·                             estimated row count  1 (missing stats)  ·               ·
-·                             table                l@primary          ·               ·
-·                             spans                /3-/3/#            ·               ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b1, b2)
+│ estimated row count: 1 (missing stats)
+│
+└── • merge join (left outer)
+    │ columns: (a, b2, a, b1)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b2)
+    │     estimated row count: 1 (missing stats)
+    │     table: r@primary
+    │     spans: /3-/3/#
+    │
+    └── • scan
+          columns: (a, b1)
+          estimated row count: 1 (missing stats)
+          table: l@primary
+          spans: /3-/3/#
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-·                        distribution         local              ·               ·
-·                        vectorized           true               ·               ·
-merge join (left outer)  ·                    ·                  (a, b1, a, b2)  ·
- │                       estimated row count  1 (missing stats)  ·               ·
- │                       equality             (a) = (a)          ·               ·
- │                       left cols are key    ·                  ·               ·
- │                       right cols are key   ·                  ·               ·
- │                       merge ordering       +"(a=a)"           ·               ·
- ├── scan                ·                    ·                  (a, b2)         ·
- │                       estimated row count  1 (missing stats)  ·               ·
- │                       table                r@primary          ·               ·
- │                       spans                /3-/3/#            ·               ·
- └── scan                ·                    ·                  (a, b1)         ·
-·                        estimated row count  1 (missing stats)  ·               ·
-·                        table                l@primary          ·               ·
-·                        spans                /3-/3/#            ·               ·
+distribution: local
+vectorized: true
+·
+• merge join (left outer)
+│ columns: (a, b1, a, b2)
+│ estimated row count: 1 (missing stats)
+│ equality: (a) = (a)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(a=a)"
+│
+├── • scan
+│     columns: (a, b2)
+│     estimated row count: 1 (missing stats)
+│     table: r@primary
+│     spans: /3-/3/#
+│
+└── • scan
+      columns: (a, b1)
+      estimated row count: 1 (missing stats)
+      table: l@primary
+      spans: /3-/3/#
 
 # Regression tests for #21243
 statement ok
@@ -1298,22 +1737,25 @@ CREATE TABLE abg (
   PRIMARY KEY (a ASC, b ASC)
 );
 
-query TTT
+query T
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
-·           distribution        local
-·           vectorized          true
-merge join  ·                   ·
- │          equality            (a, b) = (a, b)
- │          right cols are key  ·
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               abcdef@primary
- │          spans               [/1/2/6/9 - ]
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               abg@primary
-·           spans               FULL SCAN
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (a, b) = (a, b)
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: abcdef@primary
+│     spans: [/1/2/6/9 - ]
+│
+└── • scan
+      missing stats
+      table: abg@primary
+      spans: FULL SCAN
 
 # Regression tests for mixed-type equality columns (#22514).
 statement ok
@@ -1333,194 +1775,237 @@ CREATE TABLE bar (
 )
 
 # Only a and c can be equality columns.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo NATURAL JOIN bar
-]
 ----
-·                       distribution         local
-·                       vectorized           true
-project                 ·                    ·
- │                      estimated row count  0 (missing stats)
- └── hash join (inner)  ·                    ·
-      │                 estimated row count  0 (missing stats)
-      │                 equality             (a, c) = (a, c)
-      │                 pred                 (b = b) AND (d = d)
-      ├── scan          ·                    ·
-      │                 estimated row count  1000 (missing stats)
-      │                 table                foo@primary
-      │                 spans                FULL SCAN
-      └── scan          ·                    ·
-·                       estimated row count  1000 (missing stats)
-·                       table                bar@primary
-·                       spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d)
+│ estimated row count: 0 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 0 (missing stats)
+    │ equality: (a, c) = (a, c)
+    │ pred: (b = b) AND (d = d)
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     estimated row count: 1000 (missing stats)
+    │     table: foo@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: bar@primary
+          spans: FULL SCAN
 
 # b can't be an equality column.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (b)
-]
 ----
-·                        distribution         local
-·                        vectorized           true
-project                  ·                    ·
- │                       estimated row count  9801 (missing stats)
- └── cross join (inner)  ·                    ·
-      │                  estimated row count  9801 (missing stats)
-      │                  pred                 b = b
-      ├── scan           ·                    ·
-      │                  estimated row count  1000 (missing stats)
-      │                  table                foo@primary
-      │                  spans                FULL SCAN
-      └── scan           ·                    ·
-·                        estimated row count  1000 (missing stats)
-·                        table                bar@primary
-·                        spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b, a, c, d, a, c, d)
+│ estimated row count: 9801 (missing stats)
+│
+└── • cross join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 9801 (missing stats)
+    │ pred: b = b
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     estimated row count: 1000 (missing stats)
+    │     table: foo@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: bar@primary
+          spans: FULL SCAN
 
 # Only a can be an equality column.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b)
-]
 ----
-·                       distribution         local
-·                       vectorized           true
-project                 ·                    ·
- │                      estimated row count  96 (missing stats)
- └── hash join (inner)  ·                    ·
-      │                 estimated row count  96 (missing stats)
-      │                 equality             (a) = (a)
-      │                 pred                 b = b
-      ├── scan          ·                    ·
-      │                 estimated row count  1000 (missing stats)
-      │                 table                foo@primary
-      │                 spans                FULL SCAN
-      └── scan          ·                    ·
-·                       estimated row count  1000 (missing stats)
-·                       table                bar@primary
-·                       spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, c, d)
+│ estimated row count: 96 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 96 (missing stats)
+    │ equality: (a) = (a)
+    │ pred: b = b
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     estimated row count: 1000 (missing stats)
+    │     table: foo@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: bar@primary
+          spans: FULL SCAN
 
 # Only a and c can be equality columns.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b, c)
-]
 ----
-·                       distribution         local
-·                       vectorized           true
-project                 ·                    ·
- │                      estimated row count  1 (missing stats)
- └── hash join (inner)  ·                    ·
-      │                 estimated row count  1 (missing stats)
-      │                 equality             (a, c) = (a, c)
-      │                 pred                 b = b
-      ├── scan          ·                    ·
-      │                 estimated row count  1000 (missing stats)
-      │                 table                foo@primary
-      │                 spans                FULL SCAN
-      └── scan          ·                    ·
-·                       estimated row count  1000 (missing stats)
-·                       table                bar@primary
-·                       spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, d)
+│ estimated row count: 1 (missing stats)
+│
+└── • hash join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (a, c) = (a, c)
+    │ pred: b = b
+    │
+    ├── • scan
+    │     columns: (a, b, c, d)
+    │     estimated row count: 1000 (missing stats)
+    │     table: foo@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: bar@primary
+          spans: FULL SCAN
 
 # b can't be an equality column.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
-]
 ----
-·                   distribution         local
-·                   vectorized           true
-cross join (inner)  ·                    ·
- │                  estimated row count  9801 (missing stats)
- │                  pred                 b = b
- ├── scan           ·                    ·
- │                  estimated row count  1000 (missing stats)
- │                  table                foo@primary
- │                  spans                FULL SCAN
- └── scan           ·                    ·
-·                   estimated row count  1000 (missing stats)
-·                   table                bar@primary
-·                   spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 9801 (missing stats)
+│ pred: b = b
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     estimated row count: 1000 (missing stats)
+│     table: foo@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: bar@primary
+      spans: FULL SCAN
 
 # Only a can be an equality column.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
-]
 ----
-·                  distribution         local
-·                  vectorized           true
-hash join (inner)  ·                    ·
- │                 estimated row count  96 (missing stats)
- │                 equality             (a) = (a)
- │                 pred                 b = b
- ├── scan          ·                    ·
- │                 estimated row count  1000 (missing stats)
- │                 table                foo@primary
- │                 spans                FULL SCAN
- └── scan          ·                    ·
-·                  estimated row count  1000 (missing stats)
-·                  table                bar@primary
-·                  spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 96 (missing stats)
+│ equality: (a) = (a)
+│ pred: b = b
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     estimated row count: 1000 (missing stats)
+│     table: foo@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: bar@primary
+      spans: FULL SCAN
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
-]
 ----
-·                   distribution         local
-·                   vectorized           true
-cross join (inner)  ·                    ·
- │                  estimated row count  9801 (missing stats)
- │                  pred                 b = b
- ├── scan           ·                    ·
- │                  estimated row count  1000 (missing stats)
- │                  table                foo@primary
- │                  spans                FULL SCAN
- └── scan           ·                    ·
-·                   estimated row count  1000 (missing stats)
-·                   table                bar@primary
-·                   spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 9801 (missing stats)
+│ pred: b = b
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     estimated row count: 1000 (missing stats)
+│     table: foo@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: bar@primary
+      spans: FULL SCAN
 
 # Only a can be an equality column.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
-]
 ----
-·                  distribution         local
-·                  vectorized           true
-hash join (inner)  ·                    ·
- │                 estimated row count  96 (missing stats)
- │                 equality             (a) = (a)
- │                 pred                 b = b
- ├── scan          ·                    ·
- │                 estimated row count  1000 (missing stats)
- │                 table                foo@primary
- │                 spans                FULL SCAN
- └── scan          ·                    ·
-·                  estimated row count  1000 (missing stats)
-·                  table                bar@primary
-·                  spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (a, b, c, d, a, b, c, d)
+│ estimated row count: 96 (missing stats)
+│ equality: (a) = (a)
+│ pred: b = b
+│
+├── • scan
+│     columns: (a, b, c, d)
+│     estimated row count: 1000 (missing stats)
+│     table: foo@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: bar@primary
+      spans: FULL SCAN
 
 # Only a and c can be equality columns.
-query TTT
+query T
 EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
-·          distribution   local
-·          vectorized     true
-hash join  ·              ·
- │         equality       (a, c) = (a, c)
- │         pred           (b = b) AND (d = d)
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          foo@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          bar@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (a, c) = (a, c)
+│ pred: (b = b) AND (d = d)
+│
+├── • scan
+│     missing stats
+│     table: foo@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: bar@primary
+      spans: FULL SCAN
 
 # Zigzag join tests.
 statement ok
@@ -1537,78 +2022,86 @@ CREATE TABLE zigzag (
 statement ok
 SET enable_zigzag_join = false
 
-query TTT
+query T
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         c = 6.0
- └── index join  ·              ·
-      │          table          zigzag@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          zigzag@b_idx
-·                spans          [/5 - /5]
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 6.0
+│
+└── • index join
+    │ table: zigzag@primary
+    │
+    └── • scan
+          missing stats
+          table: zigzag@b_idx
+          spans: [/5 - /5]
 
 # Enable zigzag joins.
 statement ok
 SET enable_zigzag_join = true
 
 # Simple zigzag case - fixed columns, output cols from indexes only.
-query TTT
+query T
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·            distribution        local
-·            vectorized          true
-zigzag join  ·                   ·
-·            pred                (b = 5) AND (c = 6.0)
-·            left table          zigzag@b_idx
-·            left columns        (a, b)
-·            left fixed values   1 column
-·            right table         zigzag@c_idx
-·            right columns       (c)
-·            right fixed values  1 column
+distribution: local
+vectorized: true
+·
+• zigzag join
+  pred: (b = 5) AND (c = 6.0)
+  left table: zigzag@b_idx
+  left columns: (a, b)
+  left fixed values: 1 column
+  right table: zigzag@c_idx
+  right columns: (c)
+  right fixed values: 1 column
 
 
 # Zigzag join nested inside a lookup.
-query TTT
+query T
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·                 distribution           local
-·                 vectorized             true
-lookup join       ·                      ·
- │                table                  zigzag@primary
- │                equality               (a) = (a)
- │                equality cols are key  ·
- └── zigzag join  ·                      ·
-·                 pred                   (b = 5) AND (c = 6.0)
-·                 left table             zigzag@b_idx
-·                 left columns           (a, b)
-·                 left fixed values      1 column
-·                 right table            zigzag@c_idx
-·                 right columns          (c)
-·                 right fixed values     1 column
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: zigzag@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│
+└── • zigzag join
+      pred: (b = 5) AND (c = 6.0)
+      left table: zigzag@b_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: zigzag@c_idx
+      right columns: (c)
+      right fixed values: 1 column
 
 # Zigzag join nested inside a lookup, with an on condition on lookup join.
-query TTT
+query T
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
-·                 distribution           local
-·                 vectorized             true
-lookup join       ·                      ·
- │                table                  zigzag@primary
- │                equality               (a) = (a)
- │                equality cols are key  ·
- │                pred                   d > 4.0
- └── zigzag join  ·                      ·
-·                 pred                   (b = 5) AND (c = 6.0)
-·                 left table             zigzag@b_idx
-·                 left columns           (a, b)
-·                 left fixed values      1 column
-·                 right table            zigzag@c_idx
-·                 right columns          (c)
-·                 right fixed values     1 column
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: zigzag@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: d > 4.0
+│
+└── • zigzag join
+      pred: (b = 5) AND (c = 6.0)
+      left table: zigzag@b_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: zigzag@c_idx
+      right columns: (c)
+      right fixed values: 1 column
 
 
 # Regression test for part of #34695.
@@ -1624,82 +2117,100 @@ CREATE TABLE zigzag2 (
 
 # Check a value which is equated to NULL.
 
-query TTT
+query T
 EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         c IS NULL
- └── index join  ·              ·
-      │          table          zigzag2@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          zigzag2@a_b_idx
-·                spans          [/1/2 - /1/2]
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c IS NULL
+│
+└── • index join
+    │ table: zigzag2@primary
+    │
+    └── • scan
+          missing stats
+          table: zigzag2@a_b_idx
+          spans: [/1/2 - /1/2]
 
 # Test that we can force a merge join.
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
-·               distribution   local
-·               vectorized     true
-merge join      ·              ·
- │              equality       (x) = (x)
- ├── sort       ·              ·
- │    │         order          +x
- │    └── scan  ·              ·
- │              missing stats  ·
- │              table          onecolumn@primary
- │              spans          FULL SCAN
- └── sort       ·              ·
-      │         order          +x
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          twocolumn@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (x) = (x)
+│
+├── • sort
+│   │ order: +x
+│   │
+│   └── • scan
+│         missing stats
+│         table: onecolumn@primary
+│         spans: FULL SCAN
+│
+└── • sort
+    │ order: +x
+    │
+    └── • scan
+          missing stats
+          table: twocolumn@primary
+          spans: FULL SCAN
 
 # Test that we can force a merge join using the NATURAL syntax.
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
-·               distribution   local
-·               vectorized     true
-merge join      ·              ·
- │              equality       (x) = (x)
- ├── sort       ·              ·
- │    │         order          +x
- │    └── scan  ·              ·
- │              missing stats  ·
- │              table          onecolumn@primary
- │              spans          FULL SCAN
- └── sort       ·              ·
-      │         order          +x
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          twocolumn@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (x) = (x)
+│
+├── • sort
+│   │ order: +x
+│   │
+│   └── • scan
+│         missing stats
+│         table: onecolumn@primary
+│         spans: FULL SCAN
+│
+└── • sort
+    │ order: +x
+    │
+    └── • scan
+          missing stats
+          table: twocolumn@primary
+          spans: FULL SCAN
 
 # Test that we can force a merge join using the CROSS syntax.
-query TTT
+query T
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
-·               distribution   local
-·               vectorized     true
-merge join      ·              ·
- │              equality       (x) = (x)
- ├── sort       ·              ·
- │    │         order          +x
- │    └── scan  ·              ·
- │              missing stats  ·
- │              table          onecolumn@primary
- │              spans          FULL SCAN
- └── sort       ·              ·
-      │         order          +x
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          twocolumn@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (x) = (x)
+│
+├── • sort
+│   │ order: +x
+│   │
+│   └── • scan
+│         missing stats
+│         table: onecolumn@primary
+│         spans: FULL SCAN
+│
+└── • sort
+    │ order: +x
+    │
+    └── • scan
+          missing stats
+          table: twocolumn@primary
+          spans: FULL SCAN
 
 statement error LOOKUP can only be used with INNER or LEFT joins
 EXPLAIN SELECT * FROM onecolumn RIGHT LOOKUP JOIN twocolumn USING(x)
@@ -1711,19 +2222,22 @@ statement error could not produce a query plan conforming to the MERGE JOIN hint
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn ON onecolumn.x > twocolumn.y
 
 # Test that we can force a hash join (instead of merge join).
-query TTT
+query T
 EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
 ----
-·          distribution        local
-·          vectorized          true
-hash join  ·                   ·
- │         equality            (cust) = (id)
- │         right cols are key  ·
- ├── scan  ·                   ·
- │         missing stats       ·
- │         table               cards@primary
- │         spans               FULL SCAN
- └── scan  ·                   ·
-·          missing stats       ·
-·          table               customers@primary
-·          spans               FULL SCAN
+distribution: local
+vectorized: true
+·
+• hash join
+│ equality: (cust) = (id)
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: cards@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: customers@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -36,45 +36,57 @@ SET CLUSTER SETTING sql.defaults.reorder_joins_limit = -1
 statement error cannot set sql.defaults.reorder_joins_limit to a value less than 0 or greater than 63
 SET CLUSTER SETTING sql.defaults.reorder_joins_limit = 65
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                         distribution           local              ·                         ·
-·                         vectorized             true               ·                         ·
-lookup join (inner)       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
- │                        estimated row count    1 (missing stats)  ·                         ·
- │                        table                  cy@primary         ·                         ·
- │                        equality               (c) = (c)          ·                         ·
- │                        equality cols are key  ·                  ·                         ·
- └── lookup join (inner)  ·                      ·                  (a, b, c, d, b, x)        ·
-      │                   estimated row count    1 (missing stats)  ·                         ·
-      │                   table                  bx@primary         ·                         ·
-      │                   equality               (b) = (b)          ·                         ·
-      │                   equality cols are key  ·                  ·                         ·
-      └── scan            ·                      ·                  (a, b, c, d)              ·
-·                         estimated row count    1 (missing stats)  ·                         ·
-·                         table                  abc@primary        ·                         ·
-·                         spans                  /1-/1/#            ·                         ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, b, x, c, y)
+│ estimated row count: 1 (missing stats)
+│ table: cy@primary
+│ equality: (c) = (c)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, d, b, x)
+    │ estimated row count: 1 (missing stats)
+    │ table: bx@primary
+    │ equality: (b) = (b)
+    │ equality cols are key
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1 (missing stats)
+          table: abc@primary
+          spans: /1-/1/#
 
 statement ok
 SET reorder_joins_limit = 3
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                         distribution           local              ·                         ·
-·                         vectorized             true               ·                         ·
-lookup join (inner)       ·                      ·                  (a, b, c, d, b, x, c, y)  ·
- │                        estimated row count    1 (missing stats)  ·                         ·
- │                        table                  cy@primary         ·                         ·
- │                        equality               (c) = (c)          ·                         ·
- │                        equality cols are key  ·                  ·                         ·
- └── lookup join (inner)  ·                      ·                  (a, b, c, d, b, x)        ·
-      │                   estimated row count    1 (missing stats)  ·                         ·
-      │                   table                  bx@primary         ·                         ·
-      │                   equality               (b) = (b)          ·                         ·
-      │                   equality cols are key  ·                  ·                         ·
-      └── scan            ·                      ·                  (a, b, c, d)              ·
-·                         estimated row count    1 (missing stats)  ·                         ·
-·                         table                  abc@primary        ·                         ·
-·                         spans                  /1-/1/#            ·                         ·
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, b, x, c, y)
+│ estimated row count: 1 (missing stats)
+│ table: cy@primary
+│ equality: (c) = (c)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, d, b, x)
+    │ estimated row count: 1 (missing stats)
+    │ table: bx@primary
+    │ equality: (b) = (b)
+    │ equality cols are key
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1 (missing stats)
+          table: abc@primary
+          spans: /1-/1/#

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -4,243 +4,344 @@ statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 
 # There must be no limit at the index scan level.
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND v < 8 AND w > 30 ORDER BY v LIMIT 2
 ----
-tree                  field                description         columns    ordering
-·                     distribution         local               ·          ·
-·                     vectorized           true                ·          ·
-limit                 ·                    ·                   (k, v, w)  ·
- │                    estimated row count  2 (missing stats)   ·          ·
- │                    count                2                   ·          ·
- └── filter           ·                    ·                   (k, v, w)  +v
-      │               estimated row count  28 (missing stats)  ·          ·
-      │               filter               w > 30              ·          ·
-      └── index join  ·                    ·                   (k, v, w)  +v
-           │          estimated row count  30 (missing stats)  ·          ·
-           │          table                t@primary           ·          ·
-           │          key columns          k                   ·          ·
-           └── scan   ·                    ·                   (k, v)     +v
-·                     estimated row count  30 (missing stats)  ·          ·
-·                     table                t@t_v_idx           ·          ·
-·                     spans                /5-/8               ·          ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, v, w)
+│ estimated row count: 2 (missing stats)
+│ count: 2
+│
+└── • filter
+    │ columns: (k, v, w)
+    │ ordering: +v
+    │ estimated row count: 28 (missing stats)
+    │ filter: w > 30
+    │
+    └── • index join
+        │ columns: (k, v, w)
+        │ ordering: +v
+        │ estimated row count: 30 (missing stats)
+        │ table: t@primary
+        │ key columns: k
+        │
+        └── • scan
+              columns: (k, v)
+              ordering: +v
+              estimated row count: 30 (missing stats)
+              table: t@t_v_idx
+              spans: /5-/8
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
 # limit we will only store 100 rows in the sort node). See #19677.
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
 ----
-tree                      field                description           columns  ordering
-·                         distribution         local                 ·        ·
-·                         vectorized           true                  ·        ·
-limit                     ·                    ·                     (w)      ·
- │                        estimated row count  25 (missing stats)    ·        ·
- │                        count                25                    ·        ·
- └── distinct             ·                    ·                     (w)      +w
-      │                   estimated row count  65 (missing stats)    ·        ·
-      │                   distinct on          w                     ·        ·
-      │                   order key            w                     ·        ·
-      └── limit           ·                    ·                     (w)      ·
-           │              estimated row count  100 (missing stats)   ·        ·
-           │              count                100                   ·        ·
-           └── sort       ·                    ·                     (w)      +w
-                │         estimated row count  1000 (missing stats)  ·        ·
-                │         order                +w                    ·        ·
-                └── scan  ·                    ·                     (w)      ·
-·                         estimated row count  1000 (missing stats)  ·        ·
-·                         table                t@primary             ·        ·
-·                         spans                FULL SCAN             ·        ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (w)
+│ estimated row count: 25 (missing stats)
+│ count: 25
+│
+└── • distinct
+    │ columns: (w)
+    │ ordering: +w
+    │ estimated row count: 65 (missing stats)
+    │ distinct on: w
+    │ order key: w
+    │
+    └── • limit
+        │ columns: (w)
+        │ estimated row count: 100 (missing stats)
+        │ count: 100
+        │
+        └── • sort
+            │ columns: (w)
+            │ ordering: +w
+            │ estimated row count: 1000 (missing stats)
+            │ order: +w
+            │
+            └── • scan
+                  columns: (w)
+                  estimated row count: 1000 (missing stats)
+                  table: t@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (k, v)  +k
-·     estimated row count  5 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                LIMITED SCAN       ·       ·
-·     limit                5                  ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, v)
+  ordering: +k
+  estimated row count: 5 (missing stats)
+  table: t@primary
+  spans: LIMITED SCAN
+  limit: 5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-limit      ·                    ·                     (k, v)  ·
- │         estimated row count  995 (missing stats)   ·       ·
- │         offset               5                     ·       ·
- └── scan  ·                    ·                     (k, v)  +k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, v)
+│ estimated row count: 995 (missing stats)
+│ offset: 5
+│
+└── • scan
+      columns: (k, v)
+      ordering: +k
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-·          distribution         local              ·       ·
-·          vectorized           true               ·       ·
-limit      ·                    ·                  (k, v)  ·
- │         estimated row count  5 (missing stats)  ·       ·
- │         offset               1                  ·       ·
- └── scan  ·                    ·                  (k, v)  +v
-·          estimated row count  6 (missing stats)  ·       ·
-·          table                t@t_v_idx          ·       ·
-·          spans                LIMITED SCAN       ·       ·
-·          limit                6                  ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, v)
+│ estimated row count: 5 (missing stats)
+│ offset: 1
+│
+└── • scan
+      columns: (k, v)
+      ordering: +v
+      estimated row count: 6 (missing stats)
+      table: t@t_v_idx
+      spans: LIMITED SCAN
+      limit: 6
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
-·             distribution         local              ·       ·
-·             vectorized           true               ·       ·
-limit         ·                    ·                  (k, v)  ·
- │            estimated row count  5 (missing stats)  ·       ·
- │            offset               1                  ·       ·
- └── revscan  ·                    ·                  (k, v)  -v
-·             estimated row count  6 (missing stats)  ·       ·
-·             table                t@t_v_idx          ·       ·
-·             spans                LIMITED SCAN       ·       ·
-·             limit                6                  ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, v)
+│ estimated row count: 5 (missing stats)
+│ offset: 1
+│
+└── • revscan
+      columns: (k, v)
+      ordering: -v
+      estimated row count: 6 (missing stats)
+      table: t@t_v_idx
+      spans: LIMITED SCAN
+      limit: 6
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
-·                              distribution         local                 ·                       ·
-·                              vectorized           true                  ·                       ·
-project                        ·                    ·                     (sum)                   ·
- └── project                   ·                    ·                     (any_not_null, sum)     -any_not_null
-      │                        estimated row count  10 (missing stats)    ·                       ·
-      └── limit                ·                    ·                     (k, sum, any_not_null)  ·
-           │                   estimated row count  10 (missing stats)    ·                       ·
-           │                   count                10                    ·                       ·
-           └── sort            ·                    ·                     (k, sum, any_not_null)  -any_not_null
-                │              estimated row count  1000 (missing stats)  ·                       ·
-                │              order                -any_not_null         ·                       ·
-                └── group      ·                    ·                     (k, sum, any_not_null)  ·
-                     │         estimated row count  1000 (missing stats)  ·                       ·
-                     │         aggregate 0          sum(w)                ·                       ·
-                     │         aggregate 1          any_not_null(v)       ·                       ·
-                     │         group by             k                     ·                       ·
-                     │         ordered              +k                    ·                       ·
-                     └── scan  ·                    ·                     (k, v, w)               +k
-·                              estimated row count  1000 (missing stats)  ·                       ·
-·                              table                t@primary             ·                       ·
-·                              spans                FULL SCAN             ·                       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (sum)
+│
+└── • project
+    │ columns: (any_not_null, sum)
+    │ ordering: -any_not_null
+    │ estimated row count: 10 (missing stats)
+    │
+    └── • limit
+        │ columns: (k, sum, any_not_null)
+        │ estimated row count: 10 (missing stats)
+        │ count: 10
+        │
+        └── • sort
+            │ columns: (k, sum, any_not_null)
+            │ ordering: -any_not_null
+            │ estimated row count: 1000 (missing stats)
+            │ order: -any_not_null
+            │
+            └── • group
+                │ columns: (k, sum, any_not_null)
+                │ estimated row count: 1000 (missing stats)
+                │ aggregate 0: sum(w)
+                │ aggregate 1: any_not_null(v)
+                │ group by: k
+                │ ordered: +k
+                │
+                └── • scan
+                      columns: (k, v, w)
+                      ordering: +k
+                      estimated row count: 1000 (missing stats)
+                      table: t@primary
+                      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
-·          distribution         local              ·       ·
-·          vectorized           true               ·       ·
-project    ·                    ·                  (k)     ·
- │         estimated row count  4 (missing stats)  ·       ·
- └── scan  ·                    ·                  (k, v)  ·
-·          estimated row count  4 (missing stats)  ·       ·
-·          table                t@t_v_idx          ·       ·
-·          spans                LIMITED SCAN       ·       ·
-·          limit                4                  ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│ estimated row count: 4 (missing stats)
+│
+└── • scan
+      columns: (k, v)
+      estimated row count: 4 (missing stats)
+      table: t@t_v_idx
+      spans: LIMITED SCAN
+      limit: 4
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
-·          distribution         local              ·       ·
-·          vectorized           true               ·       ·
-project    ·                    ·                  (k)     ·
- │         estimated row count  4 (missing stats)  ·       ·
- └── scan  ·                    ·                  (k, v)  ·
-·          estimated row count  4 (missing stats)  ·       ·
-·          table                t@t_v_idx          ·       ·
-·          spans                LIMITED SCAN       ·       ·
-·          limit                4                  ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│ estimated row count: 4 (missing stats)
+│
+└── • scan
+      columns: (k, v)
+      estimated row count: 4 (missing stats)
+      table: t@t_v_idx
+      spans: LIMITED SCAN
+      limit: 4
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k FROM t LIMIT 5) WHERE k != 2
 ----
-·          distribution         local              ·    ·
-·          vectorized           true               ·    ·
-filter     ·                    ·                  (k)  ·
- │         estimated row count  2 (missing stats)  ·    ·
- │         filter               k != 2             ·    ·
- └── scan  ·                    ·                  (k)  ·
-·          estimated row count  5 (missing stats)  ·    ·
-·          table                t@t_v_idx          ·    ·
-·          spans                LIMITED SCAN       ·    ·
-·          limit                5                  ·    ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k)
+│ estimated row count: 2 (missing stats)
+│ filter: k != 2
+│
+└── • scan
+      columns: (k)
+      estimated row count: 5 (missing stats)
+      table: t@t_v_idx
+      spans: LIMITED SCAN
+      limit: 5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-·                    distribution         local                    ·          ·
-·                    vectorized           true                     ·          ·
-project              ·                    ·                        (k, w)     ·
- │                   estimated row count  10 (missing stats)       ·          ·
- └── limit           ·                    ·                        (k, v, w)  ·
-      │              estimated row count  10 (missing stats)       ·          ·
-      │              count                10                       ·          ·
-      └── filter     ·                    ·                        (k, v, w)  ·
-           │         estimated row count  990 (missing stats)      ·          ·
-           │         filter               (v >= 1) AND (v <= 100)  ·          ·
-           └── scan  ·                    ·                        (k, v, w)  ·
-·                    estimated row count  1000 (missing stats)     ·          ·
-·                    table                t@primary                ·          ·
-·                    spans                FULL SCAN                ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k, w)
+│ estimated row count: 10 (missing stats)
+│
+└── • limit
+    │ columns: (k, v, w)
+    │ estimated row count: 10 (missing stats)
+    │ count: 10
+    │
+    └── • filter
+        │ columns: (k, v, w)
+        │ estimated row count: 990 (missing stats)
+        │ filter: (v >= 1) AND (v <= 100)
+        │
+        └── • scan
+              columns: (k, v, w)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
 ----
-·                distribution         local               ·          ·
-·                vectorized           true                ·          ·
-project          ·                    ·                   (k, w)     ·
- └── index join  ·                    ·                   (k, v, w)  +v
-      │          estimated row count  10 (missing stats)  ·          ·
-      │          table                t@primary           ·          ·
-      │          key columns          k                   ·          ·
-      └── scan   ·                    ·                   (k, v)     +v
-·                estimated row count  10 (missing stats)  ·          ·
-·                table                t@t_v_idx           ·          ·
-·                spans                /1-/101             ·          ·
-·                limit                10                  ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k, w)
+│
+└── • index join
+    │ columns: (k, v, w)
+    │ ordering: +v
+    │ estimated row count: 10 (missing stats)
+    │ table: t@primary
+    │ key columns: k
+    │
+    └── • scan
+          columns: (k, v)
+          ordering: +v
+          estimated row count: 10 (missing stats)
+          table: t@t_v_idx
+          spans: /1-/101
+          limit: 10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v
 ----
-·                         distribution         local                    ·          ·
-·                         vectorized           true                     ·          ·
-project                   ·                    ·                        (k, w)     ·
- └── sort                 ·                    ·                        (k, v, w)  +v
-      │                   estimated row count  10 (missing stats)       ·          ·
-      │                   order                +v                       ·          ·
-      └── limit           ·                    ·                        (k, v, w)  ·
-           │              estimated row count  10 (missing stats)       ·          ·
-           │              count                10                       ·          ·
-           └── filter     ·                    ·                        (k, v, w)  +k
-                │         estimated row count  990 (missing stats)      ·          ·
-                │         filter               (v >= 1) AND (v <= 100)  ·          ·
-                └── scan  ·                    ·                        (k, v, w)  +k
-·                         estimated row count  1000 (missing stats)     ·          ·
-·                         table                t@primary                ·          ·
-·                         spans                FULL SCAN                ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k, w)
+│
+└── • sort
+    │ columns: (k, v, w)
+    │ ordering: +v
+    │ estimated row count: 10 (missing stats)
+    │ order: +v
+    │
+    └── • limit
+        │ columns: (k, v, w)
+        │ estimated row count: 10 (missing stats)
+        │ count: 10
+        │
+        └── • filter
+            │ columns: (k, v, w)
+            │ ordering: +k
+            │ estimated row count: 990 (missing stats)
+            │ filter: (v >= 1) AND (v <= 100)
+            │
+            └── • scan
+                  columns: (k, v, w)
+                  ordering: +k
+                  estimated row count: 1000 (missing stats)
+                  table: t@primary
+                  spans: FULL SCAN
 
 # Regression test for #47283: scan with both hard limit and soft limit.
 statement ok
 CREATE TABLE t_47283(k INT PRIMARY KEY, a INT)
 
 # The scan should have a hard limit.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
 ----
-·               distribution         local              ·       ·
-·               vectorized           true               ·       ·
-limit           ·                    ·                  (k, a)  ·
- │              estimated row count  1 (missing stats)  ·       ·
- │              count                1                  ·       ·
- └── filter     ·                    ·                  (k, a)  ·
-      │         estimated row count  2 (missing stats)  ·       ·
-      │         filter               a > 5              ·       ·
-      └── scan  ·                    ·                  (k, a)  ·
-·               estimated row count  4 (missing stats)  ·       ·
-·               table                t_47283@primary    ·       ·
-·               spans                LIMITED SCAN       ·       ·
-·               limit                4                  ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (k, a)
+│ estimated row count: 1 (missing stats)
+│ count: 1
+│
+└── • filter
+    │ columns: (k, a)
+    │ estimated row count: 2 (missing stats)
+    │ filter: a > 5
+    │
+    └── • scan
+          columns: (k, a)
+          estimated row count: 4 (missing stats)
+          table: t_47283@primary
+          spans: LIMITED SCAN
+          limit: 4

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -28,100 +28,118 @@ ALTER TABLE def INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
-tree                 field                description  columns             ordering
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
- │                   estimated row count  99           ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (b) = (f)    ·                   ·
- └── scan            ·                    ·            (a, b, c)           ·
-·                    estimated row count  100          ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 99
+│ table: def@primary
+│ equality: (b) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 ----
-tree                 field                  description     columns             ordering
-·                    distribution           full            ·                   ·
-·                    vectorized             true            ·                   ·
-lookup join (inner)  ·                      ·               (a, b, c, d, e, f)  ·
- │                   estimated row count    0               ·                   ·
- │                   table                  def@primary     ·                   ·
- │                   equality               (b, c) = (f,e)  ·                   ·
- │                   equality cols are key  ·               ·                   ·
- └── scan            ·                      ·               (a, b, c)           ·
-·                    estimated row count    100             ·                   ·
-·                    table                  abc@primary     ·                   ·
-·                    spans                  FULL SCAN       ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 0
+│ table: def@primary
+│ equality: (b, c) = (f,e)
+│ equality cols are key
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 ----
-tree                 field                description  columns             ordering
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
- │                   estimated row count  33           ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (b) = (f)    ·                   ·
- │                   pred                 e > 1        ·                   ·
- └── scan            ·                    ·            (a, b, c)           ·
-·                    estimated row count  33           ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                /2-          ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def@primary
+│ equality: (b) = (f)
+│ pred: e > 1
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 33
+      table: abc@primary
+      spans: /2-
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
-tree                 field                description  columns             ordering
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
- │                   estimated row count  33           ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (a) = (f)    ·                   ·
- │                   pred                 f > 1        ·                   ·
- └── scan            ·                    ·            (a, b, c)           ·
-·                    estimated row count  33           ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                /2-          ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def@primary
+│ equality: (a) = (f)
+│ pred: f > 1
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 33
+      table: abc@primary
+      spans: /2-
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 ----
-tree                 field                description  columns             ordering
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
- │                   estimated row count  33           ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (b) = (f)    ·                   ·
- │                   pred                 a >= e       ·                   ·
- └── scan            ·                    ·            (a, b, c)           ·
-·                    estimated row count  100          ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def@primary
+│ equality: (b) = (f)
+│ pred: a >= e
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 ----
-tree                 field                description  columns             ordering
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (a, b, c, d, e, f)  ·
- │                   estimated row count  33           ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (b) = (f)    ·                   ·
- │                   pred                 a >= e       ·                   ·
- └── scan            ·                    ·            (a, b, c)           ·
-·                    estimated row count  100          ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def@primary
+│ equality: (b) = (f)
+│ pred: a >= e
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
 # Verify a distsql plan.
 statement ok
@@ -162,29 +180,37 @@ NULL       /1       {1}       1
 /8         /9       {4}       4
 /9         NULL     {5}       5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT *
 FROM (SELECT * FROM data WHERE c = 1) AS l
 NATURAL JOIN (SELECT * FROM data WHERE c > 0) AS r
 ----
-·                         distribution           full                      ·                         ·
-·                         vectorized             true                      ·                         ·
-project                   ·                      ·                         (a, b, c, d)              ·
- │                        estimated row count    0                         ·                         ·
- └── lookup join (inner)  ·                      ·                         (a, b, c, d, a, b, c, d)  ·
-      │                   estimated row count    0                         ·                         ·
-      │                   table                  data@primary              ·                         ·
-      │                   equality               (a, b, c, d) = (a,b,c,d)  ·                         ·
-      │                   equality cols are key  ·                         ·                         ·
-      │                   pred                   c > 0                     ·                         ·
-      └── filter          ·                      ·                         (a, b, c, d)              ·
-           │              estimated row count    10                        ·                         ·
-           │              filter                 c = 1                     ·                         ·
-           └── scan       ·                      ·                         (a, b, c, d)              ·
-·                         estimated row count    100000                    ·                         ·
-·                         table                  data@primary              ·                         ·
-·                         spans                  FULL SCAN                 ·                         ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d)
+│ estimated row count: 0
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 0
+    │ table: data@primary
+    │ equality: (a, b, c, d) = (a,b,c,d)
+    │ equality cols are key
+    │ pred: c > 0
+    │
+    └── • filter
+        │ columns: (a, b, c, d)
+        │ estimated row count: 10
+        │ filter: c = 1
+        │
+        └── • scan
+              columns: (a, b, c, d)
+              estimated row count: 100000
+              table: data@primary
+              spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -220,26 +246,36 @@ ALTER TABLE books2 INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
-tree                           field                description        columns                       ordering
-·                              distribution         full               ·                             ·
-·                              vectorized           true               ·                             ·
-distinct                       ·                    ·                  (title)                       ·
- │                             estimated row count  100                ·                             ·
- │                             distinct on          title              ·                             ·
- │                             order key            title              ·                             ·
- └── project                   ·                    ·                  (title)                       +title
-      └── lookup join (inner)  ·                    ·                  (title, shelf, title, shelf)  +title
-           │                   estimated row count  327                ·                             ·
-           │                   table                books2@primary     ·                             ·
-           │                   equality             (title) = (title)  ·                             ·
-           │                   pred                 shelf != shelf     ·                             ·
-           └── scan            ·                    ·                  (title, shelf)                +title
-·                              estimated row count  100                ·                             ·
-·                              table                books@primary      ·                             ·
-·                              spans                FULL SCAN          ·                             ·
+distribution: full
+vectorized: true
+·
+• distinct
+│ columns: (title)
+│ estimated row count: 100
+│ distinct on: title
+│ order key: title
+│
+└── • project
+    │ columns: (title)
+    │ ordering: +title
+    │
+    └── • lookup join (inner)
+        │ columns: (title, shelf, title, shelf)
+        │ ordering: +title
+        │ estimated row count: 327
+        │ table: books2@primary
+        │ equality: (title) = (title)
+        │ pred: shelf != shelf
+        │
+        └── • scan
+              columns: (title, shelf)
+              ordering: +title
+              estimated row count: 100
+              table: books@primary
+              spans: FULL SCAN
 
 statement ok
 CREATE TABLE authors (name STRING, book STRING)
@@ -254,32 +290,43 @@ ALTER TABLE authors INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
-tree                              field                description       columns                                   ordering
-·                                 distribution         full              ·                                         ·
-·                                 vectorized           true              ·                                         ·
-distinct                          ·                    ·                 (name)                                    ·
- │                                estimated row count  96                ·                                         ·
- │                                distinct on          name              ·                                         ·
- └── project                      ·                    ·                 (name)                                    ·
-      └── lookup join (inner)     ·                    ·                 (title, shelf, name, book, title, shelf)  ·
-           │                      estimated row count  323               ·                                         ·
-           │                      table                books2@primary    ·                                         ·
-           │                      equality             (book) = (title)  ·                                         ·
-           │                      pred                 shelf != shelf    ·                                         ·
-           └── hash join (inner)  ·                    ·                 (title, shelf, name, book)                ·
-                │                 estimated row count  99                ·                                         ·
-                │                 equality             (title) = (book)  ·                                         ·
-                ├── scan          ·                    ·                 (title, shelf)                            ·
-                │                 estimated row count  100               ·                                         ·
-                │                 table                books@primary     ·                                         ·
-                │                 spans                FULL SCAN         ·                                         ·
-                └── scan          ·                    ·                 (name, book)                              ·
-·                                 estimated row count  100               ·                                         ·
-·                                 table                authors@primary   ·                                         ·
-·                                 spans                FULL SCAN         ·                                         ·
+distribution: full
+vectorized: true
+·
+• distinct
+│ columns: (name)
+│ estimated row count: 96
+│ distinct on: name
+│
+└── • project
+    │ columns: (name)
+    │
+    └── • lookup join (inner)
+        │ columns: (title, shelf, name, book, title, shelf)
+        │ estimated row count: 323
+        │ table: books2@primary
+        │ equality: (book) = (title)
+        │ pred: shelf != shelf
+        │
+        └── • hash join (inner)
+            │ columns: (title, shelf, name, book)
+            │ estimated row count: 99
+            │ equality: (title) = (book)
+            │
+            ├── • scan
+            │     columns: (title, shelf)
+            │     estimated row count: 100
+            │     table: books@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  columns: (name, book)
+                  estimated row count: 100
+                  table: authors@primary
+                  spans: FULL SCAN
 
 # Verify data placement.
 query TTTI colnames
@@ -293,43 +340,58 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT authors.name FROM books AS b1
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyck1Fv2jAQx9_3Kbx7SiS34CRQKVIlo8JUJhY6QNqkioeEXCFrsDPbkTYhvvuUhK4ENaH0zee739__O9s70L9T8GE-mozuFiRXKfkym34jj6OfD5PBOCDWcDxfzL9PbHIoKeJxcLcgYW42UulrEW6xgiIpnzUZzEnEaBU4ZeTQl2Ly4340GxHLiti1SUyK5JZETrW0ySAYEutFtuCL7KHQPqQjdq03mD6RzyVZru0lUBAyxiDcogb_ERhQ6MGSQqbkCrWWqtjelUXj-A_4XQqJyHJTbC8prKRC8HdQHgU-BPJKZp0-UIjRhElalu0pyNy8QtqEawT_Zk-PhFm78CKMUpxhGKPqdGvyUA6MZyrZhuovUJhnodA-uQIK09z4hDPKXWhywT7qgtVdHMZ_xofT6MNp9PF6fC6kilFhfDrf8yVvNHMf6s1XmQhUHafeS4pPxuLMvlXJemMs7ti1Hih3KfcaO3EvmWhh4DBQ941rdY7mOZHyOc_IL5kIIoVPuFe4Cgh3ijfNb_57bL5s7xJrw0SbRKxMx6sb46xRv_ch_d679fs1_TN_cYY6k0Ljuz5jt3ghGK-xenFa5mqFD0quymOqcFpy5UaM2lTZmyoYiypVGDyGWSvs1mB2CjsXwM4p7LbCXrttrxXutcO9VrjfDvdb4e4JvNx_-hcAAP__NdMdAw==
 
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
-tree                      field                description       columns              ordering
-·                         distribution         full              ·                    ·
-·                         vectorized           true              ·                    ·
-project                   ·                    ·                 (name)               +name
- │                        estimated row count  990               ·                    ·
- └── lookup join (inner)  ·                    ·                 (name, book, title)  +name
-      │                   estimated row count  990               ·                    ·
-      │                   table                books2@primary    ·                    ·
-      │                   equality             (book) = (title)  ·                    ·
-      └── sort            ·                    ·                 (name, book)         +name
-           │              estimated row count  100               ·                    ·
-           │              order                +name             ·                    ·
-           └── scan       ·                    ·                 (name, book)         ·
-·                         estimated row count  100               ·                    ·
-·                         table                authors@primary   ·                    ·
-·                         spans                FULL SCAN         ·                    ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (name)
+│ ordering: +name
+│ estimated row count: 990
+│
+└── • lookup join (inner)
+    │ columns: (name, book, title)
+    │ ordering: +name
+    │ estimated row count: 990
+    │ table: books2@primary
+    │ equality: (book) = (title)
+    │
+    └── • sort
+        │ columns: (name, book)
+        │ ordering: +name
+        │ estimated row count: 100
+        │ order: +name
+        │
+        └── • scan
+              columns: (name, book)
+              estimated row count: 100
+              table: authors@primary
+              spans: FULL SCAN
 
 # Cross joins should not be planned as lookup joins.
-query TTTTT colnames
+query T
 EXPLAIN (VERBOSE) SELECT * FROM books CROSS JOIN books2
 ----
-tree                field                description     columns                                         ordering
-·                   distribution         full            ·                                               ·
-·                   vectorized           true            ·                                               ·
-cross join (inner)  ·                    ·               (title, edition, shelf, title, edition, shelf)  ·
- │                  estimated row count  1000000         ·                                               ·
- ├── scan           ·                    ·               (title, edition, shelf)                         ·
- │                  estimated row count  10000           ·                                               ·
- │                  table                books2@primary  ·                                               ·
- │                  spans                FULL SCAN       ·                                               ·
- └── scan           ·                    ·               (title, edition, shelf)                         ·
-·                   estimated row count  100             ·                                               ·
-·                   table                books@primary   ·                                               ·
-·                   spans                FULL SCAN       ·                                               ·
+distribution: full
+vectorized: true
+·
+• cross join (inner)
+│ columns: (title, edition, shelf, title, edition, shelf)
+│ estimated row count: 1000000
+│
+├── • scan
+│     columns: (title, edition, shelf)
+│     estimated row count: 10000
+│     table: books2@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (title, edition, shelf)
+      estimated row count: 100
+      table: books@primary
+      spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
@@ -378,81 +440,110 @@ ALTER TABLE large INJECT STATISTICS '[
 ]'
 
 # Lookup join on covering secondary index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
 ----
-·                         distribution         full           ·          ·
-·                         vectorized           true           ·          ·
-project                   ·                    ·              (a, c)     ·
- │                        estimated row count  1000           ·          ·
- └── lookup join (inner)  ·                    ·              (a, b, c)  ·
-      │                   estimated row count  1000           ·          ·
-      │                   table                large@bc       ·          ·
-      │                   equality             (a) = (b)      ·          ·
-      └── scan            ·                    ·              (a)        ·
-·                         estimated row count  100            ·          ·
-·                         table                small@primary  ·          ·
-·                         spans                FULL SCAN      ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, c)
+│ estimated row count: 1000
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c)
+    │ estimated row count: 1000
+    │ table: large@bc
+    │ equality: (a) = (b)
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 100
+          table: small@primary
+          spans: FULL SCAN
 
 # Lookup join on non-covering secondary index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
 ----
-·                                   distribution           full            ·             ·
-·                                   vectorized             true            ·             ·
-project                             ·                      ·               (a, d)        ·
- │                                  estimated row count    1000            ·             ·
- └── project                        ·                      ·               (a, b, d)     ·
-      │                             estimated row count    1000            ·             ·
-      └── lookup join (inner)       ·                      ·               (a, a, b, d)  ·
-           │                        table                  large@primary   ·             ·
-           │                        equality               (a, b) = (a,b)  ·             ·
-           │                        equality cols are key  ·               ·             ·
-           └── lookup join (inner)  ·                      ·               (a, a, b)     ·
-                │                   estimated row count    1000            ·             ·
-                │                   table                  large@bc        ·             ·
-                │                   equality               (a) = (b)       ·             ·
-                └── scan            ·                      ·               (a)           ·
-·                                   estimated row count    100             ·             ·
-·                                   table                  small@primary   ·             ·
-·                                   spans                  FULL SCAN       ·             ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, d)
+│ estimated row count: 1000
+│
+└── • project
+    │ columns: (a, b, d)
+    │ estimated row count: 1000
+    │
+    └── • lookup join (inner)
+        │ columns: (a, a, b, d)
+        │ table: large@primary
+        │ equality: (a, b) = (a,b)
+        │ equality cols are key
+        │
+        └── • lookup join (inner)
+            │ columns: (a, a, b)
+            │ estimated row count: 1000
+            │ table: large@bc
+            │ equality: (a) = (b)
+            │
+            └── • scan
+                  columns: (a)
+                  estimated row count: 100
+                  table: small@primary
+                  spans: FULL SCAN
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
 ############################
 
 # Left join against primary index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
 ----
-·                         distribution         full           ·       ·
-·                         vectorized           true           ·       ·
-lookup join (left outer)  ·                    ·              (b, a)  ·
- │                        estimated row count  100            ·       ·
- │                        table                large@primary  ·       ·
- │                        equality             (b) = (a)      ·       ·
- └── scan                 ·                    ·              (b)     ·
-·                         estimated row count  100            ·       ·
-·                         table                small@primary  ·       ·
-·                         spans                FULL SCAN      ·       ·
+distribution: full
+vectorized: true
+·
+• lookup join (left outer)
+│ columns: (b, a)
+│ estimated row count: 100
+│ table: large@primary
+│ equality: (b) = (a)
+│
+└── • scan
+      columns: (b)
+      estimated row count: 100
+      table: small@primary
+      spans: FULL SCAN
 
 # Left join should preserve input order.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a
 ----
-·                              distribution         full           ·          ·
-·                              vectorized           true           ·          ·
-project                        ·                    ·              (a, b)     +a
- │                             estimated row count  100            ·          ·
- └── lookup join (left outer)  ·                    ·              (a, a, b)  +a
-      │                        estimated row count  100            ·          ·
-      │                        table                large@primary  ·          ·
-      │                        equality             (a) = (a)      ·          ·
-      │                        pred                 (b % 6) = 0    ·          ·
-      └── scan                 ·                    ·              (a)        +a
-·                              estimated row count  100            ·          ·
-·                              table                small@primary  ·          ·
-·                              spans                FULL SCAN      ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ ordering: +a
+│ estimated row count: 100
+│
+└── • lookup join (left outer)
+    │ columns: (a, a, b)
+    │ ordering: +a
+    │ estimated row count: 100
+    │ table: large@primary
+    │ equality: (a) = (a)
+    │ pred: (b % 6) = 0
+    │
+    └── • scan
+          columns: (a)
+          ordering: +a
+          estimated row count: 100
+          table: small@primary
+          spans: FULL SCAN
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -460,87 +551,119 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN lar
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlV9r2zwUxu_fT3E48ELClDqynTQVFNKtKaRkdud4sFF8ocai8-ZanizDSsl3H5YLdcpiG3yTu-jPk-c5vyN8XrD4nSLD7Wqz-hRCqVK4CfzPcL_6dre5Wnswul5vw-2XzRher2h6xglo--yhvlk88TSFqy1oCpvVTQi3_tqDlKtHYXZt8D0YVSq4rGR8DFfeNYxG5i_-h_kYLmE6Bj-4XgXw8bsxiJBgJmPh8SdRILtHigRtJOggQRcJzjAimCu5E0UhVXXlxQjW8R9kU4JJlpe62o4I7qQSyF5QJzoVyDDkD6kIBI-FsqZIMBaaJ6mxMcUsc5U8cfWMBLc5zwoGE4sCz2KgIPUPoZCgX2oGS4rRnqAs9ZtZofmjQEb3pH-gW5lkr3lmh3nC51ywGqv_NVwFBi4SNHgbOTdS_ipz-CmTDGRmkhGsuC-dCjFjbO2FC0P69fdbDWTpHC3DPlrGW3qpYqFEfBh8ST9gtP9HrZ6cyNyih9yP2TsH9rR_W2mvtlp0YtmDGtsRqdHY-Sk31u5P1u5H1p5YziCyHZEaZM9PmazTn6zTj6wzsdxBZDsiNcguTpms25-s24-sO7Fmg8h2RGqQvThlsh3TKhBFLrNC9PqCT6sZIOJHUc-MQpZqJ-6U3BmbeukbndmIRaHrU1ov1ll9VAVsimmr2D4Q0_diu925w9ppVbvtYndI7lmreN7uPB_ifN4qXrQ7L4Y4X7T3atrxTNof2XvvaP_f3wAAAP__d9J4OQ==
 
 # Left join against covering secondary index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                              distribution         full           ·          ·
-·                              vectorized           true           ·          ·
-project                        ·                    ·              (c, c)     ·
- │                             estimated row count  1000           ·          ·
- └── lookup join (left outer)  ·                    ·              (c, b, c)  ·
-      │                        estimated row count  1000           ·          ·
-      │                        table                large@bc       ·          ·
-      │                        equality             (c) = (b)      ·          ·
-      └── scan                 ·                    ·              (c)        ·
-·                              estimated row count  100            ·          ·
-·                              table                small@primary  ·          ·
-·                              spans                FULL SCAN      ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (c, c)
+│ estimated row count: 1000
+│
+└── • lookup join (left outer)
+    │ columns: (c, b, c)
+    │ estimated row count: 1000
+    │ table: large@bc
+    │ equality: (c) = (b)
+    │
+    └── • scan
+          columns: (c)
+          estimated row count: 100
+          table: small@primary
+          spans: FULL SCAN
 
 # Left join against non-covering secondary index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                                        distribution           full            ·             ·
-·                                        vectorized             true            ·             ·
-project                                  ·                      ·               (c, d)        ·
- │                                       estimated row count    1000            ·             ·
- └── project                             ·                      ·               (c, b, d)     ·
-      │                                  estimated row count    1000            ·             ·
-      └── lookup join (left outer)       ·                      ·               (c, a, b, d)  ·
-           │                             table                  large@primary   ·             ·
-           │                             equality               (a, b) = (a,b)  ·             ·
-           │                             equality cols are key  ·               ·             ·
-           └── lookup join (left outer)  ·                      ·               (c, a, b)     ·
-                │                        estimated row count    1000            ·             ·
-                │                        table                  large@bc        ·             ·
-                │                        equality               (c) = (b)       ·             ·
-                └── scan                 ·                      ·               (c)           ·
-·                                        estimated row count    100             ·             ·
-·                                        table                  small@primary   ·             ·
-·                                        spans                  FULL SCAN       ·             ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (c, d)
+│ estimated row count: 1000
+│
+└── • project
+    │ columns: (c, b, d)
+    │ estimated row count: 1000
+    │
+    └── • lookup join (left outer)
+        │ columns: (c, a, b, d)
+        │ table: large@primary
+        │ equality: (a, b) = (a,b)
+        │ equality cols are key
+        │
+        └── • lookup join (left outer)
+            │ columns: (c, a, b)
+            │ estimated row count: 1000
+            │ table: large@bc
+            │ equality: (c) = (b)
+            │
+            └── • scan
+                  columns: (c)
+                  estimated row count: 100
+                  table: small@primary
+                  spans: FULL SCAN
 
 # Left join with ON filter on covering index
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
 ----
-·                              distribution         full           ·          ·
-·                              vectorized           true           ·          ·
-project                        ·                    ·              (c, c)     ·
- │                             estimated row count  336            ·          ·
- └── lookup join (left outer)  ·                    ·              (c, b, c)  ·
-      │                        estimated row count  336            ·          ·
-      │                        table                large@bc       ·          ·
-      │                        equality             (c) = (b)      ·          ·
-      │                        pred                 c < 20         ·          ·
-      └── scan                 ·                    ·              (c)        ·
-·                              estimated row count  100            ·          ·
-·                              table                small@primary  ·          ·
-·                              spans                FULL SCAN      ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (c, c)
+│ estimated row count: 336
+│
+└── • lookup join (left outer)
+    │ columns: (c, b, c)
+    │ estimated row count: 336
+    │ table: large@bc
+    │ equality: (c) = (b)
+    │ pred: c < 20
+    │
+    └── • scan
+          columns: (c)
+          estimated row count: 100
+          table: small@primary
+          spans: FULL SCAN
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
 # left join with ON condition on columns that are not covered by the index.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
 ----
-·                             distribution         full           ·          ·
-·                             vectorized           true           ·          ·
-project                       ·                    ·              (c, d)     ·
- │                            estimated row count  336            ·          ·
- └── hash join (right outer)  ·                    ·              (b, d, c)  ·
-      │                       estimated row count  336            ·          ·
-      │                       equality             (b) = (c)      ·          ·
-      ├── filter              ·                    ·              (b, d)     ·
-      │    │                  estimated row count  3303           ·          ·
-      │    │                  filter               d < 30         ·          ·
-      │    └── scan           ·                    ·              (b, d)     ·
-      │                       estimated row count  10000          ·          ·
-      │                       table                large@primary  ·          ·
-      │                       spans                FULL SCAN      ·          ·
-      └── scan                ·                    ·              (c)        ·
-·                             estimated row count  100            ·          ·
-·                             table                small@primary  ·          ·
-·                             spans                FULL SCAN      ·          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (c, d)
+│ estimated row count: 336
+│
+└── • hash join (right outer)
+    │ columns: (b, d, c)
+    │ estimated row count: 336
+    │ equality: (b) = (c)
+    │
+    ├── • filter
+    │   │ columns: (b, d)
+    │   │ estimated row count: 3303
+    │   │ filter: d < 30
+    │   │
+    │   └── • scan
+    │         columns: (b, d)
+    │         estimated row count: 10000
+    │         table: large@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          columns: (c)
+          estimated row count: 100
+          table: small@primary
+          spans: FULL SCAN
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -556,24 +679,32 @@ CREATE TABLE u (a INT, b INT, c INT, d INT, e INT, PRIMARY KEY (a DESC, b, c))
 statement ok
 CREATE INDEX idx ON u (d)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                         distribution         full                  ·                ·
-·                         vectorized           true                  ·                ·
-project                   ·                    ·                     (a)              ·
- │                        estimated row count  1 (missing stats)     ·                ·
- └── lookup join (inner)  ·                    ·                     (a, d, e, a, d)  ·
-      │                   estimated row count  1 (missing stats)     ·                ·
-      │                   table                u@idx                 ·                ·
-      │                   equality             (d, a) = (d,a)        ·                ·
-      └── filter          ·                    ·                     (a, d, e)        ·
-           │              estimated row count  10 (missing stats)    ·                ·
-           │              filter               e = 5                 ·                ·
-           └── scan       ·                    ·                     (a, d, e)        ·
-·                         estimated row count  1000 (missing stats)  ·                ·
-·                         table                t@primary             ·                ·
-·                         spans                FULL SCAN             ·                ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 1 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, d, e, a, d)
+    │ estimated row count: 1 (missing stats)
+    │ table: u@idx
+    │ equality: (d, a) = (d,a)
+    │
+    └── • filter
+        │ columns: (a, d, e)
+        │ estimated row count: 10 (missing stats)
+        │ filter: e = 5
+        │
+        └── • scan
+              columns: (a, d, e)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -582,26 +713,34 @@ DROP INDEX u@idx
 statement ok
 CREATE UNIQUE INDEX idx ON u (d)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                         distribution           full                  ·                ·
-·                         vectorized             true                  ·                ·
-project                   ·                      ·                     (a)              ·
- │                        estimated row count    0 (missing stats)     ·                ·
- └── lookup join (inner)  ·                      ·                     (a, d, e, a, d)  ·
-      │                   estimated row count    0 (missing stats)     ·                ·
-      │                   table                  u@idx                 ·                ·
-      │                   equality               (d) = (d)             ·                ·
-      │                   equality cols are key  ·                     ·                ·
-      │                   pred                   a = a                 ·                ·
-      └── filter          ·                      ·                     (a, d, e)        ·
-           │              estimated row count    10 (missing stats)    ·                ·
-           │              filter                 e = 5                 ·                ·
-           └── scan       ·                      ·                     (a, d, e)        ·
-·                         estimated row count    1000 (missing stats)  ·                ·
-·                         table                  t@primary             ·                ·
-·                         spans                  FULL SCAN             ·                ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 0 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, d, e, a, d)
+    │ estimated row count: 0 (missing stats)
+    │ table: u@idx
+    │ equality: (d) = (d)
+    │ equality cols are key
+    │ pred: a = a
+    │
+    └── • filter
+        │ columns: (a, d, e)
+        │ estimated row count: 10 (missing stats)
+        │ filter: e = 5
+        │
+        └── • scan
+              columns: (a, d, e)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
 # Test index with first primary key column explicit and the rest implicit.
 statement ok
@@ -610,24 +749,32 @@ DROP INDEX u@idx CASCADE
 statement ok
 CREATE INDEX idx ON u (d, a)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                         distribution         full                  ·                      ·
-·                         vectorized           true                  ·                      ·
-project                   ·                    ·                     (a)                    ·
- │                        estimated row count  0 (missing stats)     ·                      ·
- └── lookup join (inner)  ·                    ·                     (a, b, d, e, a, b, d)  ·
-      │                   estimated row count  0 (missing stats)     ·                      ·
-      │                   table                u@idx                 ·                      ·
-      │                   equality             (d, a, b) = (d,a,b)   ·                      ·
-      └── filter          ·                    ·                     (a, b, d, e)           ·
-           │              estimated row count  10 (missing stats)    ·                      ·
-           │              filter               e = 5                 ·                      ·
-           └── scan       ·                    ·                     (a, b, d, e)           ·
-·                         estimated row count  1000 (missing stats)  ·                      ·
-·                         table                t@primary             ·                      ·
-·                         spans                FULL SCAN             ·                      ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 0 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, b, d, e, a, b, d)
+    │ estimated row count: 0 (missing stats)
+    │ table: u@idx
+    │ equality: (d, a, b) = (d,a,b)
+    │
+    └── • filter
+        │ columns: (a, b, d, e)
+        │ estimated row count: 10 (missing stats)
+        │ filter: e = 5
+        │
+        └── • scan
+              columns: (a, b, d, e)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -636,24 +783,32 @@ DROP INDEX u@idx
 statement ok
 CREATE INDEX idx ON u (d, b)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                         distribution         full                  ·                      ·
-·                         vectorized           true                  ·                      ·
-project                   ·                    ·                     (a)                    ·
- │                        estimated row count  0 (missing stats)     ·                      ·
- └── lookup join (inner)  ·                    ·                     (a, b, d, e, a, b, d)  ·
-      │                   estimated row count  0 (missing stats)     ·                      ·
-      │                   table                u@idx                 ·                      ·
-      │                   equality             (d, b, a) = (d,b,a)   ·                      ·
-      └── filter          ·                    ·                     (a, b, d, e)           ·
-           │              estimated row count  10 (missing stats)    ·                      ·
-           │              filter               e = 5                 ·                      ·
-           └── scan       ·                    ·                     (a, b, d, e)           ·
-·                         estimated row count  1000 (missing stats)  ·                      ·
-·                         table                t@primary             ·                      ·
-·                         spans                FULL SCAN             ·                      ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 0 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, b, d, e, a, b, d)
+    │ estimated row count: 0 (missing stats)
+    │ table: u@idx
+    │ equality: (d, b, a) = (d,b,a)
+    │
+    └── • filter
+        │ columns: (a, b, d, e)
+        │ estimated row count: 10 (missing stats)
+        │ filter: e = 5
+        │
+        └── • scan
+              columns: (a, b, d, e)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -662,168 +817,224 @@ DROP INDEX u@idx
 statement ok
 CREATE INDEX idx ON u (d, c)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
-·                         distribution         full                  ·                ·
-·                         vectorized           true                  ·                ·
-project                   ·                    ·                     (a)              ·
- │                        estimated row count  1 (missing stats)     ·                ·
- └── lookup join (inner)  ·                    ·                     (a, d, e, a, d)  ·
-      │                   estimated row count  1 (missing stats)     ·                ·
-      │                   table                u@idx                 ·                ·
-      │                   equality             (d) = (d)             ·                ·
-      │                   pred                 a = a                 ·                ·
-      └── filter          ·                    ·                     (a, d, e)        ·
-           │              estimated row count  10 (missing stats)    ·                ·
-           │              filter               e = 5                 ·                ·
-           └── scan       ·                    ·                     (a, d, e)        ·
-·                         estimated row count  1000 (missing stats)  ·                ·
-·                         table                t@primary             ·                ·
-·                         spans                FULL SCAN             ·                ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 1 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, d, e, a, d)
+    │ estimated row count: 1 (missing stats)
+    │ table: u@idx
+    │ equality: (d) = (d)
+    │ pred: a = a
+    │
+    └── • filter
+        │ columns: (a, d, e)
+        │ estimated row count: 10 (missing stats)
+        │ filter: e = 5
+        │
+        └── • scan
+              columns: (a, d, e)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
 ----
-·                    distribution         full         ·                   ·
-·                    vectorized           true         ·                   ·
-lookup join (inner)  ·                    ·            (d, e, f, a, b, c)  +a
- │                   estimated row count  100          ·                   ·
- │                   table                def@primary  ·                   ·
- │                   equality             (a) = (f)    ·                   ·
- └── scan            ·                    ·            (a, b, c)           +a
-·                    estimated row count  100          ·                   ·
-·                    table                abc@primary  ·                   ·
-·                    spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (d, e, f, a, b, c)
+│ ordering: +a
+│ estimated row count: 100
+│ table: def@primary
+│ equality: (a) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
 # Test that we don't get a lookup join if we force a merge join.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
-·                   distribution         full         ·                   ·
-·                   vectorized           true         ·                   ·
-merge join (inner)  ·                    ·            (d, e, f, a, b, c)  +f
- │                  estimated row count  100          ·                   ·
- │                  equality             (f) = (a)    ·                   ·
- │                  merge ordering       +"(f=a)"     ·                   ·
- ├── scan           ·                    ·            (d, e, f)           +f
- │                  estimated row count  10000        ·                   ·
- │                  table                def@primary  ·                   ·
- │                  spans                FULL SCAN    ·                   ·
- └── scan           ·                    ·            (a, b, c)           +a
-·                   estimated row count  100          ·                   ·
-·                   table                abc@primary  ·                   ·
-·                   spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• merge join (inner)
+│ columns: (d, e, f, a, b, c)
+│ ordering: +f
+│ estimated row count: 100
+│ equality: (f) = (a)
+│ merge ordering: +"(f=a)"
+│
+├── • scan
+│     columns: (d, e, f)
+│     ordering: +f
+│     estimated row count: 10000
+│     table: def@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
 # Test that we don't get a lookup join if we force a hash join.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ----
-·                       distribution         full         ·                   ·
-·                       vectorized           true         ·                   ·
-sort                    ·                    ·            (d, e, f, a, b, c)  +f
- │                      estimated row count  100          ·                   ·
- │                      order                +f           ·                   ·
- └── hash join (inner)  ·                    ·            (d, e, f, a, b, c)  ·
-      │                 estimated row count  100          ·                   ·
-      │                 equality             (f) = (a)    ·                   ·
-      ├── scan          ·                    ·            (d, e, f)           ·
-      │                 estimated row count  10000        ·                   ·
-      │                 table                def@primary  ·                   ·
-      │                 spans                FULL SCAN    ·                   ·
-      └── scan          ·                    ·            (a, b, c)           ·
-·                       estimated row count  100          ·                   ·
-·                       table                abc@primary  ·                   ·
-·                       spans                FULL SCAN    ·                   ·
+distribution: full
+vectorized: true
+·
+• sort
+│ columns: (d, e, f, a, b, c)
+│ ordering: +f
+│ estimated row count: 100
+│ order: +f
+│
+└── • hash join (inner)
+    │ columns: (d, e, f, a, b, c)
+    │ estimated row count: 100
+    │ equality: (f) = (a)
+    │
+    ├── • scan
+    │     columns: (d, e, f)
+    │     estimated row count: 10000
+    │     table: def@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 100
+          table: abc@primary
+          spans: FULL SCAN
 
 # Test lookup semi and anti join.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·                   distribution         full         ·          ·
-·                   vectorized           true         ·          ·
-lookup join (semi)  ·                    ·            (a, b, c)  ·
- │                  estimated row count  100          ·          ·
- │                  table                def@primary  ·          ·
- │                  equality             (a) = (f)    ·          ·
- └── scan           ·                    ·            (a, b, c)  ·
-·                   estimated row count  100          ·          ·
-·                   table                abc@primary  ·          ·
-·                   spans                FULL SCAN    ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, c)
+│ estimated row count: 100
+│ table: def@primary
+│ equality: (a) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·                   distribution         full         ·          ·
-·                   vectorized           true         ·          ·
-lookup join (anti)  ·                    ·            (a, b, c)  ·
- │                  estimated row count  0            ·          ·
- │                  table                def@primary  ·          ·
- │                  equality             (a) = (f)    ·          ·
- └── scan           ·                    ·            (a, b, c)  ·
-·                   estimated row count  100          ·          ·
-·                   table                abc@primary  ·          ·
-·                   spans                FULL SCAN    ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (anti)
+│ columns: (a, b, c)
+│ estimated row count: 0
+│ table: def@primary
+│ equality: (a) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·                   distribution           full            ·          ·
-·                   vectorized             true            ·          ·
-lookup join (semi)  ·                      ·               (a, b, c)  ·
- │                  estimated row count    100             ·          ·
- │                  table                  def@primary     ·          ·
- │                  equality               (a, c) = (f,e)  ·          ·
- │                  equality cols are key  ·               ·          ·
- └── scan           ·                      ·               (a, b, c)  ·
-·                   estimated row count    100             ·          ·
-·                   table                  abc@primary     ·          ·
-·                   spans                  FULL SCAN       ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, c)
+│ estimated row count: 100
+│ table: def@primary
+│ equality: (a, c) = (f,e)
+│ equality cols are key
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·                   distribution           full            ·          ·
-·                   vectorized             true            ·          ·
-lookup join (anti)  ·                      ·               (a, b, c)  ·
- │                  estimated row count    0               ·          ·
- │                  table                  def@primary     ·          ·
- │                  equality               (a, c) = (f,e)  ·          ·
- │                  equality cols are key  ·               ·          ·
- └── scan           ·                      ·               (a, b, c)  ·
-·                   estimated row count    100             ·          ·
-·                   table                  abc@primary     ·          ·
-·                   spans                  FULL SCAN       ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (anti)
+│ columns: (a, b, c)
+│ estimated row count: 0
+│ table: def@primary
+│ equality: (a, c) = (f,e)
+│ equality cols are key
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·                   distribution         full         ·          ·
-·                   vectorized           true         ·          ·
-lookup join (semi)  ·                    ·            (a, b, c)  ·
- │                  estimated row count  33           ·          ·
- │                  table                def@primary  ·          ·
- │                  equality             (a) = (f)    ·          ·
- │                  pred                 (d + b) > 1  ·          ·
- └── scan           ·                    ·            (a, b, c)  ·
-·                   estimated row count  100          ·          ·
-·                   table                abc@primary  ·          ·
-·                   spans                FULL SCAN    ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, c)
+│ estimated row count: 33
+│ table: def@primary
+│ equality: (a) = (f)
+│ pred: (d + b) > 1
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·                   distribution         full         ·          ·
-·                   vectorized           true         ·          ·
-lookup join (anti)  ·                    ·            (a, b, c)  ·
- │                  estimated row count  67           ·          ·
- │                  table                def@primary  ·          ·
- │                  equality             (a) = (f)    ·          ·
- │                  pred                 (d + b) > 1  ·          ·
- └── scan           ·                    ·            (a, b, c)  ·
-·                   estimated row count  100          ·          ·
-·                   table                abc@primary  ·          ·
-·                   spans                FULL SCAN    ·          ·
+distribution: full
+vectorized: true
+·
+• lookup join (anti)
+│ columns: (a, b, c)
+│ estimated row count: 67
+│ table: def@primary
+│ equality: (a) = (f)
+│ pred: (d + b) > 1
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100
+      table: abc@primary
+      spans: FULL SCAN
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -855,19 +1066,22 @@ INSERT INTO a SELECT 1, g FROM generate_series(1,11000) g
 statement ok
 INSERT INTO b VALUES(1)
 
-query TTT
+query T
 EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
 ----
-·                 distribution   full
-·                 vectorized     true
-group (scalar)    ·              ·
- └── lookup join  ·              ·
-      │           table          a@primary
-      │           equality       (a) = (a)
-      └── scan    ·              ·
-·                 missing stats  ·
-·                 table          b@primary
-·                 spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• group (scalar)
+│
+└── • lookup join
+    │ table: a@primary
+    │ equality: (a) = (a)
+    │
+    └── • scan
+          missing stats
+          table: b@primary
+          spans: FULL SCAN
 
 statement ok
 SET tracing = on
@@ -1419,7 +1633,7 @@ ALTER TABLE public.lineitem INJECT STATISTICS '[
   }
 ]'
 
-query TTT
+query T
 EXPLAIN SELECT s_name, count(*) AS numwait
     FROM supplier, lineitem AS l1, orders, nation
    WHERE s_suppkey = l1.l_suppkey
@@ -1444,48 +1658,60 @@ GROUP BY s_name
 ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
-·                                                            distribution           full
-·                                                            vectorized             true
-limit                                                        ·                      ·
- │                                                           count                  100
- └── sort                                                    ·                      ·
-      │                                                      order                  -count_rows,+s_name
-      └── group                                              ·                      ·
-           │                                                 group by               s_name
-           └── lookup join (semi)                            ·                      ·
-                │                                            table                  lineitem@primary
-                │                                            equality               (l_orderkey) = (l_orderkey)
-                │                                            pred                   l_suppkey != l_suppkey
-                └── lookup join                              ·                      ·
-                     │                                       table                  orders@primary
-                     │                                       equality               (l_orderkey) = (o_orderkey)
-                     │                                       equality cols are key  ·
-                     │                                       pred                   o_orderstatus = 'F'
-                     └── lookup join (anti)                  ·                      ·
-                          │                                  table                  lineitem@primary
-                          │                                  equality               (l_orderkey) = (l_orderkey)
-                          │                                  pred                   l_receiptdate > l_commitdate
-                          └── lookup join                    ·                      ·
-                               │                             table                  lineitem@primary
-                               │                             equality               (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
-                               │                             equality cols are key  ·
-                               │                             pred                   l_receiptdate > l_commitdate
-                               └── lookup join               ·                      ·
-                                    │                        table                  lineitem@l_sk
-                                    │                        equality               (s_suppkey) = (l_suppkey)
-                                    └── lookup join          ·                      ·
-                                         │                   table                  supplier@primary
-                                         │                   equality               (s_suppkey) = (s_suppkey)
-                                         │                   equality cols are key  ·
-                                         └── lookup join     ·                      ·
-                                              │              table                  supplier@s_nk
-                                              │              equality               (n_nationkey) = (s_nationkey)
-                                              └── filter     ·                      ·
-                                                   │         filter                 n_name = 'SAUDI ARABIA'
-                                                   └── scan  ·                      ·
-·                                                            estimated row count    25
-·                                                            table                  nation@primary
-·                                                            spans                  FULL SCAN
+distribution: full
+vectorized: true
+·
+• limit
+│ count: 100
+│
+└── • sort
+    │ order: -count_rows,+s_name
+    │
+    └── • group
+        │ group by: s_name
+        │
+        └── • lookup join (semi)
+            │ table: lineitem@primary
+            │ equality: (l_orderkey) = (l_orderkey)
+            │ pred: l_suppkey != l_suppkey
+            │
+            └── • lookup join
+                │ table: orders@primary
+                │ equality: (l_orderkey) = (o_orderkey)
+                │ equality cols are key
+                │ pred: o_orderstatus = 'F'
+                │
+                └── • lookup join (anti)
+                    │ table: lineitem@primary
+                    │ equality: (l_orderkey) = (l_orderkey)
+                    │ pred: l_receiptdate > l_commitdate
+                    │
+                    └── • lookup join
+                        │ table: lineitem@primary
+                        │ equality: (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
+                        │ equality cols are key
+                        │ pred: l_receiptdate > l_commitdate
+                        │
+                        └── • lookup join
+                            │ table: lineitem@l_sk
+                            │ equality: (s_suppkey) = (l_suppkey)
+                            │
+                            └── • lookup join
+                                │ table: supplier@primary
+                                │ equality: (s_suppkey) = (s_suppkey)
+                                │ equality cols are key
+                                │
+                                └── • lookup join
+                                    │ table: supplier@s_nk
+                                    │ equality: (n_nationkey) = (s_nationkey)
+                                    │
+                                    └── • filter
+                                        │ filter: n_name = 'SAUDI ARABIA'
+                                        │
+                                        └── • scan
+                                              estimated row count: 25
+                                              table: nation@primary
+                                              spans: FULL SCAN
 
 # Regression test for #50964.
 statement ok
@@ -1494,34 +1720,46 @@ CREATE TABLE tab4 (
   UNIQUE (col3 DESC, col4 DESC)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE col4 = 495.6) AND (col3 IS NULL)
 ----
-·                               distribution           full                                         ·                                          ·
-·                               vectorized             true                                         ·                                          ·
-project                         ·                      ·                                            (pk)                                       ·
- │                              estimated row count    10 (missing stats)                           ·                                          ·
- └── project                    ·                      ·                                            (pk, col0, col3)                           ·
-      │                         estimated row count    10 (missing stats)                           ·                                          ·
-      └── lookup join (semi)    ·                      ·                                            ("project_const_col_@15", pk, col0, col3)  ·
-           │                    table                  tab4@tab4_col3_col4_key                      ·                                          ·
-           │                    equality               (col0, project_const_col_@15) = (col3,col4)  ·                                          ·
-           │                    equality cols are key  ·                                            ·                                          ·
-           └── render           ·                      ·                                            ("project_const_col_@15", pk, col0, col3)  ·
-                │               estimated row count    10 (missing stats)                           ·                                          ·
-                │               render 0               495.6                                        ·                                          ·
-                │               render 1               pk                                           ·                                          ·
-                │               render 2               col0                                         ·                                          ·
-                │               render 3               col3                                         ·                                          ·
-                └── index join  ·                      ·                                            (pk, col0, col3)                           ·
-                     │          estimated row count    10 (missing stats)                           ·                                          ·
-                     │          table                  tab4@primary                                 ·                                          ·
-                     │          key columns            pk                                           ·                                          ·
-                     └── scan   ·                      ·                                            (pk, col3)                                 ·
-·                               estimated row count    10 (missing stats)                           ·                                          ·
-·                               table                  tab4@tab4_col3_col4_key                      ·                                          ·
-·                               spans                  /NULL-                                       ·                                          ·
+distribution: full
+vectorized: true
+·
+• project
+│ columns: (pk)
+│ estimated row count: 10 (missing stats)
+│
+└── • project
+    │ columns: (pk, col0, col3)
+    │ estimated row count: 10 (missing stats)
+    │
+    └── • lookup join (semi)
+        │ columns: ("project_const_col_@15", pk, col0, col3)
+        │ table: tab4@tab4_col3_col4_key
+        │ equality: (col0, project_const_col_@15) = (col3,col4)
+        │ equality cols are key
+        │
+        └── • render
+            │ columns: ("project_const_col_@15", pk, col0, col3)
+            │ estimated row count: 10 (missing stats)
+            │ render 0: 495.6
+            │ render 1: pk
+            │ render 2: col0
+            │ render 3: col3
+            │
+            └── • index join
+                │ columns: (pk, col0, col3)
+                │ estimated row count: 10 (missing stats)
+                │ table: tab4@primary
+                │ key columns: pk
+                │
+                └── • scan
+                      columns: (pk, col3)
+                      estimated row count: 10 (missing stats)
+                      table: tab4@tab4_col3_col4_key
+                      spans: /NULL-
 
 # The following tests check that if the joiners can separate a row request
 # into separate families that it does, and generates spans for each family

--- a/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
+++ b/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
@@ -10,28 +10,31 @@ INSERT INTO t VALUES (1, 2), (3, 4), (5, 6)
 statement ok
 CREATE MATERIALIZED VIEW v AS SELECT x, y FROM t
 
-query TTT
+query T
 EXPLAIN SELECT * FROM v
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          v@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: v@primary
+  spans: FULL SCAN
 
 # Create an index on a materialized view, and ensure that we use it.
 statement ok
 CREATE INDEX i ON v (y)
 
-query TTT
+query T
 EXPLAIN SELECT * FROM v WHERE y = 3
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          v@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          v@i
-·           spans          [/3 - /3]
+distribution: local
+vectorized: true
+·
+• index join
+│ table: v@primary
+│
+└── • scan
+      missing stats
+      table: v@i
+      spans: [/3 - /3]

--- a/pkg/sql/opt/exec/execbuilder/testdata/mvcc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/mvcc
@@ -6,25 +6,27 @@ CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, FAMILY (x), FAMILY (y), FAMILY 
 
 # When doing a lookup where we could split families, but the MVCC column is
 # requested, we shouldn't split the family.
-query TTT
+query T
 EXPLAIN SELECT z FROM t WHERE x = 1
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/1 - /1]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/1 - /1]
 
-query TTT
+query T
 EXPLAIN SELECT crdb_internal_mvcc_timestamp, z FROM t WHERE x = 1
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          [/1 - /1]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: [/1 - /1]
 
 # Ensure that the presence of mutation columns doesn't affect accessing system
 # columns.
@@ -32,15 +34,16 @@ statement ok
 BEGIN;
 ALTER TABLE t ADD COLUMN w INT
 
-query TTT
+query T
 EXPLAIN SELECT x, crdb_internal_mvcc_timestamp FROM t
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
 statement ok
 ROLLBACK
@@ -49,12 +52,13 @@ ROLLBACK
 let $t_id
 SELECT id FROM system.namespace WHERE name = 't'
 
-query TTT
+query T
 EXPLAIN SELECT * FROM [$t_id(4294967295) AS _]
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -8,223 +8,281 @@ CREATE TABLE t (
   FAMILY "primary" (a, b, c)
 )
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-·          distribution   local
-·          vectorized     true
-sort       ·              ·
- │         order          +b
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +b
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-·          distribution   local
-·          vectorized     true
-sort       ·              ·
- │         order          -b
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: -b
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
 # TODO(radu): Should set "strategy top 2" on sort node
-query TTT
+query T
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-·               distribution   local
-·               vectorized     true
-limit           ·              ·
- │              count          2
- └── sort       ·              ·
-      │         order          +b
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          t@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 2
+│
+└── • sort
+    │ order: +b
+    │
+    └── • scan
+          missing stats
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
-·                    distribution         local                 ·       ·
-·                    vectorized           true                  ·       ·
-limit                ·                    ·                     (c, b)  ·
- │                   estimated row count  2 (missing stats)     ·       ·
- │                   count                2                     ·       ·
- └── sort            ·                    ·                     (b, c)  +b
-      │              estimated row count  300 (missing stats)   ·       ·
-      │              order                +b                    ·       ·
-      └── distinct   ·                    ·                     (b, c)  ·
-           │         estimated row count  300 (missing stats)   ·       ·
-           │         distinct on          b, c                  ·       ·
-           └── scan  ·                    ·                     (b, c)  ·
-·                    estimated row count  1000 (missing stats)  ·       ·
-·                    table                t@primary             ·       ·
-·                    spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (c, b)
+│ estimated row count: 2 (missing stats)
+│ count: 2
+│
+└── • sort
+    │ columns: (b, c)
+    │ ordering: +b
+    │ estimated row count: 300 (missing stats)
+    │ order: +b
+    │
+    └── • distinct
+        │ columns: (b, c)
+        │ estimated row count: 300 (missing stats)
+        │ distinct on: b, c
+        │
+        └── • scan
+              columns: (b, c)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          t@primary
-·        spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
 # Check that LIMIT propagates past nosort nodes.
-query TTT
+query T
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          LIMITED SCAN
-·     limit          1
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: LIMITED SCAN
+  limit: 1
 
-query TTT
+query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          t@primary
-·        spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          t@primary
-·        spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-sort       ·                    ·                     (a, b, c)  +b,+a
- │         estimated row count  1000 (missing stats)  ·          ·
- │         order                +b,+a                 ·          ·
- └── scan  ·                    ·                     (a, b, c)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c)
+│ ordering: +b,+a
+│ estimated row count: 1000 (missing stats)
+│ order: +b,+a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-sort       ·                    ·                     (a, b, c)  +b,+a
- │         estimated row count  1000 (missing stats)  ·          ·
- │         order                +b,+a                 ·          ·
- └── scan  ·                    ·                     (a, b, c)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c)
+│ ordering: +b,+a
+│ estimated row count: 1000 (missing stats)
+│ order: +b,+a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-sort       ·                    ·                     (a, b, c)  +b,+a
- │         estimated row count  1000 (missing stats)  ·          ·
- │         order                +b,+a                 ·          ·
- └── scan  ·                    ·                     (a, b, c)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c)
+│ ordering: +b,+a
+│ estimated row count: 1000 (missing stats)
+│ order: +b,+a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-sort       ·                    ·                     (a, b, c)  +b,+a
- │         estimated row count  1000 (missing stats)  ·          ·
- │         order                +b,+a                 ·          ·
- └── scan  ·                    ·                     (a, b, c)  ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c)
+│ ordering: +b,+a
+│ estimated row count: 1000 (missing stats)
+│ order: +b,+a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
 # Check that sort is skipped if the ORDER BY clause is constant.
-query TTT
+query T
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
-·          distribution   local
-·          vectorized     true
-render     ·              ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          t@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@primary
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@primary
+  spans: FULL SCAN
 
 # Check that the sort key reuses the existing render.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b+2 r FROM t ORDER BY b+2
 ----
-·               distribution         local                 ·    ·
-·               vectorized           true                  ·    ·
-sort            ·                    ·                     (r)  +r
- │              estimated row count  1000 (missing stats)  ·    ·
- │              order                +r                    ·    ·
- └── render     ·                    ·                     (r)  ·
-      │         estimated row count  1000 (missing stats)  ·    ·
-      │         render 0             b + 2                 ·    ·
-      └── scan  ·                    ·                     (b)  ·
-·               estimated row count  1000 (missing stats)  ·    ·
-·               table                t@primary             ·    ·
-·               spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (r)
+│ ordering: +r
+│ estimated row count: 1000 (missing stats)
+│ order: +r
+│
+└── • render
+    │ columns: (r)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: b + 2
+    │
+    └── • scan
+          columns: (b)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
 # Check that the sort picks up a renamed render properly.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
-·               distribution         local                 ·    ·
-·               vectorized           true                  ·    ·
-sort            ·                    ·                     (y)  +y
- │              estimated row count  1000 (missing stats)  ·    ·
- │              order                +y                    ·    ·
- └── render     ·                    ·                     (y)  ·
-      │         estimated row count  1000 (missing stats)  ·    ·
-      │         render 0             b + 2                 ·    ·
-      └── scan  ·                    ·                     (b)  ·
-·               estimated row count  1000 (missing stats)  ·    ·
-·               table                t@primary             ·    ·
-·               spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (y)
+│ ordering: +y
+│ estimated row count: 1000 (missing stats)
+│ order: +y
+│
+└── • render
+    │ columns: (y)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: b + 2
+    │
+    └── • scan
+          columns: (b)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE abc (
@@ -272,46 +330,53 @@ output row: [4 5]
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abc@ba
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abc@ba
+  spans: FULL SCAN
 
 # We use the WHERE condition to force the use of the index.
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 AND b < 15 ORDER BY b, a, d
 ----
-·                distribution     local
-·                vectorized       true
-sort             ·                ·
- │               order            +b,+a,+d
- │               already ordered  +b,+a
- └── index join  ·                ·
-      │          table            abc@primary
-      └── scan   ·                ·
-·                missing stats    ·
-·                table            abc@ba
-·                spans            [/11 - /14]
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +b,+a,+d
+│ already ordered: +b,+a
+│
+└── • index join
+    │ table: abc@primary
+    │
+    └── • scan
+          missing stats
+          table: abc@ba
+          spans: [/11 - /14]
 
 # An inequality should not be enough to force the use of the index.
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +b,+a,+d
- └── filter     ·              ·
-      │         filter         b > 10
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          abc@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +b,+a,+d
+│
+└── • filter
+    │ filter: b > 10
+    │
+    └── • scan
+          missing stats
+          table: abc@primary
+          spans: FULL SCAN
 
 query III
 SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
@@ -325,62 +390,77 @@ SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-sort            ·                    ·                     (a, b, c, d)  +b,+a,+c
- │              estimated row count  333 (missing stats)   ·             ·
- │              order                +b,+a,+c              ·             ·
- └── filter     ·                    ·                     (a, b, c, d)  ·
-      │         estimated row count  333 (missing stats)   ·             ·
-      │         filter               b > 10                ·             ·
-      └── scan  ·                    ·                     (a, b, c, d)  ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                abc@primary           ·             ·
-·               spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d)
+│ ordering: +b,+a,+c
+│ estimated row count: 333 (missing stats)
+│ order: +b,+a,+c
+│
+└── • filter
+    │ columns: (a, b, c, d)
+    │ estimated row count: 333 (missing stats)
+    │ filter: b > 10
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: abc@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abc@bc
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abc@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-project    ·                    ·                     (a, b)     ·
- └── scan  ·                    ·                     (a, b, c)  +b,+c
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                abc@bc                ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +b,+c
+      estimated row count: 1000 (missing stats)
+      table: abc@bc
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abc@bc
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abc@bc
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abc@bc
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abc@bc
+  spans: FULL SCAN
 
 statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
@@ -423,61 +503,73 @@ fetched: /abc/primary/1/2/3 -> NULL
 output row: [4]
 output row: [1]
 
-query TTT
+query T
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          abc@primary
-·        spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: abc@primary
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abc@bc
-·     spans          [/2 - /2]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abc@bc
+  spans: [/2 - /2]
 
-query TTT
+query T
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          abc@bc
-·        spans          [/2 - /2]
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: abc@bc
+  spans: [/2 - /2]
 
 # Verify that the ordering of the primary index is still used for the outer sort.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-·          distribution         local               ·          ·
-·          vectorized           true                ·          ·
-project    ·                    ·                   (b, c)     +b,+c
- │         estimated row count  10 (missing stats)  ·          ·
- └── scan  ·                    ·                   (a, b, c)  +b,+c
-·          estimated row count  10 (missing stats)  ·          ·
-·          table                abc@primary         ·          ·
-·          spans                /1-/2               ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b, c)
+│ ordering: +b,+c
+│ estimated row count: 10 (missing stats)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +b,+c
+      estimated row count: 10 (missing stats)
+      table: abc@primary
+      spans: /1-/2
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, id
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (id, baz)  +baz,+id
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                bar@i_bar             ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (id, baz)
+  ordering: +baz,+id
+  estimated row count: 1000 (missing stats)
+  table: bar@i_bar
+  spans: FULL SCAN
 
 statement ok
 CREATE TABLE abcd (
@@ -494,165 +586,205 @@ CREATE TABLE abcd (
 # guarantee that it will preserve the order.
 
 # The following tests verify we recognize that sorting is not necessary
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@abc
-·     spans          [/1/4 - /1/4]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@abc
+  spans: [/1/4 - /1/4]
 
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@abc
-·     spans          [/1/4 - /1/4]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@abc
+  spans: [/1/4 - /1/4]
 
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@abc
-·     spans          [/1/4 - /1/4]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@abc
+  spans: [/1/4 - /1/4]
 
-query TTT
+query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@abc
-·     spans          [/1/4 - /1/4]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@abc
+  spans: [/1/4 - /1/4]
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
-·       distribution   local             ·    ·
-·       vectorized     false             ·    ·
-values  ·              ·                 (x)  ·
-·       size           1 column, 3 rows  ·    ·
-·       row 0, expr 0  'a'               ·    ·
-·       row 1, expr 0  'b'               ·    ·
-·       row 2, expr 0  'c'               ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (x)
+  size: 1 column, 3 rows
+  row 0, expr 0: 'a'
+  row 1, expr 0: 'b'
+  row 2, expr 0: 'c'
 
-query TTT
+query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
-·            distribution  local
-·            vectorized    false
-ordinality   ·             ·
- └── values  ·             ·
-·            size          1 column, 3 rows
+distribution: local
+vectorized: false
+·
+• ordinality
+│
+└── • values
+      size: 1 column, 3 rows
 
-query TTT
+query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
-·                 distribution  local
-·                 vectorized    false
-sort              ·             ·
- │                order         -"ordinality"
- └── ordinality   ·             ·
-      └── values  ·             ·
-·                 size          1 column, 3 rows
+distribution: local
+vectorized: false
+·
+• sort
+│ order: -"ordinality"
+│
+└── • ordinality
+    │
+    └── • values
+          size: 1 column, 3 rows
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-·            distribution         local             ·                  ·
-·            vectorized           false             ·                  ·
-ordinality   ·                    ·                 (x, "ordinality")  ·
- │           estimated row count  3                 ·                  ·
- └── values  ·                    ·                 (column1)          ·
-·            size                 1 column, 3 rows  ·                  ·
-·            row 0, expr 0        'a'               ·                  ·
-·            row 1, expr 0        'b'               ·                  ·
-·            row 2, expr 0        'c'               ·                  ·
+distribution: local
+vectorized: false
+·
+• ordinality
+│ columns: (x, "ordinality")
+│ estimated row count: 3
+│
+└── • values
+      columns: (column1)
+      size: 1 column, 3 rows
+      row 0, expr 0: 'a'
+      row 1, expr 0: 'b'
+      row 2, expr 0: 'c'
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-·                 distribution         local             ·                  ·
-·                 vectorized           false             ·                  ·
-ordinality        ·                    ·                 (x, "ordinality")  ·
- │                estimated row count  3                 ·                  ·
- └── sort         ·                    ·                 (column1)          +column1
-      │           estimated row count  3                 ·                  ·
-      │           order                +column1          ·                  ·
-      └── values  ·                    ·                 (column1)          ·
-·                 size                 1 column, 3 rows  ·                  ·
-·                 row 0, expr 0        'a'               ·                  ·
-·                 row 1, expr 0        'b'               ·                  ·
-·                 row 2, expr 0        'c'               ·                  ·
+distribution: local
+vectorized: false
+·
+• ordinality
+│ columns: (x, "ordinality")
+│ estimated row count: 3
+│
+└── • sort
+    │ columns: (column1)
+    │ ordering: +column1
+    │ estimated row count: 3
+    │ order: +column1
+    │
+    └── • values
+          columns: (column1)
+          size: 1 column, 3 rows
+          row 0, expr 0: 'a'
+          row 1, expr 0: 'b'
+          row 2, expr 0: 'c'
 
 # Check that the ordering of the source does not propagate blindly to RETURNING.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-·                      distribution         local               ·       ·
-·                      vectorized           false               ·       ·
-project                ·                    ·                   (b)     ·
- │                     estimated row count  1                   ·       ·
- └── insert fast path  ·                    ·                   (a, b)  ·
-·                      estimated row count  1                   ·       ·
-·                      into                 t(a, b, c)          ·       ·
-·                      auto commit          ·                   ·       ·
-·                      size                 3 columns, 1 row    ·       ·
-·                      row 0, expr 0        1                   ·       ·
-·                      row 0, expr 1        2                   ·       ·
-·                      row 0, expr 2        CAST(NULL AS BOOL)  ·       ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (b)
+│ estimated row count: 1
+│
+└── • insert fast path
+      columns: (a, b)
+      estimated row count: 1
+      into: t(a, b, c)
+      auto commit
+      size: 3 columns, 1 row
+      row 0, expr 0: 1
+      row 0, expr 1: 2
+      row 0, expr 2: CAST(NULL AS BOOL)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-·               distribution         local              ·       ·
-·               vectorized           false              ·       ·
-project         ·                    ·                  (b)     ·
- │              estimated row count  1 (missing stats)  ·       ·
- └── delete     ·                    ·                  (a, b)  ·
-      │         estimated row count  1 (missing stats)  ·       ·
-      │         from                 t                  ·       ·
-      │         auto commit          ·                  ·       ·
-      └── scan  ·                    ·                  (a, b)  ·
-·               estimated row count  1 (missing stats)  ·       ·
-·               table                t@primary          ·       ·
-·               spans                /3-/3/#            ·       ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (b)
+│ estimated row count: 1 (missing stats)
+│
+└── • delete
+    │ columns: (a, b)
+    │ estimated row count: 1 (missing stats)
+    │ from: t
+    │ auto commit
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@primary
+          spans: /3-/3/#
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
-·                    distribution         local                 ·                 ·
-·                    vectorized           false                 ·                 ·
-project              ·                    ·                     (b)               ·
- │                   estimated row count  1000 (missing stats)  ·                 ·
- └── update          ·                    ·                     (a, b)            ·
-      │              estimated row count  1000 (missing stats)  ·                 ·
-      │              table                t                     ·                 ·
-      │              set                  c                     ·                 ·
-      │              auto commit          ·                     ·                 ·
-      └── render     ·                    ·                     (a, b, c, c_new)  ·
-           │         estimated row count  1000 (missing stats)  ·                 ·
-           │         render 0             true                  ·                 ·
-           │         render 1             a                     ·                 ·
-           │         render 2             b                     ·                 ·
-           │         render 3             c                     ·                 ·
-           └── scan  ·                    ·                     (a, b, c)         ·
-·                    estimated row count  1000 (missing stats)  ·                 ·
-·                    table                t@primary             ·                 ·
-·                    spans                FULL SCAN             ·                 ·
-·                    locking strength     for update            ·                 ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (b)
+│ estimated row count: 1000 (missing stats)
+│
+└── • update
+    │ columns: (a, b)
+    │ estimated row count: 1000 (missing stats)
+    │ table: t
+    │ set: c
+    │ auto commit
+    │
+    └── • render
+        │ columns: (a, b, c, c_new)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: true
+        │ render 1: a
+        │ render 2: b
+        │ render 3: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -668,15 +800,18 @@ CREATE TABLE uvwxyz (
 
 # Verify that the outer ordering is propagated to index selection and we choose
 # the index that avoids any sorting.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-·     distribution         local               ·          ·
-·     vectorized           true                ·          ·
-scan  ·                    ·                   (y, w, x)  +w,+x
-·     estimated row count  10 (missing stats)  ·          ·
-·     table                uvwxyz@ywxz         ·          ·
-·     spans                /1-/2               ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (y, w, x)
+  ordering: +w,+x
+  estimated row count: 10 (missing stats)
+  table: uvwxyz@ywxz
+  spans: /1-/2
 
 
 statement ok
@@ -694,59 +829,81 @@ CREATE TABLE blocks (
 # ordering; if we ever plan multiple tablereaders in this case, we must make
 # sure to set the merge ordering below to the natural order of the index we are
 # scanning.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-·          distribution         local              ·                                           ·
-·          vectorized           true               ·                                           ·
-project    ·                    ·                  (block_id, writer_id, block_num, block_id)  ·
- └── scan  ·                    ·                  (block_id, writer_id, block_num)            ·
-·          estimated row count  1 (missing stats)  ·                                           ·
-·          table                blocks@primary     ·                                           ·
-·          spans                LIMITED SCAN       ·                                           ·
-·          limit                1                  ·                                           ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (block_id, writer_id, block_num, block_id)
+│
+└── • scan
+      columns: (block_id, writer_id, block_num)
+      estimated row count: 1 (missing stats)
+      table: blocks@primary
+      spans: LIMITED SCAN
+      limit: 1
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
 
 # Check that sort by ordinal picks up the existing render.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-·                    distribution         local                 ·                ·
-·                    vectorized           true                  ·                ·
-project              ·                    ·                     (b, a)           ·
- └── sort            ·                    ·                     (column6, a, b)  +a
-      │              estimated row count  1000 (missing stats)  ·                ·
-      │              order                +a                    ·                ·
-      └── render     ·                    ·                     (column6, a, b)  ·
-           │         estimated row count  1000 (missing stats)  ·                ·
-           │         render 0             a                     ·                ·
-           │         render 1             a                     ·                ·
-           │         render 2             b                     ·                ·
-           └── scan  ·                    ·                     (a, b)           ·
-·                    estimated row count  1000 (missing stats)  ·                ·
-·                    table                foo@primary           ·                ·
-·                    spans                FULL SCAN             ·                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b, a)
+│
+└── • sort
+    │ columns: (column6, a, b)
+    │ ordering: +a
+    │ estimated row count: 1000 (missing stats)
+    │ order: +a
+    │
+    └── • render
+        │ columns: (column6, a, b)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: a
+        │ render 1: a
+        │ render 2: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1000 (missing stats)
+              table: foo@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
 ----
-·                    distribution         local                 ·                ·
-·                    vectorized           true                  ·                ·
-project              ·                    ·                     (b, a)           ·
- └── sort            ·                    ·                     (column6, a, b)  +b
-      │              estimated row count  1000 (missing stats)  ·                ·
-      │              order                +b                    ·                ·
-      └── render     ·                    ·                     (column6, a, b)  ·
-           │         estimated row count  1000 (missing stats)  ·                ·
-           │         render 0             b                     ·                ·
-           │         render 1             a                     ·                ·
-           │         render 2             b                     ·                ·
-           └── scan  ·                    ·                     (a, b)           ·
-·                    estimated row count  1000 (missing stats)  ·                ·
-·                    table                foo@primary           ·                ·
-·                    spans                FULL SCAN             ·                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b, a)
+│
+└── • sort
+    │ columns: (column6, a, b)
+    │ ordering: +b
+    │ estimated row count: 1000 (missing stats)
+    │ order: +b
+    │
+    └── • render
+        │ columns: (column6, a, b)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: b
+        │ render 1: a
+        │ render 2: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1000 (missing stats)
+              table: foo@primary
+              spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Check star expansion in ORDER BY.
@@ -754,35 +911,41 @@ project              ·                    ·                     (b, a)        
 statement ok
 CREATE TABLE a(x, y) AS VALUES (1, 1), (2, 2)
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY a.*
-]
 ----
-·          distribution         local
-·          vectorized           true
-sort       ·                    ·
- │         estimated row count  1000 (missing stats)
- │         order                +x,+y
- └── scan  ·                    ·
-·          estimated row count  1000 (missing stats)
-·          table                a@primary
-·          spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, y)
+│ ordering: +x,+y
+│ estimated row count: 1000 (missing stats)
+│ order: +x,+y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY (a.*)
-]
 ----
-·          distribution         local
-·          vectorized           true
-sort       ·                    ·
- │         estimated row count  1000 (missing stats)
- │         order                +x,+y
- └── scan  ·                    ·
-·          estimated row count  1000 (missing stats)
-·          table                a@primary
-·          spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, y)
+│ ordering: +x,+y
+│ estimated row count: 1000 (missing stats)
+│ order: +x,+y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # ORDER BY INDEX test cases.
@@ -792,96 +955,138 @@ sort       ·                    ·
 statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (v)     ·
- └── scan  ·                    ·                     (k, v)  +k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                kv@primary            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (v)
+│
+└── • scan
+      columns: (k, v)
+      ordering: +k
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (v)     ·
- └── scan  ·                    ·                     (k, v)  +k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                kv@primary            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (v)
+│
+└── • scan
+      columns: (k, v)
+      ordering: +k
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-·             distribution         local                 ·       ·
-·             vectorized           true                  ·       ·
-project       ·                    ·                     (v)     ·
- └── revscan  ·                    ·                     (k, v)  -k
-·             estimated row count  1000 (missing stats)  ·       ·
-·             table                kv@primary            ·       ·
-·             spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (v)
+│
+└── • revscan
+      columns: (k, v)
+      ordering: -k
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (k)     ·
- └── sort       ·                    ·                     (k, v)  +v,+k
-      │         estimated row count  1000 (missing stats)  ·       ·
-      │         order                +v,+k                 ·       ·
-      └── scan  ·                    ·                     (k, v)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                kv@primary            ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • sort
+    │ columns: (k, v)
+    │ ordering: +v,+k
+    │ estimated row count: 1000 (missing stats)
+    │ order: +v,+k
+    │
+    └── • scan
+          columns: (k, v)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (k)     ·
- └── scan  ·                    ·                     (k, v)  -v,+k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                kv@foo                ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • scan
+      columns: (k, v)
+      ordering: -v,+k
+      estimated row count: 1000 (missing stats)
+      table: kv@foo
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (k)     ·
- └── scan  ·                    ·                     (k, v)  -v,+k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                kv@foo                ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • scan
+      columns: (k, v)
+      ordering: -v,+k
+      estimated row count: 1000 (missing stats)
+      table: kv@foo
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-·             distribution         local                 ·       ·
-·             vectorized           true                  ·       ·
-project       ·                    ·                     (k)     ·
- └── revscan  ·                    ·                     (k, v)  +v,-k
-·             estimated row count  1000 (missing stats)  ·       ·
-·             table                kv@foo                ·       ·
-·             spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • revscan
+      columns: (k, v)
+      ordering: +v,-k
+      estimated row count: 1000 (missing stats)
+      table: kv@foo
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (k)     ·
- └── scan  ·                    ·                     (k, v)  -v,+k
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                kv@foo                ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • scan
+      columns: (k, v)
+      ordering: -v,+k
+      estimated row count: 1000 (missing stats)
+      table: kv@foo
+      spans: FULL SCAN
 
 # Check the syntax can be used with joins.
 #
@@ -889,71 +1094,105 @@ project    ·                    ·                     (k)     ·
 # does not imply use of that index by the underlying scan.
 #
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-·                                   distribution           local              ·                ·
-·                                   vectorized             false              ·                ·
-project                             ·                      ·                  (k)              ·
- └── sort                           ·                      ·                  (k, v)           -v,+k
-      │                             estimated row count    2 (missing stats)  ·                ·
-      │                             order                  -v,+k              ·                ·
-      └── project                   ·                      ·                  (k, v)           ·
-           │                        estimated row count    2 (missing stats)  ·                ·
-           └── lookup join (inner)  ·                      ·                  (column1, k, v)  ·
-                │                   estimated row count    2 (missing stats)  ·                ·
-                │                   table                  kv@primary         ·                ·
-                │                   equality               (column1) = (k)    ·                ·
-                │                   equality cols are key  ·                  ·                ·
-                └── values          ·                      ·                  (column1)        ·
-·                                   size                   1 column, 2 rows   ·                ·
-·                                   row 0, expr 0          1                  ·                ·
-·                                   row 1, expr 0          3                  ·                ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (k)
+│
+└── • sort
+    │ columns: (k, v)
+    │ ordering: -v,+k
+    │ estimated row count: 2 (missing stats)
+    │ order: -v,+k
+    │
+    └── • project
+        │ columns: (k, v)
+        │ estimated row count: 2 (missing stats)
+        │
+        └── • lookup join (inner)
+            │ columns: (column1, k, v)
+            │ estimated row count: 2 (missing stats)
+            │ table: kv@primary
+            │ equality: (column1) = (k)
+            │ equality cols are key
+            │
+            └── • values
+                  columns: (column1)
+                  size: 1 column, 2 rows
+                  row 0, expr 0: 1
+                  row 1, expr 0: 3
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-·                             distribution         local                 ·             ·
-·                             vectorized           true                  ·             ·
-project                       ·                    ·                     (k)           ·
- └── project                  ·                    ·                     (k, k, v)     -v,+k
-      │                       estimated row count  10 (missing stats)    ·             ·
-      └── merge join (inner)  ·                    ·                     (k, v, k, v)  -v,+k
-           │                  estimated row count  10 (missing stats)    ·             ·
-           │                  equality             (v, k) = (v, k)       ·             ·
-           │                  left cols are key    ·                     ·             ·
-           │                  right cols are key   ·                     ·             ·
-           │                  merge ordering       -"(v=v)",+"(k=k)"     ·             ·
-           ├── scan           ·                    ·                     (k, v)        -v,+k
-           │                  estimated row count  1000 (missing stats)  ·             ·
-           │                  table                kv@foo                ·             ·
-           │                  spans                FULL SCAN             ·             ·
-           └── scan           ·                    ·                     (k, v)        -v,+k
-·                             estimated row count  1000 (missing stats)  ·             ·
-·                             table                kv@foo                ·             ·
-·                             spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│
+└── • project
+    │ columns: (k, k, v)
+    │ ordering: -v,+k
+    │ estimated row count: 10 (missing stats)
+    │
+    └── • merge join (inner)
+        │ columns: (k, v, k, v)
+        │ ordering: -v,+k
+        │ estimated row count: 10 (missing stats)
+        │ equality: (v, k) = (v, k)
+        │ left cols are key
+        │ right cols are key
+        │ merge ordering: -"(v=v)",+"(k=k)"
+        │
+        ├── • scan
+        │     columns: (k, v)
+        │     ordering: -v,+k
+        │     estimated row count: 1000 (missing stats)
+        │     table: kv@foo
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (k, v)
+              ordering: -v,+k
+              estimated row count: 1000 (missing stats)
+              table: kv@foo
+              spans: FULL SCAN
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 
 # Verify that we set up the ordering of the inner scan correctly (see #27347).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-·                     distribution         local               ·              ·
-·                     vectorized           true                ·              ·
-sort                  ·                    ·                   (x, y, z)      +x
- │                    estimated row count  1 (missing stats)   ·              ·
- │                    order                +x                  ·              ·
- └── filter           ·                    ·                   (x, y, z)      ·
-      │               estimated row count  1 (missing stats)   ·              ·
-      │               filter               x = y               ·              ·
-      └── index join  ·                    ·                   (x, y, z)      ·
-           │          estimated row count  10 (missing stats)  ·              ·
-           │          table                xyz@primary         ·              ·
-           │          key columns          rowid               ·              ·
-           └── scan   ·                    ·                   (y, z, rowid)  ·
-·                     estimated row count  10 (missing stats)  ·              ·
-·                     table                xyz@xyz_z_y_idx     ·              ·
-·                     spans                /1/!NULL-/2         ·              ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, y, z)
+│ ordering: +x
+│ estimated row count: 1 (missing stats)
+│ order: +x
+│
+└── • filter
+    │ columns: (x, y, z)
+    │ estimated row count: 1 (missing stats)
+    │ filter: x = y
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 10 (missing stats)
+        │ table: xyz@primary
+        │ key columns: rowid
+        │
+        └── • scan
+              columns: (y, z, rowid)
+              estimated row count: 10 (missing stats)
+              table: xyz@xyz_z_y_idx
+              spans: /1/!NULL-/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -3,80 +3,112 @@
 statement ok
 CREATE TABLE foo (x CHAR PRIMARY KEY); INSERT INTO foo(x) VALUES ('a'), ('b')
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT max(ordinality) FROM foo WITH ORDINALITY
 ----
-·                distribution         local                 ·               ·
-·                vectorized           true                  ·               ·
-group (scalar)   ·                    ·                     (max)           ·
- │               estimated row count  1 (missing stats)     ·               ·
- │               aggregate 0          max(ordinality)       ·               ·
- └── ordinality  ·                    ·                     ("ordinality")  ·
-      │          estimated row count  1000 (missing stats)  ·               ·
-      └── scan   ·                    ·                     ()              ·
-·                estimated row count  1000 (missing stats)  ·               ·
-·                table                foo@primary           ·               ·
-·                spans                FULL SCAN             ·               ·
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (max)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: max(ordinality)
+│
+└── • ordinality
+    │ columns: ("ordinality")
+    │ estimated row count: 1000 (missing stats)
+    │
+    └── • scan
+          columns: ()
+          estimated row count: 1000 (missing stats)
+          table: foo@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality
 ----
-·                distribution         local                 ·                  ·
-·                vectorized           true                  ·                  ·
-filter           ·                    ·                     (x, "ordinality")  +"ordinality"
- │               estimated row count  333 (missing stats)   ·                  ·
- │               filter               "ordinality" > 1      ·                  ·
- └── ordinality  ·                    ·                     (x, "ordinality")  ·
-      │          estimated row count  1000 (missing stats)  ·                  ·
-      └── scan   ·                    ·                     (x)                ·
-·                estimated row count  1000 (missing stats)  ·                  ·
-·                table                foo@primary           ·                  ·
-·                spans                FULL SCAN             ·                  ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, "ordinality")
+│ ordering: +"ordinality"
+│ estimated row count: 333 (missing stats)
+│ filter: "ordinality" > 1
+│
+└── • ordinality
+    │ columns: (x, "ordinality")
+    │ estimated row count: 1000 (missing stats)
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: foo@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality DESC
 ----
-·                     distribution         local                 ·                  ·
-·                     vectorized           true                  ·                  ·
-sort                  ·                    ·                     (x, "ordinality")  -"ordinality"
- │                    estimated row count  333 (missing stats)   ·                  ·
- │                    order                -"ordinality"         ·                  ·
- └── filter           ·                    ·                     (x, "ordinality")  ·
-      │               estimated row count  333 (missing stats)   ·                  ·
-      │               filter               "ordinality" > 1      ·                  ·
-      └── ordinality  ·                    ·                     (x, "ordinality")  ·
-           │          estimated row count  1000 (missing stats)  ·                  ·
-           └── scan   ·                    ·                     (x)                ·
-·                     estimated row count  1000 (missing stats)  ·                  ·
-·                     table                foo@primary           ·                  ·
-·                     spans                FULL SCAN             ·                  ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, "ordinality")
+│ ordering: -"ordinality"
+│ estimated row count: 333 (missing stats)
+│ order: -"ordinality"
+│
+└── • filter
+    │ columns: (x, "ordinality")
+    │ estimated row count: 333 (missing stats)
+    │ filter: "ordinality" > 1
+    │
+    └── • ordinality
+        │ columns: (x, "ordinality")
+        │ estimated row count: 1000 (missing stats)
+        │
+        └── • scan
+              columns: (x)
+              estimated row count: 1000 (missing stats)
+              table: foo@primary
+              spans: FULL SCAN
 
 # Show that the primary key is used under ordinalityNode.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-·           distribution         local                ·                  ·
-·           vectorized           true                 ·                  ·
-ordinality  ·                    ·                    (x, "ordinality")  ·
- │          estimated row count  333 (missing stats)  ·                  ·
- └── scan   ·                    ·                    (x)                ·
-·           estimated row count  333 (missing stats)  ·                  ·
-·           table                foo@primary          ·                  ·
-·           spans                /"a\x00"-            ·                  ·
+distribution: local
+vectorized: true
+·
+• ordinality
+│ columns: (x, "ordinality")
+│ estimated row count: 333 (missing stats)
+│
+└── • scan
+      columns: (x)
+      estimated row count: 333 (missing stats)
+      table: foo@primary
+      spans: /"a\x00"-
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-·                distribution         local                 ·                  ·
-·                vectorized           true                  ·                  ·
-filter           ·                    ·                     (x, "ordinality")  ·
- │               estimated row count  333 (missing stats)   ·                  ·
- │               filter               x > 'a'               ·                  ·
- └── ordinality  ·                    ·                     (x, "ordinality")  ·
-      │          estimated row count  1000 (missing stats)  ·                  ·
-      └── scan   ·                    ·                     (x)                ·
-·                estimated row count  1000 (missing stats)  ·                  ·
-·                table                foo@primary           ·                  ·
-·                spans                FULL SCAN             ·                  ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, "ordinality")
+│ estimated row count: 333 (missing stats)
+│ filter: x > 'a'
+│
+└── • ordinality
+    │ columns: (x, "ordinality")
+    │ estimated row count: 1000 (missing stats)
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: foo@primary
+          spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -887,48 +887,55 @@ CPut /Table/55/1/6/0 -> /TUPLE/
 # ---------------------------------------------------------
 
 # EXPLAIN output shows the partial index label on scans over partial indexes.
-query TTT
+query T
 EXPLAIN SELECT b FROM t WHERE b > 10
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@b_partial (partial index)
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@b_partial (partial index)
+  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          inv@i (partial index)
-·     spans          [/'{"x": "y"}' - /'{"x": "y"}']
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: inv@i (partial index)
+  spans: [/'{"x": "y"}' - /'{"x": "y"}']
 
-query TTT
+query T
 EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         c = 'foo'
- └── index join  ·              ·
-      │          table          inv@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          inv@i (partial index)
-·                spans          [/'{"x": "y"}' - /'{"x": "y"}']
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 'foo'
+│
+└── • index join
+    │ table: inv@primary
+    │
+    └── • scan
+          missing stats
+          table: inv@i (partial index)
+          spans: [/'{"x": "y"}' - /'{"x": "y"}']
 
-query TTT
+query T
 EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          inv@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          inv@i (partial index)
-·           spans          [/'{"x": "y"}' - /'{"x": "y"}']
+distribution: local
+vectorized: true
+·
+• index join
+│ table: inv@primary
+│
+└── • scan
+      missing stats
+      table: inv@i (partial index)
+      spans: [/'{"x": "y"}' - /'{"x": "y"}']

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -8,45 +8,50 @@ CREATE TABLE ab (a INT PRIMARY KEY, b INT); INSERT INTO ab (a, b) VALUES (1, 10)
 statement ok
 PREPARE change_index AS SELECT * FROM [EXPLAIN SELECT * FROM ab WHERE b=10]
 
-query TTT
+query T
 EXECUTE change_index
 ----
-·          distribution   full
-·          vectorized     true
-filter     ·              ·
- │         filter         b = 10
- └── scan  ·              ·
-·          missing stats  ·
-·          table          ab@primary
-·          spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• filter
+│ filter: b = 10
+│
+└── • scan
+      missing stats
+      table: ab@primary
+      spans: FULL SCAN
 
 statement ok
 CREATE INDEX bindex ON ab (b)
 
-query TTT
+query T
 EXECUTE change_index
 ----
-·     distribution   full
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          ab@bindex
-·     spans          [/10 - /10]
+distribution: full
+vectorized: true
+·
+• scan
+  missing stats
+  table: ab@bindex
+  spans: [/10 - /10]
 
 statement ok
 DROP INDEX bindex
 
-query TTT
+query T
 EXECUTE change_index
 ----
-·          distribution   full
-·          vectorized     true
-filter     ·              ·
- │         filter         b = 10
- └── scan  ·              ·
-·          missing stats  ·
-·          table          ab@primary
-·          spans          FULL SCAN
+distribution: full
+vectorized: true
+·
+• filter
+│ filter: b = 10
+│
+└── • scan
+      missing stats
+      table: ab@primary
+      spans: FULL SCAN
 
 ## Statistics change: Create statistics and ensure that the plan is recalculated.
 statement ok
@@ -55,23 +60,26 @@ CREATE TABLE cd (c INT PRIMARY KEY, d INT)
 statement ok
 PREPARE change_stats AS SELECT * FROM [EXPLAIN SELECT * FROM ab JOIN cd ON a=c]
 
-query TTT
+query T
 EXECUTE change_stats
 ----
-·           distribution        full
-·           vectorized          true
-merge join  ·                   ·
- │          equality            (a) = (c)
- │          left cols are key   ·
- │          right cols are key  ·
- ├── scan   ·                   ·
- │          missing stats       ·
- │          table               ab@primary
- │          spans               FULL SCAN
- └── scan   ·                   ·
-·           missing stats       ·
-·           table               cd@primary
-·           spans               FULL SCAN
+distribution: full
+vectorized: true
+·
+• merge join
+│ equality: (a) = (c)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: ab@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: cd@primary
+      spans: FULL SCAN
 
 statement ok
 CREATE STATISTICS s FROM ab
@@ -79,16 +87,18 @@ CREATE STATISTICS s FROM ab
 # Now that the optimizer knows table ab has one row (and it assumes a much
 # higher number of rows for cd), it should choose lookup join.
 # We allow retry because stat cache invalidation happens asynchronously.
-query TTT retry
+query T retry
 EXECUTE change_stats
 ----
-·            distribution           full
-·            vectorized             true
-lookup join  ·                      ·
- │           table                  cd@primary
- │           equality               (a) = (c)
- │           equality cols are key  ·
- └── scan    ·                      ·
-·            estimated row count    1
-·            table                  ab@primary
-·            spans                  FULL SCAN
+distribution: full
+vectorized: true
+·
+• lookup join
+│ table: cd@primary
+│ equality: (a) = (c)
+│ equality cols are key
+│
+└── • scan
+      estimated row count: 1
+      table: ab@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -7,441 +7,571 @@
 statement ok
 CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (r)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  3                ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (r)
+  size: 1 column, 1 row
+  row 0, expr 0: 3
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT true AS r
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (r)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  true             ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (r)
+  size: 1 column, 1 row
+  row 0, expr 0: true
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT false AS r
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (r)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  false            ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (r)
+  size: 1 column, 1 row
+  row 0, expr 0: false
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (1, 2) AS r
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (r)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  (1, 2)           ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (r)
+  size: 1 column, 1 row
+  row 0, expr 0: (1, 2)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (true, false) AS r
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (r)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  (true, false)    ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (r)
+  size: 1 column, 1 row
+  row 0, expr 0: (true, false)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             3                     ·    ·
- └── scan  ·                    ·                     ()   ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: 3
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a + 2 AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a + 2                 ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a + 2
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 AS r FROM t
 ----
-·          distribution         local                                 ·          ·
-·          vectorized           true                                  ·          ·
-render     ·                    ·                                     (r)        ·
- │         estimated row count  1000 (missing stats)                  ·          ·
- │         render 0             ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
- └── scan  ·                    ·                                     (a, b, c)  ·
-·          estimated row count  1000 (missing stats)                  ·          ·
-·          table                t@primary                             ·          ·
-·          spans                FULL SCAN                             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a >= 5) AND (b <= 10)) AND (c < 4)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4 AS r FROM t
 ----
-·          distribution         local                               ·          ·
-·          vectorized           true                                ·          ·
-render     ·                    ·                                   (r)        ·
- │         estimated row count  1000 (missing stats)                ·          ·
- │         render 0             ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
- └── scan  ·                    ·                                   (a, b, c)  ·
-·          estimated row count  1000 (missing stats)                ·          ·
-·          table                t@primary                           ·          ·
-·          spans                FULL SCAN                           ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a >= 5) OR (b <= 10)) OR (c < 4)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a != 5                ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a != 5
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             (a <= 5) OR (b < 10)  ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a <= 5) OR (b < 10)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) AS r FROM t
 ----
-·          distribution         local                                                ·          ·
-·          vectorized           true                                                 ·          ·
-render     ·                    ·                                                    (r)        ·
- │         estimated row count  1000 (missing stats)                                 ·          ·
- │         render 0             ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
- └── scan  ·                    ·                                                    (a, b, c)  ·
-·          estimated row count  1000 (missing stats)                                 ·          ·
-·          table                t@primary                                            ·          ·
-·          spans                FULL SCAN                                            ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) AS r FROM t
 ----
-·          distribution         local                                ·          ·
-·          vectorized           true                                 ·          ·
-render     ·                    ·                                    (r)        ·
- │         estimated row count  1000 (missing stats)                 ·          ·
- │         render 0             ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
- └── scan  ·                    ·                                    (a, b, c)  ·
-·          estimated row count  1000 (missing stats)                 ·          ·
-·          table                t@primary                            ·          ·
-·          spans                FULL SCAN                            ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a < 5) AND (b > 10)) AND (c < 10)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             (a = 1) AND (b = 2)   ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a = 1) AND (b = 2)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a IN (1, 2)           ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IN (1, 2)
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) AS r FROM t
 ----
-·          distribution         local                       ·       ·
-·          vectorized           true                        ·       ·
-render     ·                    ·                           (r)     ·
- │         estimated row count  1000 (missing stats)        ·       ·
- │         render 0             (a, b) IN ((1, 2), (3, 4))  ·       ·
- └── scan  ·                    ·                           (a, b)  ·
-·          estimated row count  1000 (missing stats)        ·       ·
-·          table                t@primary                   ·       ·
-·          spans                FULL SCAN                   ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a, b) IN ((1, 2), (3, 4))
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  AS r FROM t
 ----
-·          distribution         local                                                            ·             ·
-·          vectorized           true                                                             ·             ·
-render     ·                    ·                                                                (r)           ·
- │         estimated row count  1000 (missing stats)                                             ·             ·
- │         render 0             ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
- └── scan  ·                    ·                                                                (a, b, c, d)  ·
-·          estimated row count  1000 (missing stats)                                             ·             ·
-·          table                t@primary                                                        ·             ·
-·          spans                FULL SCAN                                                        ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  AS r FROM t
 ----
-·          distribution         local                                            ·             ·
-·          vectorized           true                                             ·             ·
-render     ·                    ·                                                (r)           ·
- │         estimated row count  1000 (missing stats)                             ·             ·
- │         render 0             (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
- └── scan  ·                    ·                                                (a, b, c, d)  ·
-·          estimated row count  1000 (missing stats)                             ·             ·
-·          table                t@primary                                        ·             ·
-·          spans                FULL SCAN                                        ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) AS r FROM t
 ----
-·          distribution         local                                                                                  ·             ·
-·          vectorized           true                                                                                   ·             ·
-render     ·                    ·                                                                                      (r)           ·
- │         estimated row count  1000 (missing stats)                                                                   ·             ·
- │         render 0             (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
- └── scan  ·                    ·                                                                                      (a, b, c, s)  ·
-·          estimated row count  1000 (missing stats)                                                                   ·             ·
-·          table                t@primary                                                                              ·             ·
-·          spans                FULL SCAN                                                                              ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)
+│
+└── • scan
+      columns: (a, b, c, s)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS NULL AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a IS NULL             ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS NULL
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a IS NULL             ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS NULL
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) IS NULL AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             (a, b) IS NULL        ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a, b) IS NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) IS NOT DISTINCT FROM NULL AS r FROM t
 ----
-·          distribution         local                             ·       ·
-·          vectorized           true                              ·       ·
-render     ·                    ·                                 (r)     ·
- │         estimated row count  1000 (missing stats)              ·       ·
- │         render 0             (a, b) IS NOT DISTINCT FROM NULL  ·       ·
- └── scan  ·                    ·                                 (a, b)  ·
-·          estimated row count  1000 (missing stats)              ·       ·
-·          table                t@primary                         ·       ·
-·          spans                FULL SCAN                         ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a, b) IS NOT DISTINCT FROM NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b AS r FROM t
 ----
-·          distribution         local                     ·       ·
-·          vectorized           true                      ·       ·
-render     ·                    ·                         (r)     ·
- │         estimated row count  1000 (missing stats)      ·       ·
- │         render 0             a IS NOT DISTINCT FROM b  ·       ·
- └── scan  ·                    ·                         (a, b)  ·
-·          estimated row count  1000 (missing stats)      ·       ·
-·          table                t@primary                 ·       ·
-·          spans                FULL SCAN                 ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS NOT DISTINCT FROM b
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a IS NOT NULL         ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS NOT NULL
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a IS NOT NULL         ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS NOT NULL
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) IS NOT NULL AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             (a, b) IS NOT NULL    ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a, b) IS NOT NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (a, b) IS DISTINCT FROM NULL AS r FROM t
 ----
-·          distribution         local                         ·       ·
-·          vectorized           true                          ·       ·
-render     ·                    ·                             (r)     ·
- │         estimated row count  1000 (missing stats)          ·       ·
- │         render 0             (a, b) IS DISTINCT FROM NULL  ·       ·
- └── scan  ·                    ·                             (a, b)  ·
-·          estimated row count  1000 (missing stats)          ·       ·
-·          table                t@primary                     ·       ·
-·          spans                FULL SCAN                     ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (a, b) IS DISTINCT FROM NULL
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             a IS DISTINCT FROM b  ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a IS DISTINCT FROM b
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT +a + (-b) AS r FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (r)     ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             a + (-b)              ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a + (-b)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END AS r FROM t
 ----
-·          distribution         local                                          ·    ·
-·          vectorized           true                                           ·    ·
-render     ·                    ·                                              (r)  ·
- │         estimated row count  1000 (missing stats)                           ·    ·
- │         render 0             CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
- └── scan  ·                    ·                                              (a)  ·
-·          estimated row count  1000 (missing stats)                           ·    ·
-·          table                t@primary                                      ·    ·
-·          spans                FULL SCAN                                      ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END AS r FROM t
 ----
-·          distribution         local                              ·    ·
-·          vectorized           true                               ·    ·
-render     ·                    ·                                  (r)  ·
- │         estimated row count  1000 (missing stats)               ·    ·
- │         render 0             CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
- └── scan  ·                    ·                                  (a)  ·
-·          estimated row count  1000 (missing stats)               ·    ·
-·          table                t@primary                          ·    ·
-·          spans                FULL SCAN                          ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: CASE WHEN a = 2 THEN 1 ELSE 2 END
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END AS r FROM t
 ----
-·          distribution         local                                                       ·       ·
-·          vectorized           true                                                        ·       ·
-render     ·                    ·                                                           (r)     ·
- │         estimated row count  1000 (missing stats)                                        ·       ·
- │         render 0             CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
- └── scan  ·                    ·                                                           (a, b)  ·
-·          estimated row count  1000 (missing stats)                                        ·       ·
-·          table                t@primary                                                   ·       ·
-·          spans                FULL SCAN                                                   ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
 # Tests for CASE with no ELSE statement
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END AS r FROM t
 ----
-·          distribution         local                                               ·    ·
-·          vectorized           true                                                ·    ·
-render     ·                    ·                                                   (r)  ·
- │         estimated row count  1000 (missing stats)                                ·    ·
- │         render 0             CASE WHEN a = 2 THEN 1 ELSE CAST(NULL AS INT8) END  ·    ·
- └── scan  ·                    ·                                                   (a)  ·
-·          estimated row count  1000 (missing stats)                                ·    ·
-·          table                t@primary                                           ·    ·
-·          spans                FULL SCAN                                           ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: CASE WHEN a = 2 THEN 1 ELSE CAST(NULL AS INT8) END
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END AS r FROM t
 ----
-·          distribution         local                                             ·    ·
-·          vectorized           true                                              ·    ·
-render     ·                    ·                                                 (r)  ·
- │         estimated row count  1000 (missing stats)                              ·    ·
- │         render 0             CASE a WHEN 2 THEN 1 ELSE CAST(NULL AS INT8) END  ·    ·
- └── scan  ·                    ·                                                 (a)  ·
-·          estimated row count  1000 (missing stats)                              ·    ·
-·          table                t@primary                                         ·    ·
-·          spans                FULL SCAN                                         ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: CASE a WHEN 2 THEN 1 ELSE CAST(NULL AS INT8) END
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
 # TODO(radu): IS OF not supported yet.
 #query TTTTT
@@ -453,465 +583,609 @@ render     ·                    ·                                             
 #·          table   t@primary        ·    ·
 #·          spans   ALL              ·    ·
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT length(s) FROM t
 ----
-·          distribution         local                 ·         ·
-·          vectorized           true                  ·         ·
-render     ·                    ·                     (length)  ·
- │         estimated row count  1000 (missing stats)  ·         ·
- │         render 0             length(s)             ·         ·
- └── scan  ·                    ·                     (s)       ·
-·          estimated row count  1000 (missing stats)  ·         ·
-·          table                t@primary             ·         ·
-·          spans                FULL SCAN             ·         ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (length)
+│ estimated row count: 1000 (missing stats)
+│ render 0: length(s)
+│
+└── • scan
+      columns: (s)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j @> '{"a": 1}'       ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j @> '{"a": 1}'
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j @> '{"a": 1}'       ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j @> '{"a": 1}'
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j->>'a' AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j->>'a'               ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j->>'a'
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j->'a' AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j->'a'                ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j->'a'
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j ? 'a' AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j ? 'a'               ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j ? 'a'
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-·          distribution         local                    ·    ·
-·          vectorized           true                     ·    ·
-render     ·                    ·                        (r)  ·
- │         estimated row count  1000 (missing stats)     ·    ·
- │         render 0             j ?| ARRAY['a','b','c']  ·    ·
- └── scan  ·                    ·                        (j)  ·
-·          estimated row count  1000 (missing stats)     ·    ·
-·          table                t@primary                ·    ·
-·          spans                FULL SCAN                ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j ?| ARRAY['a','b','c']
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-·          distribution         local                    ·    ·
-·          vectorized           true                     ·    ·
-render     ·                    ·                        (r)  ·
- │         estimated row count  1000 (missing stats)     ·    ·
- │         render 0             j ?& ARRAY['a','b','c']  ·    ·
- └── scan  ·                    ·                        (j)  ·
-·          estimated row count  1000 (missing stats)     ·    ·
-·          table                t@primary                ·    ·
-·          spans                FULL SCAN                ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j ?& ARRAY['a','b','c']
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j#>ARRAY['a']         ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j#>ARRAY['a']
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] AS r FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             j#>>ARRAY['a']        ·    ·
- └── scan  ·                    ·                     (j)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: j#>>ARRAY['a']
+│
+└── • scan
+      columns: (j)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-render     ·                    ·                     (a, b)  ·
- │         estimated row count  1000 (missing stats)  ·       ·
- │         render 0             a::STRING             ·       ·
- │         render 1             b::FLOAT8             ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                t@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, b)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a::STRING
+│ render 1: b::FLOAT8
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
-·          distribution         local                  ·          ·
-·          vectorized           true                   ·          ·
-render     ·                    ·                      (text)     ·
- │         estimated row count  1000 (missing stats)   ·          ·
- │         render 0             (c + (a + b))::STRING  ·          ·
- └── scan  ·                    ·                      (a, b, c)  ·
-·          estimated row count  1000 (missing stats)   ·          ·
-·          table                t@primary              ·          ·
-·          spans                FULL SCAN              ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (text)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (c + (a + b))::STRING
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT s::VARCHAR(2) FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (s)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             s::VARCHAR(2)         ·    ·
- └── scan  ·                    ·                     (s)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (s)
+│ estimated row count: 1000 (missing stats)
+│ render 0: s::VARCHAR(2)
+│
+└── • scan
+      columns: (s)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
-·            distribution         local                       ·                   ·
-·            vectorized           false                       ·                   ·
-render       ·                    ·                           ("coalesce")        ·
- │           estimated row count  4                           ·                   ·
- │           render 0             COALESCE(column1, column2)  ·                   ·
- └── values  ·                    ·                           (column1, column2)  ·
-·            size                 2 columns, 4 rows           ·                   ·
-·            row 0, expr 0        1                           ·                   ·
-·            row 0, expr 1        2                           ·                   ·
-·            row 1, expr 0        3                           ·                   ·
-·            row 1, expr 1        CAST(NULL AS INT8)          ·                   ·
-·            row 2, expr 0        CAST(NULL AS INT8)          ·                   ·
-·            row 2, expr 1        4                           ·                   ·
-·            row 3, expr 0        CAST(NULL AS INT8)          ·                   ·
-·            row 3, expr 1        CAST(NULL AS INT8)          ·                   ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: ("coalesce")
+│ estimated row count: 4
+│ render 0: COALESCE(column1, column2)
+│
+└── • values
+      columns: (column1, column2)
+      size: 2 columns, 4 rows
+      row 0, expr 0: 1
+      row 0, expr 1: 2
+      row 1, expr 0: 3
+      row 1, expr 1: CAST(NULL AS INT8)
+      row 2, expr 0: CAST(NULL AS INT8)
+      row 2, expr 1: 4
+      row 3, expr 0: CAST(NULL AS INT8)
+      row 3, expr 1: CAST(NULL AS INT8)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
-·            distribution         local                                ·                            ·
-·            vectorized           false                                ·                            ·
-render       ·                    ·                                    ("coalesce")                 ·
- │           estimated row count  4                                    ·                            ·
- │           render 0             COALESCE(column1, column2, column3)  ·                            ·
- └── values  ·                    ·                                    (column1, column2, column3)  ·
-·            size                 3 columns, 4 rows                    ·                            ·
-·            row 0, expr 0        1                                    ·                            ·
-·            row 0, expr 1        2                                    ·                            ·
-·            row 0, expr 2        3                                    ·                            ·
-·            row 1, expr 0        CAST(NULL AS INT8)                   ·                            ·
-·            row 1, expr 1        4                                    ·                            ·
-·            row 1, expr 2        5                                    ·                            ·
-·            row 2, expr 0        CAST(NULL AS INT8)                   ·                            ·
-·            row 2, expr 1        CAST(NULL AS INT8)                   ·                            ·
-·            row 2, expr 2        6                                    ·                            ·
-·            row 3, expr 0        CAST(NULL AS INT8)                   ·                            ·
-·            row 3, expr 1        CAST(NULL AS INT8)                   ·                            ·
-·            row 3, expr 2        CAST(NULL AS INT8)                   ·                            ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: ("coalesce")
+│ estimated row count: 4
+│ render 0: COALESCE(column1, column2, column3)
+│
+└── • values
+      columns: (column1, column2, column3)
+      size: 3 columns, 4 rows
+      row 0, expr 0: 1
+      row 0, expr 1: 2
+      row 0, expr 2: 3
+      row 1, expr 0: CAST(NULL AS INT8)
+      row 1, expr 1: 4
+      row 1, expr 2: 5
+      row 2, expr 0: CAST(NULL AS INT8)
+      row 2, expr 1: CAST(NULL AS INT8)
+      row 2, expr 2: 6
+      row 3, expr 0: CAST(NULL AS INT8)
+      row 3, expr 1: CAST(NULL AS INT8)
+      row 3, expr 2: CAST(NULL AS INT8)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
-·               distribution         local                  ·          ·
-·               vectorized           true                   ·          ·
-project         ·                    ·                      (a)        ·
- │              estimated row count  110 (missing stats)    ·          ·
- └── filter     ·                    ·                      (a, b, d)  ·
-      │         estimated row count  110 (missing stats)    ·          ·
-      │         filter               (a >= b) AND (a <= d)  ·          ·
-      └── scan  ·                    ·                      (a, b, d)  ·
-·               estimated row count  1000 (missing stats)   ·          ·
-·               table                t@primary              ·          ·
-·               spans                FULL SCAN              ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 110 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, d)
+    │ estimated row count: 110 (missing stats)
+    │ filter: (a >= b) AND (a <= d)
+    │
+    └── • scan
+          columns: (a, b, d)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
-·               distribution         local                 ·          ·
-·               vectorized           true                  ·          ·
-project         ·                    ·                     (a)        ·
- │              estimated row count  330 (missing stats)   ·          ·
- └── filter     ·                    ·                     (a, b, d)  ·
-      │         estimated row count  330 (missing stats)   ·          ·
-      │         filter               (a < b) OR (a > d)    ·          ·
-      └── scan  ·                    ·                     (a, b, d)  ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                t@primary             ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 330 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, d)
+    │ estimated row count: 330 (missing stats)
+    │ filter: (a < b) OR (a > d)
+    │
+    └── • scan
+          columns: (a, b, d)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-·          distribution         local                                               ·          ·
-·          vectorized           true                                                ·          ·
-render     ·                    ·                                                   (r)        ·
- │         estimated row count  1000 (missing stats)                                ·          ·
- │         render 0             ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
- └── scan  ·                    ·                                                   (a, b, d)  ·
-·          estimated row count  1000 (missing stats)                                ·          ·
-·          table                t@primary                                           ·          ·
-·          spans                FULL SCAN                                           ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))
+│
+└── • scan
+      columns: (a, b, d)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-·          distribution         local                                          ·          ·
-·          vectorized           true                                           ·          ·
-render     ·                    ·                                              (r)        ·
- │         estimated row count  1000 (missing stats)                           ·          ·
- │         render 0             ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
- └── scan  ·                    ·                                              (a, b, d)  ·
-·          estimated row count  1000 (missing stats)                           ·          ·
-·          table                t@primary                                      ·          ·
-·          spans                FULL SCAN                                      ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((a < b) OR (a > d)) AND ((a < d) OR (a > b))
+│
+└── • scan
+      columns: (a, b, d)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY[]:::int[] FROM t
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-render     ·                    ·                     ("array")  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         render 0             ARRAY[]               ·          ·
- └── scan  ·                    ·                     ()         ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("array")
+│ estimated row count: 1000 (missing stats)
+│ render 0: ARRAY[]
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY[1, 2, 3] FROM t
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-render     ·                    ·                     ("array")  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         render 0             ARRAY[1,2,3]          ·          ·
- └── scan  ·                    ·                     ()         ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("array")
+│ estimated row count: 1000 (missing stats)
+│ render 0: ARRAY[1,2,3]
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-render     ·                    ·                     ("array")  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         render 0             ARRAY[a + 1, 2, 3]    ·          ·
- └── scan  ·                    ·                     (a)        ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("array")
+│ estimated row count: 1000 (missing stats)
+│ render 0: ARRAY[a + 1, 2, 3]
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
 ----
-·          distribution         local                       ·             ·
-·          vectorized           true                        ·             ·
-render     ·                    ·                           ("?column?")  ·
- │         estimated row count  1000 (missing stats)        ·             ·
- │         render 0             1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
- └── scan  ·                    ·                           (a)           ·
-·          estimated row count  1000 (missing stats)        ·             ·
-·          table                t@primary                   ·             ·
-·          spans                FULL SCAN                   ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1000 (missing stats)
+│ render 0: 1 > ANY ARRAY[a + 1, 2, 3]
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-render     ·                    ·                     ("?column?")  ·
- │         estimated row count  1000 (missing stats)  ·             ·
- │         render 0             true                  ·             ·
- └── scan  ·                    ·                     ()            ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                t@primary             ·             ·
-·          spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1000 (missing stats)
+│ render 0: true
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-render     ·                    ·                     ("?column?")  ·
- │         estimated row count  1000 (missing stats)  ·             ·
- │         render 0             false                 ·             ·
- └── scan  ·                    ·                     ()            ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                t@primary             ·             ·
-·          spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1000 (missing stats)
+│ render 0: false
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
 ----
-·          distribution         local                 ·          ·
-·          vectorized           true                  ·          ·
-render     ·                    ·                     ("least")  ·
- │         estimated row count  1000 (missing stats)  ·          ·
- │         render 0             least(NULL, 3, 6, a)  ·          ·
- └── scan  ·                    ·                     (a)        ·
-·          estimated row count  1000 (missing stats)  ·          ·
-·          table                t@primary             ·          ·
-·          spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("least")
+│ estimated row count: 1000 (missing stats)
+│ render 0: least(NULL, 3, 6, a)
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='t'::regclass
 ----
-·              distribution         local                                   ·                                                                                                                                                                                                                                                                         ·
-·              vectorized           false                                   ·                                                                                                                                                                                                                                                                         ·
-virtual table  ·                    ·                                       (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
-·              estimated row count  10 (missing stats)                      ·                                                                                                                                                                                                                                                                         ·
-·              table                pg_attribute@pg_attribute_attrelid_idx  ·                                                                                                                                                                                                                                                                         ·
-·              spans                /53-/54                                 ·                                                                                                                                                                                                                                                                         ·
+distribution: local
+vectorized: false
+·
+• virtual table
+  columns: (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)
+  estimated row count: 10 (missing stats)
+  table: pg_attribute@pg_attribute_attrelid_idx
+  spans: /53-/54
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
-·       distribution   local            ·         ·
-·       vectorized     false            ·         ·
-values  ·              ·                ("case")  ·
-·       size           1 column, 1 row  ·         ·
-·       row 0, expr 0  42               ·         ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: ("case")
+  size: 1 column, 1 row
+  row 0, expr 0: 42
 
 # Don't fold random(), but fold current_database().
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT random(), current_database()
 ----
-·       distribution   local             ·                           ·
-·       vectorized     false             ·                           ·
-values  ·              ·                 (random, current_database)  ·
-·       size           2 columns, 1 row  ·                           ·
-·       row 0, expr 0  random()          ·                           ·
-·       row 0, expr 1  'test'            ·                           ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (random, current_database)
+  size: 2 columns, 1 row
+  row 0, expr 0: random()
+  row 0, expr 1: 'test'
 
 # Don't fold non-constants.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1::FLOAT + length(upper(concat('a', 'b', 'c')))::FLOAT AS r1,
                          1::FLOAT + length(upper(concat('a', 'b', s)))::FLOAT AS r2 FROM t
 ----
-·          distribution         local                                             ·         ·
-·          vectorized           true                                              ·         ·
-render     ·                    ·                                                 (r1, r2)  ·
- │         estimated row count  1000 (missing stats)                              ·         ·
- │         render 0             4.0                                               ·         ·
- │         render 1             length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
- └── scan  ·                    ·                                                 (s)       ·
-·          estimated row count  1000 (missing stats)                              ·         ·
-·          table                t@primary                                         ·         ·
-·          spans                FULL SCAN                                         ·         ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r1, r2)
+│ estimated row count: 1000 (missing stats)
+│ render 0: 4.0
+│ render 1: length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0
+│
+└── • scan
+      columns: (s)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC)
 ----
-·                             distribution         local                                            ·                  ·
-·                             vectorized           false                                            ·                  ·
-root                          ·                    ·                                                ("array")          ·
- ├── values                   ·                    ·                                                ("array")          ·
- │                            size                 1 column, 1 row                                  ·                  ·
- │                            row 0, expr 0        ARRAY @S1                                        ·                  ·
- └── subquery                 ·                    ·                                                ·                  ·
-      │                       id                   @S1                                              ·                  ·
-      │                       original sql         (SELECT generate_series(1, 10) ORDER BY 1 DESC)  ·                  ·
-      │                       exec mode            all rows                                         ·                  ·
-      └── sort                ·                    ·                                                (generate_series)  -generate_series
-           │                  estimated row count  10                                               ·                  ·
-           │                  order                -generate_series                                 ·                  ·
-           └── project set    ·                    ·                                                (generate_series)  ·
-                │             estimated row count  10                                               ·                  ·
-                │             render 0             generate_series(1, 10)                           ·                  ·
-                └── emptyrow  ·                    ·                                                ()                 ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: ("array")
+│
+├── • values
+│     columns: ("array")
+│     size: 1 column, 1 row
+│     row 0, expr 0: ARRAY @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT generate_series(1, 10) ORDER BY 1 DESC)
+    │ exec mode: all rows
+    │
+    └── • sort
+        │ columns: (generate_series)
+        │ ordering: -generate_series
+        │ estimated row count: 10
+        │ order: -generate_series
+        │
+        └── • project set
+            │ columns: (generate_series)
+            │ estimated row count: 10
+            │ render 0: generate_series(1, 10)
+            │
+            └── • emptyrow
+                  columns: ()
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT a FROM t ORDER BY b)
 ----
-·                         distribution         local                         ·          ·
-·                         vectorized           false                         ·          ·
-root                      ·                    ·                             ("array")  ·
- ├── values               ·                    ·                             ("array")  ·
- │                        size                 1 column, 1 row               ·          ·
- │                        row 0, expr 0        ARRAY @S1                     ·          ·
- └── subquery             ·                    ·                             ·          ·
-      │                   id                   @S1                           ·          ·
-      │                   original sql         (SELECT a FROM t ORDER BY b)  ·          ·
-      │                   exec mode            all rows                      ·          ·
-      └── project         ·                    ·                             (a)        ·
-           └── sort       ·                    ·                             (a, b)     +b
-                │         estimated row count  1000 (missing stats)          ·          ·
-                │         order                +b                            ·          ·
-                └── scan  ·                    ·                             (a, b)     ·
-·                         estimated row count  1000 (missing stats)          ·          ·
-·                         table                t@primary                     ·          ·
-·                         spans                FULL SCAN                     ·          ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: ("array")
+│
+├── • values
+│     columns: ("array")
+│     size: 1 column, 1 row
+│     row 0, expr 0: ARRAY @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t ORDER BY b)
+    │ exec mode: all rows
+    │
+    └── • project
+        │ columns: (a)
+        │
+        └── • sort
+            │ columns: (a, b)
+            │ ordering: +b
+            │ estimated row count: 1000 (missing stats)
+            │ order: +b
+            │
+            └── • scan
+                  columns: (a, b)
+                  estimated row count: 1000 (missing stats)
+                  table: t@primary
+                  spans: FULL SCAN
 
 # Regression test for #47327. The span should have an end value of -1.
 statement ok
 CREATE TABLE t0(c0 DECIMAL UNIQUE); INSERT INTO t0(c0) VALUES(0);
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
 ----
-·     distribution         local                 ·     ·
-·     vectorized           true                  ·     ·
-scan  ·                    ·                     (c0)  ·
-·     estimated row count  330 (missing stats)   ·     ·
-·     table                t0@t0_c0_key          ·     ·
-·     spans                /!NULL-/-1/PrefixEnd  ·     ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c0)
+  estimated row count: 330 (missing stats)
+  table: t0@t0_c0_key
+  spans: /!NULL-/-1/PrefixEnd

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -255,15 +255,16 @@ SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
 Scan /Table/55/2/2.01/3.001/{0-1}, /Table/55/2/2.01/3.001/2/{1-2}
 
-query TTT
+query T
 EXPLAIN SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t@i
-·     spans          [/2.01/3.001 - /2.01/3.001]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@i
+  spans: [/2.01/3.001 - /2.01/3.001]
 
 # Ensure that we always have a k/v in family 0.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -61,195 +61,233 @@ ALTER TABLE num_ref RENAME COLUMN a TO p
 statement ok
 ALTER TABLE num_ref DROP COLUMN xx
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS num_ref_alias]
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (p, d, c)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                num_ref@primary       ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p, d, c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (c)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@primary       ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (p, c)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                num_ref@primary       ·       ·
-·     spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p, c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (p, d, c)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                num_ref@primary       ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p, d, c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (c, d, p)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                num_ref@primary       ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c, d, p)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias(col1,col2,col3)]
 ----
-·     distribution         local                 ·                   ·
-·     vectorized           true                  ·                   ·
-scan  ·                    ·                     (col1, col2, col3)  ·
-·     estimated row count  1000 (missing stats)  ·                   ·
-·     table                num_ref@primary       ·                   ·
-·     spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (col1, col2, col3)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]@bc
 ----
-·     distribution         local                 ·          ·
-·     vectorized           true                  ·          ·
-scan  ·                    ·                     (c, d, p)  ·
-·     estimated row count  1000 (missing stats)  ·          ·
-·     table                num_ref@bc            ·          ·
-·     spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c, d, p)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (c)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (d)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (p)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (p)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@primary       ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (p)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (p)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (d)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@primary       ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (d)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (c)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@primary       ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (c)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                num_ref@bc            ·    ·
-·     spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c)
+  estimated row count: 1000 (missing stats)
+  table: num_ref@bc
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
 ----
-·     distribution         local                   ·    ·
-·     vectorized           true                    ·    ·
-scan  ·                    ·                       (a)  ·
-·     estimated row count  1000 (missing stats)    ·    ·
-·     table                num_ref_hidden@primary  ·    ·
-·     spans                FULL SCAN               ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: num_ref_hidden@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
 ----
-·     distribution         local                   ·   ·
-·     vectorized           true                    ·   ·
-scan  ·                    ·                       ()  ·
-·     estimated row count  1000 (missing stats)    ·   ·
-·     table                num_ref_hidden@primary  ·   ·
-·     spans                FULL SCAN               ·   ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: ()
+  estimated row count: 1000 (missing stats)
+  table: num_ref_hidden@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
 ----
-·     distribution         local                   ·        ·
-·     vectorized           true                    ·        ·
-scan  ·                    ·                       (rowid)  ·
-·     estimated row count  1000 (missing stats)    ·        ·
-·     table                num_ref_hidden@primary  ·        ·
-·     spans                FULL SCAN               ·        ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (rowid)
+  estimated row count: 1000 (missing stats)
+  table: num_ref_hidden@primary
+  spans: FULL SCAN
 
 query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
 EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
@@ -278,126 +316,162 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]
 statement ok
 CREATE TABLE a (x INT PRIMARY KEY, y INT, FAMILY (x, y));
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1
 ----
-·     distribution         local                ·       ·
-·     vectorized           true                 ·       ·
-scan  ·                    ·                    (x, y)  ·
-·     estimated row count  333 (missing stats)  ·       ·
-·     table                a@primary            ·       ·
-·     spans                /2-                  ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y)
+  estimated row count: 333 (missing stats)
+  table: a@primary
+  spans: /2-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (x, y)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               y > 10                ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                a@primary             ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y)
+│ estimated row count: 333 (missing stats)
+│ filter: y > 10
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (x, y)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                a@primary          ·       ·
-·     spans                /2-/2/#            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y)
+  estimated row count: 1 (missing stats)
+  table: a@primary
+  spans: /2-/2/#
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
-·          distribution         local                ·       ·
-·          vectorized           true                 ·       ·
-filter     ·                    ·                    (x, y)  ·
- │         estimated row count  311 (missing stats)  ·       ·
- │         filter               y < 30               ·       ·
- └── scan  ·                    ·                    (x, y)  ·
-·          estimated row count  333 (missing stats)  ·       ·
-·          table                a@primary            ·       ·
-·          spans                /2-                  ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y)
+│ estimated row count: 311 (missing stats)
+│ filter: y < 30
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 333 (missing stats)
+      table: a@primary
+      spans: /2-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x + 1 AS r FROM a
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (r)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             x + 1                 ·    ·
- └── scan  ·                    ·                     (x)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                a@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: x + 1
+│
+└── • scan
+      columns: (x)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x AS a, x + 1 AS b, y, y + 1 AS c, x + y AS d FROM a
 ----
-·          distribution         local                 ·                ·
-·          vectorized           true                  ·                ·
-render     ·                    ·                     (a, b, y, c, d)  ·
- │         estimated row count  1000 (missing stats)  ·                ·
- │         render 0             x + 1                 ·                ·
- │         render 1             y + 1                 ·                ·
- │         render 2             x + y                 ·                ·
- │         render 3             x                     ·                ·
- │         render 4             y                     ·                ·
- └── scan  ·                    ·                     (x, y)           ·
-·          estimated row count  1000 (missing stats)  ·                ·
-·          table                a@primary             ·                ·
-·          spans                FULL SCAN             ·                ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, b, y, c, d)
+│ estimated row count: 1000 (missing stats)
+│ render 0: x + 1
+│ render 1: y + 1
+│ render 2: x + y
+│ render 3: x
+│ render 4: y
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT u * v + v AS r FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
-·               distribution         local                                   ·                         ·
-·               vectorized           true                                    ·                         ·
-render          ·                    ·                                       (r)                       ·
- │              estimated row count  1000 (missing stats)                    ·                         ·
- │              render 0             "?column?" + ("?column?" * "?column?")  ·                         ·
- └── render     ·                    ·                                       ("?column?", "?column?")  ·
-      │         estimated row count  1000 (missing stats)                    ·                         ·
-      │         render 0             x + 3                                   ·                         ·
-      │         render 1             y + 10                                  ·                         ·
-      └── scan  ·                    ·                                       (x, y)                    ·
-·               estimated row count  1000 (missing stats)                    ·                         ·
-·               table                a@primary                               ·                         ·
-·               spans                FULL SCAN                               ·                         ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (r)
+│ estimated row count: 1000 (missing stats)
+│ render 0: "?column?" + ("?column?" * "?column?")
+│
+└── • render
+    │ columns: ("?column?", "?column?")
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: x + 3
+    │ render 1: y + 10
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: a@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x, x, y, x FROM a
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-project    ·                    ·                     (x, x, y, x)  ·
- └── scan  ·                    ·                     (x, y)        ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                a@primary             ·             ·
-·          spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x, x, y, x)
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: a@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x + 1 AS a, x + y AS b FROM a WHERE x + y > 20
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-render          ·                    ·                     (a, b)  ·
- │              estimated row count  333 (missing stats)   ·       ·
- │              render 0             x + 1                 ·       ·
- │              render 1             x + y                 ·       ·
- └── filter     ·                    ·                     (x, y)  ·
-      │         estimated row count  333 (missing stats)   ·       ·
-      │         filter               (x + y) > 20          ·       ·
-      └── scan  ·                    ·                     (x, y)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                a@primary             ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ render 0: x + 1
+│ render 1: x + y
+│
+└── • filter
+    │ columns: (x, y)
+    │ estimated row count: 333 (missing stats)
+    │ filter: (x + y) > 20
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1000 (missing stats)
+          table: a@primary
+          spans: FULL SCAN
 
 statement ok
 DROP TABLE a
@@ -408,25 +482,29 @@ DROP TABLE a
 statement ok
 CREATE TABLE b (x INT, y INT);
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM b
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (x, y)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                b@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y)
+  estimated row count: 1000 (missing stats)
+  table: b@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
-·     distribution         local                ·              ·
-·     vectorized           true                 ·              ·
-scan  ·                    ·                    (x, y, rowid)  ·
-·     estimated row count  333 (missing stats)  ·              ·
-·     table                b@primary            ·              ·
-·     spans                /1-                  ·              ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y, rowid)
+  estimated row count: 333 (missing stats)
+  table: b@primary
+  spans: /1-
 
 statement ok
 DROP TABLE b
@@ -544,15 +622,16 @@ CREATE TABLE t14601 (a STRING, b BOOL)
 statement ok
 CREATE INDEX i14601 ON t14601 (a) STORING (b)
 
-query TTT
+query T
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t14601@i14601
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t14601@i14601
+  spans: FULL SCAN
 
 # Updates were broken too.
 
@@ -569,15 +648,16 @@ CREATE TABLE t14601a (
 statement ok
 CREATE INDEX i14601a ON t14601a (a) STORING (b, c)
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t14601a@i14601a
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t14601a@i14601a
+  spans: FULL SCAN
 
 statement ok
 DROP index i14601a
@@ -585,15 +665,16 @@ DROP index i14601a
 statement ok
 CREATE UNIQUE INDEX i14601a ON t14601a (a) STORING (b)
 
-query TTT
+query T
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t14601a@i14601a
-·     spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t14601a@i14601a
+  spans: FULL SCAN
 
 statement ok
 DROP TABLE t; DROP TABLE t14601; DROP TABLE t14601a
@@ -604,15 +685,17 @@ DROP TABLE t; DROP TABLE t14601; DROP TABLE t14601a
 statement ok
 CREATE TABLE c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM c WHERE str >= 'moo'
 ----
-·     distribution         local                ·         ·
-·     vectorized           true                 ·         ·
-scan  ·                    ·                    (n, str)  ·
-·     estimated row count  333 (missing stats)  ·         ·
-·     table                c@str                ·         ·
-·     spans                -/"moo"/PrefixEnd    ·         ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (n, str)
+  estimated row count: 333 (missing stats)
+  table: c@str
+  spans: -/"moo"/PrefixEnd
 
 statement ok
 DROP TABLE c
@@ -623,18 +706,22 @@ DROP TABLE c
 statement ok
 CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 AS a, * FROM nocols
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (a)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             1                     ·    ·
- └── scan  ·                    ·                     ()   ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                nocols@primary        ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a)
+│ estimated row count: 1000 (missing stats)
+│ render 0: 1
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: nocols@primary
+      spans: FULL SCAN
 
 statement ok
 DROP TABLE nocols
@@ -651,25 +738,31 @@ CREATE TABLE coll (
   INDEX (b, a) STORING (c)
 )
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT a, b FROM coll ORDER BY a, b
 ----
-·     distribution         local                 ·                              ·
-·     vectorized           true                  ·                              ·
-scan  ·                    ·                     (a collatedstring{da}, b int)  +a,+b
-·     estimated row count  1000 (missing stats)  ·                              ·
-·     table                coll@primary          ·                              ·
-·     spans                FULL SCAN             ·                              ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a collatedstring{da}, b int)
+  ordering: +a,+b
+  estimated row count: 1000 (missing stats)
+  table: coll@primary
+  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
 ----
-·     distribution         local                 ·                              ·
-·     vectorized           true                  ·                              ·
-scan  ·                    ·                     (b int, a collatedstring{da})  +b,+a
-·     estimated row count  1000 (missing stats)  ·                              ·
-·     table                coll@coll_b_a_idx     ·                              ·
-·     spans                FULL SCAN             ·                              ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (b int, a collatedstring{da})
+  ordering: +b,+a
+  estimated row count: 1000 (missing stats)
+  table: coll@coll_b_a_idx
+  spans: FULL SCAN
 
 statement ok
 DROP TABLE coll
@@ -685,15 +778,18 @@ CREATE TABLE computed (
   INDEX (b)
 )
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
 ----
-·     distribution         local                    ·           ·
-·     vectorized           true                     ·           ·
-scan  ·                    ·                        (b string)  +b
-·     estimated row count  1000 (missing stats)     ·           ·
-·     table                computed@computed_b_idx  ·           ·
-·     spans                FULL SCAN                ·           ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (b string)
+  ordering: +b
+  estimated row count: 1000 (missing stats)
+  table: computed@computed_b_idx
+  spans: FULL SCAN
 
 statement ok
 DROP TABLE computed
@@ -766,36 +862,42 @@ DROP TABLE dt
 statement ok
 CREATE TABLE dec (d decimal, v decimal(3, 1), primary key (d, v))
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d IS NaN and v IS NaN
 ----
-·     distribution         local                ·                       ·
-·     vectorized           true                 ·                       ·
-scan  ·                    ·                    (d decimal, v decimal)  ·
-·     estimated row count  1 (missing stats)    ·                       ·
-·     table                dec@primary          ·                       ·
-·     spans                /NaN/NaN-/NaN/NaN/#  ·                       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal, v decimal)
+  estimated row count: 1 (missing stats)
+  table: dec@primary
+  spans: /NaN/NaN-/NaN/NaN/#
 
 # The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = 'Infinity' and v = 'Infinity'
 ----
-·     distribution         local                                    ·                       ·
-·     vectorized           true                                     ·                       ·
-scan  ·                    ·                                        (d decimal, v decimal)  ·
-·     estimated row count  1 (missing stats)                        ·                       ·
-·     table                dec@primary                              ·                       ·
-·     spans                /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal, v decimal)
+  estimated row count: 1 (missing stats)
+  table: dec@primary
+  spans: /Infinity/Infinity-/Infinity/Infinity/#
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = '-Infinity' and v = '-Infinity'
 ----
-·     distribution         local                                        ·                       ·
-·     vectorized           true                                         ·                       ·
-scan  ·                    ·                                            (d decimal, v decimal)  ·
-·     estimated row count  1 (missing stats)                            ·                       ·
-·     table                dec@primary                                  ·                       ·
-·     spans                /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal, v decimal)
+  estimated row count: 1 (missing stats)
+  table: dec@primary
+  spans: /-Infinity/-Infinity-/-Infinity/-Infinity/#
 
 statement ok
 DROP TABLE dec
@@ -842,38 +944,46 @@ output row: [1 0.40]
 statement ok
 CREATE TABLE dec2 (d decimal null, index (d))
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d IS NaN
 ----
-·     distribution         local               ·            ·
-·     vectorized           true                ·            ·
-scan  ·                    ·                   (d decimal)  ·
-·     estimated row count  10 (missing stats)  ·            ·
-·     table                dec2@dec2_d_idx     ·            ·
-·     spans                /NaN-/-Infinity     ·            ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal)
+  estimated row count: 10 (missing stats)
+  table: dec2@dec2_d_idx
+  spans: /NaN-/-Infinity
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d = 'NaN'
 ----
-·     distribution         local               ·            ·
-·     vectorized           true                ·            ·
-scan  ·                    ·                   (d decimal)  ·
-·     estimated row count  10 (missing stats)  ·            ·
-·     table                dec2@dec2_d_idx     ·            ·
-·     spans                /NaN-/-Infinity     ·            ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal)
+  estimated row count: 10 (missing stats)
+  table: dec2@dec2_d_idx
+  spans: /NaN-/-Infinity
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
-·          distribution         local                        ·            ·
-·          vectorized           true                         ·            ·
-filter     ·                    ·                            (d decimal)  ·
- │         estimated row count  330 (missing stats)          ·            ·
- │         filter               (isnan((d)[decimal]))[bool]  ·            ·
- └── scan  ·                    ·                            (d decimal)  ·
-·          estimated row count  1000 (missing stats)         ·            ·
-·          table                dec2@primary                 ·            ·
-·          spans                FULL SCAN                    ·            ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (d decimal)
+│ estimated row count: 330 (missing stats)
+│ filter: (isnan((d)[decimal]))[bool]
+│
+└── • scan
+      columns: (d decimal)
+      estimated row count: 1000 (missing stats)
+      table: dec2@primary
+      spans: FULL SCAN
 
 statement ok
 DROP TABLE dec2
@@ -887,38 +997,46 @@ DROP TABLE dec2
 statement ok
 CREATE TABLE flt (f float null, unique index (f))
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f IS NaN
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (f float)  ·
-·     estimated row count  1 (missing stats)    ·          ·
-·     table                flt@flt_f_key        ·          ·
-·     spans                /NaN-/NaN/PrefixEnd  ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (f float)
+  estimated row count: 1 (missing stats)
+  table: flt@flt_f_key
+  spans: /NaN-/NaN/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f = 'NaN'
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (f float)  ·
-·     estimated row count  1 (missing stats)    ·          ·
-·     table                flt@flt_f_key        ·          ·
-·     spans                /NaN-/NaN/PrefixEnd  ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (f float)
+  estimated row count: 1 (missing stats)
+  table: flt@flt_f_key
+  spans: /NaN-/NaN/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
-·          distribution         local                      ·          ·
-·          vectorized           true                       ·          ·
-filter     ·                    ·                          (f float)  ·
- │         estimated row count  330 (missing stats)        ·          ·
- │         filter               (isnan((f)[float]))[bool]  ·          ·
- └── scan  ·                    ·                          (f float)  ·
-·          estimated row count  1000 (missing stats)       ·          ·
-·          table                flt@primary                ·          ·
-·          spans                FULL SCAN                  ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (f float)
+│ estimated row count: 330 (missing stats)
+│ filter: (isnan((f)[float]))[bool]
+│
+└── • scan
+      columns: (f float)
+      estimated row count: 1000 (missing stats)
+      table: flt@primary
+      spans: FULL SCAN
 
 statement ok
 DROP TABLE flt
@@ -940,45 +1058,53 @@ CREATE TABLE num (
   unique index (n)
 )
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT i FROM num WHERE i = -1:::INT
 ----
-·     distribution         local              ·        ·
-·     vectorized           true               ·        ·
-scan  ·                    ·                  (i int)  ·
-·     estimated row count  1 (missing stats)  ·        ·
-·     table                num@num_i_key      ·        ·
-·     spans                /-1-/0             ·        ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (i int)
+  estimated row count: 1 (missing stats)
+  table: num@num_i_key
+  spans: /-1-/0
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT f FROM num WHERE f = -1:::FLOAT
 ----
-·     distribution         local              ·          ·
-·     vectorized           true               ·          ·
-scan  ·                    ·                  (f float)  ·
-·     estimated row count  1 (missing stats)  ·          ·
-·     table                num@num_f_key      ·          ·
-·     spans                /-1-/-1/PrefixEnd  ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (f float)
+  estimated row count: 1 (missing stats)
+  table: num@num_f_key
+  spans: /-1-/-1/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT d FROM num WHERE d = -1:::DECIMAL
 ----
-·     distribution         local              ·            ·
-·     vectorized           true               ·            ·
-scan  ·                    ·                  (d decimal)  ·
-·     estimated row count  1 (missing stats)  ·            ·
-·     table                num@num_d_key      ·            ·
-·     spans                /-1-/-1/PrefixEnd  ·            ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (d decimal)
+  estimated row count: 1 (missing stats)
+  table: num@num_d_key
+  spans: /-1-/-1/PrefixEnd
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT n FROM num WHERE n = -'1h':::INTERVAL
 ----
-·     distribution         local                        ·             ·
-·     vectorized           true                         ·             ·
-scan  ·                    ·                            (n interval)  ·
-·     estimated row count  1 (missing stats)            ·             ·
-·     table                num@num_n_key                ·             ·
-·     spans                /-01:00:00-/1 day -25:00:00  ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (n interval)
+  estimated row count: 1 (missing stats)
+  table: num@num_n_key
+  spans: /-01:00:00-/1 day -25:00:00
 
 statement ok
 DROP TABLE num
@@ -1176,135 +1302,194 @@ statement ok
 CREATE TABLE abcd (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b))
 
 # Ensure that (non-top-level) render nodes get populated with the correct ordering.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b + c AS x FROM abcd) ORDER BY a
 ----
-·               distribution         local                 ·                ·
-·               vectorized           true                  ·                ·
-project         ·                    ·                     ("?column?")     ·
- └── render     ·                    ·                     ("?column?", a)  +a
-      │         estimated row count  1000 (missing stats)  ·                ·
-      │         render 0             a + (b + c)           ·                ·
-      │         render 1             a                     ·                ·
-      └── scan  ·                    ·                     (a, b, c)        +a
-·               estimated row count  1000 (missing stats)  ·                ·
-·               table                abcd@primary          ·                ·
-·               spans                FULL SCAN             ·                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: ("?column?")
+│
+└── • render
+    │ columns: ("?column?", a)
+    │ ordering: +a
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: a + (b + c)
+    │ render 1: a
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: abcd@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY b
 ----
-·                    distribution         local                 ·                ·
-·                    vectorized           true                  ·                ·
-project              ·                    ·                     ("?column?")     ·
- └── sort            ·                    ·                     ("?column?", b)  +b
-      │              estimated row count  1000 (missing stats)  ·                ·
-      │              order                +b                    ·                ·
-      └── render     ·                    ·                     ("?column?", b)  ·
-           │         estimated row count  1000 (missing stats)  ·                ·
-           │         render 0             a + (c + (a + b))     ·                ·
-           │         render 1             b                     ·                ·
-           └── scan  ·                    ·                     (a, b, c)        ·
-·                    estimated row count  1000 (missing stats)  ·                ·
-·                    table                abcd@primary          ·                ·
-·                    spans                FULL SCAN             ·                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: ("?column?")
+│
+└── • sort
+    │ columns: ("?column?", b)
+    │ ordering: +b
+    │ estimated row count: 1000 (missing stats)
+    │ order: +b
+    │
+    └── • render
+        │ columns: ("?column?", b)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: a + (c + (a + b))
+        │ render 1: b
+        │
+        └── • scan
+              columns: (a, b, c)
+              estimated row count: 1000 (missing stats)
+              table: abcd@primary
+              spans: FULL SCAN
 
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY a DESC, b DESC
 ----
-·                  distribution         local                 ·                   ·
-·                  vectorized           true                  ·                   ·
-project            ·                    ·                     ("?column?")        ·
- └── render        ·                    ·                     ("?column?", a, b)  -a,-b
-      │            estimated row count  1000 (missing stats)  ·                   ·
-      │            render 0             a + (c + (a + b))     ·                   ·
-      │            render 1             a                     ·                   ·
-      │            render 2             b                     ·                   ·
-      └── revscan  ·                    ·                     (a, b, c)           -a,-b
-·                  estimated row count  1000 (missing stats)  ·                   ·
-·                  table                abcd@primary          ·                   ·
-·                  spans                FULL SCAN             ·                   ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: ("?column?")
+│
+└── • render
+    │ columns: ("?column?", a, b)
+    │ ordering: -a,-b
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: a + (c + (a + b))
+    │ render 1: a
+    │ render 2: b
+    │
+    └── • revscan
+          columns: (a, b, c)
+          ordering: -a,-b
+          estimated row count: 1000 (missing stats)
+          table: abcd@primary
+          spans: FULL SCAN
 
 # Ensure that filter nodes (and filtered scan nodes) get populated with the correct ordering.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-filter     ·                    ·                     (a, b, c, d)  +a
- │         estimated row count  333 (missing stats)   ·             ·
- │         filter               a > b                 ·             ·
- └── scan  ·                    ·                     (a, b, c, d)  +a
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                abcd@primary          ·             ·
-·          spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, c, d)
+│ ordering: +a
+│ estimated row count: 333 (missing stats)
+│ filter: a > b
+│
+└── • scan
+      columns: (a, b, c, d)
+      ordering: +a
+      estimated row count: 1000 (missing stats)
+      table: abcd@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a DESC, b DESC
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-sort            ·                    ·                     (a, b, c, d)  -a,-b
- │              estimated row count  333 (missing stats)   ·             ·
- │              order                -a,-b                 ·             ·
- └── filter     ·                    ·                     (a, b, c, d)  ·
-      │         estimated row count  333 (missing stats)   ·             ·
-      │         filter               a > b                 ·             ·
-      └── scan  ·                    ·                     (a, b, c, d)  ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                abcd@primary          ·             ·
-·               spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d)
+│ ordering: -a,-b
+│ estimated row count: 333 (missing stats)
+│ order: -a,-b
+│
+└── • filter
+    │ columns: (a, b, c, d)
+    │ estimated row count: 333 (missing stats)
+    │ filter: a > b
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: abcd@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, b FROM abcd LIMIT 10) WHERE a > b ORDER BY a
 ----
-·          distribution         local               ·       ·
-·          vectorized           true                ·       ·
-filter     ·                    ·                   (a, b)  +a
- │         estimated row count  3 (missing stats)   ·       ·
- │         filter               a > b               ·       ·
- └── scan  ·                    ·                   (a, b)  +a
-·          estimated row count  10 (missing stats)  ·       ·
-·          table                abcd@primary        ·       ·
-·          spans                LIMITED SCAN        ·       ·
-·          limit                10                  ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ ordering: +a
+│ estimated row count: 3 (missing stats)
+│ filter: a > b
+│
+└── • scan
+      columns: (a, b)
+      ordering: +a
+      estimated row count: 10 (missing stats)
+      table: abcd@primary
+      spans: LIMITED SCAN
+      limit: 10
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, a+b+c AS x FROM (SELECT * FROM abcd LIMIT 10)) WHERE x > 100 ORDER BY a
 ----
-·               distribution         local                ·          ·
-·               vectorized           true                 ·          ·
-render          ·                    ·                    (a, x)     +a
- │              estimated row count  3 (missing stats)    ·          ·
- │              render 0             c + (a + b)          ·          ·
- │              render 1             a                    ·          ·
- └── filter     ·                    ·                    (a, b, c)  +a
-      │         estimated row count  3 (missing stats)    ·          ·
-      │         filter               (c + (a + b)) > 100  ·          ·
-      └── scan  ·                    ·                    (a, b, c)  +a
-·               estimated row count  10 (missing stats)   ·          ·
-·               table                abcd@primary         ·          ·
-·               spans                LIMITED SCAN         ·          ·
-·               limit                10                   ·          ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, x)
+│ ordering: +a
+│ estimated row count: 3 (missing stats)
+│ render 0: c + (a + b)
+│ render 1: a
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ ordering: +a
+    │ estimated row count: 3 (missing stats)
+    │ filter: (c + (a + b)) > 100
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a
+          estimated row count: 10 (missing stats)
+          table: abcd@primary
+          spans: LIMITED SCAN
+          limit: 10
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
 
 # Verify the scan is configured with the correct ordering +x,+y,+z (#31882).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyz LIMIT 10) WHERE y = 1 ORDER BY x, y, z
 ----
-·          distribution         local               ·          ·
-·          vectorized           true                ·          ·
-filter     ·                    ·                   (x, y, z)  +x,+z
- │         estimated row count  1 (missing stats)   ·          ·
- │         filter               y = 1               ·          ·
- └── scan  ·                    ·                   (x, y, z)  +x,+y,+z
-·          estimated row count  10 (missing stats)  ·          ·
-·          table                xyz@xyz_x_y_z_idx   ·          ·
-·          spans                LIMITED SCAN        ·          ·
-·          limit                10                  ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y, z)
+│ ordering: +x,+z
+│ estimated row count: 1 (missing stats)
+│ filter: y = 1
+│
+└── • scan
+      columns: (x, y, z)
+      ordering: +x,+y,+z
+      estimated row count: 10 (missing stats)
+      table: xyz@xyz_x_y_z_idx
+      spans: LIMITED SCAN
+      limit: 10
 
 # ------------------------------------------------------
 # Verify that multi-span point lookups are parallelized.
@@ -1316,200 +1501,218 @@ statement ok
 CREATE TABLE b (a INT, b INT, c INT NULL, d INT NULL, PRIMARY KEY (a, b), FAMILY (a, b, c, d))
 
 # No parallel line printed out for single-span selects.
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a = 10
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/10 - /10]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/10 - /10]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/10 - /10] [/20 - /20]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/10 - /10] [/20 - /20]
 
 # Verify that consolidated point spans are still parallelized.
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a in (10, 11)
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/10 - /11]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/10 - /11]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a > 10 AND a < 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/11 - /19]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/11 - /19]
 
 # This ticks all the boxes for parallelization apart from the fact that there
 # is no end key in the span.
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a > 10
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/11 - ]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/11 - ]
 
 # Test non-int types.
 
 # Point queries on non-int types are parallel.
-query TTT
+query T
 EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          a@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          a@item
-·           spans          [/'ball' - /'ball'] [/'sock' - /'sock']
+distribution: local
+vectorized: true
+·
+• index join
+│ table: a@primary
+│
+└── • scan
+      missing stats
+      table: a@item
+      spans: [/'ball' - /'ball'] [/'sock' - /'sock']
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
-query TTT
+query T
 EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND price < 40
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          a@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          a@p
-·           spans          [/5.000000000000001 - /9.999999999999998] [/20.000000000000004 - /39.99999999999999]
+distribution: local
+vectorized: true
+·
+• index join
+│ table: a@primary
+│
+└── • scan
+      missing stats
+      table: a@p
+      spans: [/5.000000000000001 - /9.999999999999998] [/20.000000000000004 - /39.99999999999999]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@primary
-·     spans          [/10/10 - /10/10] [/20/20 - /20/20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@primary
+  spans: [/10/10 - /10/10] [/20/20 - /20/20]
 
 # This one isn't parallelizable because it's not a point lookup - only part of
 # the primary key is specified.
-query TTT
+query T
 EXPLAIN SELECT * FROM b WHERE a = 10 OR a = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@primary
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@primary
+  spans: [/10 - /10] [/20 - /20]
 
 # This one isn't parallelizable because it has a LIMIT clause.
-query TTT
+query T
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20 LIMIT 1
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          a@primary
-·     spans          [/10 - /10] [/20 - /20]
-·     limit          1
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: a@primary
+  spans: [/10 - /10] [/20 - /20]
+  limit: 1
 
 statement ok
 CREATE INDEX on b(b) STORING (c)
 
 # This one isn't parallelizable because its index isn't unique.
-query TTT
+query T
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_b_idx
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_b_idx
+  spans: [/10 - /10] [/20 - /20]
 
 statement ok
 CREATE UNIQUE INDEX on b(c)
 
 # If the index has nullable values, parallelize only when the spans do not
 # specify any nulls.
-query TTT
+query T
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_c_key
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_c_key
+  spans: [/10 - /10] [/20 - /20]
 
-query TTT
+query T
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c < 2
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_c_key
-·     spans          (/NULL - /1] [/10 - /10]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_c_key
+  spans: (/NULL - /1] [/10 - /10]
 
 statement ok
 CREATE UNIQUE INDEX on b(d DESC)
 
 # This scan is not parallelizable because the second span has a null in its end
 # key.
-query TTT
+query T
 EXPLAIN SELECT d FROM b WHERE d = 10 OR d < 2
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_d_key
-·     spans          [/10 - /10] [/1 - /NULL)
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_d_key
+  spans: [/10 - /10] [/1 - /NULL)
 
 statement ok
 CREATE UNIQUE INDEX ON b(c, d)
 
 # This scan is not parallelizable because although the second column is
 # constrained, the first column is null.
-query TTT
+query T
 EXPLAIN SELECT d FROM b WHERE c = 10 AND d = 10 OR c IS NULL AND d > 0 AND d < 2
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_c_d_key
-·     spans          [/NULL/1 - /NULL/1] [/10/10 - /10/10]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_c_d_key
+  spans: [/NULL/1 - /NULL/1] [/10/10 - /10/10]
 
 statement ok
 DROP INDEX b_b_idx
@@ -1518,15 +1721,16 @@ statement ok
 CREATE UNIQUE INDEX on b(b) STORING (c)
 
 # This one is parallelizable because its index is unique and non-null.
-query TTT
+query T
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          b@b_b_key
-·     spans          [/10 - /10] [/20 - /20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: b@b_b_key
+  spans: [/10 - /10] [/20 - /20]
 
 statement ok
 ALTER TABLE a SPLIT AT VALUES(5)
@@ -1560,23 +1764,29 @@ statement ok
 CREATE TABLE e (x INT PRIMARY KEY, y INT, z STRING);
 CREATE TABLE s (x INT PRIMARY KEY, y INT, z INT)
 
-query TTT
+query T
 EXPLAIN SELECT e.z, s.z, n FROM e, s, generate_series(0, s.z, 1000) as n WHERE e.y = s.y ORDER BY s.z LIMIT 10
 ----
-·                         distribution   local
-·                         vectorized     true
-limit                     ·              ·
- │                        count          10
- └── sort                 ·              ·
-      │                   order          +z
-      └── project set     ·              ·
-           └── hash join  ·              ·
-                │         equality       (y) = (y)
-                ├── scan  ·              ·
-                │         missing stats  ·
-                │         table          e@primary
-                │         spans          FULL SCAN
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          s@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 10
+│
+└── • sort
+    │ order: +z
+    │
+    └── • project set
+        │
+        └── • hash join
+            │ equality: (y) = (y)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: e@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  missing stats
+                  table: s@primary
+                  spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -13,271 +13,319 @@ CREATE VIEW v AS SELECT a FROM t AS t2
 # Basic tests.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for no key update     ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for share             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for key share         ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for key share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for share             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for no key update     ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-render     ·                    ·                     ("?column?")  ·
- │         estimated row count  1000 (missing stats)  ·             ·
- │         render 0             1                     ·             ·
- └── scan  ·                    ·                     ()            ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                t@primary             ·             ·
-·          spans                FULL SCAN             ·             ·
-·          locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1000 (missing stats)
+│ render 0: 1
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
+      locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for no key update  ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for no key update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for share          ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for key share      ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for key share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for share          ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for no key update  ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for no key update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·          distribution         local              ·             ·
-·          vectorized           true               ·             ·
-render     ·                    ·                  ("?column?")  ·
- │         estimated row count  1 (missing stats)  ·             ·
- │         render 0             1                  ·             ·
- └── scan  ·                    ·                  (a)           ·
-·          estimated row count  1 (missing stats)  ·             ·
-·          table                t@primary          ·             ·
-·          spans                /1-/1/#            ·             ·
-·          locking strength     for update         ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1 (missing stats)
+│ render 0: 1
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1 (missing stats)
+      table: t@primary
+      spans: /1-/1/#
+      locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with table aliases.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 FOR UPDATE OF t2
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with numeric table references.
 # Cockroach numeric references start after 53 for user tables.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE OF t
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE OF t2
@@ -286,27 +334,31 @@ EXPLAIN (VERBOSE) SELECT * FROM [53 AS t] FOR UPDATE OF t2
 # Tests with views.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "v2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF v2
@@ -321,30 +373,34 @@ EXPLAIN (VERBOSE) SELECT * FROM v FOR UPDATE OF t2
 # Tests with aliased views.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "v" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM v AS v2 FOR UPDATE OF v2
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -354,311 +410,413 @@ scan  ·                    ·                     (a)  ·
 # the filter.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for no key update     ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for no key update     ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·     distribution         local                 ·    ·
-·     vectorized           true                  ·    ·
-scan  ·                    ·                     (a)  ·
-·     estimated row count  1000 (missing stats)  ·    ·
-·     table                t@primary             ·    ·
-·     spans                FULL SCAN             ·    ·
-·     locking strength     for update            ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE
 ----
-·                    distribution         local                 ·    ·
-·                    vectorized           false                 ·    ·
-root                 ·                    ·                     (a)  ·
- ├── values          ·                    ·                     (a)  ·
- │                   size                 1 column, 1 row       ·    ·
- │                   row 0, expr 0        @S1                   ·    ·
- └── subquery        ·                    ·                     ·    ·
-      │              id                   @S1                   ·    ·
-      │              original sql         (SELECT a FROM t)     ·    ·
-      │              exec mode            one row               ·    ·
-      └── max1row    ·                    ·                     (a)  ·
-           │         estimated row count  1                     ·    ·
-           └── scan  ·                    ·                     (a)  ·
-·                    estimated row count  1000 (missing stats)  ·    ·
-·                    table                t@primary             ·    ·
-·                    spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • values
+│     columns: (a)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE)
 ----
-·                    distribution         local                         ·    ·
-·                    vectorized           false                         ·    ·
-root                 ·                    ·                             (a)  ·
- ├── values          ·                    ·                             (a)  ·
- │                   size                 1 column, 1 row               ·    ·
- │                   row 0, expr 0        @S1                           ·    ·
- └── subquery        ·                    ·                             ·    ·
-      │              id                   @S1                           ·    ·
-      │              original sql         (SELECT a FROM t FOR UPDATE)  ·    ·
-      │              exec mode            one row                       ·    ·
-      └── max1row    ·                    ·                             (a)  ·
-           │         estimated row count  1                             ·    ·
-           └── scan  ·                    ·                             (a)  ·
-·                    estimated row count  1000 (missing stats)          ·    ·
-·                    table                t@primary                     ·    ·
-·                    spans                FULL SCAN                     ·    ·
-·                    locking strength     for update                    ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • values
+│     columns: (a)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t FOR UPDATE)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE OF t
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t)
 ----
-·                    distribution         local                              ·    ·
-·                    vectorized           false                              ·    ·
-root                 ·                    ·                                  (a)  ·
- ├── values          ·                    ·                                  (a)  ·
- │                   size                 1 column, 1 row                    ·    ·
- │                   row 0, expr 0        @S1                                ·    ·
- └── subquery        ·                    ·                                  ·    ·
-      │              id                   @S1                                ·    ·
-      │              original sql         (SELECT a FROM t FOR UPDATE OF t)  ·    ·
-      │              exec mode            one row                            ·    ·
-      └── max1row    ·                    ·                                  (a)  ·
-           │         estimated row count  1                                  ·    ·
-           └── scan  ·                    ·                                  (a)  ·
-·                    estimated row count  1000 (missing stats)               ·    ·
-·                    table                t@primary                          ·    ·
-·                    spans                FULL SCAN                          ·    ·
-·                    locking strength     for update                         ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • values
+│     columns: (a)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t FOR UPDATE OF t)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE
 ----
-·                    distribution         local                 ·    ·
-·                    vectorized           false                 ·    ·
-root                 ·                    ·                     (r)  ·
- ├── values          ·                    ·                     (r)  ·
- │                   size                 1 column, 1 row       ·    ·
- │                   row 0, expr 0        @S1                   ·    ·
- └── subquery        ·                    ·                     ·    ·
-      │              id                   @S1                   ·    ·
-      │              original sql         (SELECT a FROM t)     ·    ·
-      │              exec mode            one row               ·    ·
-      └── max1row    ·                    ·                     (a)  ·
-           │         estimated row count  1                     ·    ·
-           └── scan  ·                    ·                     (a)  ·
-·                    estimated row count  1000 (missing stats)  ·    ·
-·                    table                t@primary             ·    ·
-·                    spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (r)
+│
+├── • values
+│     columns: (r)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE) AS r
 ----
-·                    distribution         local                         ·    ·
-·                    vectorized           false                         ·    ·
-root                 ·                    ·                             (r)  ·
- ├── values          ·                    ·                             (r)  ·
- │                   size                 1 column, 1 row               ·    ·
- │                   row 0, expr 0        @S1                           ·    ·
- └── subquery        ·                    ·                             ·    ·
-      │              id                   @S1                           ·    ·
-      │              original sql         (SELECT a FROM t FOR UPDATE)  ·    ·
-      │              exec mode            one row                       ·    ·
-      └── max1row    ·                    ·                             (a)  ·
-           │         estimated row count  1                             ·    ·
-           └── scan  ·                    ·                             (a)  ·
-·                    estimated row count  1000 (missing stats)          ·    ·
-·                    table                t@primary                     ·    ·
-·                    spans                FULL SCAN                     ·    ·
-·                    locking strength     for update                    ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (r)
+│
+├── • values
+│     columns: (r)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t FOR UPDATE)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·                    distribution         local                              ·    ·
-·                    vectorized           false                              ·    ·
-root                 ·                    ·                                  (r)  ·
- ├── values          ·                    ·                                  (r)  ·
- │                   size                 1 column, 1 row                    ·    ·
- │                   row 0, expr 0        @S1                                ·    ·
- └── subquery        ·                    ·                                  ·    ·
-      │              id                   @S1                                ·    ·
-      │              original sql         (SELECT a FROM t FOR UPDATE OF t)  ·    ·
-      │              exec mode            one row                            ·    ·
-      └── max1row    ·                    ·                                  (a)  ·
-           │         estimated row count  1                                  ·    ·
-           └── scan  ·                    ·                                  (a)  ·
-·                    estimated row count  1000 (missing stats)               ·    ·
-·                    table                t@primary                          ·    ·
-·                    spans                FULL SCAN                          ·    ·
-·                    locking strength     for update                         ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (r)
+│
+├── • values
+│     columns: (r)
+│     size: 1 column, 1 row
+│     row 0, expr 0: @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM t FOR UPDATE OF t)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (a)
+        │ estimated row count: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ----
-·                         distribution           local                 ·          ·
-·                         vectorized             true                  ·          ·
-project                   ·                      ·                     (a, b)     ·
- │                        estimated row count    100 (missing stats)   ·          ·
- └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
-      │                   estimated row count    99 (missing stats)    ·          ·
-      │                   table                  t@primary             ·          ·
-      │                   equality               (b) = (a)             ·          ·
-      │                   equality cols are key  ·                     ·          ·
-      └── distinct        ·                      ·                     (b)        ·
-           │              estimated row count    100 (missing stats)   ·          ·
-           │              distinct on            b                     ·          ·
-           └── scan       ·                      ·                     (b)        ·
-·                         estimated row count    1000 (missing stats)  ·          ·
-·                         table                  t@primary             ·          ·
-·                         spans                  FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ estimated row count: 100 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (b, a, b)
+    │ estimated row count: 99 (missing stats)
+    │ table: t@primary
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ columns: (b)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: b
+        │
+        └── • scan
+              columns: (b)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
 ----
-·                         distribution           local                 ·          ·
-·                         vectorized             true                  ·          ·
-project                   ·                      ·                     (a, b)     ·
- │                        estimated row count    100 (missing stats)   ·          ·
- └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
-      │                   estimated row count    99 (missing stats)    ·          ·
-      │                   table                  t@primary             ·          ·
-      │                   equality               (b) = (a)             ·          ·
-      │                   equality cols are key  ·                     ·          ·
-      └── distinct        ·                      ·                     (b)        ·
-           │              estimated row count    100 (missing stats)   ·          ·
-           │              distinct on            b                     ·          ·
-           └── scan       ·                      ·                     (b)        ·
-·                         estimated row count    1000 (missing stats)  ·          ·
-·                         table                  t@primary             ·          ·
-·                         spans                  FULL SCAN             ·          ·
-·                         locking strength       for update            ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ estimated row count: 100 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (b, a, b)
+    │ estimated row count: 99 (missing stats)
+    │ table: t@primary
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ columns: (b)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: b
+        │
+        └── • scan
+              columns: (b)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
 ----
-·                         distribution           local                 ·          ·
-·                         vectorized             true                  ·          ·
-project                   ·                      ·                     (a, b)     ·
- │                        estimated row count    100 (missing stats)   ·          ·
- └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
-      │                   estimated row count    99 (missing stats)    ·          ·
-      │                   table                  t@primary             ·          ·
-      │                   equality               (b) = (a)             ·          ·
-      │                   equality cols are key  ·                     ·          ·
-      └── distinct        ·                      ·                     (b)        ·
-           │              estimated row count    100 (missing stats)   ·          ·
-           │              distinct on            b                     ·          ·
-           └── scan       ·                      ·                     (b)        ·
-·                         estimated row count    1000 (missing stats)  ·          ·
-·                         table                  t@primary             ·          ·
-·                         spans                  FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ estimated row count: 100 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (b, a, b)
+    │ estimated row count: 99 (missing stats)
+    │ table: t@primary
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ columns: (b)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: b
+        │
+        └── • scan
+              columns: (b)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
 ----
-·                         distribution           local                 ·          ·
-·                         vectorized             true                  ·          ·
-project                   ·                      ·                     (a, b)     ·
- │                        estimated row count    100 (missing stats)   ·          ·
- └── lookup join (inner)  ·                      ·                     (b, a, b)  ·
-      │                   estimated row count    99 (missing stats)    ·          ·
-      │                   table                  t@primary             ·          ·
-      │                   equality               (b) = (a)             ·          ·
-      │                   equality cols are key  ·                     ·          ·
-      └── distinct        ·                      ·                     (b)        ·
-           │              estimated row count    100 (missing stats)   ·          ·
-           │              distinct on            b                     ·          ·
-           └── scan       ·                      ·                     (b)        ·
-·                         estimated row count    1000 (missing stats)  ·          ·
-·                         table                  t@primary             ·          ·
-·                         spans                  FULL SCAN             ·          ·
-·                         locking strength       for update            ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│ estimated row count: 100 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (b, a, b)
+    │ estimated row count: 99 (missing stats)
+    │ table: t@primary
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ columns: (b)
+        │ estimated row count: 100 (missing stats)
+        │ distinct on: b
+        │
+        └── • scan
+              columns: (b)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
@@ -671,347 +829,482 @@ project                   ·                      ·                     (a, b) 
 # contain locking clauses are not inlined.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [SELECT a FROM t] FOR UPDATE
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (a)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a                     ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (a)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a                     ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                t@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
-·                    distribution         local                       ·    ·
-·                    vectorized           false                       ·    ·
-root                 ·                    ·                           (a)  ·
- ├── scan buffer     ·                    ·                           (a)  ·
- │                   estimated row count  1000 (missing stats)        ·    ·
- │                   label                buffer 1                    ·    ·
- └── subquery        ·                    ·                           ·    ·
-      │              id                   @S1                         ·    ·
-      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
-      │              exec mode            all rows                    ·    ·
-      └── buffer     ·                    ·                           (a)  ·
-           │         label                buffer 1                    ·    ·
-           └── scan  ·                    ·                           (a)  ·
-·                    estimated row count  1000 (missing stats)        ·    ·
-·                    table                t@primary                   ·    ·
-·                    spans                FULL SCAN                   ·    ·
-·                    locking strength     for update                  ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • scan buffer
+│     columns: (a)
+│     estimated row count: 1000 (missing stats)
+│     label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: SELECT a FROM t FOR UPDATE
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
-·                    distribution         local                       ·    ·
-·                    vectorized           false                       ·    ·
-root                 ·                    ·                           (a)  ·
- ├── scan buffer     ·                    ·                           (a)  ·
- │                   estimated row count  1000 (missing stats)        ·    ·
- │                   label                buffer 1 (cte)              ·    ·
- └── subquery        ·                    ·                           ·    ·
-      │              id                   @S1                         ·    ·
-      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
-      │              exec mode            all rows                    ·    ·
-      └── buffer     ·                    ·                           (a)  ·
-           │         label                buffer 1 (cte)              ·    ·
-           └── scan  ·                    ·                           (a)  ·
-·                    estimated row count  1000 (missing stats)        ·    ·
-·                    table                t@primary                   ·    ·
-·                    spans                FULL SCAN                   ·    ·
-·                    locking strength     for update                  ·    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • scan buffer
+│     columns: (a)
+│     estimated row count: 1000 (missing stats)
+│     label: buffer 1 (cte)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: SELECT a FROM t FOR UPDATE
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1 (cte)
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 # Verify that the unused CTE doesn't get eliminated.
 # TODO(radu): we should at least not buffer the rows in this case.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) WITH sfu AS (SELECT a FROM t FOR UPDATE)
 SELECT c FROM u
 ----
-·                    distribution         local                       ·    ·
-·                    vectorized           true                        ·    ·
-root                 ·                    ·                           (c)  ·
- ├── scan            ·                    ·                           (c)  ·
- │                   estimated row count  1000 (missing stats)        ·    ·
- │                   table                u@primary                   ·    ·
- │                   spans                FULL SCAN                   ·    ·
- └── subquery        ·                    ·                           ·    ·
-      │              id                   @S1                         ·    ·
-      │              original sql         SELECT a FROM t FOR UPDATE  ·    ·
-      │              exec mode            all rows                    ·    ·
-      └── buffer     ·                    ·                           (a)  ·
-           │         label                buffer 1 (sfu)              ·    ·
-           └── scan  ·                    ·                           (a)  ·
-·                    estimated row count  1000 (missing stats)        ·    ·
-·                    table                t@primary                   ·    ·
-·                    spans                FULL SCAN                   ·    ·
-·                    locking strength     for update                  ·    ·
+distribution: local
+vectorized: true
+·
+• root
+│ columns: (c)
+│
+├── • scan
+│     columns: (c)
+│     estimated row count: 1000 (missing stats)
+│     table: u@primary
+│     spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: SELECT a FROM t FOR UPDATE
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1 (sfu)
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with joins.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for share             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for share
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for share             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for no key update     ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for key share         ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for no key update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for key share
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for no key update     ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for no key update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
@@ -1022,103 +1315,143 @@ EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 # Postgres doesn't support applying locking clauses to joins. The following
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
 # We could do the same, but it's not hard to support these, so we do.
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
@@ -1129,353 +1462,433 @@ EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u
 query error pgcode 42P01 relation "u2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ----
-·                        distribution         local                 ·             ·
-·                        vectorized           true                  ·             ·
-project                  ·                    ·                     (a, b, c)     ·
- │                       estimated row count  1000 (missing stats)  ·             ·
- └── merge join (inner)  ·                    ·                     (a, b, a, c)  ·
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  equality             (a) = (a)             ·             ·
-      │                  left cols are key    ·                     ·             ·
-      │                  right cols are key   ·                     ·             ·
-      │                  merge ordering       +"(a=a)"              ·             ·
-      ├── scan           ·                    ·                     (a, b)        +a
-      │                  estimated row count  1000 (missing stats)  ·             ·
-      │                  table                t@primary             ·             ·
-      │                  spans                FULL SCAN             ·             ·
-      │                  locking strength     for update            ·             ·
-      └── scan           ·                    ·                     (a, c)        +a
-·                        estimated row count  1000 (missing stats)  ·             ·
-·                        table                u@primary             ·             ·
-·                        spans                FULL SCAN             ·             ·
-·                        locking strength     for update            ·             ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1000 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1000 (missing stats)
+    │ equality: (a) = (a)
+    │ left cols are key
+    │ right cols are key
+    │ merge ordering: +"(a=a)"
+    │
+    ├── • scan
+    │     columns: (a, b)
+    │     ordering: +a
+    │     estimated row count: 1000 (missing stats)
+    │     table: t@primary
+    │     spans: FULL SCAN
+    │     locking strength: for update
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: u@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE
 ----
-·                   distribution         local                    ·             ·
-·                   vectorized           true                     ·             ·
-cross join (inner)  ·                    ·                        (a, b, a, c)  ·
- │                  estimated row count  1000000 (missing stats)  ·             ·
- ├── scan           ·                    ·                        (a, b)        ·
- │                  estimated row count  1000 (missing stats)     ·             ·
- │                  table                t@primary                ·             ·
- │                  spans                FULL SCAN                ·             ·
- │                  locking strength     for update               ·             ·
- └── scan           ·                    ·                        (a, c)        ·
-·                   estimated row count  1000 (missing stats)     ·             ·
-·                   table                u@primary                ·             ·
-·                   spans                FULL SCAN                ·             ·
-·                   locking strength     for update               ·             ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, a, c)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1000 (missing stats)
+│     table: t@primary
+│     spans: FULL SCAN
+│     locking strength: for update
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1000 (missing stats)
+      table: u@primary
+      spans: FULL SCAN
+      locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR UPDATE OF t
 ----
-·                   distribution         local                    ·             ·
-·                   vectorized           true                     ·             ·
-cross join (inner)  ·                    ·                        (a, b, a, c)  ·
- │                  estimated row count  1000000 (missing stats)  ·             ·
- ├── scan           ·                    ·                        (a, b)        ·
- │                  estimated row count  1000 (missing stats)     ·             ·
- │                  table                t@primary                ·             ·
- │                  spans                FULL SCAN                ·             ·
- │                  locking strength     for update               ·             ·
- └── scan           ·                    ·                        (a, c)        ·
-·                   estimated row count  1000 (missing stats)     ·             ·
-·                   table                u@primary                ·             ·
-·                   spans                FULL SCAN                ·             ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, a, c)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1000 (missing stats)
+│     table: t@primary
+│     spans: FULL SCAN
+│     locking strength: for update
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1000 (missing stats)
+      table: u@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
-·                   distribution         local                    ·             ·
-·                   vectorized           true                     ·             ·
-cross join (inner)  ·                    ·                        (a, b, a, c)  ·
- │                  estimated row count  1000000 (missing stats)  ·             ·
- ├── scan           ·                    ·                        (a, b)        ·
- │                  estimated row count  1000 (missing stats)     ·             ·
- │                  table                t@primary                ·             ·
- │                  spans                FULL SCAN                ·             ·
- │                  locking strength     for share                ·             ·
- └── scan           ·                    ·                        (a, c)        ·
-·                   estimated row count  1000 (missing stats)     ·             ·
-·                   table                u@primary                ·             ·
-·                   spans                FULL SCAN                ·             ·
-·                   locking strength     for update               ·             ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, a, c)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1000 (missing stats)
+│     table: t@primary
+│     spans: FULL SCAN
+│     locking strength: for share
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1000 (missing stats)
+      table: u@primary
+      spans: FULL SCAN
+      locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
-·                   distribution         local                    ·             ·
-·                   vectorized           true                     ·             ·
-cross join (inner)  ·                    ·                        (a, b, a, c)  ·
- │                  estimated row count  1000000 (missing stats)  ·             ·
- ├── scan           ·                    ·                        (a, b)        ·
- │                  estimated row count  1000 (missing stats)     ·             ·
- │                  table                t@primary                ·             ·
- │                  spans                FULL SCAN                ·             ·
- │                  locking strength     for update               ·             ·
- └── scan           ·                    ·                        (a, c)        ·
-·                   estimated row count  1000 (missing stats)     ·             ·
-·                   table                u@primary                ·             ·
-·                   spans                FULL SCAN                ·             ·
-·                   locking strength     for update               ·             ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, a, c)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1000 (missing stats)
+│     table: t@primary
+│     spans: FULL SCAN
+│     locking strength: for update
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1000 (missing stats)
+      table: u@primary
+      spans: FULL SCAN
+      locking strength: for update
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
-·                   distribution         local                    ·             ·
-·                   vectorized           true                     ·             ·
-cross join (inner)  ·                    ·                        (a, b, a, c)  ·
- │                  estimated row count  1000000 (missing stats)  ·             ·
- ├── scan           ·                    ·                        (a, b)        ·
- │                  estimated row count  1000 (missing stats)     ·             ·
- │                  table                t@primary                ·             ·
- │                  spans                FULL SCAN                ·             ·
- └── scan           ·                    ·                        (a, c)        ·
-·                   estimated row count  1000 (missing stats)     ·             ·
-·                   table                u@primary                ·             ·
-·                   spans                FULL SCAN                ·             ·
-·                   locking strength     for update               ·             ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, a, c)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: (a, b)
+│     estimated row count: 1000 (missing stats)
+│     table: t@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1000 (missing stats)
+      table: u@primary
+      spans: FULL SCAN
+      locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.
 # ------------------------------------------------------------------------------
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for no key update     ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for share             ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for key share         ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for key share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for share             ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for no key update     ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t NOWAIT
 ----
-·     distribution         local                 ·       ·
-·     vectorized           true                  ·       ·
-scan  ·                    ·                     (a, b)  ·
-·     estimated row count  1000 (missing stats)  ·       ·
-·     table                t@primary             ·       ·
-·     spans                FULL SCAN             ·       ·
-·     locking strength     for update            ·       ·
-·     locking wait policy  nowait                ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1000 (missing stats)
+  table: t@primary
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: nowait
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 NOWAIT
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t NOWAIT
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-render     ·                    ·                     ("?column?")  ·
- │         estimated row count  1000 (missing stats)  ·             ·
- │         render 0             1                     ·             ·
- └── scan  ·                    ·                     ()            ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                t@primary             ·             ·
-·          spans                FULL SCAN             ·             ·
-·          locking strength     for update            ·             ·
-·          locking wait policy  nowait                ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1000 (missing stats)
+│ render 0: 1
+│
+└── • scan
+      columns: ()
+      estimated row count: 1000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
+      locking strength: for update
+      locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for no key update  ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for no key update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for share          ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for key share      ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for key share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for share          ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for share
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for no key update  ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for no key update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
+  locking wait policy: nowait
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (a, b)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                t@primary          ·       ·
-·     spans                /1-/1/#            ·       ·
-·     locking strength     for update         ·       ·
-·     locking wait policy  nowait             ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@primary
+  spans: /1-/1/#
+  locking strength: for update
+  locking wait policy: nowait
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
 ----
-·          distribution         local              ·             ·
-·          vectorized           true               ·             ·
-render     ·                    ·                  ("?column?")  ·
- │         estimated row count  1 (missing stats)  ·             ·
- │         render 0             1                  ·             ·
- └── scan  ·                    ·                  (a)           ·
-·          estimated row count  1 (missing stats)  ·             ·
-·          table                t@primary          ·             ·
-·          spans                /1-/1/#            ·             ·
-·          locking strength     for update         ·             ·
-·          locking wait policy  nowait             ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1 (missing stats)
+│ render 0: 1
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1 (missing stats)
+      table: t@primary
+      spans: /1-/1/#
+      locking strength: for update
+      locking wait policy: nowait

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -192,33 +192,45 @@ output row: [3]
 output row: [2]
 
 # Index selection occurs in direct join operands too.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t x JOIN t y USING(b) WHERE x.b = '3'
 ----
-·                        distribution         local                ·                         ·
-·                        vectorized           true                 ·                         ·
-project                  ·                    ·                    (b, a, c, d, a, c, d)     ·
- │                       estimated row count  100 (missing stats)  ·                         ·
- └── merge join (inner)  ·                    ·                    (a, b, c, d, a, b, c, d)  ·
-      │                  estimated row count  100 (missing stats)  ·                         ·
-      │                  equality             (b) = (b)            ·                         ·
-      │                  merge ordering       +"(b=b)"             ·                         ·
-      ├── index join     ·                    ·                    (a, b, c, d)              ·
-      │    │             estimated row count  10 (missing stats)   ·                         ·
-      │    │             table                t@primary            ·                         ·
-      │    │             key columns          a, b                 ·                         ·
-      │    └── scan      ·                    ·                    (a, b, c)                 ·
-      │                  estimated row count  10 (missing stats)   ·                         ·
-      │                  table                t@bc                 ·                         ·
-      │                  spans                /"3"-/"3"/PrefixEnd  ·                         ·
-      └── index join     ·                    ·                    (a, b, c, d)              ·
-           │             estimated row count  10 (missing stats)   ·                         ·
-           │             table                t@primary            ·                         ·
-           │             key columns          a, b                 ·                         ·
-           └── scan      ·                    ·                    (a, b, c)                 ·
-·                        estimated row count  10 (missing stats)   ·                         ·
-·                        table                t@bc                 ·                         ·
-·                        spans                /"3"-/"3"/PrefixEnd  ·                         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b, a, c, d, a, c, d)
+│ estimated row count: 100 (missing stats)
+│
+└── • merge join (inner)
+    │ columns: (a, b, c, d, a, b, c, d)
+    │ estimated row count: 100 (missing stats)
+    │ equality: (b) = (b)
+    │ merge ordering: +"(b=b)"
+    │
+    ├── • index join
+    │   │ columns: (a, b, c, d)
+    │   │ estimated row count: 10 (missing stats)
+    │   │ table: t@primary
+    │   │ key columns: a, b
+    │   │
+    │   └── • scan
+    │         columns: (a, b, c)
+    │         estimated row count: 10 (missing stats)
+    │         table: t@bc
+    │         spans: /"3"-/"3"/PrefixEnd
+    │
+    └── • index join
+        │ columns: (a, b, c, d)
+        │ estimated row count: 10 (missing stats)
+        │ table: t@primary
+        │ key columns: a, b
+        │
+        └── • scan
+              columns: (a, b, c)
+              estimated row count: 10 (missing stats)
+              table: t@bc
+              spans: /"3"-/"3"/PrefixEnd
 
 statement ok
 TRUNCATE TABLE t
@@ -260,12 +272,13 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b; SET tracing = off
@@ -428,26 +441,29 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
 ----
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
-query TTT
+query T
 EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
 ----
-·       distribution  local
-·       vectorized    true
-norows  ·             ·
+distribution: local
+vectorized: true
+·
+• norows
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -464,147 +480,201 @@ CREATE TABLE t (
   INDEX bc (b, c)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (a)     ·
- │              estimated row count  333 (missing stats)   ·       ·
- └── filter     ·                    ·                     (a, c)  ·
-      │         estimated row count  333 (missing stats)   ·       ·
-      │         filter               c > 1                 ·       ·
-      └── scan  ·                    ·                     (a, c)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                t@primary             ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│
+└── • filter
+    │ columns: (a, c)
+    │ estimated row count: 333 (missing stats)
+    │ filter: c > 1
+    │
+    └── • scan
+          columns: (a, c)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-·               distribution         local                ·          ·
-·               vectorized           true                 ·          ·
-project         ·                    ·                    (a)        ·
- │              estimated row count  311 (missing stats)  ·          ·
- └── filter     ·                    ·                    (a, b, c)  ·
-      │         estimated row count  311 (missing stats)  ·          ·
-      │         filter               c < 1                ·          ·
-      └── scan  ·                    ·                    (a, b, c)  ·
-·               estimated row count  333 (missing stats)  ·          ·
-·               table                t@bc                 ·          ·
-·               spans                /!NULL-/4/1          ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 311 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ estimated row count: 311 (missing stats)
+    │ filter: c < 1
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 333 (missing stats)
+          table: t@bc
+          spans: /!NULL-/4/1
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (a)     ·
- │              estimated row count  333 (missing stats)   ·       ·
- └── filter     ·                    ·                     (a, c)  ·
-      │         estimated row count  333 (missing stats)   ·       ·
-      │         filter               c > 1                 ·       ·
-      └── scan  ·                    ·                     (a, c)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                t@primary             ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│
+└── • filter
+    │ columns: (a, c)
+    │ estimated row count: 333 (missing stats)
+    │ filter: c > 1
+    │
+    └── • scan
+          columns: (a, c)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1.0
 ----
-·               distribution         local                 ·       ·
-·               vectorized           true                  ·       ·
-project         ·                    ·                     (a)     ·
- │              estimated row count  333 (missing stats)   ·       ·
- └── filter     ·                    ·                     (a, c)  ·
-      │         estimated row count  333 (missing stats)   ·       ·
-      │         filter               c < 1                 ·       ·
-      └── scan  ·                    ·                     (a, c)  ·
-·               estimated row count  1000 (missing stats)  ·       ·
-·               table                t@primary             ·       ·
-·               spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│
+└── • filter
+    │ columns: (a, c)
+    │ estimated row count: 333 (missing stats)
+    │ filter: c < 1
+    │
+    └── • scan
+          columns: (a, c)
+          estimated row count: 1000 (missing stats)
+          table: t@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-·               distribution         local                ·          ·
-·               vectorized           true                 ·          ·
-project         ·                    ·                    (a)        ·
- │              estimated row count  311 (missing stats)  ·          ·
- └── filter     ·                    ·                    (a, b, c)  ·
-      │         estimated row count  311 (missing stats)  ·          ·
-      │         filter               c > 1                ·          ·
-      └── scan  ·                    ·                    (a, b, c)  ·
-·               estimated row count  333 (missing stats)  ·          ·
-·               table                t@bc                 ·          ·
-·               spans                /!NULL-/5            ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 311 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ estimated row count: 311 (missing stats)
+    │ filter: c > 1
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 333 (missing stats)
+          table: t@bc
+          spans: /!NULL-/5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-·               distribution         local                ·          ·
-·               vectorized           true                 ·          ·
-project         ·                    ·                    (a)        ·
- │              estimated row count  311 (missing stats)  ·          ·
- └── filter     ·                    ·                    (a, b, c)  ·
-      │         estimated row count  311 (missing stats)  ·          ·
-      │         filter               c < 1                ·          ·
-      └── scan  ·                    ·                    (a, b, c)  ·
-·               estimated row count  333 (missing stats)  ·          ·
-·               table                t@bc                 ·          ·
-·               spans                /!NULL-/4/1          ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 311 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ estimated row count: 311 (missing stats)
+    │ filter: c < 1
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 333 (missing stats)
+          table: t@bc
+          spans: /!NULL-/4/1
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-·          distribution         local              ·          ·
-·          vectorized           true               ·          ·
-project    ·                    ·                  (a)        ·
- │         estimated row count  1 (missing stats)  ·          ·
- └── scan  ·                    ·                  (a, b, c)  ·
-·          estimated row count  1 (missing stats)  ·          ·
-·          table                t@bc               ·          ·
-·          spans                /5/1-/5/2          ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 1 (missing stats)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1 (missing stats)
+      table: t@bc
+      spans: /5/1-/5/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-·          distribution         local              ·          ·
-·          vectorized           true               ·          ·
-project    ·                    ·                  (a)        ·
- │         estimated row count  1 (missing stats)  ·          ·
- └── scan  ·                    ·                  (a, b, c)  ·
-·          estimated row count  1 (missing stats)  ·          ·
-·          table                t@bc               ·          ·
-·          spans                /5/1-/5/2          ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 1 (missing stats)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1 (missing stats)
+      table: t@bc
+      spans: /5/1-/5/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-·               distribution         local                  ·          ·
-·               vectorized           true                   ·          ·
-project         ·                    ·                      (a)        ·
- │              estimated row count  3 (missing stats)      ·          ·
- └── filter     ·                    ·                      (a, b, c)  ·
-      │         estimated row count  3 (missing stats)      ·          ·
-      │         filter               (b = 5.1) AND (c = 1)  ·          ·
-      └── scan  ·                    ·                      (a, b, c)  ·
-·               estimated row count  990 (missing stats)    ·          ·
-·               table                t@bc                   ·          ·
-·               spans                /!NULL-                ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 3 (missing stats)
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ estimated row count: 3 (missing stats)
+    │ filter: (b = 5.1) AND (c = 1)
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 990 (missing stats)
+          table: t@bc
+          spans: /!NULL-
 
 # Note the span is reversed because of #20203.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-·          distribution         local               ·       ·
-·          vectorized           true                ·       ·
-project    ·                    ·                   (a)     ·
- │         estimated row count  20 (missing stats)  ·       ·
- └── scan  ·                    ·                   (a, b)  ·
-·          estimated row count  20 (missing stats)  ·       ·
-·          table                t@b_desc            ·       ·
-·          spans                /5-/4 /1-/0         ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 20 (missing stats)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 20 (missing stats)
+      table: t@b_desc
+      spans: /5-/4 /1-/0
 
 statement ok
 CREATE TABLE abcd (
@@ -618,29 +688,37 @@ CREATE TABLE abcd (
 
 # Verify that we prefer the index where more columns are constrained, even if it
 # has more keys per row.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-·          distribution         local              ·       ·
-·          vectorized           true               ·       ·
-project    ·                    ·                  (b)     ·
- │         estimated row count  1 (missing stats)  ·       ·
- └── scan  ·                    ·                  (a, b)  ·
-·          estimated row count  1 (missing stats)  ·       ·
-·          table                abcd@abcd          ·       ·
-·          spans                /1/4-/1/5          ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│ estimated row count: 1 (missing stats)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1 (missing stats)
+      table: abcd@abcd
+      spans: /1/4-/1/5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-project    ·                    ·                     (b)     ·
- │         estimated row count  4 (missing stats)     ·       ·
- └── scan  ·                    ·                     (a, b)  ·
-·          estimated row count  4 (missing stats)     ·       ·
-·          table                abcd@abcd             ·       ·
-·          spans                /1/4-/1/5 /2/9-/2/10  ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│ estimated row count: 4 (missing stats)
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 4 (missing stats)
+      table: abcd@abcd
+      spans: /1/4-/1/5 /2/9-/2/10
 
 statement ok
 CREATE TABLE ab (
@@ -648,34 +726,42 @@ CREATE TABLE ab (
   i INT
 );
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT i, s FROM ab WHERE (i, s) < (1, 'c')
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (i, s)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               (i, s) < (1, 'c')     ·       ·
- └── scan  ·                    ·                     (s, i)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                ab@primary            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (i, s)
+│ estimated row count: 333 (missing stats)
+│ filter: (i, s) < (1, 'c')
+│
+└── • scan
+      columns: (s, i)
+      estimated row count: 1000 (missing stats)
+      table: ab@primary
+      spans: FULL SCAN
 
 statement ok
 CREATE INDEX baz ON ab (i, s)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-·          distribution         local                ·       ·
-·          vectorized           true                 ·       ·
-filter     ·                    ·                    (i, s)  ·
- │         estimated row count  333 (missing stats)  ·       ·
- │         filter               (i, s) < (1, 'c')    ·       ·
- └── scan  ·                    ·                    (s, i)  ·
-·          estimated row count  333 (missing stats)  ·       ·
-·          table                ab@baz               ·       ·
-·          spans                /!NULL-/1/"c"        ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (i, s)
+│ estimated row count: 333 (missing stats)
+│ filter: (i, s) < (1, 'c')
+│
+└── • scan
+      columns: (s, i)
+      estimated row count: 333 (missing stats)
+      table: ab@baz
+      spans: /!NULL-/1/"c"
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -689,27 +775,31 @@ abz  abz_c_b_key  false  1  c  DESC  false  false
 abz  abz_c_b_key  false  2  b  ASC   false  false
 abz  abz_c_b_key  false  3  a  ASC   false  true
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-·     distribution         local              ·    ·
-·     vectorized           true               ·    ·
-scan  ·                    ·                  (a)  ·
-·     estimated row count  1 (missing stats)  ·    ·
-·     table                abz@primary        ·    ·
-·     spans                LIMITED SCAN       ·    ·
-·     limit                1                  ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 1 (missing stats)
+  table: abz@primary
+  spans: LIMITED SCAN
+  limit: 1
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ----
-·     distribution         local              ·    ·
-·     vectorized           true               ·    ·
-scan  ·                    ·                  (c)  ·
-·     estimated row count  1 (missing stats)  ·    ·
-·     table                abz@abz_c_b_key    ·    ·
-·     spans                LIMITED SCAN       ·    ·
-·     limit                1                  ·    ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (c)
+  estimated row count: 1 (missing stats)
+  table: abz@abz_c_b_key
+  spans: LIMITED SCAN
+  limit: 1
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -720,20 +810,26 @@ CREATE TABLE tab0(
   b INT
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-·               distribution         local                                  ·          ·
-·               vectorized           true                                   ·          ·
-project         ·                    ·                                      (k)        ·
- │              estimated row count  333 (missing stats)                    ·          ·
- └── filter     ·                    ·                                      (k, a, b)  ·
-      │         estimated row count  333 (missing stats)                    ·          ·
-      │         filter               ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
-      └── scan  ·                    ·                                      (k, a, b)  ·
-·               estimated row count  1000 (missing stats)                   ·          ·
-·               table                tab0@primary                           ·          ·
-·               spans                FULL SCAN                              ·          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k)
+│ estimated row count: 333 (missing stats)
+│
+└── • filter
+    │ columns: (k, a, b)
+    │ estimated row count: 333 (missing stats)
+    │ filter: ((a IN (6,)) AND (a > 6)) OR (b >= 4)
+    │
+    └── • scan
+          columns: (k, a, b)
+          estimated row count: 1000 (missing stats)
+          table: tab0@primary
+          spans: FULL SCAN
 
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
 # The test is composed of three parts: populate a table, check
@@ -750,20 +846,26 @@ INSERT INTO test2(k)
 # Plan check:
 # The query is using an index-join and the limit is propagated to the scan.
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
-·             distribution         local                    ·           ·
-·             vectorized           true                     ·           ·
-index join    ·                    ·                        (id, k, v)  -k
- │            estimated row count  20 (missing stats)       ·           ·
- │            table                test2@primary            ·           ·
- │            key columns          id                       ·           ·
- └── revscan  ·                    ·                        (id, k)     -k
-·             estimated row count  20 (missing stats)       ·           ·
-·             table                test2@test2_k_key        ·           ·
-·             spans                /!NULL-/"100"/PrefixEnd  ·           ·
-·             limit                20                       ·           ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (id, k, v)
+│ ordering: -k
+│ estimated row count: 20 (missing stats)
+│ table: test2@primary
+│ key columns: id
+│
+└── • revscan
+      columns: (id, k)
+      ordering: -k
+      estimated row count: 20 (missing stats)
+      table: test2@test2_k_key
+      spans: /!NULL-/"100"/PrefixEnd
+      limit: 20
 
 # The result output of this test requires that vectorized execution
 # is not used, so it has been moved to select_index_vectorize_off.
@@ -798,7 +900,7 @@ INSERT INTO favorites (customerid, guid_id, resource_type, device_group, jurisdi
          (5, '5', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts3'),
          (6, '6', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts4')
 
-query TTT
+query T
 EXPLAIN SELECT
   resource_key,
   count(resource_key) total
@@ -812,16 +914,19 @@ AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
 GROUP BY resource_key
 ORDER BY total DESC
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          -count_rows
- └── group      ·              ·
-      │         group by       resource_key
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          favorites@favorites_glob_fav_idx
-·               spans          [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts'] [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts2' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts2'] [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts3' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts3']
+distribution: local
+vectorized: true
+·
+• sort
+│ order: -count_rows
+│
+└── • group
+    │ group by: resource_key
+    │
+    └── • scan
+          missing stats
+          table: favorites@favorites_glob_fav_idx
+          spans: [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts'] [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts2' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts2'] [/'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts3' - /'GAME'/'web'/'MT'/'xxx'/'en_GB'/'ts3']
 
 query TI rowsort
 SELECT
@@ -842,82 +947,102 @@ ts2 1
 ts3 1
 
 # Regression tests for #20362 (IS NULL handling).
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
 ----
-·     distribution         local              ·             ·
-·     vectorized           true               ·             ·
-scan  ·                    ·                  (a, b, c, d)  ·
-·     estimated row count  9 (missing stats)  ·             ·
-·     table                abcd@abcd          ·             ·
-·     spans                /NULL/6-/!NULL     ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c, d)
+  estimated row count: 9 (missing stats)
+  table: abcd@abcd
+  spans: /NULL/6-/!NULL
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
 ----
-·     distribution         local                ·             ·
-·     vectorized           true                 ·             ·
-scan  ·                    ·                    (a, b, c, d)  ·
-·     estimated row count  9 (missing stats)    ·             ·
-·     table                abcd@abcd            ·             ·
-·     spans                /NULL/!NULL-/NULL/5  ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c, d)
+  estimated row count: 9 (missing stats)
+  table: abcd@abcd
+  spans: /NULL/!NULL-/NULL/5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
 ----
-·     distribution         local               ·             ·
-·     vectorized           true                ·             ·
-scan  ·                    ·                   (a, b, c, d)  +b
-·     estimated row count  10 (missing stats)  ·             ·
-·     table                abcd@abcd           ·             ·
-·     spans                /NULL-/!NULL        ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c, d)
+  ordering: +b
+  estimated row count: 10 (missing stats)
+  table: abcd@abcd
+  spans: /NULL-/!NULL
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
-·     distribution         local                 ·             ·
-·     vectorized           true                  ·             ·
-scan  ·                    ·                     (a, b, c, d)  +c
-·     estimated row count  1 (missing stats)     ·             ·
-·     table                abcd@abcd             ·             ·
-·     spans                /1/NULL/1-/1/NULL/10  ·             ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b, c, d)
+  ordering: +c
+  estimated row count: 1 (missing stats)
+  table: abcd@abcd
+  spans: /1/NULL/1-/1/NULL/10
 
 # Regression test for #3548: verify we create constraints on implicit columns
 # when they are part of the key (non-unique index).
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT c FROM abc WHERE c = 1 and a = 3
 ----
-·          distribution         local              ·       ·
-·          vectorized           true               ·       ·
-project    ·                    ·                  (c)     ·
- │         estimated row count  1 (missing stats)  ·       ·
- └── scan  ·                    ·                  (a, c)  ·
-·          estimated row count  1 (missing stats)  ·       ·
-·          table                abc@abc_c_idx      ·       ·
-·          spans                /1/3-/1/4          ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (c)
+│ estimated row count: 1 (missing stats)
+│
+└── • scan
+      columns: (a, c)
+      estimated row count: 1 (missing stats)
+      table: abc@abc_c_idx
+      spans: /1/3-/1/4
 
 # Verify we don't create constraints on implicit columns when they may be part
 # of the key (unique index on nullable column).
 statement ok
 CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·               distribution         local              ·       ·
-·               vectorized           true               ·       ·
-project         ·                    ·                  (f)     ·
- │              estimated row count  1 (missing stats)  ·       ·
- └── filter     ·                    ·                  (d, f)  ·
-      │         estimated row count  1 (missing stats)  ·       ·
-      │         filter               d = 3              ·       ·
-      └── scan  ·                    ·                  (d, f)  ·
-·               estimated row count  1 (missing stats)  ·       ·
-·               table                def@def_f_key      ·       ·
-·               spans                /1-/2              ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (f)
+│ estimated row count: 1 (missing stats)
+│
+└── • filter
+    │ columns: (d, f)
+    │ estimated row count: 1 (missing stats)
+    │ filter: d = 3
+    │
+    └── • scan
+          columns: (d, f)
+          estimated row count: 1 (missing stats)
+          table: def@def_f_key
+          spans: /1-/2
 
 statement ok
 DROP TABLE def
@@ -927,144 +1052,184 @@ DROP TABLE def
 statement ok
 CREATE TABLE def (d INT, e INT, f INT NOT NULL, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·               distribution         local              ·       ·
-·               vectorized           true               ·       ·
-project         ·                    ·                  (f)     ·
- │              estimated row count  1 (missing stats)  ·       ·
- └── filter     ·                    ·                  (d, f)  ·
-      │         estimated row count  1 (missing stats)  ·       ·
-      │         filter               d = 3              ·       ·
-      └── scan  ·                    ·                  (d, f)  ·
-·               estimated row count  1 (missing stats)  ·       ·
-·               table                def@def_f_key      ·       ·
-·               spans                /1-/2              ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (f)
+│ estimated row count: 1 (missing stats)
+│
+└── • filter
+    │ columns: (d, f)
+    │ estimated row count: 1 (missing stats)
+    │ filter: d = 3
+    │
+    └── • scan
+          columns: (d, f)
+          estimated row count: 1 (missing stats)
+          table: def@def_f_key
+          spans: /1-/2
 
 # Regression test for #20504.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a, b FROM abc WHERE (a, b) BETWEEN (1, 2) AND (3, 4)
 ----
-·     distribution         local                ·       ·
-·     vectorized           true                 ·       ·
-scan  ·                    ·                    (a, b)  ·
-·     estimated row count  333 (missing stats)  ·       ·
-·     table                abc@primary          ·       ·
-·     spans                /1/2-/3/4/#          ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 333 (missing stats)
+  table: abc@primary
+  spans: /1/2-/3/4/#
 
 # Regression test for #21831.
 statement ok
 CREATE TABLE str (k INT PRIMARY KEY, v STRING, INDEX(v))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%'
 ----
-·     distribution         local                ·       ·
-·     vectorized           true                 ·       ·
-scan  ·                    ·                    (k, v)  ·
-·     estimated row count  111 (missing stats)  ·       ·
-·     table                str@str_v_idx        ·       ·
-·     spans                /"ABC"-/"ABD"        ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, v)
+  estimated row count: 111 (missing stats)
+  table: str@str_v_idx
+  spans: /"ABC"-/"ABD"
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
 ----
-·          distribution         local                ·       ·
-·          vectorized           true                 ·       ·
-filter     ·                    ·                    (k, v)  ·
- │         estimated row count  37 (missing stats)   ·       ·
- │         filter               v LIKE 'ABC%Z'       ·       ·
- └── scan  ·                    ·                    (k, v)  ·
-·          estimated row count  111 (missing stats)  ·       ·
-·          table                str@str_v_idx        ·       ·
-·          spans                /"ABC"-/"ABD"        ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k, v)
+│ estimated row count: 37 (missing stats)
+│ filter: v LIKE 'ABC%Z'
+│
+└── • scan
+      columns: (k, v)
+      estimated row count: 111 (missing stats)
+      table: str@str_v_idx
+      spans: /"ABC"-/"ABD"
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (k, v)  ·
- │         estimated row count  37 (missing stats)    ·       ·
- │         filter               v SIMILAR TO 'ABC_*'  ·       ·
- └── scan  ·                    ·                     (k, v)  ·
-·          estimated row count  111 (missing stats)   ·       ·
-·          table                str@str_v_idx         ·       ·
-·          spans                /"ABC"-/"ABD"         ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k, v)
+│ estimated row count: 37 (missing stats)
+│ filter: v SIMILAR TO 'ABC_*'
+│
+└── • scan
+      columns: (k, v)
+      estimated row count: 111 (missing stats)
+      table: str@str_v_idx
+      spans: /"ABC"-/"ABD"
 
 # Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
 CREATE TABLE xy (x INT, y INT, INDEX (y))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
-·           distribution         local               ·           ·
-·           vectorized           true                ·           ·
-index join  ·                    ·                   (x, y)      ·
- │          estimated row count  10 (missing stats)  ·           ·
- │          table                xy@primary          ·           ·
- │          key columns          rowid               ·           ·
- └── scan   ·                    ·                   (y, rowid)  ·
-·           estimated row count  10 (missing stats)  ·           ·
-·           table                xy@xy_y_idx         ·           ·
-·           spans                /NULL-/!NULL        ·           ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (x, y)
+│ estimated row count: 10 (missing stats)
+│ table: xy@primary
+│ key columns: rowid
+│
+└── • scan
+      columns: (y, rowid)
+      estimated row count: 10 (missing stats)
+      table: xy@xy_y_idx
+      spans: /NULL-/!NULL
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
-·           distribution         local               ·           ·
-·           vectorized           true                ·           ·
-index join  ·                    ·                   (x, y)      ·
- │          estimated row count  10 (missing stats)  ·           ·
- │          table                xy@primary          ·           ·
- │          key columns          rowid               ·           ·
- └── scan   ·                    ·                   (y, rowid)  ·
-·           estimated row count  10 (missing stats)  ·           ·
-·           table                xy@xy_y_idx         ·           ·
-·           spans                /4-/5               ·           ·
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (x, y)
+│ estimated row count: 10 (missing stats)
+│ table: xy@primary
+│ key columns: rowid
+│
+└── • scan
+      columns: (y, rowid)
+      estimated row count: 10 (missing stats)
+      table: xy@xy_y_idx
+      spans: /4-/5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-·                distribution         local               ·           ·
-·                vectorized           true                ·           ·
-project          ·                    ·                   (x)         ·
- └── index join  ·                    ·                   (x, y)      ·
-      │          estimated row count  10 (missing stats)  ·           ·
-      │          table                xy@primary          ·           ·
-      │          key columns          rowid               ·           ·
-      └── scan   ·                    ·                   (y, rowid)  ·
-·                estimated row count  10 (missing stats)  ·           ·
-·                table                xy@xy_y_idx         ·           ·
-·                spans                /1-/2               ·           ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (x)
+│
+└── • index join
+    │ columns: (x, y)
+    │ estimated row count: 10 (missing stats)
+    │ table: xy@primary
+    │ key columns: rowid
+    │
+    └── • scan
+          columns: (y, rowid)
+          estimated row count: 10 (missing stats)
+          table: xy@xy_y_idx
+          spans: /1-/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (x, y)  ·
- │         estimated row count  990 (missing stats)   ·       ·
- │         filter               y IS NOT NULL         ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xy@primary            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y)
+│ estimated row count: 990 (missing stats)
+│ filter: y IS NOT NULL
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xy@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ----
-·          distribution         local                 ·       ·
-·          vectorized           true                  ·       ·
-filter     ·                    ·                     (x, y)  ·
- │         estimated row count  333 (missing stats)   ·       ·
- │         filter               y IS DISTINCT FROM 4  ·       ·
- └── scan  ·                    ·                     (x, y)  ·
-·          estimated row count  1000 (missing stats)  ·       ·
-·          table                xy@primary            ·       ·
-·          spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y)
+│ estimated row count: 333 (missing stats)
+│ filter: y IS DISTINCT FROM 4
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 1000 (missing stats)
+      table: xy@primary
+      spans: FULL SCAN
 
 # Regression tests for #22670.
 statement ok
@@ -1073,25 +1238,29 @@ CREATE INDEX xy_idx ON xy (x, y)
 statement ok
 INSERT INTO xy VALUES (NULL, NULL), (1, NULL), (NULL, 1), (1, 1)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE x IN (NULL, 1, 2)
 ----
-·     distribution         local               ·       ·
-·     vectorized           true                ·       ·
-scan  ·                    ·                   (x, y)  ·
-·     estimated row count  20 (missing stats)  ·       ·
-·     table                xy@xy_idx           ·       ·
-·     spans                /1-/3               ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y)
+  estimated row count: 20 (missing stats)
+  table: xy@xy_idx
+  spans: /1-/3
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
-·     distribution         local              ·       ·
-·     vectorized           true               ·       ·
-scan  ·                    ·                  (x, y)  ·
-·     estimated row count  1 (missing stats)  ·       ·
-·     table                xy@xy_idx          ·       ·
-·     spans                /1/1-/1/3          ·       ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (x, y)
+  estimated row count: 1 (missing stats)
+  table: xy@xy_idx
+  spans: /1/1-/1/3
 
 # ------------------------------------------------------------------------------
 # Non-covering index
@@ -1113,17 +1282,19 @@ CREATE TABLE noncover (
 statement ok
 INSERT INTO noncover VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-query TTT
+query T
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          noncover@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          noncover@b
-·           spans          [/2 - /2]
+distribution: local
+vectorized: true
+·
+• index join
+│ table: noncover@primary
+│
+└── • scan
+      missing stats
+      table: noncover@b
+      spans: [/2 - /2]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -1148,17 +1319,19 @@ WHERE message LIKE 'Scan /Table/67/1%'
 ----
 Scan /Table/67/1/1{-/#}
 
-query TTT
+query T
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          noncover@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          noncover@c
-·           spans          [/6 - /6]
+distribution: local
+vectorized: true
+·
+• index join
+│ table: noncover@primary
+│
+└── • scan
+      missing stats
+      table: noncover@c
+      spans: [/6 - /6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1175,135 +1348,173 @@ fetched: /noncover/primary/5/c -> 7
 fetched: /noncover/primary/5/d -> 8
 output row: [5 6 7 8]
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-sort            ·                    ·                     (a, b, c, d)  -c
- │              estimated row count  330 (missing stats)   ·             ·
- │              order                -c                    ·             ·
- └── filter     ·                    ·                     (a, b, c, d)  ·
-      │         estimated row count  330 (missing stats)   ·             ·
-      │         filter               c > 0                 ·             ·
-      └── scan  ·                    ·                     (a, b, c, d)  ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                noncover@primary      ·             ·
-·               spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d)
+│ ordering: -c
+│ estimated row count: 330 (missing stats)
+│ order: -c
+│
+└── • filter
+    │ columns: (a, b, c, d)
+    │ estimated row count: 330 (missing stats)
+    │ filter: c > 0
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: noncover@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c
 ----
-·               distribution         local                 ·             ·
-·               vectorized           true                  ·             ·
-sort            ·                    ·                     (a, b, c, d)  +c
- │              estimated row count  330 (missing stats)   ·             ·
- │              order                +c                    ·             ·
- └── filter     ·                    ·                     (a, b, c, d)  ·
-      │         estimated row count  330 (missing stats)   ·             ·
-      │         filter               c > 0                 ·             ·
-      └── scan  ·                    ·                     (a, b, c, d)  ·
-·               estimated row count  1000 (missing stats)  ·             ·
-·               table                noncover@primary      ·             ·
-·               spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d)
+│ ordering: +c
+│ estimated row count: 330 (missing stats)
+│ order: +c
+│
+└── • filter
+    │ columns: (a, b, c, d)
+    │ estimated row count: 330 (missing stats)
+    │ filter: c > 0
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: noncover@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-·          distribution         local                 ·             ·
-·          vectorized           true                  ·             ·
-filter     ·                    ·                     (a, b, c, d)  ·
- │         estimated row count  9 (missing stats)     ·             ·
- │         filter               (c > 0) AND (d = 8)   ·             ·
- └── scan  ·                    ·                     (a, b, c, d)  ·
-·          estimated row count  1000 (missing stats)  ·             ·
-·          table                noncover@primary      ·             ·
-·          spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, c, d)
+│ estimated row count: 9 (missing stats)
+│ filter: (c > 0) AND (d = 8)
+│
+└── • scan
+      columns: (a, b, c, d)
+      estimated row count: 1000 (missing stats)
+      table: noncover@primary
+      spans: FULL SCAN
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
 
-query TTT
+query T
 EXPLAIN SELECT * FROM noncover ORDER BY c
 ----
-·          distribution   local
-·          vectorized     true
-sort       ·              ·
- │         order          +c
- └── scan  ·              ·
-·          missing stats  ·
-·          table          noncover@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +c
+│
+└── • scan
+      missing stats
+      table: noncover@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          noncover@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          noncover@c
-·           spans          LIMITED SCAN
-·           limit          5
+distribution: local
+vectorized: true
+·
+• index join
+│ table: noncover@primary
+│
+└── • scan
+      missing stats
+      table: noncover@c
+      spans: LIMITED SCAN
+      limit: 5
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c OFFSET 5
-]
 ----
-·               distribution         local
-·               vectorized           true
-limit           ·                    ·
- │              estimated row count  995 (missing stats)
- │              offset               5
- └── sort       ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         order                +c
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                noncover@primary
-·               spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (a, b, c, d)
+│ estimated row count: 995 (missing stats)
+│ offset: 5
+│
+└── • sort
+    │ columns: (a, b, c, d)
+    │ ordering: +c
+    │ estimated row count: 1000 (missing stats)
+    │ order: +c
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: noncover@primary
+          spans: FULL SCAN
 
 # TODO(radu): need to prefer the order-matching index when OFFSET is present.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
-]
 ----
-·                distribution         local
-·                vectorized           true
-limit            ·                    ·
- │               estimated row count  5 (missing stats)
- │               offset               5
- └── index join  ·                    ·
-      │          estimated row count  10 (missing stats)
-      │          table                noncover@primary
-      │          key columns          a
-      └── scan   ·                    ·
-·                estimated row count  10 (missing stats)
-·                table                noncover@c
-·                spans                LIMITED SCAN
-·                limit                10
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (a, b, c, d)
+│ estimated row count: 5 (missing stats)
+│ offset: 5
+│
+└── • index join
+    │ columns: (a, b, c, d)
+    │ ordering: +c
+    │ estimated row count: 10 (missing stats)
+    │ table: noncover@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a, c)
+          ordering: +c
+          estimated row count: 10 (missing stats)
+          table: noncover@c
+          spans: LIMITED SCAN
+          limit: 10
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 1000000
-]
 ----
-·               distribution         local
-·               vectorized           true
-limit           ·                    ·
- │              estimated row count  1000 (missing stats)
- │              count                1000000
- └── sort       ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         order                +c
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                noncover@primary
-·               spans                FULL SCAN
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (a, b, c, d)
+│ estimated row count: 1000 (missing stats)
+│ count: 1000000
+│
+└── • sort
+    │ columns: (a, b, c, d)
+    │ ordering: +c
+    │ estimated row count: 1000 (missing stats)
+    │ order: +c
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          estimated row count: 1000 (missing stats)
+          table: noncover@primary
+          spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # These tests verify that while we are joining an index with the table, we
@@ -1346,24 +1557,28 @@ ALTER TABLE t2 INJECT STATISTICS '[
   }
 ]'
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
-]
 ----
-·               distribution         local
-·               vectorized           true
-index join      ·                    ·
- │              estimated row count  1
- │              table                t2@primary
- │              key columns          a
- └── filter     ·                    ·
-      │         estimated row count  1
-      │         filter               (c % 2) = 0
-      └── scan  ·                    ·
-·               estimated row count  3
-·               table                t2@bc
-·               spans                /2-/3
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c, s)
+│ estimated row count: 1
+│ table: t2@primary
+│ key columns: a
+│
+└── • filter
+    │ columns: (a, b, c)
+    │ estimated row count: 1
+    │ filter: (c % 2) = 0
+    │
+    └── • scan
+          columns: (a, b, c)
+          estimated row count: 3
+          table: t2@bc
+          spans: /2-/3
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok
@@ -1383,21 +1598,23 @@ fetched: /t2/primary/5/c -> 2
 fetched: /t2/primary/5/s -> '22'
 output row: [5 2 2 '22']
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
-]
 ----
-·           distribution         local
-·           vectorized           true
-index join  ·                    ·
- │          estimated row count  3
- │          table                t2@primary
- │          key columns          a
- └── scan   ·                    ·
-·           estimated row count  3
-·           table                t2@bc
-·           spans                /2/!NULL-/2/2 /2/3-/3
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c, s)
+│ estimated row count: 3
+│ table: t2@primary
+│ key columns: a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 3
+      table: t2@bc
+      spans: /2/!NULL-/2/2 /2/3-/3
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1494,35 +1711,47 @@ output row: [9 3 3 '33']
 # bring non-indexed columns (s) under the index scanNode. (#12582)
 # To test this we need an expression containing non-indexed
 # columns that disappears during range simplification.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-·          distribution         local  ·       ·
-·          vectorized           true   ·       ·
-project    ·                    ·      (a)     ·
- │         estimated row count  3      ·       ·
- └── scan  ·                    ·      (a, b)  ·
-·          estimated row count  3      ·       ·
-·          table                t2@bc  ·       ·
-·          spans                /2-/3  ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a)
+│ estimated row count: 3
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 3
+      table: t2@bc
+      spans: /2-/3
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 10 ORDER BY v
 ----
-·                distribution         local               ·       ·
-·                vectorized           true                ·       ·
-project          ·                    ·                   (w)     ·
- └── index join  ·                    ·                   (v, w)  +v
-      │          estimated row count  90 (missing stats)  ·       ·
-      │          table                t3@primary          ·       ·
-      │          key columns          k                   ·       ·
-      └── scan   ·                    ·                   (k, v)  +v
-·                estimated row count  90 (missing stats)  ·       ·
-·                table                t3@v                ·       ·
-·                spans                /1-/10              ·       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (w)
+│
+└── • index join
+    │ columns: (v, w)
+    │ ordering: +v
+    │ estimated row count: 90 (missing stats)
+    │ table: t3@primary
+    │ key columns: k
+    │
+    └── • scan
+          columns: (k, v)
+          ordering: +v
+          estimated row count: 90 (missing stats)
+          table: t3@v
+          spans: /1-/10
 
 # ------------------------------------------------------------------------------
 # These tests are for the point lookup optimization: for single row lookups on
@@ -1548,15 +1777,16 @@ statement ok
 INSERT INTO t4 VALUES (10, 20, 30, 40, 50)
 
 # Point lookup on c does not touch the d or e families.
-query TTT
+query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/10/20 - /10/20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/10/20 - /10/20]
 
 statement ok
 SET tracing = on,kv,results; SELECT c FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1571,15 +1801,16 @@ fetched: /t4/primary/10/20/c -> 30
 output row: [30]
 
 # Point lookup on d does not touch the c or e families.
-query TTT
+query T
 EXPLAIN SELECT d FROM t4 WHERE a = 10 and b = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/10/20 - /10/20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/10/20 - /10/20]
 
 statement ok
 SET tracing = on,kv,results; SELECT d FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1595,74 +1826,82 @@ output row: [40]
 
 # Point lookup on both d and e uses a single span for the two adjacent column
 # families.
-query TTT
+query T
 EXPLAIN SELECT d, e FROM t4 WHERE a = 10 and b = 20
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/10/20 - /10/20]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/10/20 - /10/20]
 
 # Optimization should also be applied for updates.
-query TTT
+query T
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             t4
- │              set               c
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             t4@primary
-·               spans             [/10/20 - /10/20]
-·               locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: t4
+│ set: c
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: t4@primary
+          spans: [/10/20 - /10/20]
+          locking strength: for update
 
 # Optimization should not be applied for deletes.
-query TTT
+query T
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
-·             distribution  local
-·             vectorized    false
-delete range  ·             ·
-·             from          t4
-·             auto commit   ·
-·             spans         [/10/20 - /10/20]
+distribution: local
+vectorized: false
+·
+• delete range
+  from: t4
+  auto commit
+  spans: [/10/20 - /10/20]
 
 # Optimization should not be applied for non point lookups.
-query TTT
+query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b >= 20 and b < 22
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/10/20 - /10/21]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/10/20 - /10/21]
 
 # Optimization should not be applied for partial primary key filter.
-query TTT
+query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/10 - /10]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/10 - /10]
 
 # Regression test for #40890: a point lookup on a single column family of a
 # table should still work properly in the face of a constraint disjunction.
-query TTT
+query T
 EXPLAIN SELECT a FROM t4 WHERE a in (1, 5) and b in (1, 5)
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          t4@primary
-·     spans          [/1/1 - /1/1] [/1/5 - /1/5] [/5/1 - /5/1] [/5/5 - /5/5]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t4@primary
+  spans: [/1/1 - /1/1] [/1/5 - /1/5] [/5/1 - /5/1] [/5/5 - /5/5]

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -12,302 +12,350 @@ CREATE TABLE abcd (
 )
 
 # No hint
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@primary
-·     spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@primary
+  spans: [/20 - /30]
 
 # No hint, reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          abcd@primary
-·        spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: abcd@primary
+  spans: [/20 - /30]
 
 # Force primary
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@primary
-·     spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@primary
+  spans: [/20 - /30]
 
 # Force primary, reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          abcd@primary
-·        spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: abcd@primary
+  spans: [/20 - /30]
 
 # Force primary, allow reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·        distribution   local
-·        vectorized     true
-revscan  ·              ·
-·        missing stats  ·
-·        table          abcd@primary
-·        spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• revscan
+  missing stats
+  table: abcd@primary
+  spans: [/20 - /30]
 
 # Force primary, forward scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,ASC} WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·          distribution   local
-·          vectorized     true
-sort       ·              ·
- │         order          -a
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@primary
-·          spans          [/20 - /30]
+distribution: local
+vectorized: true
+·
+• sort
+│ order: -a
+│
+└── • scan
+      missing stats
+      table: abcd@primary
+      spans: [/20 - /30]
 
 # Force index b
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         (a >= 20) AND (a <= 30)
- └── index join  ·              ·
-      │          table          abcd@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          abcd@b
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • scan
+          missing stats
+          table: abcd@b
+          spans: FULL SCAN
 
 # Force index b, reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ----
-·                  distribution   local
-·                  vectorized     true
-filter             ·              ·
- │                 filter         (a >= 20) AND (a <= 30)
- └── index join    ·              ·
-      │            table          abcd@primary
-      └── revscan  ·              ·
-·                  missing stats  ·
-·                  table          abcd@b
-·                  spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • revscan
+          missing stats
+          table: abcd@b
+          spans: FULL SCAN
 
 # Force index b, allowing reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
-·             distribution   local
-·             vectorized     true
-index join    ·              ·
- │            table          abcd@primary
- └── revscan  ·              ·
-·             missing stats  ·
-·             table          abcd@b
-·             spans          LIMITED SCAN
-·             limit          5
+distribution: local
+vectorized: true
+·
+• index join
+│ table: abcd@primary
+│
+└── • revscan
+      missing stats
+      table: abcd@b
+      spans: LIMITED SCAN
+      limit: 5
 
 # Force index b, reverse scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
-·             distribution   local
-·             vectorized     true
-index join    ·              ·
- │            table          abcd@primary
- └── revscan  ·              ·
-·             missing stats  ·
-·             table          abcd@b
-·             spans          LIMITED SCAN
-·             limit          5
+distribution: local
+vectorized: true
+·
+• index join
+│ table: abcd@primary
+│
+└── • revscan
+      missing stats
+      table: abcd@b
+      spans: LIMITED SCAN
+      limit: 5
 
 
 # Force index b, forward scan.
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
-·                    distribution   local
-·                    vectorized     true
-index join           ·              ·
- │                   table          abcd@primary
- └── limit           ·              ·
-      │              count          5
-      └── sort       ·              ·
-           │         order          -b
-           └── scan  ·              ·
-·                    missing stats  ·
-·                    table          abcd@b
-·                    spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• index join
+│ table: abcd@primary
+│
+└── • limit
+    │ count: 5
+    │
+    └── • sort
+        │ order: -b
+        │
+        └── • scan
+              missing stats
+              table: abcd@b
+              spans: FULL SCAN
 
 # Force index cd
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         (a >= 20) AND (a <= 30)
- └── index join  ·              ·
-      │          table          abcd@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          abcd@cd
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • scan
+          missing stats
+          table: abcd@cd
+          spans: FULL SCAN
 
 # Force index bcd
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         (a >= 20) AND (a <= 30)
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@bcd
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • scan
+      missing stats
+      table: abcd@bcd
+      spans: FULL SCAN
 
 # Force index b (covering)
-query TTT
+query T
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         (a >= 20) AND (a <= 30)
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@b
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • scan
+      missing stats
+      table: abcd@b
+      spans: FULL SCAN
 
 # Force index b (non-covering due to WHERE clause)
-query TTT
+query T
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         (c >= 20) AND (c <= 30)
- └── index join  ·              ·
-      │          table          abcd@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          abcd@b
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (c >= 20) AND (c <= 30)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • scan
+          missing stats
+          table: abcd@b
+          spans: FULL SCAN
 
 # No hint, should be using index cd
-query TTT
+query T
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     missing stats  ·
-·     table          abcd@cd
-·     spans          [/20 - /39]
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: abcd@cd
+  spans: [/20 - /39]
 
 # Force primary index
-query TTT
+query T
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         (c >= 20) AND (c < 40)
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (c >= 20) AND (c < 40)
+│
+└── • scan
+      missing stats
+      table: abcd@primary
+      spans: FULL SCAN
 
 # Force index b
-query TTT
+query T
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         (c >= 20) AND (c < 40)
- └── index join  ·              ·
-      │          table          abcd@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          abcd@b
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (c >= 20) AND (c < 40)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • scan
+          missing stats
+          table: abcd@b
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-·                distribution   local
-·                vectorized     true
-filter           ·              ·
- │               filter         (a >= 20) AND (a <= 30)
- └── index join  ·              ·
-      │          table          abcd@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          abcd@b
-·                spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: (a >= 20) AND (a <= 30)
+│
+└── • index join
+    │ table: abcd@primary
+    │
+    └── • scan
+          missing stats
+          table: abcd@b
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-·           distribution   local
-·           vectorized     true
-index join  ·              ·
- │          table          abcd@primary
- └── scan   ·              ·
-·           missing stats  ·
-·           table          abcd@cd
-·           spans          [/10 - /10]
+distribution: local
+vectorized: true
+·
+• index join
+│ table: abcd@primary
+│
+└── • scan
+      missing stats
+      table: abcd@cd
+      spans: [/10 - /10]
 
-query TTT
+query T
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         c = 10
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 10
+│
+└── • scan
+      missing stats
+      table: abcd@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         c = 10
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@bcd
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 10
+│
+└── • scan
+      missing stats
+      table: abcd@bcd
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
-·          distribution   local
-·          vectorized     true
-filter     ·              ·
- │         filter         c = 10
- └── scan  ·              ·
-·          missing stats  ·
-·          table          abcd@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 10
+│
+└── • scan
+      missing stats
+      table: abcd@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -7,382 +7,498 @@ statement ok
 CREATE TABLE t2(x INT PRIMARY KEY)
 
 # Check that if a mutation uses further processing, a spool is added.
-query TTT
+query T
 EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── limit                ·              ·
- │    │                   count          1
- │    └── scan buffer     ·              ·
- │                        label          buffer 1 (a)
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1 (a)
-           └── insert     ·              ·
-                │         into           t(x)
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t2@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1 (a)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1 (a)
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── limit                ·              ·
- │    │                   count          1
- │    └── scan buffer     ·              ·
- │                        label          buffer 1 (a)
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   DELETE FROM t RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1 (a)
-           └── delete     ·              ·
-                │         from           t
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1 (a)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: DELETE FROM t RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1 (a)
+        │
+        └── • delete
+            │ from: t
+            │
+            └── • scan
+                  missing stats
+                  table: t@primary
+                  spans: FULL SCAN
 
 
-query TTT
+query T
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                              distribution      local
-·                              vectorized        false
-root                           ·                 ·
- ├── limit                     ·                 ·
- │    │                        count             1
- │    └── scan buffer          ·                 ·
- │                             label             buffer 1 (a)
- └── subquery                  ·                 ·
-      │                        id                @S1
-      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode         all rows
-      └── buffer               ·                 ·
-           │                   label             buffer 1 (a)
-           └── update          ·                 ·
-                │              table             t
-                │              set               x
-                └── render     ·                 ·
-                     └── scan  ·                 ·
-·                              missing stats     ·
-·                              table             t@primary
-·                              spans             FULL SCAN
-·                              locking strength  for update
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1 (a)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPDATE t SET x = x + 1 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1 (a)
+        │
+        └── • update
+            │ table: t
+            │ set: x
+            │
+            └── • render
+                │
+                └── • scan
+                      missing stats
+                      table: t@primary
+                      spans: FULL SCAN
+                      locking strength: for update
 
-query TTT
+query T
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                           distribution  local
-·                           vectorized    false
-root                        ·             ·
- ├── limit                  ·             ·
- │    │                     count         1
- │    └── scan buffer       ·             ·
- │                          label         buffer 1 (a)
- └── subquery               ·             ·
-      │                     id            @S1
-      │                     original sql  UPSERT INTO t VALUES (2), (3) RETURNING x
-      │                     exec mode     all rows
-      └── buffer            ·             ·
-           │                label         buffer 1 (a)
-           └── upsert       ·             ·
-                │           into          t(x)
-                └── values  ·             ·
-·                           size          1 column, 2 rows
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1 (a)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPSERT INTO t VALUES (2), (3) RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1 (a)
+        │
+        └── • upsert
+            │ into: t(x)
+            │
+            └── • values
+                  size: 1 column, 2 rows
 
 # Ditto all mutations, with the statement source syntax.
-query TTT
+query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── limit                ·              ·
- │    │                   count          1
- │    └── scan buffer     ·              ·
- │                        label          buffer 1
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1
-           └── insert     ·              ·
-                │         into           t(x)
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t2@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── limit                ·              ·
- │    │                   count          1
- │    └── scan buffer     ·              ·
- │                        label          buffer 1
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   DELETE FROM t RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1
-           └── delete     ·              ·
-                │         from           t
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: DELETE FROM t RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • delete
+            │ from: t
+            │
+            └── • scan
+                  missing stats
+                  table: t@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-·                              distribution      local
-·                              vectorized        false
-root                           ·                 ·
- ├── limit                     ·                 ·
- │    │                        count             1
- │    └── scan buffer          ·                 ·
- │                             label             buffer 1
- └── subquery                  ·                 ·
-      │                        id                @S1
-      │                        original sql      UPDATE t SET x = x + 1 RETURNING x
-      │                        exec mode         all rows
-      └── buffer               ·                 ·
-           │                   label             buffer 1
-           └── update          ·                 ·
-                │              table             t
-                │              set               x
-                └── render     ·                 ·
-                     └── scan  ·                 ·
-·                              missing stats     ·
-·                              table             t@primary
-·                              spans             FULL SCAN
-·                              locking strength  for update
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPDATE t SET x = x + 1 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • update
+            │ table: t
+            │ set: x
+            │
+            └── • render
+                │
+                └── • scan
+                      missing stats
+                      table: t@primary
+                      spans: FULL SCAN
+                      locking strength: for update
 
-query TTT
+query T
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
-·                           distribution  local
-·                           vectorized    false
-root                        ·             ·
- ├── limit                  ·             ·
- │    │                     count         1
- │    └── scan buffer       ·             ·
- │                          label         buffer 1
- └── subquery               ·             ·
-      │                     id            @S1
-      │                     original sql  UPSERT INTO t VALUES (2), (3) RETURNING x
-      │                     exec mode     all rows
-      └── buffer            ·             ·
-           │                label         buffer 1
-           └── upsert       ·             ·
-                │           into          t(x)
-                └── values  ·             ·
-·                           size          1 column, 2 rows
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPSERT INTO t VALUES (2), (3) RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • upsert
+            │ into: t(x)
+            │
+            └── • values
+                  size: 1 column, 2 rows
 
 # Check that a spool is also inserted for other processings than LIMIT.
-query TTT
+query T
 EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── group (scalar)       ·              ·
- │    └── scan buffer     ·              ·
- │                        label          buffer 1
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1
-           └── insert     ·              ·
-                │         into           t(x)
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t2@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • group (scalar)
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── cross join           ·              ·
- │    ├── scan buffer     ·              ·
- │    │                   label          buffer 1
- │    └── scan            ·              ·
- │                        missing stats  ·
- │                        table          t@primary
- │                        spans          FULL SCAN
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1
-           └── insert     ·              ·
-                │         into           t(x)
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t2@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • cross join
+│   │
+│   ├── • scan buffer
+│   │     label: buffer 1
+│   │
+│   └── • scan
+│         missing stats
+│         table: t@primary
+│         spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
 # Check that if a spool is already added at some level, then it is not added
 # again at levels below.
 # TODO(andyk): This optimization is not part of CBO yet.
-query TTT
+query T
 EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-·                                     distribution   local
-·                                     vectorized     false
-root                                  ·              ·
- ├── limit                            ·              ·
- │    │                               count          1
- │    └── scan buffer                 ·              ·
- │                                    label          buffer 2 (b)
- ├── subquery                         ·              ·
- │    │                               id             @S1
- │    │                               original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
- │    │                               exec mode      all rows
- │    └── buffer                      ·              ·
- │         │                          label          buffer 1 (a)
- │         └── insert                 ·              ·
- │              │                     into           t(x)
- │              └── scan              ·              ·
- │                                    missing stats  ·
- │                                    table          t2@primary
- │                                    spans          FULL SCAN
- └── subquery                         ·              ·
-      │                               id             @S2
-      │                               original sql   INSERT INTO t SELECT x + 1 FROM a RETURNING x
-      │                               exec mode      all rows
-      └── buffer                      ·              ·
-           │                          label          buffer 2 (b)
-           └── insert                 ·              ·
-                │                     into           t(x)
-                └── render            ·              ·
-                     └── scan buffer  ·              ·
-·                                     label          buffer 1 (a)
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 1
+│   │
+│   └── • scan buffer
+│         label: buffer 2 (b)
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+│   │ exec mode: all rows
+│   │
+│   └── • buffer
+│       │ label: buffer 1 (a)
+│       │
+│       └── • insert
+│           │ into: t(x)
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: t2@primary
+│                 spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: INSERT INTO t SELECT x + 1 FROM a RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 2 (b)
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • render
+                │
+                └── • scan buffer
+                      label: buffer 1 (a)
 
 # Check that no spool is inserted if a top-level render is elided.
-query TTT
+query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                         distribution   local
-·                         vectorized     false
-root                      ·              ·
- ├── scan buffer          ·              ·
- │                        label          buffer 1
- └── subquery             ·              ·
-      │                   id             @S1
-      │                   original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                   exec mode      all rows
-      └── buffer          ·              ·
-           │              label          buffer 1
-           └── insert     ·              ·
-                │         into           t(x)
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          t2@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • scan buffer
+│     label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
 # Check that no spool is used for a top-level INSERT, but
 # sub-INSERTs still get a spool.
-query TTT
+query T
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                           distribution   local
-·                           vectorized     false
-root                        ·              ·
- ├── insert                 ·              ·
- │    │                     into           t(x)
- │    └── render            ·              ·
- │         └── scan buffer  ·              ·
- │                          label          buffer 1
- └── subquery               ·              ·
-      │                     id             @S1
-      │                     original sql   INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                     exec mode      all rows
-      └── buffer            ·              ·
-           │                label          buffer 1
-           └── insert       ·              ·
-                │           into           t(x)
-                └── scan    ·              ·
-·                           missing stats  ·
-·                           table          t2@primary
-·                           spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • insert
+│   │ into: t(x)
+│   │
+│   └── • render
+│       │
+│       └── • scan buffer
+│             label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: t(x)
+            │
+            └── • scan
+                  missing stats
+                  table: t2@primary
+                  spans: FULL SCAN
 
 # Check that simple computations using RETURNING get their spool pulled up.
-query TTT
+query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
-·                              distribution   local
-·                              vectorized     false
-root                           ·              ·
- ├── limit                     ·              ·
- │    │                        count          10
- │    └── filter               ·              ·
- │         │                   filter         "?column?" < 3
- │         └── scan buffer     ·              ·
- │                             label          buffer 1
- └── subquery                  ·              ·
-      │                        id             @S1
-      │                        original sql   INSERT INTO t SELECT * FROM t2 RETURNING x + 10
-      │                        exec mode      all rows
-      └── buffer               ·              ·
-           │                   label          buffer 1
-           └── render          ·              ·
-                └── insert     ·              ·
-                     │         into           t(x)
-                     └── scan  ·              ·
-·                              missing stats  ·
-·                              table          t2@primary
-·                              spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • limit
+│   │ count: 10
+│   │
+│   └── • filter
+│       │ filter: "?column?" < 3
+│       │
+│       └── • scan buffer
+│             label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x + 10
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • render
+            │
+            └── • insert
+                │ into: t(x)
+                │
+                └── • scan
+                      missing stats
+                      table: t2@primary
+                      spans: FULL SCAN
 
 # Check that a pulled up spool gets elided at the top level.
-query TTT
+query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3
 ----
-·                              distribution   local
-·                              vectorized     false
-root                           ·              ·
- ├── filter                    ·              ·
- │    │                        filter         "?column?" < 3
- │    └── scan buffer          ·              ·
- │                             label          buffer 1
- └── subquery                  ·              ·
-      │                        id             @S1
-      │                        original sql   INSERT INTO t SELECT * FROM t2 RETURNING x + 10
-      │                        exec mode      all rows
-      └── buffer               ·              ·
-           │                   label          buffer 1
-           └── render          ·              ·
-                └── insert     ·              ·
-                     │         into           t(x)
-                     └── scan  ·              ·
-·                              missing stats  ·
-·                              table          t2@primary
-·                              spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • filter
+│   │ filter: "?column?" < 3
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x + 10
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • render
+            │
+            └── • insert
+                │ into: t(x)
+                │
+                └── • scan
+                      missing stats
+                      table: t2@primary
+                      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -11,23 +11,32 @@ SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT
 ----
 test.public.my_spatial_table.geom1 SRID:4326 TYPE:POINT DIMS:2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT',2)
 ----
-·                           distribution         local                                                                               ·                    ·
-·                           vectorized           false                                                                               ·                    ·
-root                        ·                    ·                                                                                   (addgeometrycolumn)  ·
- ├── values                 ·                    ·                                                                                   (addgeometrycolumn)  ·
- │                          size                 1 column, 1 row                                                                     ·                    ·
- │                          row 0, expr 0        addgeometrycolumn('test', 'public', 'my_spatial_table', 'geom1', 4326, 'POINT', 2)  ·                    ·
- └── subquery               ·                    ·                                                                                   ·                    ·
-      │                     id                   @S1                                                                                 ·                    ·
-      │                     original sql         ALTER TABLE test.public.my_spatial_table ADD COLUMN geom1 GEOMETRY(POINT,4326)      ·                    ·
-      │                     exec mode            all rows                                                                            ·                    ·
-      └── buffer            ·                    ·                                                                                   ()                   ·
-           │                label                buffer 1                                                                            ·                    ·
-           └── alter table  ·                    ·                                                                                   ()                   ·
-·                           estimated row count  10 (missing stats)                                                                  ·                    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (addgeometrycolumn)
+│
+├── • values
+│     columns: (addgeometrycolumn)
+│     size: 1 column, 1 row
+│     row 0, expr 0: addgeometrycolumn('test', 'public', 'my_spatial_table', 'geom1', 4326, 'POINT', 2)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: ALTER TABLE test.public.my_spatial_table ADD COLUMN geom1 GEOMETRY(POINT,4326)
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: ()
+        │ label: buffer 1
+        │
+        └── • alter table
+              columns: ()
+              estimated row count: 10 (missing stats)
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
@@ -162,41 +171,57 @@ FROM other_table
 1  my_spatial_table.geom7 SRID:4326 TYPE:POINT DIMS:2  my_spatial_table.geom8 SRID:4326 TYPE:POINT DIMS:2
 2  my_spatial_table.geom7 SRID:4326 TYPE:POINT DIMS:2  my_spatial_table.geom8 SRID:4326 TYPE:POINT DIMS:2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT
   k,
   AddGeometryColumn ('my_spatial_table','geom7',4326,'POINT',2),
   AddGeometryColumn ('my_spatial_table','geom8',4326,'POINT',2)
 FROM other_table
 ----
-·                           distribution         local                                                               ·                                          ·
-·                           vectorized           true                                                                ·                                          ·
-root                        ·                    ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·
- ├── render                 ·                    ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·
- │    │                     estimated row count  1000 (missing stats)                                                ·                                          ·
- │    │                     render 0             addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)    ·                                          ·
- │    │                     render 1             addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)    ·                                          ·
- │    │                     render 2             k                                                                   ·                                          ·
- │    └── scan              ·                    ·                                                                   (k)                                        ·
- │                          estimated row count  1000 (missing stats)                                                ·                                          ·
- │                          table                other_table@primary                                                 ·                                          ·
- │                          spans                FULL SCAN                                                           ·                                          ·
- ├── subquery               ·                    ·                                                                   ·                                          ·
- │    │                     id                   @S1                                                                 ·                                          ·
- │    │                     original sql         ALTER TABLE my_spatial_table ADD COLUMN geom7 GEOMETRY(POINT,4326)  ·                                          ·
- │    │                     exec mode            all rows                                                            ·                                          ·
- │    └── buffer            ·                    ·                                                                   ()                                         ·
- │         │                label                buffer 1                                                            ·                                          ·
- │         └── alter table  ·                    ·                                                                   ()                                         ·
- │                          estimated row count  10 (missing stats)                                                  ·                                          ·
- └── subquery               ·                    ·                                                                   ·                                          ·
-      │                     id                   @S2                                                                 ·                                          ·
-      │                     original sql         ALTER TABLE my_spatial_table ADD COLUMN geom8 GEOMETRY(POINT,4326)  ·                                          ·
-      │                     exec mode            all rows                                                            ·                                          ·
-      └── buffer            ·                    ·                                                                   ()                                         ·
-           │                label                buffer 2                                                            ·                                          ·
-           └── alter table  ·                    ·                                                                   ()                                         ·
-·                           estimated row count  10 (missing stats)                                                  ·                                          ·
+distribution: local
+vectorized: true
+·
+• root
+│ columns: (k, addgeometrycolumn, addgeometrycolumn)
+│
+├── • render
+│   │ columns: (k, addgeometrycolumn, addgeometrycolumn)
+│   │ estimated row count: 1000 (missing stats)
+│   │ render 0: addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)
+│   │ render 1: addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)
+│   │ render 2: k
+│   │
+│   └── • scan
+│         columns: (k)
+│         estimated row count: 1000 (missing stats)
+│         table: other_table@primary
+│         spans: FULL SCAN
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: ALTER TABLE my_spatial_table ADD COLUMN geom7 GEOMETRY(POINT,4326)
+│   │ exec mode: all rows
+│   │
+│   └── • buffer
+│       │ columns: ()
+│       │ label: buffer 1
+│       │
+│       └── • alter table
+│             columns: ()
+│             estimated row count: 10 (missing stats)
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: ALTER TABLE my_spatial_table ADD COLUMN geom8 GEOMETRY(POINT,4326)
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: ()
+        │ label: buffer 2
+        │
+        └── • alter table
+              columns: ()
+              estimated row count: 10 (missing stats)
 
 # TODO(rytaft): Figure out why goem7 didn't get added even though the ALTER
 # TABLE statement is included in the EXPLAIN plan above.

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -2,51 +2,64 @@
 
 subtest generate_series
 
-query TTT
+query T
 EXPLAIN SELECT * FROM generate_series(1, 3)
 ----
-·              distribution  local
-·              vectorized    true
-project set    ·             ·
- └── emptyrow  ·             ·
+distribution: local
+vectorized: true
+·
+• project set
+│
+└── • emptyrow
 
-query TTT
+query T
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-·                   distribution  local
-·                   vectorized    true
-cross join          ·             ·
- ├── project set    ·             ·
- │    └── emptyrow  ·             ·
- └── project set    ·             ·
-      └── emptyrow  ·             ·
+distribution: local
+vectorized: true
+·
+• cross join
+│
+├── • project set
+│   │
+│   └── • emptyrow
+│
+└── • project set
+    │
+    └── • emptyrow
 
-query TTT
+query T
 EXPLAIN SELECT * FROM ROWS FROM (cos(1))
 ----
-·              distribution  local
-·              vectorized    true
-project set    ·             ·
- └── emptyrow  ·             ·
+distribution: local
+vectorized: true
+·
+• project set
+│
+└── • emptyrow
 
-query TTT
+query T
 EXPLAIN SELECT generate_series(1, 3)
 ----
-·              distribution  local
-·              vectorized    true
-project set    ·             ·
- └── emptyrow  ·             ·
+distribution: local
+vectorized: true
+·
+• project set
+│
+└── • emptyrow
 
 subtest multiple_SRFs
 # See #20511
 
-query TTT
+query T
 EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
 ----
-·              distribution  local
-·              vectorized    true
-project set    ·             ·
- └── emptyrow  ·             ·
+distribution: local
+vectorized: true
+·
+• project set
+│
+└── • emptyrow
 
 statement ok
 CREATE TABLE t (a string)
@@ -54,49 +67,68 @@ CREATE TABLE t (a string)
 statement ok
 CREATE TABLE u (b string)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-·                        distribution         local                     ·                                         ·
-·                        vectorized           true                      ·                                         ·
-cross join (inner)       ·                    ·                         (a, b, generate_series, generate_series)  ·
- │                       estimated row count  10000000 (missing stats)  ·                                         ·
- ├── cross join (inner)  ·                    ·                         (a, b)                                    ·
- │    │                  estimated row count  1000000 (missing stats)   ·                                         ·
- │    ├── scan           ·                    ·                         (a)                                       ·
- │    │                  estimated row count  1000 (missing stats)      ·                                         ·
- │    │                  table                t@primary                 ·                                         ·
- │    │                  spans                FULL SCAN                 ·                                         ·
- │    └── scan           ·                    ·                         (b)                                       ·
- │                       estimated row count  1000 (missing stats)      ·                                         ·
- │                       table                u@primary                 ·                                         ·
- │                       spans                FULL SCAN                 ·                                         ·
- └── project set         ·                    ·                         (generate_series, generate_series)        ·
-      │                  estimated row count  10                        ·                                         ·
-      │                  render 0             generate_series(1, 2)     ·                                         ·
-      │                  render 1             generate_series(3, 4)     ·                                         ·
-      └── emptyrow       ·                    ·                         ()                                        ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (a, b, generate_series, generate_series)
+│ estimated row count: 10000000 (missing stats)
+│
+├── • cross join (inner)
+│   │ columns: (a, b)
+│   │ estimated row count: 1000000 (missing stats)
+│   │
+│   ├── • scan
+│   │     columns: (a)
+│   │     estimated row count: 1000 (missing stats)
+│   │     table: t@primary
+│   │     spans: FULL SCAN
+│   │
+│   └── • scan
+│         columns: (b)
+│         estimated row count: 1000 (missing stats)
+│         table: u@primary
+│         spans: FULL SCAN
+│
+└── • project set
+    │ columns: (generate_series, generate_series)
+    │ estimated row count: 10
+    │ render 0: generate_series(1, 2)
+    │ render 1: generate_series(3, 4)
+    │
+    └── • emptyrow
+          columns: ()
 
 subtest correlated_SRFs
 
 statement ok
 CREATE TABLE data (a INT PRIMARY KEY)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a, generate_series(a, a + 1) FROM data ORDER BY 1, 2
 ----
-·                 distribution         local                      ·                     ·
-·                 vectorized           true                       ·                     ·
-sort              ·                    ·                          (a, generate_series)  +a,+generate_series
- │                estimated row count  10000 (missing stats)      ·                     ·
- │                order                +a,+generate_series        ·                     ·
- └── project set  ·                    ·                          (a, generate_series)  ·
-      │           estimated row count  10000 (missing stats)      ·                     ·
-      │           render 0             generate_series(a, a + 1)  ·                     ·
-      └── scan    ·                    ·                          (a)                   ·
-·                 estimated row count  1000 (missing stats)       ·                     ·
-·                 table                data@primary               ·                     ·
-·                 spans                FULL SCAN                  ·                     ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, generate_series)
+│ ordering: +a,+generate_series
+│ estimated row count: 10000 (missing stats)
+│ order: +a,+generate_series
+│
+└── • project set
+    │ columns: (a, generate_series)
+    │ estimated row count: 10000 (missing stats)
+    │ render 0: generate_series(a, a + 1)
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 1000 (missing stats)
+          table: data@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
@@ -104,122 +136,178 @@ CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 statement ok
 CREATE TABLE xz (x INT PRIMARY KEY, z INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
   FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
 ----
-·                                  distribution         local                                               ·                                                ·
-·                                  vectorized           true                                                ·                                                ·
-sort                               ·                    ·                                                   (x, y, z, "information_schema._pg_expandarray")  +x
- │                                 estimated row count  3267 (missing stats)                                ·                                                ·
- │                                 order                +x                                                  ·                                                ·
- └── render                        ·                    ·                                                   ("information_schema._pg_expandarray", x, y, z)  ·
-      │                            estimated row count  3267 (missing stats)                                ·                                                ·
-      │                            render 0             ((x, n) AS x, n)                                    ·                                                ·
-      │                            render 1             x                                                   ·                                                ·
-      │                            render 2             y                                                   ·                                                ·
-      │                            render 3             z                                                   ·                                                ·
-      └── project set              ·                    ·                                                   (x, y, x, z, x, n)                               ·
-           │                       estimated row count  3267 (missing stats)                                ·                                                ·
-           │                       render 0             information_schema._pg_expandarray(ARRAY[x, y, z])  ·                                                ·
-           └── merge join (inner)  ·                    ·                                                   (x, y, x, z)                                     ·
-                │                  estimated row count  327 (missing stats)                                 ·                                                ·
-                │                  equality             (x) = (x)                                           ·                                                ·
-                │                  left cols are key    ·                                                   ·                                                ·
-                │                  right cols are key   ·                                                   ·                                                ·
-                │                  pred                 y < z                                               ·                                                ·
-                │                  merge ordering       +"(x=x)"                                            ·                                                ·
-                ├── scan           ·                    ·                                                   (x, y)                                           +x
-                │                  estimated row count  1000 (missing stats)                                ·                                                ·
-                │                  table                xy@primary                                          ·                                                ·
-                │                  spans                FULL SCAN                                           ·                                                ·
-                └── scan           ·                    ·                                                   (x, z)                                           +x
-·                                  estimated row count  1000 (missing stats)                                ·                                                ·
-·                                  table                xz@primary                                          ·                                                ·
-·                                  spans                FULL SCAN                                           ·                                                ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (x, y, z, "information_schema._pg_expandarray")
+│ ordering: +x
+│ estimated row count: 3267 (missing stats)
+│ order: +x
+│
+└── • render
+    │ columns: ("information_schema._pg_expandarray", x, y, z)
+    │ estimated row count: 3267 (missing stats)
+    │ render 0: ((x, n) AS x, n)
+    │ render 1: x
+    │ render 2: y
+    │ render 3: z
+    │
+    └── • project set
+        │ columns: (x, y, x, z, x, n)
+        │ estimated row count: 3267 (missing stats)
+        │ render 0: information_schema._pg_expandarray(ARRAY[x, y, z])
+        │
+        └── • merge join (inner)
+            │ columns: (x, y, x, z)
+            │ estimated row count: 327 (missing stats)
+            │ equality: (x) = (x)
+            │ left cols are key
+            │ right cols are key
+            │ pred: y < z
+            │ merge ordering: +"(x=x)"
+            │
+            ├── • scan
+            │     columns: (x, y)
+            │     ordering: +x
+            │     estimated row count: 1000 (missing stats)
+            │     table: xy@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  columns: (x, z)
+                  ordering: +x
+                  estimated row count: 1000 (missing stats)
+                  table: xz@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
 ----
-·                            distribution         local                  ·                        ·
-·                            vectorized           true                   ·                        ·
-project                      ·                    ·                      (generate_series)        ·
- │                           estimated row count  3333 (missing stats)   ·                        ·
- └── project set             ·                    ·                      (x, z, generate_series)  ·
-      │                      estimated row count  3333 (missing stats)   ·                        ·
-      │                      render 0             generate_series(x, z)  ·                        ·
-      └── cross join (semi)  ·                    ·                      (x, z)                   ·
-           │                 estimated row count  333 (missing stats)    ·                        ·
-           │                 pred                 z < generate_series    ·                        ·
-           ├── scan          ·                    ·                      (x, z)                   ·
-           │                 estimated row count  1000 (missing stats)   ·                        ·
-           │                 table                xz@primary             ·                        ·
-           │                 spans                FULL SCAN              ·                        ·
-           └── project set   ·                    ·                      (x, y, generate_series)  ·
-                │            estimated row count  10000 (missing stats)  ·                        ·
-                │            render 0             generate_series(x, y)  ·                        ·
-                └── scan     ·                    ·                      (x, y)                   ·
-·                            estimated row count  1000 (missing stats)   ·                        ·
-·                            table                xy@primary             ·                        ·
-·                            spans                FULL SCAN              ·                        ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (generate_series)
+│ estimated row count: 3333 (missing stats)
+│
+└── • project set
+    │ columns: (x, z, generate_series)
+    │ estimated row count: 3333 (missing stats)
+    │ render 0: generate_series(x, z)
+    │
+    └── • cross join (semi)
+        │ columns: (x, z)
+        │ estimated row count: 333 (missing stats)
+        │ pred: z < generate_series
+        │
+        ├── • scan
+        │     columns: (x, z)
+        │     estimated row count: 1000 (missing stats)
+        │     table: xz@primary
+        │     spans: FULL SCAN
+        │
+        └── • project set
+            │ columns: (x, y, generate_series)
+            │ estimated row count: 10000 (missing stats)
+            │ render 0: generate_series(x, y)
+            │
+            └── • scan
+                  columns: (x, y)
+                  estimated row count: 1000 (missing stats)
+                  table: xy@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
   FROM xy NATURAL LEFT OUTER JOIN xz
 ----
-·                                  distribution         local                                   ·                                                           ·
-·                                  vectorized           true                                    ·                                                           ·
-project                            ·                    ·                                       (generate_subscripts, generate_series, unnest, y, z)        ·
- │                                 estimated row count  10000 (missing stats)                   ·                                                           ·
- └── project set                   ·                    ·                                       (x, y, x, z, generate_subscripts, generate_series, unnest)  ·
-      │                            estimated row count  10000 (missing stats)                   ·                                                           ·
-      │                            render 0             generate_subscripts(ARRAY[0, x, 1, 2])  ·                                                           ·
-      │                            render 1             generate_series(x, y)                   ·                                                           ·
-      │                            render 2             unnest(ARRAY[0, x, y, z])               ·                                                           ·
-      └── merge join (left outer)  ·                    ·                                       (x, y, x, z)                                                ·
-           │                       estimated row count  1000 (missing stats)                    ·                                                           ·
-           │                       equality             (x) = (x)                               ·                                                           ·
-           │                       left cols are key    ·                                       ·                                                           ·
-           │                       right cols are key   ·                                       ·                                                           ·
-           │                       merge ordering       +"(x=x)"                                ·                                                           ·
-           ├── scan                ·                    ·                                       (x, y)                                                      +x
-           │                       estimated row count  1000 (missing stats)                    ·                                                           ·
-           │                       table                xy@primary                              ·                                                           ·
-           │                       spans                FULL SCAN                               ·                                                           ·
-           └── scan                ·                    ·                                       (x, z)                                                      +x
-·                                  estimated row count  1000 (missing stats)                    ·                                                           ·
-·                                  table                xz@primary                              ·                                                           ·
-·                                  spans                FULL SCAN                               ·                                                           ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (generate_subscripts, generate_series, unnest, y, z)
+│ estimated row count: 10000 (missing stats)
+│
+└── • project set
+    │ columns: (x, y, x, z, generate_subscripts, generate_series, unnest)
+    │ estimated row count: 10000 (missing stats)
+    │ render 0: generate_subscripts(ARRAY[0, x, 1, 2])
+    │ render 1: generate_series(x, y)
+    │ render 2: unnest(ARRAY[0, x, y, z])
+    │
+    └── • merge join (left outer)
+        │ columns: (x, y, x, z)
+        │ estimated row count: 1000 (missing stats)
+        │ equality: (x) = (x)
+        │ left cols are key
+        │ right cols are key
+        │ merge ordering: +"(x=x)"
+        │
+        ├── • scan
+        │     columns: (x, y)
+        │     ordering: +x
+        │     estimated row count: 1000 (missing stats)
+        │     table: xy@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (x, z)
+              ordering: +x
+              estimated row count: 1000 (missing stats)
+              table: xz@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-·                                       distribution         local                                 ·                     ·
-·                                       vectorized           true                                  ·                     ·
-root                                    ·                    ·                                     (generate_series)     ·
- ├── project                            ·                    ·                                     (generate_series)     ·
- │    │                                 estimated row count  10000 (missing stats)                 ·                     ·
- │    └── project set                   ·                    ·                                     (z, generate_series)  ·
- │         │                            estimated row count  10000 (missing stats)                 ·                     ·
- │         │                            render 0             generate_series(@S1, z)               ·                     ·
- │         └── scan                     ·                    ·                                     (z)                   ·
- │                                      estimated row count  1000 (missing stats)                  ·                     ·
- │                                      table                xz@primary                            ·                     ·
- │                                      spans                FULL SCAN                             ·                     ·
- └── subquery                           ·                    ·                                     ·                     ·
-      │                                 id                   @S1                                   ·                     ·
-      │                                 original sql         (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
-      │                                 exec mode            one row                               ·                     ·
-      └── max1row                       ·                    ·                                     (unnest)              ·
-           │                            estimated row count  1                                     ·                     ·
-           └── project                  ·                    ·                                     (unnest)              ·
-                │                       estimated row count  2000 (missing stats)                  ·                     ·
-                └── apply join (inner)  ·                    ·                                     (x, y, unnest)        ·
-                     │                  estimated row count  2000 (missing stats)                  ·                     ·
-                     └── scan           ·                    ·                                     (x, y)                ·
-·                                       estimated row count  1000 (missing stats)                  ·                     ·
-·                                       table                xy@primary                            ·                     ·
-·                                       spans                FULL SCAN                             ·                     ·
+distribution: local
+vectorized: true
+·
+• root
+│ columns: (generate_series)
+│
+├── • project
+│   │ columns: (generate_series)
+│   │ estimated row count: 10000 (missing stats)
+│   │
+│   └── • project set
+│       │ columns: (z, generate_series)
+│       │ estimated row count: 10000 (missing stats)
+│       │ render 0: generate_series(@S1, z)
+│       │
+│       └── • scan
+│             columns: (z)
+│             estimated row count: 1000 (missing stats)
+│             table: xz@primary
+│             spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT unnest(ARRAY[x, y]) FROM xy)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │ columns: (unnest)
+        │ estimated row count: 1
+        │
+        └── • project
+            │ columns: (unnest)
+            │ estimated row count: 2000 (missing stats)
+            │
+            └── • apply join (inner)
+                │ columns: (x, y, unnest)
+                │ estimated row count: 2000 (missing stats)
+                │
+                └── • scan
+                      columns: (x, y)
+                      estimated row count: 1000 (missing stats)
+                      table: xy@primary
+                      spans: FULL SCAN
 
 # Regression test for #24676.
 statement ok
@@ -229,58 +317,80 @@ CREATE TABLE groups(
   primary key (id)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT
   g.data->>'name' AS group_name,
   jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
 FROM
   groups g
 ----
-·                                           distribution         local                             ·                                             ·
-·                                           vectorized           true                              ·                                             ·
-render                                      ·                    ·                                 (group_name, jsonb_array_elements)            ·
- │                                          estimated row count  100000 (missing stats)            ·                                             ·
- │                                          render 0             data->>'name'                     ·                                             ·
- │                                          render 1             jsonb_array_elements              ·                                             ·
- └── project set                            ·                    ·                                 (id, data, "?column?", jsonb_array_elements)  ·
-      │                                     estimated row count  100000 (missing stats)            ·                                             ·
-      │                                     render 0             jsonb_array_elements("?column?")  ·                                             ·
-      └── distinct                          ·                    ·                                 (id, data, "?column?")                        ·
-           │                                estimated row count  10000 (missing stats)             ·                                             ·
-           │                                distinct on          id                                ·                                             ·
-           │                                error on duplicate   ·                                 ·                                             ·
-           └── project                      ·                    ·                                 (id, data, "?column?")                        ·
-                └── hash join (left outer)  ·                    ·                                 (column12, id, data, column13, "?column?")    ·
-                     │                      estimated row count  10000 (missing stats)             ·                                             ·
-                     │                      equality             (column12) = (column13)           ·                                             ·
-                     ├── render             ·                    ·                                 (column12, id, data)                          ·
-                     │    │                 estimated row count  1000 (missing stats)              ·                                             ·
-                     │    │                 render 0             data->>'name'                     ·                                             ·
-                     │    │                 render 1             id                                ·                                             ·
-                     │    │                 render 2             data                              ·                                             ·
-                     │    └── scan          ·                    ·                                 (id, data)                                    ·
-                     │                      estimated row count  1000 (missing stats)              ·                                             ·
-                     │                      table                groups@primary                    ·                                             ·
-                     │                      spans                FULL SCAN                         ·                                             ·
-                     └── render             ·                    ·                                 (column13, "?column?")                        ·
-                          │                 estimated row count  1000 (missing stats)              ·                                             ·
-                          │                 render 0             data->>'name'                     ·                                             ·
-                          │                 render 1             data->'members'                   ·                                             ·
-                          └── scan          ·                    ·                                 (data)                                        ·
-·                                           estimated row count  1000 (missing stats)              ·                                             ·
-·                                           table                groups@primary                    ·                                             ·
-·                                           spans                FULL SCAN                         ·                                             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (group_name, jsonb_array_elements)
+│ estimated row count: 100000 (missing stats)
+│ render 0: data->>'name'
+│ render 1: jsonb_array_elements
+│
+└── • project set
+    │ columns: (id, data, "?column?", jsonb_array_elements)
+    │ estimated row count: 100000 (missing stats)
+    │ render 0: jsonb_array_elements("?column?")
+    │
+    └── • distinct
+        │ columns: (id, data, "?column?")
+        │ estimated row count: 10000 (missing stats)
+        │ distinct on: id
+        │ error on duplicate
+        │
+        └── • project
+            │ columns: (id, data, "?column?")
+            │
+            └── • hash join (left outer)
+                │ columns: (column12, id, data, column13, "?column?")
+                │ estimated row count: 10000 (missing stats)
+                │ equality: (column12) = (column13)
+                │
+                ├── • render
+                │   │ columns: (column12, id, data)
+                │   │ estimated row count: 1000 (missing stats)
+                │   │ render 0: data->>'name'
+                │   │ render 1: id
+                │   │ render 2: data
+                │   │
+                │   └── • scan
+                │         columns: (id, data)
+                │         estimated row count: 1000 (missing stats)
+                │         table: groups@primary
+                │         spans: FULL SCAN
+                │
+                └── • render
+                    │ columns: (column13, "?column?")
+                    │ estimated row count: 1000 (missing stats)
+                    │ render 0: data->>'name'
+                    │ render 1: data->'members'
+                    │
+                    └── • scan
+                          columns: (data)
+                          estimated row count: 1000 (missing stats)
+                          table: groups@primary
+                          spans: FULL SCAN
 
 # Regression test for #32162.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM ROWS FROM (IF(length('abc') = length('def'), 1, 0))
 ----
-·              distribution         local  ·       ·
-·              vectorized           true   ·       ·
-project set    ·                    ·      ("if")  ·
- │             estimated row count  1      ·       ·
- │             render 0             1      ·       ·
- └── emptyrow  ·                    ·      ()      ·
+distribution: local
+vectorized: true
+·
+• project set
+│ columns: ("if")
+│ estimated row count: 1
+│ render 0: 1
+│
+└── • emptyrow
+      columns: ()
 
 statement ok
 CREATE TABLE articles (
@@ -296,7 +406,7 @@ CREATE TABLE articles (
 )
 
 # Regression test for #31706.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a0.id, a0.body, a0.description, a0.title, a0.slug, a0.tag_list, a0.user_id, a0.created_at, a0.updated_at
     FROM articles AS a0
    WHERE EXISTS(SELECT * FROM unnest(a0.tag_list) AS tag WHERE tag = 'dragons')
@@ -304,59 +414,88 @@ ORDER BY a0.created_at
    LIMIT 10
   OFFSET 0;
 ----
-·                                     distribution         local                      ·                                                                                                                     ·
-·                                     vectorized           true                       ·                                                                                                                     ·
-limit                                 ·                    ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)                                       ·
- │                                    estimated row count  10 (missing stats)         ·                                                                                                                     ·
- │                                    count                10                         ·                                                                                                                     ·
- └── sort                             ·                    ·                          (id, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)  +any_not_null
-      │                               estimated row count  14 (missing stats)         ·                                                                                                                     ·
-      │                               order                +any_not_null              ·                                                                                                                     ·
-      └── group                       ·                    ·                          (id, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)  ·
-           │                          estimated row count  14 (missing stats)         ·                                                                                                                     ·
-           │                          aggregate 0          any_not_null(body)         ·                                                                                                                     ·
-           │                          aggregate 1          any_not_null(description)  ·                                                                                                                     ·
-           │                          aggregate 2          any_not_null(title)        ·                                                                                                                     ·
-           │                          aggregate 3          any_not_null(slug)         ·                                                                                                                     ·
-           │                          aggregate 4          any_not_null(tag_list)     ·                                                                                                                     ·
-           │                          aggregate 5          any_not_null(user_id)      ·                                                                                                                     ·
-           │                          aggregate 6          any_not_null(created_at)   ·                                                                                                                     ·
-           │                          aggregate 7          any_not_null(updated_at)   ·                                                                                                                     ·
-           │                          group by             id                         ·                                                                                                                     ·
-           └── project                ·                    ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)                                       ·
-                └── filter            ·                    ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)                               ·
-                     │                estimated row count  14 (missing stats)         ·                                                                                                                     ·
-                     │                filter               unnest = 'dragons'         ·                                                                                                                     ·
-                     └── project set  ·                    ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)                               ·
-                          │           estimated row count  10000 (missing stats)      ·                                                                                                                     ·
-                          │           render 0             unnest(tag_list)           ·                                                                                                                     ·
-                          └── scan    ·                    ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)                                       ·
-·                                     estimated row count  1000 (missing stats)       ·                                                                                                                     ·
-·                                     table                articles@primary           ·                                                                                                                     ·
-·                                     spans                FULL SCAN                  ·                                                                                                                     ·
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)
+│ estimated row count: 10 (missing stats)
+│ count: 10
+│
+└── • sort
+    │ columns: (id, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)
+    │ ordering: +any_not_null
+    │ estimated row count: 14 (missing stats)
+    │ order: +any_not_null
+    │
+    └── • group
+        │ columns: (id, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)
+        │ estimated row count: 14 (missing stats)
+        │ aggregate 0: any_not_null(body)
+        │ aggregate 1: any_not_null(description)
+        │ aggregate 2: any_not_null(title)
+        │ aggregate 3: any_not_null(slug)
+        │ aggregate 4: any_not_null(tag_list)
+        │ aggregate 5: any_not_null(user_id)
+        │ aggregate 6: any_not_null(created_at)
+        │ aggregate 7: any_not_null(updated_at)
+        │ group by: id
+        │
+        └── • project
+            │ columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)
+            │
+            └── • filter
+                │ columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)
+                │ estimated row count: 14 (missing stats)
+                │ filter: unnest = 'dragons'
+                │
+                └── • project set
+                    │ columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)
+                    │ estimated row count: 10000 (missing stats)
+                    │ render 0: unnest(tag_list)
+                    │
+                    └── • scan
+                          columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)
+                          estimated row count: 1000 (missing stats)
+                          table: articles@primary
+                          spans: FULL SCAN
 
 # Regression test for #32723.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         generate_series(a + 1, a + 1)
     FROM
         (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
 ----
-·                           distribution         local                          ·                         ·
-·                           vectorized           false                          ·                         ·
-project                     ·                    ·                              (generate_series)         ·
- │                          estimated row count  10                             ·                         ·
- └── project set            ·                    ·                              (a, a, generate_series)   ·
-      │                     estimated row count  10                             ·                         ·
-      │                     render 0             generate_series(a + 1, a + 1)  ·                         ·
-      └── except all        ·                    ·                              (a, a)                    ·
-           │                estimated row count  1                              ·                         ·
-           ├── project      ·                    ·                              (a, a)                    ·
-           │    └── values  ·                    ·                              (a)                       ·
-           │                size                 1 column, 1 row                ·                         ·
-           │                row 0, expr 0        1                              ·                         ·
-           └── project      ·                    ·                              ("?column?", "?column?")  ·
-                └── values  ·                    ·                              ("?column?")              ·
-·                           size                 1 column, 1 row                ·                         ·
-·                           row 0, expr 0        0                              ·                         ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (generate_series)
+│ estimated row count: 10
+│
+└── • project set
+    │ columns: (a, a, generate_series)
+    │ estimated row count: 10
+    │ render 0: generate_series(a + 1, a + 1)
+    │
+    └── • except all
+        │ columns: (a, a)
+        │ estimated row count: 1
+        │
+        ├── • project
+        │   │ columns: (a, a)
+        │   │
+        │   └── • values
+        │         columns: (a)
+        │         size: 1 column, 1 row
+        │         row 0, expr 0: 1
+        │
+        └── • project
+            │ columns: ("?column?", "?column?")
+            │
+            └── • values
+                  columns: ("?column?")
+                  size: 1 column, 1 row
+                  row 0, expr 0: 0

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -34,18 +34,22 @@ statement ok
 set enable_zigzag_join = false
 
 # Verify we scan index v which has the more selective constraint.
-query TTTTT retry
+query T retry
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·          distribution         full         ·       ·
-·          vectorized           true         ·       ·
-filter     ·                    ·            (u, v)  ·
- │         estimated row count  1            ·       ·
- │         filter               u = 1        ·       ·
- └── scan  ·                    ·            (u, v)  ·
-·          estimated row count  1            ·       ·
-·          table                uv@uv_v_idx  ·       ·
-·          spans                /1-/2        ·       ·
+distribution: full
+vectorized: true
+·
+• filter
+│ columns: (u, v)
+│ estimated row count: 1
+│ filter: u = 1
+│
+└── • scan
+      columns: (u, v)
+      estimated row count: 1
+      table: uv@uv_v_idx
+      spans: /1-/2
 
 # Verify that injecting different statistics changes the plan.
 statement ok
@@ -64,18 +68,22 @@ ALTER TABLE uv INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·          distribution         full         ·       ·
-·          vectorized           true         ·       ·
-filter     ·                    ·            (u, v)  ·
- │         estimated row count  1            ·       ·
- │         filter               v = 1        ·       ·
- └── scan  ·                    ·            (u, v)  ·
-·          estimated row count  1            ·       ·
-·          table                uv@uv_u_idx  ·       ·
-·          spans                /1-/2        ·       ·
+distribution: full
+vectorized: true
+·
+• filter
+│ columns: (u, v)
+│ estimated row count: 1
+│ filter: v = 1
+│
+└── • scan
+      columns: (u, v)
+      estimated row count: 1
+      table: uv@uv_u_idx
+      spans: /1-/2
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
@@ -97,18 +105,22 @@ ALTER TABLE uv INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·          distribution         full         ·       ·
-·          vectorized           true         ·       ·
-filter     ·                    ·            (u, v)  ·
- │         estimated row count  1            ·       ·
- │         filter               v = 1        ·       ·
- └── scan  ·                    ·            (u, v)  ·
-·          estimated row count  5            ·       ·
-·          table                uv@uv_u_idx  ·       ·
-·          spans                /1-/2        ·       ·
+distribution: full
+vectorized: true
+·
+• filter
+│ columns: (u, v)
+│ estimated row count: 1
+│ filter: v = 1
+│
+└── • scan
+      columns: (u, v)
+      estimated row count: 5
+      table: uv@uv_u_idx
+      spans: /1-/2
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[
@@ -128,18 +140,22 @@ ALTER TABLE uv INJECT STATISTICS '[
   }
 ]'
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·          distribution         full         ·       ·
-·          vectorized           true         ·       ·
-filter     ·                    ·            (u, v)  ·
- │         estimated row count  1            ·       ·
- │         filter               u = 1        ·       ·
- └── scan  ·                    ·            (u, v)  ·
-·          estimated row count  1            ·       ·
-·          table                uv@uv_v_idx  ·       ·
-·          spans                /1-/2        ·       ·
+distribution: full
+vectorized: true
+·
+• filter
+│ columns: (u, v)
+│ estimated row count: 1
+│ filter: u = 1
+│
+└── • scan
+      columns: (u, v)
+      estimated row count: 1
+      table: uv@uv_v_idx
+      spans: /1-/2
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -6,137 +6,187 @@
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 
-query TTT
+query T
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-·                 distribution  local
-·                 vectorized    false
-root              ·             ·
- ├── split        ·             ·
- │    └── values  ·             ·
- │                size          1 column, 1 row
- └── subquery     ·             ·
-      │           id            @S1
-      │           original sql  (SELECT 42)
-      │           exec mode     one row
-      └── values  ·             ·
-·                 size          1 column, 1 row
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • split
+│   │
+│   └── • values
+│         size: 1 column, 1 row
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT 42)
+    │ exec mode: one row
+    │
+    └── • values
+          size: 1 column, 1 row
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 
-query TTT
+query T
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-·               distribution   local
-·               vectorized     false
-root            ·              ·
- ├── values     ·              ·
- │              size           1 column, 1 row
- └── subquery   ·              ·
-      │         id             @S1
-      │         original sql   EXISTS (SELECT a FROM abc)
-      │         exec mode      exists
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          abc@primary
-·               spans          LIMITED SCAN
-·               limit          1
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • values
+│     size: 1 column, 1 row
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: EXISTS (SELECT a FROM abc)
+    │ exec mode: exists
+    │
+    └── • scan
+          missing stats
+          table: abc@primary
+          spans: LIMITED SCAN
+          limit: 1
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-·                                 distribution         local                                                                        ·               ·
-·                                 vectorized           true                                                                         ·               ·
-root                              ·                    ·                                                                            (a, b, c)       ·
- ├── filter                       ·                    ·                                                                            (a, b, c)       ·
- │    │                           estimated row count  333 (missing stats)                                                          ·               ·
- │    │                           filter               a = @S2                                                                      ·               ·
- │    └── scan                    ·                    ·                                                                            (a, b, c)       ·
- │                                estimated row count  1000 (missing stats)                                                         ·               ·
- │                                table                abc@primary                                                                  ·               ·
- │                                spans                FULL SCAN                                                                    ·               ·
- ├── subquery                     ·                    ·                                                                            ·               ·
- │    │                           id                   @S1                                                                          ·               ·
- │    │                           original sql         EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
- │    │                           exec mode            exists                                                                       ·               ·
- │    └── limit                   ·                    ·                                                                            (a, b, c)       ·
- │         │                      estimated row count  1 (missing stats)                                                            ·               ·
- │         │                      count                1                                                                            ·               ·
- │         └── filter             ·                    ·                                                                            (a, b, c)       ·
- │              │                 estimated row count  330 (missing stats)                                                          ·               ·
- │              │                 filter               c = (a + 3)                                                                  ·               ·
- │              └── scan          ·                    ·                                                                            (a, b, c)       ·
- │                                estimated row count  1000 (missing stats)                                                         ·               ·
- │                                table                abc@primary                                                                  ·               ·
- │                                spans                FULL SCAN                                                                    ·               ·
- └── subquery                     ·                    ·                                                                            ·               ·
-      │                           id                   @S2                                                                          ·               ·
-      │                           original sql         (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
-      │                           exec mode            one row                                                                      ·               ·
-      └── group (scalar)          ·                    ·                                                                            (any_not_null)  ·
-           │                      estimated row count  1 (missing stats)                                                            ·               ·
-           │                      aggregate 0          any_not_null(a)                                                              ·               ·
-           └── limit              ·                    ·                                                                            (a)             ·
-                │                 estimated row count  1 (missing stats)                                                            ·               ·
-                │                 count                1                                                                            ·               ·
-                └── filter        ·                    ·                                                                            (a)             -a
-                     │            estimated row count  333 (missing stats)                                                          ·               ·
-                     │            filter               @S1                                                                          ·               ·
-                     └── revscan  ·                    ·                                                                            (a)             -a
-·                                 estimated row count  1000 (missing stats)                                                         ·               ·
-·                                 table                abc@primary                                                                  ·               ·
-·                                 spans                FULL SCAN                                                                    ·               ·
+distribution: local
+vectorized: true
+·
+• root
+│ columns: (a, b, c)
+│
+├── • filter
+│   │ columns: (a, b, c)
+│   │ estimated row count: 333 (missing stats)
+│   │ filter: a = @S2
+│   │
+│   └── • scan
+│         columns: (a, b, c)
+│         estimated row count: 1000 (missing stats)
+│         table: abc@primary
+│         spans: FULL SCAN
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: EXISTS (SELECT * FROM abc WHERE c = (a + 3))
+│   │ exec mode: exists
+│   │
+│   └── • limit
+│       │ columns: (a, b, c)
+│       │ estimated row count: 1 (missing stats)
+│       │ count: 1
+│       │
+│       └── • filter
+│           │ columns: (a, b, c)
+│           │ estimated row count: 330 (missing stats)
+│           │ filter: c = (a + 3)
+│           │
+│           └── • scan
+│                 columns: (a, b, c)
+│                 estimated row count: 1000 (missing stats)
+│                 table: abc@primary
+│                 spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │ columns: (any_not_null)
+        │ estimated row count: 1 (missing stats)
+        │ aggregate 0: any_not_null(a)
+        │
+        └── • limit
+            │ columns: (a)
+            │ estimated row count: 1 (missing stats)
+            │ count: 1
+            │
+            └── • filter
+                │ columns: (a)
+                │ ordering: -a
+                │ estimated row count: 333 (missing stats)
+                │ filter: @S1
+                │
+                └── • revscan
+                      columns: (a)
+                      ordering: -a
+                      estimated row count: 1000 (missing stats)
+                      table: abc@primary
+                      spans: FULL SCAN
 
 # IN expression transformed into semi-join.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc WHERE b < 0)
 ----
-·                  distribution         local                 ·       ·
-·                  vectorized           true                  ·       ·
-merge join (semi)  ·                    ·                     (a)     ·
- │                 estimated row count  333 (missing stats)   ·       ·
- │                 equality             (a) = (a)             ·       ·
- │                 left cols are key    ·                     ·       ·
- │                 right cols are key   ·                     ·       ·
- │                 merge ordering       +"(a=a)"              ·       ·
- ├── scan          ·                    ·                     (a)     +a
- │                 estimated row count  1000 (missing stats)  ·       ·
- │                 table                abc@primary           ·       ·
- │                 spans                FULL SCAN             ·       ·
- └── filter        ·                    ·                     (a, b)  +a
-      │            estimated row count  333 (missing stats)   ·       ·
-      │            filter               b < 0                 ·       ·
-      └── scan     ·                    ·                     (a, b)  +a
-·                  estimated row count  1000 (missing stats)  ·       ·
-·                  table                abc@primary           ·       ·
-·                  spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• merge join (semi)
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│ equality: (a) = (a)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(a=a)"
+│
+├── • scan
+│     columns: (a)
+│     ordering: +a
+│     estimated row count: 1000 (missing stats)
+│     table: abc@primary
+│     spans: FULL SCAN
+│
+└── • filter
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 333 (missing stats)
+    │ filter: b < 0
+    │
+    └── • scan
+          columns: (a, b)
+          ordering: +a
+          estimated row count: 1000 (missing stats)
+          table: abc@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-·            distribution  local
-·            vectorized    false
-sort         ·             ·
- │           order         +foo1
- └── values  ·             ·
-·            size          3 columns, 3 rows
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +foo1
+│
+└── • values
+      size: 3 columns, 3 rows
 
 # the subquery's plan must be visible in EXPLAIN
-query TTT
+query T
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-·                 distribution  local
-·                 vectorized    false
-root              ·             ·
- ├── values       ·             ·
- │                size          1 column, 2 rows
- └── subquery     ·             ·
-      │           id            @S1
-      │           original sql  (SELECT 2)
-      │           exec mode     one row
-      └── values  ·             ·
-·                 size          1 column, 1 row
+distribution: local
+vectorized: false
+·
+• root
+│
+├── • values
+│     size: 1 column, 2 rows
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT 2)
+    │ exec mode: one row
+    │
+    └── • values
+          size: 1 column, 1 row
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -147,7 +197,7 @@ CREATE TABLE tab4(col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT)
 statement ok
 CREATE INDEX idx_tab4_0 ON tab4 (col4,col0)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT col0
 FROM tab4
@@ -156,19 +206,27 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-·                    distribution         local                           ·                          ·
-·                    vectorized           true                            ·                          ·
-project              ·                    ·                               (col0)                     ·
- │                   estimated row count  311 (missing stats)             ·                          ·
- └── project         ·                    ·                               (col0, col3, col4)         ·
-      │              estimated row count  311 (missing stats)             ·                          ·
-      └── filter     ·                    ·                               (col0, col3, col4, rowid)  ·
-           │         estimated row count  311 (missing stats)             ·                          ·
-           │         filter               (col0 <= 0) AND (col4 <= 5.38)  ·                          ·
-           └── scan  ·                    ·                               (col0, col3, col4, rowid)  ·
-·                    estimated row count  1000 (missing stats)            ·                          ·
-·                    table                tab4@primary                    ·                          ·
-·                    spans                FULL SCAN                       ·                          ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (col0)
+│ estimated row count: 311 (missing stats)
+│
+└── • project
+    │ columns: (col0, col3, col4)
+    │ estimated row count: 311 (missing stats)
+    │
+    └── • filter
+        │ columns: (col0, col3, col4, rowid)
+        │ estimated row count: 311 (missing stats)
+        │ filter: (col0 <= 0) AND (col4 <= 5.38)
+        │
+        └── • scan
+              columns: (col0, col3, col4, rowid)
+              estimated row count: 1000 (missing stats)
+              table: tab4@primary
+              spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.
@@ -177,116 +235,159 @@ statement ok
 CREATE TABLE a (x INT PRIMARY KEY, y INT);
 CREATE TABLE b (x INT PRIMARY KEY, z INT);
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
-·                  distribution         local                 ·       ·
-·                  vectorized           true                  ·       ·
-merge join (semi)  ·                    ·                     (x, y)  ·
- │                 estimated row count  1000 (missing stats)  ·       ·
- │                 equality             (x) = (x)             ·       ·
- │                 left cols are key    ·                     ·       ·
- │                 right cols are key   ·                     ·       ·
- │                 merge ordering       +"(x=x)"              ·       ·
- ├── scan          ·                    ·                     (x, y)  +x
- │                 estimated row count  1000 (missing stats)  ·       ·
- │                 table                a@primary             ·       ·
- │                 spans                FULL SCAN             ·       ·
- └── scan          ·                    ·                     (x)     +x
-·                  estimated row count  1000 (missing stats)  ·       ·
-·                  table                b@primary             ·       ·
-·                  spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• merge join (semi)
+│ columns: (x, y)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x) = (x)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(x=x)"
+│
+├── • scan
+│     columns: (x, y)
+│     ordering: +x
+│     estimated row count: 1000 (missing stats)
+│     table: a@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      ordering: +x
+      estimated row count: 1000 (missing stats)
+      table: b@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
-·                 distribution         local                 ·          ·
-·                 vectorized           true                  ·          ·
-hash join (semi)  ·                    ·                     (x, y)     ·
- │                estimated row count  1000 (missing stats)  ·          ·
- │                equality             (x) = (column9)       ·          ·
- │                left cols are key    ·                     ·          ·
- ├── scan         ·                    ·                     (x, y)     ·
- │                estimated row count  1000 (missing stats)  ·          ·
- │                table                a@primary             ·          ·
- │                spans                FULL SCAN             ·          ·
- └── render       ·                    ·                     (column9)  ·
-      │           estimated row count  1000 (missing stats)  ·          ·
-      │           render 0             x - 1                 ·          ·
-      └── scan    ·                    ·                     (x)        ·
-·                 estimated row count  1000 (missing stats)  ·          ·
-·                 table                b@primary             ·          ·
-·                 spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• hash join (semi)
+│ columns: (x, y)
+│ estimated row count: 1000 (missing stats)
+│ equality: (x) = (column9)
+│ left cols are key
+│
+├── • scan
+│     columns: (x, y)
+│     estimated row count: 1000 (missing stats)
+│     table: a@primary
+│     spans: FULL SCAN
+│
+└── • render
+    │ columns: (column9)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: x - 1
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: b@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
 ----
-·                  distribution         local                 ·       ·
-·                  vectorized           true                  ·       ·
-merge join (anti)  ·                    ·                     (x, y)  ·
- │                 estimated row count  0 (missing stats)     ·       ·
- │                 equality             (x) = (x)             ·       ·
- │                 left cols are key    ·                     ·       ·
- │                 right cols are key   ·                     ·       ·
- │                 merge ordering       +"(x=x)"              ·       ·
- ├── scan          ·                    ·                     (x, y)  +x
- │                 estimated row count  1000 (missing stats)  ·       ·
- │                 table                a@primary             ·       ·
- │                 spans                FULL SCAN             ·       ·
- └── scan          ·                    ·                     (x)     +x
-·                  estimated row count  1000 (missing stats)  ·       ·
-·                  table                b@primary             ·       ·
-·                  spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• merge join (anti)
+│ columns: (x, y)
+│ estimated row count: 0 (missing stats)
+│ equality: (x) = (x)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(x=x)"
+│
+├── • scan
+│     columns: (x, y)
+│     ordering: +x
+│     estimated row count: 1000 (missing stats)
+│     table: a@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      ordering: +x
+      estimated row count: 1000 (missing stats)
+      table: b@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
-·                 distribution         local                 ·          ·
-·                 vectorized           true                  ·          ·
-hash join (anti)  ·                    ·                     (x, z)     ·
- │                estimated row count  0 (missing stats)     ·          ·
- │                equality             (x) = (column9)       ·          ·
- │                left cols are key    ·                     ·          ·
- ├── scan         ·                    ·                     (x, z)     ·
- │                estimated row count  1000 (missing stats)  ·          ·
- │                table                b@primary             ·          ·
- │                spans                FULL SCAN             ·          ·
- └── render       ·                    ·                     (column9)  ·
-      │           estimated row count  1000 (missing stats)  ·          ·
-      │           render 0             x - 1                 ·          ·
-      └── scan    ·                    ·                     (x)        ·
-·                 estimated row count  1000 (missing stats)  ·          ·
-·                 table                a@primary             ·          ·
-·                 spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: true
+·
+• hash join (anti)
+│ columns: (x, z)
+│ estimated row count: 0 (missing stats)
+│ equality: (x) = (column9)
+│ left cols are key
+│
+├── • scan
+│     columns: (x, z)
+│     estimated row count: 1000 (missing stats)
+│     table: b@primary
+│     spans: FULL SCAN
+│
+└── • render
+    │ columns: (column9)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: x - 1
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: a@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
-·               distribution         local                 ·          ·
-·               vectorized           false                 ·          ·
-root            ·                    ·                     ("array")  ·
- ├── values     ·                    ·                     ("array")  ·
- │              size                 1 column, 1 row       ·          ·
- │              row 0, expr 0        ARRAY @S1             ·          ·
- └── subquery   ·                    ·                     ·          ·
-      │         id                   @S1                   ·          ·
-      │         original sql         (SELECT x FROM b)     ·          ·
-      │         exec mode            all rows              ·          ·
-      └── scan  ·                    ·                     (x)        ·
-·               estimated row count  1000 (missing stats)  ·          ·
-·               table                b@primary             ·          ·
-·               spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: ("array")
+│
+├── • values
+│     columns: ("array")
+│     size: 1 column, 1 row
+│     row 0, expr 0: ARRAY @S1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT x FROM b)
+    │ exec mode: all rows
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 1000 (missing stats)
+          table: b@primary
+          spans: FULL SCAN
 
 # Case where the plan has an apply join.
-query TTTTT
+query T
 EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
 ----
-·                  distribution         local                 ·          ·
-·                  vectorized           false                 ·          ·
-apply join (semi)  ·                    ·                     (a, b, c)  ·
- │                 estimated row count  2 (missing stats)     ·          ·
- │                 pred                 column1 = a           ·          ·
- └── scan          ·                    ·                     (a, b, c)  ·
-·                  estimated row count  1000 (missing stats)  ·          ·
-·                  table                abc@primary           ·          ·
-·                  spans                FULL SCAN             ·          ·
+distribution: local
+vectorized: false
+·
+• apply join (semi)
+│ columns: (a, b, c)
+│ estimated row count: 2 (missing stats)
+│ pred: column1 = a
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 1000 (missing stats)
+      table: abc@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -8,84 +8,114 @@ CREATE TABLE uvw (
   INDEX (u,v,w)
 )
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (u, v, w)  +u,+v,+w
-·     estimated row count  333 (missing stats)  ·          ·
-·     table                uvw@uvw_u_v_w_idx    ·          ·
-·     spans                /1/2/3-              ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (u, v, w)
+  ordering: +u,+v,+w
+  estimated row count: 333 (missing stats)
+  table: uvw@uvw_u_v_w_idx
+  spans: /1/2/3-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (u, v, w)  +u,+v,+w
-·     estimated row count  333 (missing stats)  ·          ·
-·     table                uvw@uvw_u_v_w_idx    ·          ·
-·     spans                /2/1/2-              ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (u, v, w)
+  ordering: +u,+v,+w
+  estimated row count: 333 (missing stats)
+  table: uvw@uvw_u_v_w_idx
+  spans: /2/1/2-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-·          distribution         local                   ·          ·
-·          vectorized           true                    ·          ·
-filter     ·                    ·                       (u, v, w)  +u,+v,+w
- │         estimated row count  333 (missing stats)     ·          ·
- │         filter               (u, v, w) <= (2, 3, 1)  ·          ·
- └── scan  ·                    ·                       (u, v, w)  +u,+v,+w
-·          estimated row count  333 (missing stats)     ·          ·
-·          table                uvw@uvw_u_v_w_idx       ·          ·
-·          spans                /!NULL-/2/3/2           ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (u, v, w)
+│ ordering: +u,+v,+w
+│ estimated row count: 333 (missing stats)
+│ filter: (u, v, w) <= (2, 3, 1)
+│
+└── • scan
+      columns: (u, v, w)
+      ordering: +u,+v,+w
+      estimated row count: 333 (missing stats)
+      table: uvw@uvw_u_v_w_idx
+      spans: /!NULL-/2/3/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-·          distribution         local                  ·          ·
-·          vectorized           true                   ·          ·
-filter     ·                    ·                      (u, v, w)  +u,+v,+w
- │         estimated row count  333 (missing stats)    ·          ·
- │         filter               (u, v, w) < (2, 2, 2)  ·          ·
- └── scan  ·                    ·                      (u, v, w)  +u,+v,+w
-·          estimated row count  333 (missing stats)    ·          ·
-·          table                uvw@uvw_u_v_w_idx      ·          ·
-·          spans                /!NULL-/2/2/2          ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (u, v, w)
+│ ordering: +u,+v,+w
+│ estimated row count: 333 (missing stats)
+│ filter: (u, v, w) < (2, 2, 2)
+│
+└── • scan
+      columns: (u, v, w)
+      ordering: +u,+v,+w
+      estimated row count: 333 (missing stats)
+      table: uvw@uvw_u_v_w_idx
+      spans: /!NULL-/2/2/2
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-·          distribution         local                   ·          ·
-·          vectorized           true                    ·          ·
-filter     ·                    ·                       (u, v, w)  +u,+v,+w
- │         estimated row count  333 (missing stats)     ·          ·
- │         filter               (u, v, w) != (1, 2, 3)  ·          ·
- └── scan  ·                    ·                       (u, v, w)  +u,+v,+w
-·          estimated row count  333 (missing stats)     ·          ·
-·          table                uvw@uvw_u_v_w_idx       ·          ·
-·          spans                -/1/2/3 /1/2/4-         ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (u, v, w)
+│ ordering: +u,+v,+w
+│ estimated row count: 333 (missing stats)
+│ filter: (u, v, w) != (1, 2, 3)
+│
+└── • scan
+      columns: (u, v, w)
+      ordering: +u,+v,+w
+      estimated row count: 333 (missing stats)
+      table: uvw@uvw_u_v_w_idx
+      spans: -/1/2/3 /1/2/4-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (u, v, w)  +u,+v,+w
-·     estimated row count  333 (missing stats)  ·          ·
-·     table                uvw@uvw_u_v_w_idx    ·          ·
-·     spans                /2-                  ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (u, v, w)
+  ordering: +u,+v,+w
+  estimated row count: 333 (missing stats)
+  table: uvw@uvw_u_v_w_idx
+  spans: /2-
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 ----
-·     distribution         local                ·          ·
-·     vectorized           true                 ·          ·
-scan  ·                    ·                    (u, v, w)  +u,+v,+w
-·     estimated row count  333 (missing stats)  ·          ·
-·     table                uvw@uvw_u_v_w_idx    ·          ·
-·     spans                /!NULL-/2            ·          ·
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (u, v, w)
+  ordering: +u,+v,+w
+  estimated row count: 333 (missing stats)
+  table: uvw@uvw_u_v_w_idx
+  spans: /!NULL-/2
 
 statement ok
 DROP TABLE uvw
@@ -94,22 +124,28 @@ DROP TABLE uvw
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8, 9, 10)
 ----
-·                distribution         local                                                 ·              ·
-·                vectorized           true                                                  ·              ·
-filter           ·                    ·                                                     (a, b, c)      ·
- │               estimated row count  333 (missing stats)                                   ·              ·
- │               filter               ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·              ·
- └── index join  ·                    ·                                                     (a, b, c)      ·
-      │          estimated row count  80 (missing stats)                                    ·              ·
-      │          table                abc@primary                                           ·              ·
-      │          key columns          rowid                                                 ·              ·
-      └── scan   ·                    ·                                                     (a, b, rowid)  ·
-·                estimated row count  80 (missing stats)                                    ·              ·
-·                table                abc@abc_a_b_idx                                       ·              ·
-·                spans                /1/2-/8/10                                            ·              ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, c)
+│ estimated row count: 333 (missing stats)
+│ filter: ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))
+│
+└── • index join
+    │ columns: (a, b, c)
+    │ estimated row count: 80 (missing stats)
+    │ table: abc@primary
+    │ key columns: rowid
+    │
+    └── • scan
+          columns: (a, b, rowid)
+          estimated row count: 80 (missing stats)
+          table: abc@abc_a_b_idx
+          spans: /1/2-/8/10
 
 statement ok
 DROP TABLE abc
@@ -117,18 +153,22 @@ DROP TABLE abc
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
-·          distribution         local                  ·          ·
-·          vectorized           true                   ·          ·
-filter     ·                    ·                      (a, b, c)  ·
- │         estimated row count  333 (missing stats)    ·          ·
- │         filter               (a, b, c) > (1, 2, 3)  ·          ·
- └── scan  ·                    ·                      (a, b, c)  ·
-·          estimated row count  333 (missing stats)    ·          ·
-·          table                abc@abc_a_b_c_idx      ·          ·
-·          spans                /1-                    ·          ·
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, c)
+│ estimated row count: 333 (missing stats)
+│ filter: (a, b, c) > (1, 2, 3)
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 333 (missing stats)
+      table: abc@abc_a_b_c_idx
+      spans: /1-
 
 statement ok
 DROP TABLE abc
@@ -138,47 +178,59 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 
 # Regression test for #27398.
 # Check that tuple type includes labels.
-query TTTTT
+query T
 EXPLAIN (VERBOSE, TYPES) SELECT x FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-·          distribution         local                                                                               ·                                        ·
-·          vectorized           true                                                                                ·                                        ·
-render     ·                    ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
- │         estimated row count  1000 (missing stats)                                                                ·                                        ·
- │         render 0             ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
- └── scan  ·                    ·                                                                                   (v int)                                  ·
-·          estimated row count  1000 (missing stats)                                                                ·                                        ·
-·          table                kv@primary                                                                          ·                                        ·
-·          spans                FULL SCAN                                                                           ·                                        ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (x tuple{int AS a, int AS b, int AS c})
+│ estimated row count: 1000 (missing stats)
+│ render 0: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
+│
+└── • scan
+      columns: (v int)
+      estimated row count: 1000 (missing stats)
+      table: kv@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE, TYPES) SELECT (x).a, (x).b, (x).c FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-·               distribution         local                                                                               ·                                        ·
-·               vectorized           true                                                                                ·                                        ·
-render          ·                    ·                                                                                   (a int, b int, c int)                    ·
- │              estimated row count  1000 (missing stats)                                                                ·                                        ·
- │              render 0             (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
- │              render 1             (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
- │              render 2             (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
- └── render     ·                    ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
-      │         estimated row count  1000 (missing stats)                                                                ·                                        ·
-      │         render 0             ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
-      └── scan  ·                    ·                                                                                   (v int)                                  ·
-·               estimated row count  1000 (missing stats)                                                                ·                                        ·
-·               table                kv@primary                                                                          ·                                        ·
-·               spans                FULL SCAN                                                                           ·                                        ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a int, b int, c int)
+│ estimated row count: 1000 (missing stats)
+│ render 0: (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]
+│ render 1: (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]
+│ render 2: (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]
+│
+└── • render
+    │ columns: (x tuple{int AS a, int AS b, int AS c})
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
+    │
+    └── • scan
+          columns: (v int)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE, TYPES) SELECT (x).e, (x).f, (x).g
 FROM (
   SELECT ((1,'2',true) AS e,f,g) AS x
 )
 ----
-·       distribution   local             ·                          ·
-·       vectorized     false             ·                          ·
-values  ·              ·                 (e int, f string, g bool)  ·
-·       size           3 columns, 1 row  ·                          ·
-·       row 0, expr 0  (1)[int]          ·                          ·
-·       row 0, expr 1  ('2')[string]     ·                          ·
-·       row 0, expr 2  (true)[bool]      ·                          ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (e int, f string, g bool)
+  size: 3 columns, 1 row
+  row 0, expr 0: (1)[int]
+  row 0, expr 1: ('2')[string]
+  row 0, expr 2: (true)[bool]

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -6,138 +6,194 @@ CREATE TABLE uniontest (
   v INT
 )
 
-query TTT
+query T
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-·          distribution   local
-·          vectorized     true
-union      ·              ·
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          uniontest@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          uniontest@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• union
+│
+├── • scan
+│     missing stats
+│     table: uniontest@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: uniontest@primary
+      spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-·          distribution   local
-·          vectorized     true
-union all  ·              ·
- ├── scan  ·              ·
- │         missing stats  ·
- │         table          uniontest@primary
- │         spans          FULL SCAN
- └── scan  ·              ·
-·          missing stats  ·
-·          table          uniontest@primary
-·          spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• union all
+│
+├── • scan
+│     missing stats
+│     table: uniontest@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: uniontest@primary
+      spans: FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
-query TTT
+query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-·                   distribution  local
-·                   vectorized    false
-union               ·             ·
- ├── virtual table  ·             ·
- │                  table         node_build_info@primary
- └── values         ·             ·
-·                   size          1 column, 1 row
+distribution: local
+vectorized: false
+·
+• union
+│
+├── • virtual table
+│     table: node_build_info@primary
+│
+└── • values
+      size: 1 column, 1 row
 
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc ORDER BY c) ORDER BY a
 ----
-·                    distribution         local                 ·       ·
-·                    vectorized           true                  ·       ·
-sort                 ·                    ·                     (a)     +a
- │                   estimated row count  100 (missing stats)   ·       ·
- │                   order                +a                    ·       ·
- └── intersect       ·                    ·                     (a)     ·
-      │              estimated row count  100 (missing stats)   ·       ·
-      ├── project    ·                    ·                     (a)     ·
-      │    └── scan  ·                    ·                     (a, b)  ·
-      │              estimated row count  1000 (missing stats)  ·       ·
-      │              table                abc@primary           ·       ·
-      │              spans                FULL SCAN             ·       ·
-      └── project    ·                    ·                     (a)     ·
-           └── scan  ·                    ·                     (a, c)  ·
-·                    estimated row count  1000 (missing stats)  ·       ·
-·                    table                abc@primary           ·       ·
-·                    spans                FULL SCAN             ·       ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a)
+│ ordering: +a
+│ estimated row count: 100 (missing stats)
+│ order: +a
+│
+└── • intersect
+    │ columns: (a)
+    │ estimated row count: 100 (missing stats)
+    │
+    ├── • project
+    │   │ columns: (a)
+    │   │
+    │   └── • scan
+    │         columns: (a, b)
+    │         estimated row count: 1000 (missing stats)
+    │         table: abc@primary
+    │         spans: FULL SCAN
+    │
+    └── • project
+        │ columns: (a)
+        │
+        └── • scan
+              columns: (a, c)
+              estimated row count: 1000 (missing stats)
+              table: abc@primary
+              spans: FULL SCAN
 
 # Regression test for #32723.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
-·                      distribution         local            ·                         ·
-·                      vectorized           false            ·                         ·
-project                ·                    ·                (a)                       ·
- └── except all        ·                    ·                (a, a)                    ·
-      │                estimated row count  1                ·                         ·
-      ├── project      ·                    ·                (a, a)                    ·
-      │    └── values  ·                    ·                (a)                       ·
-      │                size                 1 column, 1 row  ·                         ·
-      │                row 0, expr 0        ''               ·                         ·
-      └── project      ·                    ·                ("?column?", "?column?")  ·
-           └── values  ·                    ·                ("?column?")              ·
-·                      size                 1 column, 1 row  ·                         ·
-·                      row 0, expr 0        ''               ·                         ·
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (a)
+│
+└── • except all
+    │ columns: (a, a)
+    │ estimated row count: 1
+    │
+    ├── • project
+    │   │ columns: (a, a)
+    │   │
+    │   └── • values
+    │         columns: (a)
+    │         size: 1 column, 1 row
+    │         row 0, expr 0: ''
+    │
+    └── • project
+        │ columns: ("?column?", "?column?")
+        │
+        └── • values
+              columns: ("?column?")
+              size: 1 column, 1 row
+              row 0, expr 0: ''
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
-·                      distribution         local             ·                                     ·
-·                      vectorized           false             ·                                     ·
-render                 ·                    ·                 ("?column?", "?column?", "?column?")  ·
- │                     estimated row count  1                 ·                                     ·
- │                     render 0             "?column?"        ·                                     ·
- │                     render 1             "?column?"        ·                                     ·
- │                     render 2             "?column?"        ·                                     ·
- └── except            ·                    ·                 ("?column?", "?column?", "?column?")  ·
-      │                estimated row count  1                 ·                                     ·
-      ├── project      ·                    ·                 ("?column?", "?column?", "?column?")  ·
-      │    └── values  ·                    ·                 ("?column?", "?column?")              ·
-      │                size                 2 columns, 1 row  ·                                     ·
-      │                row 0, expr 0        ''                ·                                     ·
-      │                row 0, expr 1        'x'               ·                                     ·
-      └── values       ·                    ·                 (column1, column2, column3)           ·
-·                      size                 3 columns, 1 row  ·                                     ·
-·                      row 0, expr 0        ''                ·                                     ·
-·                      row 0, expr 1        ''                ·                                     ·
-·                      row 0, expr 2        'x'               ·                                     ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: ("?column?", "?column?", "?column?")
+│ estimated row count: 1
+│ render 0: "?column?"
+│ render 1: "?column?"
+│ render 2: "?column?"
+│
+└── • except
+    │ columns: ("?column?", "?column?", "?column?")
+    │ estimated row count: 1
+    │
+    ├── • project
+    │   │ columns: ("?column?", "?column?", "?column?")
+    │   │
+    │   └── • values
+    │         columns: ("?column?", "?column?")
+    │         size: 2 columns, 1 row
+    │         row 0, expr 0: ''
+    │         row 0, expr 1: 'x'
+    │
+    └── • values
+          columns: (column1, column2, column3)
+          size: 3 columns, 1 row
+          row 0, expr 0: ''
+          row 0, expr 1: ''
+          row 0, expr 2: 'x'
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 SELECT 1 FROM (SELECT k FROM uniontest WHERE k > 3 UNION ALL SELECT k FROM uniontest)
 ----
-·                         distribution         local                 ·             ·
-·                         vectorized           true                  ·             ·
-render                    ·                    ·                     ("?column?")  ·
- │                        estimated row count  1333 (missing stats)  ·             ·
- │                        render 0             1                     ·             ·
- └── union all            ·                    ·                     ()            ·
-      │                   estimated row count  1333 (missing stats)  ·             ·
-      ├── project         ·                    ·                     ()            ·
-      │    │              estimated row count  333 (missing stats)   ·             ·
-      │    └── filter     ·                    ·                     (k)           ·
-      │         │         estimated row count  333 (missing stats)   ·             ·
-      │         │         filter               k > 3                 ·             ·
-      │         └── scan  ·                    ·                     (k)           ·
-      │                   estimated row count  1000 (missing stats)  ·             ·
-      │                   table                uniontest@primary     ·             ·
-      │                   spans                FULL SCAN             ·             ·
-      └── scan            ·                    ·                     ()            ·
-·                         estimated row count  1000 (missing stats)  ·             ·
-·                         table                uniontest@primary     ·             ·
-·                         spans                FULL SCAN             ·             ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1333 (missing stats)
+│ render 0: 1
+│
+└── • union all
+    │ columns: ()
+    │ estimated row count: 1333 (missing stats)
+    │
+    ├── • project
+    │   │ columns: ()
+    │   │ estimated row count: 333 (missing stats)
+    │   │
+    │   └── • filter
+    │       │ columns: (k)
+    │       │ estimated row count: 333 (missing stats)
+    │       │ filter: k > 3
+    │       │
+    │       └── • scan
+    │             columns: (k)
+    │             estimated row count: 1000 (missing stats)
+    │             table: uniontest@primary
+    │             spans: FULL SCAN
+    │
+    └── • scan
+          columns: ()
+          estimated row count: 1000 (missing stats)
+          table: uniontest@primary
+          spans: FULL SCAN
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -98,83 +98,105 @@ CREATE TABLE xyz (
   z INT
 )
 
-query TTT
+query T
 EXPLAIN UPDATE xyz SET y = x
 ----
-·          distribution      local
-·          vectorized        false
-update     ·                 ·
- │         table             xyz
- │         set               y
- │         auto commit       ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             xyz@primary
-·          spans             FULL SCAN
-·          locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: xyz
+│ set: y
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: xyz@primary
+      spans: FULL SCAN
+      locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·               distribution         local                 ·                        ·
-·               vectorized           false                 ·                        ·
-update          ·                    ·                     ()                       ·
- │              estimated row count  0 (missing stats)     ·                        ·
- │              table                xyz                   ·                        ·
- │              set                  x, y                  ·                        ·
- │              auto commit          ·                     ·                        ·
- └── render     ·                    ·                     (x, y, z, x_new, y_new)  ·
-      │         estimated row count  1000 (missing stats)  ·                        ·
-      │         render 0             1                     ·                        ·
-      │         render 1             2                     ·                        ·
-      │         render 2             x                     ·                        ·
-      │         render 3             y                     ·                        ·
-      │         render 4             z                     ·                        ·
-      └── scan  ·                    ·                     (x, y, z)                ·
-·               estimated row count  1000 (missing stats)  ·                        ·
-·               table                xyz@primary           ·                        ·
-·               spans                FULL SCAN             ·                        ·
-·               locking strength     for update            ·                        ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x, y
+│ auto commit
+│
+└── • render
+    │ columns: (x, y, z, x_new, y_new)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: 1
+    │ render 1: 2
+    │ render 2: x
+    │ render 3: y
+    │ render 4: z
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
-·               distribution         local                 ·                ·
-·               vectorized           false                 ·                ·
-update          ·                    ·                     ()               ·
- │              estimated row count  0 (missing stats)     ·                ·
- │              table                xyz                   ·                ·
- │              set                  x, y                  ·                ·
- │              auto commit          ·                     ·                ·
- └── project    ·                    ·                     (x, y, z, y, x)  ·
-      └── scan  ·                    ·                     (x, y, z)        ·
-·               estimated row count  1000 (missing stats)  ·                ·
-·               table                xyz@primary           ·                ·
-·               spans                FULL SCAN             ·                ·
-·               locking strength     for update            ·                ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x, y
+│ auto commit
+│
+└── • project
+    │ columns: (x, y, z, y, x)
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
+          locking strength: for update
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
-·                    distribution         local                 ·                        ·
-·                    vectorized           false                 ·                        ·
-update               ·                    ·                     ()                       ·
- │                   estimated row count  0 (missing stats)     ·                        ·
- │                   table                xyz                   ·                        ·
- │                   set                  x, y                  ·                        ·
- │                   auto commit          ·                     ·                        ·
- └── project         ·                    ·                     (x, y, z, x_new, x_new)  ·
-      └── render     ·                    ·                     (x_new, x, y, z)         ·
-           │         estimated row count  1000 (missing stats)  ·                        ·
-           │         render 0             2                     ·                        ·
-           │         render 1             x                     ·                        ·
-           │         render 2             y                     ·                        ·
-           │         render 3             z                     ·                        ·
-           └── scan  ·                    ·                     (x, y, z)                ·
-·                    estimated row count  1000 (missing stats)  ·                        ·
-·                    table                xyz@primary           ·                        ·
-·                    spans                FULL SCAN             ·                        ·
-·                    locking strength     for update            ·                        ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x, y
+│ auto commit
+│
+└── • project
+    │ columns: (x, y, z, x_new, x_new)
+    │
+    └── • render
+        │ columns: (x_new, x, y, z)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: 2
+        │ render 1: x
+        │ render 2: y
+        │ render 3: z
+        │
+        └── • scan
+              columns: (x, y, z)
+              estimated row count: 1000 (missing stats)
+              table: xyz@primary
+              spans: FULL SCAN
+              locking strength: for update
 
 statement ok
 CREATE TABLE pks (
@@ -219,42 +241,50 @@ CREATE TABLE kv (
   FAMILY (k, v)
 )
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
-·                         distribution   local
-·                         vectorized     false
-update                    ·              ·
- │                        table          kv
- │                        set            v
- │                        auto commit    ·
- └── render               ·              ·
-      └── limit           ·              ·
-           │              count          10
-           └── sort       ·              ·
-                │         order          -v
-                └── scan  ·              ·
-·                         missing stats  ·
-·                         table          kv@primary
-·                         spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • limit
+        │ count: 10
+        │
+        └── • sort
+            │ order: -v
+            │
+            └── • scan
+                  missing stats
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             [ - /2]
-·               limit             1
-·               locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: [ - /2]
+          limit: 1
+          locking strength: for update
 
 # Check that updates on tables with multiple column families behave as
 # they should.
@@ -264,29 +294,33 @@ CREATE TABLE tu (a INT PRIMARY KEY, b INT, c INT, d INT, FAMILY (a), FAMILY (b),
   INSERT INTO tu VALUES (1, 2, 3, 4)
 
 # Update single column family.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPDATE tu SET c=c+1
-]
 ----
-·               distribution         local
-·               vectorized           false
-update          ·                    ·
- │              estimated row count  0 (missing stats)
- │              table                tu
- │              set                  c
- │              auto commit          ·
- └── render     ·                    ·
-      │         estimated row count  1000 (missing stats)
-      │         render 0             c + 1
-      │         render 1             a
-      │         render 2             c
-      │         render 3             d
-      └── scan  ·                    ·
-·               estimated row count  1000 (missing stats)
-·               table                tu@primary
-·               spans                FULL SCAN
-·               locking strength     for update
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: tu
+│ set: c
+│ auto commit
+│
+└── • render
+    │ columns: (a, c, d, c_new)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: c + 1
+    │ render 1: a
+    │ render 2: c
+    │ render 3: d
+    │
+    └── • scan
+          columns: (a, c, d)
+          estimated row count: 1000 (missing stats)
+          table: tu@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 statement ok
 SET tracing = on,kv,results; UPDATE tu SET c=c+1; SET tracing = off
@@ -325,36 +359,54 @@ rows affected: 1
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 ----
-·                                   distribution         local                             ·                    ·
-·                                   vectorized           false                             ·                    ·
-root                                ·                    ·                                 (a)                  ·
- ├── sort                           ·                    ·                                 (a)                  +a
- │    │                             estimated row count  1000 (missing stats)              ·                    ·
- │    │                             order                +a                                ·                    ·
- │    └── scan buffer               ·                    ·                                 (a)                  ·
- │                                  estimated row count  1000 (missing stats)              ·                    ·
- │                                  label                buffer 1                          ·                    ·
- └── subquery                       ·                    ·                                 ·                    ·
-      │                             id                   @S1                               ·                    ·
-      │                             original sql         UPDATE abc SET a = c RETURNING a  ·                    ·
-      │                             exec mode            all rows                          ·                    ·
-      └── buffer                    ·                    ·                                 (a)                  ·
-           │                        label                buffer 1                          ·                    ·
-           └── project              ·                    ·                                 (a)                  ·
-                │                   estimated row count  1000 (missing stats)              ·                    ·
-                └── update          ·                    ·                                 (a, rowid)           ·
-                     │              estimated row count  1000 (missing stats)              ·                    ·
-                     │              table                abc                               ·                    ·
-                     │              set                  a                                 ·                    ·
-                     └── project    ·                    ·                                 (a, b, c, rowid, c)  ·
-                          └── scan  ·                    ·                                 (a, b, c, rowid)     ·
-·                                   estimated row count  1000 (missing stats)              ·                    ·
-·                                   table                abc@primary                       ·                    ·
-·                                   spans                FULL SCAN                         ·                    ·
-·                                   locking strength     for update                        ·                    ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • sort
+│   │ columns: (a)
+│   │ ordering: +a
+│   │ estimated row count: 1000 (missing stats)
+│   │ order: +a
+│   │
+│   └── • scan buffer
+│         columns: (a)
+│         estimated row count: 1000 (missing stats)
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPDATE abc SET a = c RETURNING a
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1
+        │
+        └── • project
+            │ columns: (a)
+            │ estimated row count: 1000 (missing stats)
+            │
+            └── • update
+                │ columns: (a, rowid)
+                │ estimated row count: 1000 (missing stats)
+                │ table: abc
+                │ set: a
+                │
+                └── • project
+                    │ columns: (a, b, c, rowid, c)
+                    │
+                    └── • scan
+                          columns: (a, b, c, rowid)
+                          estimated row count: 1000 (missing stats)
+                          table: abc@primary
+                          spans: FULL SCAN
+                          locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO
@@ -384,85 +436,103 @@ UPDATE t35364 SET x=2.5 RETURNING *
 statement ok
 CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b), FAMILY "primary" (a, b, c))
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1
 ----
-·                          distribution         local                 ·                 ·
-·                          vectorized           false                 ·                 ·
-update                     ·                    ·                     ()                ·
- │                         estimated row count  0 (missing stats)     ·                 ·
- │                         table                t38799                ·                 ·
- │                         set                  c                     ·                 ·
- │                         auto commit          ·                     ·                 ·
- └── render                ·                    ·                     (a, b, c, c_new)  ·
-      │                    estimated row count  1 (missing stats)     ·                 ·
-      │                    render 0             2                     ·                 ·
-      │                    render 1             a                     ·                 ·
-      │                    render 2             b                     ·                 ·
-      │                    render 3             c                     ·                 ·
-      └── filter           ·                    ·                     (a, b, c)         ·
-           │               estimated row count  1 (missing stats)     ·                 ·
-           │               filter               a = 1                 ·                 ·
-           └── index join  ·                    ·                     (a, b, c)         ·
-                │          estimated row count  1000 (missing stats)  ·                 ·
-                │          table                t38799@primary        ·                 ·
-                │          key columns          a                     ·                 ·
-                └── scan   ·                    ·                     (a, b)            ·
-·                          estimated row count  1000 (missing stats)  ·                 ·
-·                          table                t38799@foo            ·                 ·
-·                          spans                FULL SCAN             ·                 ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: t38799
+│ set: c
+│ auto commit
+│
+└── • render
+    │ columns: (a, b, c, c_new)
+    │ estimated row count: 1 (missing stats)
+    │ render 0: 2
+    │ render 1: a
+    │ render 2: b
+    │ render 3: c
+    │
+    └── • filter
+        │ columns: (a, b, c)
+        │ estimated row count: 1 (missing stats)
+        │ filter: a = 1
+        │
+        └── • index join
+            │ columns: (a, b, c)
+            │ estimated row count: 1000 (missing stats)
+            │ table: t38799@primary
+            │ key columns: a
+            │
+            └── • scan
+                  columns: (a, b)
+                  estimated row count: 1000 (missing stats)
+                  table: t38799@foo
+                  spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Test without implicit SELECT FOR UPDATE.
 # Some cases were all tested earlier in this file with implicit SFU enabled.
 # ------------------------------------------------------------------------------
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             [/3 - /3]
-·               locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: [/3 - /3]
+          locking strength: for update
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·          distribution      local
-·          vectorized        false
-update     ·                 ·
- │         table             kv
- │         set               v
- │         auto commit       ·
- └── scan  ·                 ·
-·          missing stats     ·
-·          table             kv@primary
-·          spans             [/2 - /9]
-·          locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: kv@primary
+      spans: [/2 - /9]
+      locking strength: for update
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = 10
 ----
-·               distribution      local
-·               vectorized        false
-update          ·                 ·
- │              table             kv
- │              set               v
- │              auto commit       ·
- └── render     ·                 ·
-      └── scan  ·                 ·
-·               missing stats     ·
-·               table             kv@primary
-·               spans             FULL SCAN
-·               locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: FULL SCAN
+          locking strength: for update
 
 statement ok
 CREATE TABLE kv3 (
@@ -473,176 +543,208 @@ CREATE TABLE kv3 (
   FAMILY (k, v, meta)
 )
 
-query TTT
+query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                     distribution      local
-·                     vectorized        false
-update                ·                 ·
- │                    table             kv3
- │                    set               k
- │                    auto commit       ·
- └── render           ·                 ·
-      └── index join  ·                 ·
-           │          table             kv3@primary
-           └── scan   ·                 ·
-·                     missing stats     ·
-·                     table             kv3@kv3_v_idx
-·                     spans             [/10 - /10]
-·                     locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv3
+│ set: k
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: kv3@primary
+        │
+        └── • scan
+              missing stats
+              table: kv3@kv3_v_idx
+              spans: [/10 - /10]
+              locking strength: for update
 
-query TTT
+query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                distribution      local
-·                vectorized        false
-update           ·                 ·
- │               table             kv3
- │               set               k
- │               auto commit       ·
- └── index join  ·                 ·
-      │          table             kv3@primary
-      └── scan   ·                 ·
-·                missing stats     ·
-·                table             kv3@kv3_v_idx
-·                spans             [/2 - /9]
-·                locking strength  for update
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv3
+│ set: k
+│ auto commit
+│
+└── • index join
+    │ table: kv3@primary
+    │
+    └── • scan
+          missing stats
+          table: kv3@kv3_v_idx
+          spans: [/2 - /9]
+          locking strength: for update
 
 statement ok
 SET enable_implicit_select_for_update = false
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          [/3 - /3]
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: [/3 - /3]
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·          distribution   local
-·          vectorized     false
-update     ·              ·
- │         table          kv
- │         set            v
- │         auto commit    ·
- └── scan  ·              ·
-·          missing stats  ·
-·          table          kv@primary
-·          spans          [/2 - /9]
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: kv@primary
+      spans: [/2 - /9]
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = 10
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·               distribution         local                 ·                        ·
-·               vectorized           false                 ·                        ·
-update          ·                    ·                     ()                       ·
- │              estimated row count  0 (missing stats)     ·                        ·
- │              table                xyz                   ·                        ·
- │              set                  x, y                  ·                        ·
- │              auto commit          ·                     ·                        ·
- └── render     ·                    ·                     (x, y, z, x_new, y_new)  ·
-      │         estimated row count  1000 (missing stats)  ·                        ·
-      │         render 0             1                     ·                        ·
-      │         render 1             2                     ·                        ·
-      │         render 2             x                     ·                        ·
-      │         render 3             y                     ·                        ·
-      │         render 4             z                     ·                        ·
-      └── scan  ·                    ·                     (x, y, z)                ·
-·               estimated row count  1000 (missing stats)  ·                        ·
-·               table                xyz@primary           ·                        ·
-·               spans                FULL SCAN             ·                        ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x, y
+│ auto commit
+│
+└── • render
+    │ columns: (x, y, z, x_new, y_new)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: 1
+    │ render 1: 2
+    │ render 2: x
+    │ render 3: y
+    │ render 4: z
+    │
+    └── • scan
+          columns: (x, y, z)
+          estimated row count: 1000 (missing stats)
+          table: xyz@primary
+          spans: FULL SCAN
 
-query TTT
+query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          kv
- │              set            v
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          [ - /2]
-·               limit          1
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv
+│ set: v
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: [ - /2]
+          limit: 1
 
-query TTT
+query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                     distribution   local
-·                     vectorized     false
-update                ·              ·
- │                    table          kv3
- │                    set            k
- │                    auto commit    ·
- └── render           ·              ·
-      └── index join  ·              ·
-           │          table          kv3@primary
-           └── scan   ·              ·
-·                     missing stats  ·
-·                     table          kv3@kv3_v_idx
-·                     spans          [/10 - /10]
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv3
+│ set: k
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: kv3@primary
+        │
+        └── • scan
+              missing stats
+              table: kv3@kv3_v_idx
+              spans: [/10 - /10]
 
-query TTT
+query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                distribution   local
-·                vectorized     false
-update           ·              ·
- │               table          kv3
- │               set            k
- │               auto commit    ·
- └── index join  ·              ·
-      │          table          kv3@primary
-      └── scan   ·              ·
-·                missing stats  ·
-·                table          kv3@kv3_v_idx
-·                spans          [/2 - /9]
+distribution: local
+vectorized: false
+·
+• update
+│ table: kv3
+│ set: k
+│ auto commit
+│
+└── • index join
+    │ table: kv3@primary
+    │
+    └── • scan
+          missing stats
+          table: kv3@kv3_v_idx
+          spans: [/2 - /9]
 
 # Update single column family.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN UPDATE tu SET c=c+1
-]
 ----
-·               distribution   local
-·               vectorized     false
-update          ·              ·
- │              table          tu
- │              set            c
- │              auto commit    ·
- └── render     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          tu@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: tu
+│ set: c
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: tu@primary
+          spans: FULL SCAN
 
 # Reset for rest of test.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -4,58 +4,68 @@ statement ok
 CREATE TABLE abc (a int primary key, b int, c int)
 
 # Updating using self join.
-query TTT
+query T
 EXPLAIN UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = other.a
 ----
-·                     distribution        local
-·                     vectorized          false
-update                ·                   ·
- │                    table               abc
- │                    set                 b, c
- │                    auto commit         ·
- └── render           ·                   ·
-      └── merge join  ·                   ·
-           │          equality            (a) = (a)
-           │          left cols are key   ·
-           │          right cols are key  ·
-           ├── scan   ·                   ·
-           │          missing stats       ·
-           │          table               abc@primary
-           │          spans               FULL SCAN
-           └── scan   ·                   ·
-·                     missing stats       ·
-·                     table               abc@primary
-·                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • render
+    │
+    └── • merge join
+        │ equality: (a) = (a)
+        │ left cols are key
+        │ right cols are key
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: abc@primary
+              spans: FULL SCAN
 
 # Update from another table.
 statement ok
 CREATE TABLE new_abc (a int, b int, c int)
 
-query TTT
+query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = other.a
 ----
-·                    distribution       local
-·                    vectorized         false
-update               ·                  ·
- │                   table              abc
- │                   set                b, c
- │                   auto commit        ·
- └── distinct        ·                  ·
-      │              distinct on        a
-      └── hash join  ·                  ·
-           │         equality           (a) = (a)
-           │         left cols are key  ·
-           ├── scan  ·                  ·
-           │         missing stats      ·
-           │         table              abc@primary
-           │         spans              FULL SCAN
-           └── scan  ·                  ·
-·                    missing stats      ·
-·                    table              new_abc@primary
-·                    spans              FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • distinct
+    │ distinct on: a
+    │
+    └── • hash join
+        │ equality: (a) = (a)
+        │ left cols are key
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: new_abc@primary
+              spans: FULL SCAN
 
 # Returning old values.
-query TTT
+query T
 EXPLAIN UPDATE abc
 SET
   b = old.b + 1, c = old.c + 2
@@ -66,80 +76,101 @@ WHERE
 RETURNING
   abc.a, abc.b AS new_b, old.b as old_b, abc.c as new_c, old.c as old_c
 ----
-·                     distribution        local
-·                     vectorized          false
-update                ·                   ·
- │                    table               abc
- │                    set                 b, c
- │                    auto commit         ·
- └── render           ·                   ·
-      └── merge join  ·                   ·
-           │          equality            (a) = (a)
-           │          left cols are key   ·
-           │          right cols are key  ·
-           ├── scan   ·                   ·
-           │          missing stats       ·
-           │          table               abc@primary
-           │          spans               FULL SCAN
-           └── scan   ·                   ·
-·                     missing stats       ·
-·                     table               abc@primary
-·                     spans               FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • render
+    │
+    └── • merge join
+        │ equality: (a) = (a)
+        │ left cols are key
+        │ right cols are key
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: abc@primary
+              spans: FULL SCAN
 
 # Check if RETURNING * returns everything
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
-·                             distribution         local                 ·                                 ·
-·                             vectorized           false                 ·                                 ·
-update                        ·                    ·                     (a, b, c, a, b, c)                ·
- │                            estimated row count  1000 (missing stats)  ·                                 ·
- │                            table                abc                   ·                                 ·
- │                            set                  b, c                  ·                                 ·
- │                            auto commit          ·                     ·                                 ·
- └── render                   ·                    ·                     (a, b, c, b_new, c_new, a, b, c)  ·
-      │                       estimated row count  1000 (missing stats)  ·                                 ·
-      │                       render 0             b + 1                 ·                                 ·
-      │                       render 1             c + 2                 ·                                 ·
-      │                       render 2             a                     ·                                 ·
-      │                       render 3             b                     ·                                 ·
-      │                       render 4             c                     ·                                 ·
-      │                       render 5             a                     ·                                 ·
-      │                       render 6             b                     ·                                 ·
-      │                       render 7             c                     ·                                 ·
-      └── merge join (inner)  ·                    ·                     (a, b, c, a, b, c)                ·
-           │                  estimated row count  1000 (missing stats)  ·                                 ·
-           │                  equality             (a) = (a)             ·                                 ·
-           │                  left cols are key    ·                     ·                                 ·
-           │                  right cols are key   ·                     ·                                 ·
-           │                  merge ordering       +"(a=a)"              ·                                 ·
-           ├── scan           ·                    ·                     (a, b, c)                         +a
-           │                  estimated row count  1000 (missing stats)  ·                                 ·
-           │                  table                abc@primary           ·                                 ·
-           │                  spans                FULL SCAN             ·                                 ·
-           └── scan           ·                    ·                     (a, b, c)                         +a
-·                             estimated row count  1000 (missing stats)  ·                                 ·
-·                             table                abc@primary           ·                                 ·
-·                             spans                FULL SCAN             ·                                 ·
+distribution: local
+vectorized: false
+·
+• update
+│ columns: (a, b, c, a, b, c)
+│ estimated row count: 1000 (missing stats)
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • render
+    │ columns: (a, b, c, b_new, c_new, a, b, c)
+    │ estimated row count: 1000 (missing stats)
+    │ render 0: b + 1
+    │ render 1: c + 2
+    │ render 2: a
+    │ render 3: b
+    │ render 4: c
+    │ render 5: a
+    │ render 6: b
+    │ render 7: c
+    │
+    └── • merge join (inner)
+        │ columns: (a, b, c, a, b, c)
+        │ estimated row count: 1000 (missing stats)
+        │ equality: (a) = (a)
+        │ left cols are key
+        │ right cols are key
+        │ merge ordering: +"(a=a)"
+        │
+        ├── • scan
+        │     columns: (a, b, c)
+        │     ordering: +a
+        │     estimated row count: 1000 (missing stats)
+        │     table: abc@primary
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a
+              estimated row count: 1000 (missing stats)
+              table: abc@primary
+              spans: FULL SCAN
 
 # Update values of table from values expression
-query TTT
+query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as other ("a", "b", "c") WHERE abc.a = other.a
 ----
-·                      distribution           local
-·                      vectorized             false
-update                 ·                      ·
- │                     table                  abc
- │                     set                    b, c
- │                     auto commit            ·
- └── distinct          ·                      ·
-      │                distinct on            a
-      └── lookup join  ·                      ·
-           │           table                  abc@primary
-           │           equality               (column1) = (a)
-           │           equality cols are key  ·
-           └── values  ·                      ·
-·                      size                   3 columns, 2 rows
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • distinct
+    │ distinct on: a
+    │
+    └── • lookup join
+        │ table: abc@primary
+        │ equality: (column1) = (a)
+        │ equality cols are key
+        │
+        └── • values
+              size: 3 columns, 2 rows
 
 # Check if UPDATE ... FROM works with multiple tables.
 statement ok
@@ -148,37 +179,44 @@ CREATE TABLE ab (a INT, b INT)
 statement ok
 CREATE TABLE ac (a INT, c INT)
 
-query TTT
+query T
 EXPLAIN UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.a
 ----
-·                         distribution       local
-·                         vectorized         false
-update                    ·                  ·
- │                        table              abc
- │                        set                b, c
- │                        auto commit        ·
- └── distinct             ·                  ·
-      │                   distinct on        a
-      └── hash join       ·                  ·
-           │              equality           (a) = (a)
-           ├── scan       ·                  ·
-           │              missing stats      ·
-           │              table              ab@primary
-           │              spans              FULL SCAN
-           └── hash join  ·                  ·
-                │         equality           (a) = (a)
-                │         left cols are key  ·
-                ├── scan  ·                  ·
-                │         missing stats      ·
-                │         table              abc@primary
-                │         spans              FULL SCAN
-                └── scan  ·                  ·
-·                         missing stats      ·
-·                         table              ac@primary
-·                         spans              FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • distinct
+    │ distinct on: a
+    │
+    └── • hash join
+        │ equality: (a) = (a)
+        │
+        ├── • scan
+        │     missing stats
+        │     table: ab@primary
+        │     spans: FULL SCAN
+        │
+        └── • hash join
+            │ equality: (a) = (a)
+            │ left cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: abc@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  missing stats
+                  table: ac@primary
+                  spans: FULL SCAN
 
 # Make sure UPDATE ... FROM works with LATERAL.
-query TTT
+query T
 EXPLAIN UPDATE abc
 SET
   b=ab.b, c = other.c
@@ -190,28 +228,35 @@ WHERE
 RETURNING
   *
 ----
-·                         distribution       local
-·                         vectorized         false
-update                    ·                  ·
- │                        table              abc
- │                        set                b, c
- │                        auto commit        ·
- └── distinct             ·                  ·
-      │                   distinct on        a
-      └── hash join       ·                  ·
-           │              equality           (a) = (a)
-           ├── scan       ·                  ·
-           │              missing stats      ·
-           │              table              ab@primary
-           │              spans              FULL SCAN
-           └── hash join  ·                  ·
-                │         equality           (a) = (a)
-                │         left cols are key  ·
-                ├── scan  ·                  ·
-                │         missing stats      ·
-                │         table              abc@primary
-                │         spans              FULL SCAN
-                └── scan  ·                  ·
-·                         missing stats      ·
-·                         table              ac@primary
-·                         spans              FULL SCAN
+distribution: local
+vectorized: false
+·
+• update
+│ table: abc
+│ set: b, c
+│ auto commit
+│
+└── • distinct
+    │ distinct on: a
+    │
+    └── • hash join
+        │ equality: (a) = (a)
+        │
+        ├── • scan
+        │     missing stats
+        │     table: ab@primary
+        │     spans: FULL SCAN
+        │
+        └── • hash join
+            │ equality: (a) = (a)
+            │ left cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: abc@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan
+                  missing stats
+                  table: ac@primary
+                  spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -7,114 +7,154 @@ CREATE TABLE kv (
 )
 
 # Use implicit target columns (which can use blind KV Put).
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC LIMIT 2
-]
 ----
-·                         distribution         local
-·                         vectorized           false
-upsert                    ·                    ·
- │                        estimated row count  0 (missing stats)
- │                        into                 kv(k, v)
- │                        auto commit          ·
- └── project              ·                    ·
-      └── limit           ·                    ·
-           │              estimated row count  2 (missing stats)
-           │              count                2
-           └── sort       ·                    ·
-                │         estimated row count  1000 (missing stats)
-                │         order                -v
-                └── scan  ·                    ·
-·                         estimated row count  1000 (missing stats)
-·                         table                kv@primary
-·                         spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: kv(k, v)
+│ auto commit
+│
+└── • project
+    │ columns: (k, v, v)
+    │
+    └── • limit
+        │ columns: (k, v)
+        │ estimated row count: 2 (missing stats)
+        │ count: 2
+        │
+        └── • sort
+            │ columns: (k, v)
+            │ ordering: -v
+            │ estimated row count: 1000 (missing stats)
+            │ order: -v
+            │
+            └── • scan
+                  columns: (k, v)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Use explicit target columns (which can use blind KV Put).
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2
-]
 ----
-·                         distribution         local
-·                         vectorized           false
-upsert                    ·                    ·
- │                        estimated row count  0 (missing stats)
- │                        into                 kv(k, v)
- │                        auto commit          ·
- └── project              ·                    ·
-      └── limit           ·                    ·
-           │              estimated row count  2 (missing stats)
-           │              count                2
-           └── sort       ·                    ·
-                │         estimated row count  1000 (missing stats)
-                │         order                -v
-                └── scan  ·                    ·
-·                         estimated row count  1000 (missing stats)
-·                         table                kv@primary
-·                         spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: kv(k, v)
+│ auto commit
+│
+└── • project
+    │ columns: (k, v, v)
+    │
+    └── • limit
+        │ columns: (k, v)
+        │ estimated row count: 2 (missing stats)
+        │ count: 2
+        │
+        └── • sort
+            │ columns: (k, v)
+            │ ordering: -v
+            │ estimated row count: 1000 (missing stats)
+            │ order: -v
+            │
+            └── • scan
+                  columns: (k, v)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Add RETURNING clause (should still use blind KV Put).
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2 RETURNING *
-]
 ----
-·                         distribution         local
-·                         vectorized           false
-upsert                    ·                    ·
- │                        estimated row count  2 (missing stats)
- │                        into                 kv(k, v)
- │                        auto commit          ·
- └── project              ·                    ·
-      └── limit           ·                    ·
-           │              estimated row count  2 (missing stats)
-           │              count                2
-           └── sort       ·                    ·
-                │         estimated row count  1000 (missing stats)
-                │         order                -v
-                └── scan  ·                    ·
-·                         estimated row count  1000 (missing stats)
-·                         table                kv@primary
-·                         spans                FULL SCAN
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: (k, v)
+│ estimated row count: 2 (missing stats)
+│ into: kv(k, v)
+│ auto commit
+│
+└── • project
+    │ columns: (k, v, v)
+    │
+    └── • limit
+        │ columns: (k, v)
+        │ estimated row count: 2 (missing stats)
+        │ count: 2
+        │
+        └── • sort
+            │ columns: (k, v)
+            │ ordering: -v
+            │ estimated row count: 1000 (missing stats)
+            │ order: -v
+            │
+            └── • scan
+                  columns: (k, v)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Use subset of explicit target columns (which cannot use blind KV Put).
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k) SELECT k FROM kv ORDER BY v DESC LIMIT 2
-]
 ----
-·                                   distribution           local
-·                                   vectorized             false
-upsert                              ·                      ·
- │                                  estimated row count    0 (missing stats)
- │                                  into                   kv(k, v)
- │                                  auto commit            ·
- │                                  arbiter indexes        primary
- └── lookup join (inner)            ·                      ·
-      │                             estimated row count    2 (missing stats)
-      │                             table                  kv@primary
-      │                             equality               (k) = (k)
-      │                             equality cols are key  ·
-      └── distinct                  ·                      ·
-           │                        estimated row count    2 (missing stats)
-           │                        distinct on            k
-           │                        nulls are distinct     ·
-           │                        error on duplicate     ·
-           └── render               ·                      ·
-                │                   estimated row count    2 (missing stats)
-                │                   render 0               CAST(NULL AS INT8)
-                │                   render 1               k
-                └── limit           ·                      ·
-                     │              estimated row count    2 (missing stats)
-                     │              count                  2
-                     └── sort       ·                      ·
-                          │         estimated row count    1000 (missing stats)
-                          │         order                  -v
-                          └── scan  ·                      ·
-·                                   estimated row count    1000 (missing stats)
-·                                   table                  kv@primary
-·                                   spans                  FULL SCAN
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: kv(k, v)
+│ auto commit
+│ arbiter indexes: primary
+│
+└── • lookup join (inner)
+    │ columns: (k, column9, k)
+    │ estimated row count: 2 (missing stats)
+    │ table: kv@primary
+    │ equality: (k) = (k)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ columns: (column9, k)
+        │ estimated row count: 2 (missing stats)
+        │ distinct on: k
+        │ nulls are distinct
+        │ error on duplicate
+        │
+        └── • render
+            │ columns: (column9, k)
+            │ estimated row count: 2 (missing stats)
+            │ render 0: CAST(NULL AS INT8)
+            │ render 1: k
+            │
+            └── • limit
+                │ columns: (k, v)
+                │ estimated row count: 2 (missing stats)
+                │ count: 2
+                │
+                └── • sort
+                    │ columns: (k, v)
+                    │ ordering: -v
+                    │ estimated row count: 1000 (missing stats)
+                    │ order: -v
+                    │
+                    └── • scan
+                          columns: (k, v)
+                          estimated row count: 1000 (missing stats)
+                          table: kv@primary
+                          spans: FULL SCAN
 
 # Use Upsert with indexed table, default columns, computed columns, and check
 # columns.
@@ -130,110 +170,134 @@ CREATE TABLE indexed (
 )
 
 # Should fetch existing values since there is a secondary index.
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
-]
 ----
-·                                       distribution         local
-·                                       vectorized           false
-upsert                                  ·                    ·
- │                                      estimated row count  0 (missing stats)
- │                                      into                 indexed(a, b, c, d)
- │                                      auto commit          ·
- │                                      arbiter indexes      primary
- └── project                            ·                    ·
-      └── render                        ·                    ·
-           │                            estimated row count  1 (missing stats)
-           │                            render 0             column9 > 0
-           │                            render 1             column1
-           │                            render 2             column8
-           │                            render 3             column9
-           │                            render 4             column10
-           │                            render 5             a
-           │                            render 6             b
-           │                            render 7             c
-           │                            render 8             d
-           └── cross join (left outer)  ·                    ·
-                │                       estimated row count  1 (missing stats)
-                ├── values              ·                    ·
-                │                       size                 4 columns, 1 row
-                │                       row 0, expr 0        1
-                │                       row 0, expr 1        CAST(NULL AS INT8)
-                │                       row 0, expr 2        10
-                │                       row 0, expr 3        11
-                └── scan                ·                    ·
-·                                       estimated row count  1 (missing stats)
-·                                       table                indexed@primary
-·                                       spans                /1-/1/#
-·                                       locking strength     for update
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: primary
+│
+└── • project
+    │ columns: (column1, column8, column9, column10, a, b, c, d, column8, column9, column10, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
+        │ estimated row count: 1 (missing stats)
+        │ render 0: column9 > 0
+        │ render 1: column1
+        │ render 2: column8
+        │ render 3: column9
+        │ render 4: column10
+        │ render 5: a
+        │ render 6: b
+        │ render 7: c
+        │ render 8: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, column8, column9, column10, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, column8, column9, column10)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • scan
+                  columns: (a, b, c, d)
+                  estimated row count: 1 (missing stats)
+                  table: indexed@primary
+                  spans: /1-/1/#
+                  locking strength: for update
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1), (2), (3), (4)
-]
 ----
-·                                        distribution           local
-·                                        vectorized             false
-upsert                                   ·                      ·
- │                                       estimated row count    0 (missing stats)
- │                                       into                   indexed(a, b, c, d)
- │                                       auto commit            ·
- │                                       arbiter indexes        primary
- └── project                             ·                      ·
-      └── render                         ·                      ·
-           │                             estimated row count    4 (missing stats)
-           │                             render 0               column9 > 0
-           │                             render 1               column1
-           │                             render 2               column8
-           │                             render 3               column9
-           │                             render 4               column10
-           │                             render 5               a
-           │                             render 6               b
-           │                             render 7               c
-           │                             render 8               d
-           └── lookup join (left outer)  ·                      ·
-                │                        estimated row count    4 (missing stats)
-                │                        table                  indexed@primary
-                │                        equality               (column1) = (a)
-                │                        equality cols are key  ·
-                │                        locking strength       for update
-                └── render               ·                      ·
-                     │                   estimated row count    4
-                     │                   render 0               column1 + 10
-                     │                   render 1               CAST(NULL AS INT8)
-                     │                   render 2               10
-                     │                   render 3               column1
-                     └── values          ·                      ·
-·                                        size                   1 column, 4 rows
-·                                        row 0, expr 0          1
-·                                        row 1, expr 0          2
-·                                        row 2, expr 0          3
-·                                        row 3, expr 0          4
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: primary
+│
+└── • project
+    │ columns: (column1, column8, column9, column10, a, b, c, d, column8, column9, column10, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
+        │ estimated row count: 4 (missing stats)
+        │ render 0: column9 > 0
+        │ render 1: column1
+        │ render 2: column8
+        │ render 3: column9
+        │ render 4: column10
+        │ render 5: a
+        │ render 6: b
+        │ render 7: c
+        │ render 8: d
+        │
+        └── • lookup join (left outer)
+            │ columns: (column10, column8, column9, column1, a, b, c, d)
+            │ estimated row count: 4 (missing stats)
+            │ table: indexed@primary
+            │ equality: (column1) = (a)
+            │ equality cols are key
+            │ locking strength: for update
+            │
+            └── • render
+                │ columns: (column10, column8, column9, column1)
+                │ estimated row count: 4
+                │ render 0: column1 + 10
+                │ render 1: CAST(NULL AS INT8)
+                │ render 2: 10
+                │ render 3: column1
+                │
+                └── • values
+                      columns: (column1)
+                      size: 1 column, 4 rows
+                      row 0, expr 0: 1
+                      row 1, expr 0: 2
+                      row 2, expr 0: 3
+                      row 3, expr 0: 4
 
 # Drop index and verify that existing values no longer need to be fetched.
 statement ok
 DROP INDEX indexed@secondary CASCADE
 
-query TTT
-SELECT tree, field, description FROM [
+query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1) RETURNING *
-]
 ----
-·                 distribution         local
-·                 vectorized           false
-upsert            ·                    ·
- │                estimated row count  1
- │                into                 indexed(a, b, c, d)
- │                auto commit          ·
- └── project      ·                    ·
-      └── values  ·                    ·
-·                 size                 5 columns, 1 row
-·                 row 0, expr 0        1
-·                 row 0, expr 1        CAST(NULL AS INT8)
-·                 row 0, expr 2        10
-·                 row 0, expr 3        11
-·                 row 0, expr 4        true
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: (a, b, c, d)
+│ estimated row count: 1
+│ into: indexed(a, b, c, d)
+│ auto commit
+│
+└── • project
+    │ columns: (column1, column8, column9, column10, column8, column9, column10, check1)
+    │
+    └── • values
+          columns: (column1, column8, column9, column10, check1)
+          size: 5 columns, 1 row
+          row 0, expr 0: 1
+          row 0, expr 1: CAST(NULL AS INT8)
+          row 0, expr 2: 10
+          row 0, expr 3: 11
+          row 0, expr 4: true
 
 # Regression test for #25726.
 # UPSERT over tables with column families, on the fast path, use the
@@ -367,40 +431,60 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT * FROM [UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-·                                        distribution         local                                                ·                             ·
-·                                        vectorized           false                                                ·                             ·
-root                                     ·                    ·                                                    (z)                           ·
- ├── sort                                ·                    ·                                                    (z)                           +z
- │    │                                  estimated row count  1000 (missing stats)                                 ·                             ·
- │    │                                  order                +z                                                   ·                             ·
- │    └── scan buffer                    ·                    ·                                                    (z)                           ·
- │                                       estimated row count  1000 (missing stats)                                 ·                             ·
- │                                       label                buffer 1                                             ·                             ·
- └── subquery                            ·                    ·                                                    ·                             ·
-      │                                  id                   @S1                                                  ·                             ·
-      │                                  original sql         UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                             ·
-      │                                  exec mode            all rows                                             ·                             ·
-      └── buffer                         ·                    ·                                                    (z)                           ·
-           │                             label                buffer 1                                             ·                             ·
-           └── project                   ·                    ·                                                    (z)                           ·
-                │                        estimated row count  1000 (missing stats)                                 ·                             ·
-                └── upsert               ·                    ·                                                    (z, rowid)                    ·
-                     │                   estimated row count  1000 (missing stats)                                 ·                             ·
-                     │                   into                 xyz(x, y, z, rowid)                                  ·                             ·
-                     └── project         ·                    ·                                                    (a, b, c, column13, a, b, c)  ·
-                          └── render     ·                    ·                                                    (column13, a, b, c)           ·
-                               │         estimated row count  1000 (missing stats)                                 ·                             ·
-                               │         render 0             unique_rowid()                                       ·                             ·
-                               │         render 1             a                                                    ·                             ·
-                               │         render 2             b                                                    ·                             ·
-                               │         render 3             c                                                    ·                             ·
-                               └── scan  ·                    ·                                                    (a, b, c)                     ·
-·                                        estimated row count  1000 (missing stats)                                 ·                             ·
-·                                        table                abc@primary                                          ·                             ·
-·                                        spans                FULL SCAN                                            ·                             ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (z)
+│
+├── • sort
+│   │ columns: (z)
+│   │ ordering: +z
+│   │ estimated row count: 1000 (missing stats)
+│   │ order: +z
+│   │
+│   └── • scan buffer
+│         columns: (z)
+│         estimated row count: 1000 (missing stats)
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (z)
+        │ label: buffer 1
+        │
+        └── • project
+            │ columns: (z)
+            │ estimated row count: 1000 (missing stats)
+            │
+            └── • upsert
+                │ columns: (z, rowid)
+                │ estimated row count: 1000 (missing stats)
+                │ into: xyz(x, y, z, rowid)
+                │
+                └── • project
+                    │ columns: (a, b, c, column13, a, b, c)
+                    │
+                    └── • render
+                        │ columns: (column13, a, b, c)
+                        │ estimated row count: 1000 (missing stats)
+                        │ render 0: unique_rowid()
+                        │ render 1: a
+                        │ render 2: b
+                        │ render 3: c
+                        │
+                        └── • scan
+                              columns: (a, b, c)
+                              estimated row count: 1000 (missing stats)
+                              table: abc@primary
+                              spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO
@@ -445,25 +529,33 @@ CREATE TABLE table38627 (a INT PRIMARY KEY, b INT, FAMILY (a, b)); INSERT INTO t
 statement ok
 BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 ----
-·                              distribution           local               ·                      ·
-·                              vectorized             false               ·                      ·
-upsert                         ·                      ·                   ()                     ·
- │                             estimated row count    0 (missing stats)   ·                      ·
- │                             into                   table38627(a, b)    ·                      ·
- │                             arbiter indexes        primary             ·                      ·
- └── project                   ·                      ·                   (a, b, a, b, c, b, a)  ·
-      └── lookup join (inner)  ·                      ·                   (a, b, a, b, c)        ·
-           │                   estimated row count    1 (missing stats)   ·                      ·
-           │                   table                  table38627@primary  ·                      ·
-           │                   equality               (a) = (a)           ·                      ·
-           │                   equality cols are key  ·                   ·                      ·
-           └── scan            ·                      ·                   (a, b)                 ·
-·                              estimated row count    1 (missing stats)   ·                      ·
-·                              table                  table38627@primary  ·                      ·
-·                              spans                  /1-/1/#             ·                      ·
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: table38627(a, b)
+│ arbiter indexes: primary
+│
+└── • project
+    │ columns: (a, b, a, b, c, b, a)
+    │
+    └── • lookup join (inner)
+        │ columns: (a, b, a, b, c)
+        │ estimated row count: 1 (missing stats)
+        │ table: table38627@primary
+        │ equality: (a) = (a)
+        │ equality cols are key
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1 (missing stats)
+              table: table38627@primary
+              spans: /1-/1/#
 
 statement ok
 COMMIT
@@ -477,45 +569,57 @@ CREATE TABLE tdup (x INT PRIMARY KEY, y INT, z INT, UNIQUE (y, z))
 
 # Show unsorted upsert-distinct-on. Plan should not contain "order key".
 # Ensure this test stays synchronized to the test in logic_test/upsert.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 INSERT INTO tdup VALUES (2, 2, 2), (3, 2, 2) ON CONFLICT (z, y) DO UPDATE SET z=1
 ----
-·                                        distribution           local                                        ·                                                  ·
-·                                        vectorized             false                                        ·                                                  ·
-upsert                                   ·                      ·                                            ()                                                 ·
- │                                       estimated row count    0 (missing stats)                            ·                                                  ·
- │                                       into                   tdup(x, y, z)                                ·                                                  ·
- │                                       auto commit            ·                                            ·                                                  ·
- │                                       arbiter indexes        tdup_y_z_key                                 ·                                                  ·
- └── project                             ·                      ·                                            (column1, column2, column3, x, y, z, upsert_z, x)  ·
-      └── render                         ·                      ·                                            (upsert_z, column1, column2, column3, x, y, z)     ·
-           │                             estimated row count    2 (missing stats)                            ·                                                  ·
-           │                             render 0               CASE WHEN x IS NULL THEN column3 ELSE 1 END  ·                                                  ·
-           │                             render 1               column1                                      ·                                                  ·
-           │                             render 2               column2                                      ·                                                  ·
-           │                             render 3               column3                                      ·                                                  ·
-           │                             render 4               x                                            ·                                                  ·
-           │                             render 5               y                                            ·                                                  ·
-           │                             render 6               z                                            ·                                                  ·
-           └── lookup join (left outer)  ·                      ·                                            (column1, column2, column3, x, y, z)               ·
-                │                        estimated row count    2 (missing stats)                            ·                                                  ·
-                │                        table                  tdup@tdup_y_z_key                            ·                                                  ·
-                │                        equality               (column2, column3) = (y,z)                   ·                                                  ·
-                │                        equality cols are key  ·                                            ·                                                  ·
-                └── distinct             ·                      ·                                            (column1, column2, column3)                        ·
-                     │                   estimated row count    2                                            ·                                                  ·
-                     │                   distinct on            column2, column3                             ·                                                  ·
-                     │                   nulls are distinct     ·                                            ·                                                  ·
-                     │                   error on duplicate     ·                                            ·                                                  ·
-                     └── values          ·                      ·                                            (column1, column2, column3)                        ·
-·                                        size                   3 columns, 2 rows                            ·                                                  ·
-·                                        row 0, expr 0          2                                            ·                                                  ·
-·                                        row 0, expr 1          2                                            ·                                                  ·
-·                                        row 0, expr 2          2                                            ·                                                  ·
-·                                        row 1, expr 0          3                                            ·                                                  ·
-·                                        row 1, expr 1          2                                            ·                                                  ·
-·                                        row 1, expr 2          2                                            ·                                                  ·
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: tdup(x, y, z)
+│ auto commit
+│ arbiter indexes: tdup_y_z_key
+│
+└── • project
+    │ columns: (column1, column2, column3, x, y, z, upsert_z, x)
+    │
+    └── • render
+        │ columns: (upsert_z, column1, column2, column3, x, y, z)
+        │ estimated row count: 2 (missing stats)
+        │ render 0: CASE WHEN x IS NULL THEN column3 ELSE 1 END
+        │ render 1: column1
+        │ render 2: column2
+        │ render 3: column3
+        │ render 4: x
+        │ render 5: y
+        │ render 6: z
+        │
+        └── • lookup join (left outer)
+            │ columns: (column1, column2, column3, x, y, z)
+            │ estimated row count: 2 (missing stats)
+            │ table: tdup@tdup_y_z_key
+            │ equality: (column2, column3) = (y,z)
+            │ equality cols are key
+            │
+            └── • distinct
+                │ columns: (column1, column2, column3)
+                │ estimated row count: 2
+                │ distinct on: column2, column3
+                │ nulls are distinct
+                │ error on duplicate
+                │
+                └── • values
+                      columns: (column1, column2, column3)
+                      size: 3 columns, 2 rows
+                      row 0, expr 0: 2
+                      row 0, expr 1: 2
+                      row 0, expr 2: 2
+                      row 1, expr 0: 3
+                      row 1, expr 1: 2
+                      row 1, expr 2: 2
 
 statement ok
 CREATE TABLE target (a INT PRIMARY KEY, b INT, c INT, UNIQUE (b, c))
@@ -525,46 +629,66 @@ CREATE TABLE source (x INT PRIMARY KEY, y INT, z INT, INDEX (y, z))
 
 # Show sorted upsert-distinct-on. "order key = y, z" should be set below.
 # Ensure this test stays synchronized to the test in logic_test/upsert.
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
 INSERT INTO target SELECT x, y, z FROM source WHERE (y IS NULL OR y > 0) AND x <> 1
 ON CONFLICT (b, c) DO UPDATE SET b=5
 ----
-·                                        distribution         local                                  ·                                ·
-·                                        vectorized           false                                  ·                                ·
-upsert                                   ·                    ·                                      ()                               ·
- │                                       estimated row count  0 (missing stats)                      ·                                ·
- │                                       into                 target(a, b, c)                        ·                                ·
- │                                       auto commit          ·                                      ·                                ·
- │                                       arbiter indexes      target_b_c_key                         ·                                ·
- └── project                             ·                    ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
-      └── render                         ·                    ·                                      (upsert_b, x, y, z, a, b, c)     ·
-           │                             estimated row count  311 (missing stats)                    ·                                ·
-           │                             render 0             CASE WHEN a IS NULL THEN y ELSE 5 END  ·                                ·
-           │                             render 1             x                                      ·                                ·
-           │                             render 2             y                                      ·                                ·
-           │                             render 3             z                                      ·                                ·
-           │                             render 4             a                                      ·                                ·
-           │                             render 5             b                                      ·                                ·
-           │                             render 6             c                                      ·                                ·
-           └── merge join (right outer)  ·                    ·                                      (a, b, c, x, y, z)               ·
-                │                        estimated row count  311 (missing stats)                    ·                                ·
-                │                        equality             (b, c) = (y, z)                        ·                                ·
-                │                        merge ordering       +"(b=y)",+"(c=z)"                      ·                                ·
-                ├── scan                 ·                    ·                                      (a, b, c)                        +b,+c
-                │                        estimated row count  1000 (missing stats)                   ·                                ·
-                │                        table                target@target_b_c_key                  ·                                ·
-                │                        spans                FULL SCAN                              ·                                ·
-                └── distinct             ·                    ·                                      (x, y, z)                        +y,+z
-                     │                   estimated row count  311 (missing stats)                    ·                                ·
-                     │                   distinct on          y, z                                   ·                                ·
-                     │                   nulls are distinct   ·                                      ·                                ·
-                     │                   error on duplicate   ·                                      ·                                ·
-                     │                   order key            y, z                                   ·                                ·
-                     └── filter          ·                    ·                                      (x, y, z)                        +y,+z
-                          │              estimated row count  311 (missing stats)                    ·                                ·
-                          │              filter               x != 1                                 ·                                ·
-                          └── scan       ·                    ·                                      (x, y, z)                        +y,+z
-·                                        estimated row count  333 (missing stats)                    ·                                ·
-·                                        table                source@source_y_z_idx                  ·                                ·
-·                                        spans                /NULL-/!NULL /1-                       ·                                ·
+distribution: local
+vectorized: false
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: target(a, b, c)
+│ auto commit
+│ arbiter indexes: target_b_c_key
+│
+└── • project
+    │ columns: (x, y, z, a, b, c, upsert_b, a)
+    │
+    └── • render
+        │ columns: (upsert_b, x, y, z, a, b, c)
+        │ estimated row count: 311 (missing stats)
+        │ render 0: CASE WHEN a IS NULL THEN y ELSE 5 END
+        │ render 1: x
+        │ render 2: y
+        │ render 3: z
+        │ render 4: a
+        │ render 5: b
+        │ render 6: c
+        │
+        └── • merge join (right outer)
+            │ columns: (a, b, c, x, y, z)
+            │ estimated row count: 311 (missing stats)
+            │ equality: (b, c) = (y, z)
+            │ merge ordering: +"(b=y)",+"(c=z)"
+            │
+            ├── • scan
+            │     columns: (a, b, c)
+            │     ordering: +b,+c
+            │     estimated row count: 1000 (missing stats)
+            │     table: target@target_b_c_key
+            │     spans: FULL SCAN
+            │
+            └── • distinct
+                │ columns: (x, y, z)
+                │ ordering: +y,+z
+                │ estimated row count: 311 (missing stats)
+                │ distinct on: y, z
+                │ nulls are distinct
+                │ error on duplicate
+                │ order key: y, z
+                │
+                └── • filter
+                    │ columns: (x, y, z)
+                    │ ordering: +y,+z
+                    │ estimated row count: 311 (missing stats)
+                    │ filter: x != 1
+                    │
+                    └── • scan
+                          columns: (x, y, z)
+                          ordering: +y,+z
+                          estimated row count: 333 (missing stats)
+                          table: source@source_y_z_idx
+                          spans: /NULL-/!NULL /1-

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -1,63 +1,75 @@
 # LogicTest: local
 
 # Tests for the implicit one row, zero column values operator.
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 a
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (a)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  1                ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a)
+  size: 1 column, 1 row
+  row 0, expr 0: 1
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT 1 + 2 a
 ----
-·       distribution   local            ·    ·
-·       vectorized     false            ·    ·
-values  ·              ·                (a)  ·
-·       size           1 column, 1 row  ·    ·
-·       row 0, expr 0  3                ·    ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (a)
+  size: 1 column, 1 row
+  row 0, expr 0: 3
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distribution   local              ·                            ·
-·       vectorized     false              ·                            ·
-values  ·              ·                  (column1, column2, column3)  ·
-·       size           3 columns, 2 rows  ·                            ·
-·       row 0, expr 0  1                  ·                            ·
-·       row 0, expr 1  2                  ·                            ·
-·       row 0, expr 2  3                  ·                            ·
-·       row 1, expr 0  4                  ·                            ·
-·       row 1, expr 1  5                  ·                            ·
-·       row 1, expr 2  6                  ·                            ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (column1, column2, column3)
+  size: 3 columns, 2 rows
+  row 0, expr 0: 1
+  row 0, expr 1: 2
+  row 0, expr 2: 3
+  row 1, expr 0: 4
+  row 1, expr 1: 5
+  row 1, expr 2: 6
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (length('ab') * 2)
 ----
-·       distribution   local             ·          ·
-·       vectorized     false             ·          ·
-values  ·              ·                 (column1)  ·
-·       size           1 column, 4 rows  ·          ·
-·       row 0, expr 0  1                 ·          ·
-·       row 1, expr 0  2                 ·          ·
-·       row 2, expr 0  3                 ·          ·
-·       row 3, expr 0  4                 ·          ·
+distribution: local
+vectorized: false
+·
+• values
+  columns: (column1)
+  size: 1 column, 4 rows
+  row 0, expr 0: 1
+  row 1, expr 0: 2
+  row 2, expr 0: 3
+  row 3, expr 0: 4
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
-·            distribution         local              ·                   ·
-·            vectorized           false              ·                   ·
-render       ·                    ·                  (r)                 ·
- │           estimated row count  3                  ·                   ·
- │           render 0             column1 + column2  ·                   ·
- └── values  ·                    ·                  (column1, column2)  ·
-·            size                 2 columns, 3 rows  ·                   ·
-·            row 0, expr 0        1                  ·                   ·
-·            row 0, expr 1        2                  ·                   ·
-·            row 1, expr 0        3                  ·                   ·
-·            row 1, expr 1        4                  ·                   ·
-·            row 2, expr 0        5                  ·                   ·
-·            row 2, expr 1        6                  ·                   ·
+distribution: local
+vectorized: false
+·
+• render
+│ columns: (r)
+│ estimated row count: 3
+│ render 0: column1 + column2
+│
+└── • values
+      columns: (column1, column2)
+      size: 2 columns, 3 rows
+      row 0, expr 0: 1
+      row 0, expr 1: 2
+      row 1, expr 0: 3
+      row 1, expr 1: 4
+      row 2, expr 0: 5
+      row 2, expr 1: 6

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -2,88 +2,102 @@
 # Note that the new factory currently has limited support of EXPLAIN (PLAN)
 # statements, so spec-planning configurations are currently skipped.
 
-query TTT
+query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----
-·              distribution  local
-·              vectorized    false
-virtual table  ·             ·
-·              table         pg_class@pg_class_oid_idx
-·              spans         [/50 - /50]
+distribution: local
+vectorized: false
+·
+• virtual table
+  table: pg_class@pg_class_oid_idx
+  spans: [/50 - /50]
 
-query TTT
+query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE relname = 'blah'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        relname = 'blah'
- └── virtual table  ·             ·
-·                   table         pg_class@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: relname = 'blah'
+│
+└── • virtual table
+      table: pg_class@primary
 
 
 # We can push the filter into information_schema.tables, which has an index
 # on the table_name field.
-query TTT
+query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        table_name = 'blah'
- └── virtual table  ·             ·
-·                   table         tables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: table_name = 'blah'
+│
+└── • virtual table
+      table: tables@primary
 
 # Make sure that if we need an ordering on one of the virtual indexes we
 # provide it using a sortNode even though the optimizer expects the virtual
 # index to provide it "naturally".
-query TTT
+query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name > 'blah' ORDER BY table_name
 ----
-·                        distribution  local
-·                        vectorized    false
-sort                     ·             ·
- │                       order         +table_name
- └── filter              ·             ·
-      │                  filter        table_name > 'blah'
-      └── virtual table  ·             ·
-·                        table         tables@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +table_name
+│
+└── • filter
+    │ filter: table_name > 'blah'
+    │
+    └── • virtual table
+          table: tables@primary
 
 # Make sure that we properly push down just part of a filter on two columns
 # where only one of them is satisfied by the virtual index.
-query TTT
+query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah' AND table_type = 'foo'
 ----
-·                   distribution  local
-·                   vectorized    false
-filter              ·             ·
- │                  filter        (table_name = 'blah') AND (table_type = 'foo')
- └── virtual table  ·             ·
-·                   table         tables@primary
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: (table_name = 'blah') AND (table_type = 'foo')
+│
+└── • virtual table
+      table: tables@primary
 
 # Lookup joins into virtual indexes.
 
-query TTT
+query T
 EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
-·                          distribution  local
-·                          vectorized    false
-virtual table lookup join  ·             ·
- │                         table         pg_class@pg_class_oid_idx
- │                         equality      (conrelid) = (oid)
- └── virtual table         ·             ·
-·                          table         pg_constraint@primary
+distribution: local
+vectorized: false
+·
+• virtual table lookup join
+│ table: pg_class@pg_class_oid_idx
+│ equality: (conrelid) = (oid)
+│
+└── • virtual table
+      table: pg_constraint@primary
 
-query TTT
+query T
 EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
-·                                       distribution  local
-·                                       vectorized    false
-virtual table lookup join (left outer)  ·             ·
- │                                      table         pg_class@pg_class_oid_idx
- │                                      equality      (conrelid) = (oid)
- └── virtual table                      ·             ·
-·                                       table         pg_constraint@primary
+distribution: local
+vectorized: false
+·
+• virtual table lookup join (left outer)
+│ table: pg_class@pg_class_oid_idx
+│ equality: (conrelid) = (oid)
+│
+└── • virtual table
+      table: pg_constraint@primary
 
 # Can't lookup into a vtable with no index.
 query error could not produce
@@ -91,7 +105,7 @@ EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_index on true
 
 # Test that a gnarly ORM query from ActiveRecord uses lookup joins for speed.
 
-query TTT
+query T
 EXPLAIN SELECT
         t2.oid::REGCLASS AS to_table,
         a1.attname AS column,
@@ -115,48 +129,64 @@ WHERE
 ORDER BY
         c.conname
 ----
-·                                                                  distribution  local
-·                                                                  vectorized    false
-sort                                                               ·             ·
- │                                                                 order         +conname
- └── render                                                        ·             ·
-      └── hash join                                                ·             ·
-           │                                                       equality      (oid) = (connamespace)
-           ├── filter                                              ·             ·
-           │    │                                                  filter        nspname IN ('public',)
-           │    └── virtual table                                  ·             ·
-           │                                                       table         pg_namespace@primary
-           └── virtual table lookup join                           ·             ·
-                │                                                  table         pg_attribute@pg_attribute_attrelid_idx
-                │                                                  equality      (oid) = (attrelid)
-                │                                                  pred          column135 = attnum
-                └── render                                         ·             ·
-                     └── hash join                                 ·             ·
-                          │                                        equality      (attrelid, attnum) = (oid, column110)
-                          ├── filter                               ·             ·
-                          │    │                                   filter        attrelid = 'b'::REGCLASS
-                          │    └── virtual table                   ·             ·
-                          │                                        table         pg_attribute@primary
-                          └── render                               ·             ·
-                               └── virtual table lookup join       ·             ·
-                                    │                              table         pg_class@pg_class_oid_idx
-                                    │                              equality      (confrelid) = (oid)
-                                    └── virtual table lookup join  ·             ·
-                                         │                         table         pg_class@pg_class_oid_idx
-                                         │                         equality      (conrelid) = (oid)
-                                         │                         pred          oid = 'b'::REGCLASS
-                                         └── filter                ·             ·
-                                              │                    filter        (conrelid = 'b'::REGCLASS) AND (contype = 'f')
-                                              └── virtual table    ·             ·
-·                                                                  table         pg_constraint@primary
+distribution: local
+vectorized: false
+·
+• sort
+│ order: +conname
+│
+└── • render
+    │
+    └── • hash join
+        │ equality: (oid) = (connamespace)
+        │
+        ├── • filter
+        │   │ filter: nspname IN ('public',)
+        │   │
+        │   └── • virtual table
+        │         table: pg_namespace@primary
+        │
+        └── • virtual table lookup join
+            │ table: pg_attribute@pg_attribute_attrelid_idx
+            │ equality: (oid) = (attrelid)
+            │ pred: column135 = attnum
+            │
+            └── • render
+                │
+                └── • hash join
+                    │ equality: (attrelid, attnum) = (oid, column110)
+                    │
+                    ├── • filter
+                    │   │ filter: attrelid = 'b'::REGCLASS
+                    │   │
+                    │   └── • virtual table
+                    │         table: pg_attribute@primary
+                    │
+                    └── • render
+                        │
+                        └── • virtual table lookup join
+                            │ table: pg_class@pg_class_oid_idx
+                            │ equality: (confrelid) = (oid)
+                            │
+                            └── • virtual table lookup join
+                                │ table: pg_class@pg_class_oid_idx
+                                │ equality: (conrelid) = (oid)
+                                │ pred: oid = 'b'::REGCLASS
+                                │
+                                └── • filter
+                                    │ filter: (conrelid = 'b'::REGCLASS) AND (contype = 'f')
+                                    │
+                                    └── • virtual table
+                                          table: pg_constraint@primary
 
 # Test that limits are respected.
-query TTT
+query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50 LIMIT 1
 ----
-·              distribution  local
-·              vectorized    false
-virtual table  ·             ·
-·              table         pg_class@pg_class_oid_idx
-·              spans         [/50 - /50]
-·              limit         1
+distribution: local
+vectorized: false
+·
+• virtual table
+  table: pg_class@pg_class_oid_idx
+  spans: [/50 - /50]
+  limit: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -55,287 +55,413 @@ output row: [7 3.4501207708330056852]
 output row: [3 3.5355339059327376220]
 output row: [8 3.5355339059327376220]
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT ntile(1) OVER () FROM kv
 ----
-·                    distribution         local                                                                         ·                      ·
-·                    vectorized           true                                                                          ·                      ·
-project              ·                    ·                                                                             (ntile)                ·
- │                   estimated row count  1000 (missing stats)                                                          ·                      ·
- └── window          ·                    ·                                                                             (ntile_1_arg1, ntile)  ·
-      │              estimated row count  1000 (missing stats)                                                          ·                      ·
-      │              window 0             ntile(ntile_1_arg1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
-      └── render     ·                    ·                                                                             (ntile_1_arg1)         ·
-           │         estimated row count  1000 (missing stats)                                                          ·                      ·
-           │         render 0             1                                                                             ·                      ·
-           └── scan  ·                    ·                                                                             ()                     ·
-·                    estimated row count  1000 (missing stats)                                                          ·                      ·
-·                    table                kv@primary                                                                    ·                      ·
-·                    spans                FULL SCAN                                                                     ·                      ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (ntile)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (ntile_1_arg1, ntile)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: ntile(ntile_1_arg1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • render
+        │ columns: (ntile_1_arg1)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: 1
+        │
+        └── • scan
+              columns: ()
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
 ----
-·                    distribution         local                                                                                                   ·                                                ·
-·                    vectorized           true                                                                                                    ·                                                ·
-project              ·                    ·                                                                                                       (nth_value)                                      ·
- │                   estimated row count  1000 (missing stats)                                                                                    ·                                                ·
- └── window          ·                    ·                                                                                                       (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
-      │              estimated row count  1000 (missing stats)                                                                                    ·                                                ·
-      │              window 0             nth_value(nth_value_1_arg1, nth_value_1_arg2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
-      └── render     ·                    ·                                                                                                       (nth_value_1_arg1, nth_value_1_arg2)             ·
-           │         estimated row count  1000 (missing stats)                                                                                    ·                                                ·
-           │         render 0             1                                                                                                       ·                                                ·
-           │         render 1             2                                                                                                       ·                                                ·
-           └── scan  ·                    ·                                                                                                       ()                                               ·
-·                    estimated row count  1000 (missing stats)                                                                                    ·                                                ·
-·                    table                kv@primary                                                                                              ·                                                ·
-·                    spans                FULL SCAN                                                                                               ·                                                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (nth_value)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (nth_value_1_arg1, nth_value_1_arg2, nth_value)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: nth_value(nth_value_1_arg1, nth_value_1_arg2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • render
+        │ columns: (nth_value_1_arg1, nth_value_1_arg2)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: 1
+        │ render 1: 2
+        │
+        └── • scan
+              columns: ()
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
 statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
 EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
 
-query TTT
+query T
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-·               distribution   local
-·               vectorized     true
-sort            ·              ·
- │              order          +variance,+k
- └── window     ·              ·
-      └── scan  ·              ·
-·               missing stats  ·
-·               table          kv@primary
-·               spans          FULL SCAN
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +variance,+k
+│
+└── • window
+    │
+    └── • scan
+          missing stats
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-·                         distribution         local                                                                                                             ·                                                            ·
-·                         vectorized           true                                                                                                              ·                                                            ·
-project                   ·                    ·                                                                                                                 (k int, stddev decimal)                                      ·
- └── sort                 ·                    ·                                                                                                                 (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                   estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-      │                   order                +variance,+k                                                                                                      ·                                                            ·
-      └── project         ·                    ·                                                                                                                 (k int, stddev decimal, variance decimal)                    ·
-           │              estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-           └── window     ·                    ·                                                                                                                 (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │         estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-                │         window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                │         window 1             (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── scan  ·                    ·                                                                                                                 (k int, v int, d decimal)                                    ·
-·                         estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-·                         table                kv@primary                                                                                                        ·                                                            ·
-·                         spans                FULL SCAN                                                                                                         ·                                                            ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k int, stddev decimal)
+│
+└── • sort
+    │ columns: (k int, stddev decimal, variance decimal)
+    │ ordering: +variance,+k
+    │ estimated row count: 1000 (missing stats)
+    │ order: +variance,+k
+    │
+    └── • project
+        │ columns: (k int, stddev decimal, variance decimal)
+        │ estimated row count: 1000 (missing stats)
+        │
+        └── • window
+            │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
+            │ estimated row count: 1000 (missing stats)
+            │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+            │ window 1: (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+            │
+            └── • scan
+                  columns: (k int, v int, d decimal)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-·                              distribution         local                                                                                                             ·                                                            ·
-·                              vectorized           true                                                                                                              ·                                                            ·
-project                        ·                    ·                                                                                                                 (k int, stddev decimal)                                      ·
- └── sort                      ·                    ·                                                                                                                 (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                        estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-      │                        order                +variance,+k                                                                                                      ·                                                            ·
-      └── project              ·                    ·                                                                                                                 (k int, stddev decimal, variance decimal)                    ·
-           │                   estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-           └── window          ·                    ·                                                                                                                 (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-                │              window 0             (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·                    ·                                                                                                                 (k int, v int, d decimal, stddev decimal)                    ·
-                     │         estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-                     │         window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·                    ·                                                                                                                 (k int, v int, d decimal)                                    ·
-·                              estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-·                              table                kv@primary                                                                                                        ·                                                            ·
-·                              spans                FULL SCAN                                                                                                         ·                                                            ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k int, stddev decimal)
+│
+└── • sort
+    │ columns: (k int, stddev decimal, variance decimal)
+    │ ordering: +variance,+k
+    │ estimated row count: 1000 (missing stats)
+    │ order: +variance,+k
+    │
+    └── • project
+        │ columns: (k int, stddev decimal, variance decimal)
+        │ estimated row count: 1000 (missing stats)
+        │
+        └── • window
+            │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
+            │ estimated row count: 1000 (missing stats)
+            │ window 0: (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+            │
+            └── • window
+                │ columns: (k int, v int, d decimal, stddev decimal)
+                │ estimated row count: 1000 (missing stats)
+                │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+                │
+                └── • scan
+                      columns: (k int, v int, d decimal)
+                      estimated row count: 1000 (missing stats)
+                      table: kv@primary
+                      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-·                    distribution         local                                                                                                           ·                                          ·
-·                    vectorized           true                                                                                                            ·                                          ·
-sort                 ·                    ·                                                                                                               (k int, stddev decimal)                    +k
- │                   estimated row count  1000 (missing stats)                                                                                            ·                                          ·
- │                   order                +k                                                                                                              ·                                          ·
- └── project         ·                    ·                                                                                                               (k int, stddev decimal)                    ·
-      │              estimated row count  1000 (missing stats)                                                                                            ·                                          ·
-      └── window     ·                    ·                                                                                                               (k int, v int, d decimal, stddev decimal)  ·
-           │         estimated row count  1000 (missing stats)                                                                                            ·                                          ·
-           │         window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
-           └── scan  ·                    ·                                                                                                               (k int, v int, d decimal)                  ·
-·                    estimated row count  1000 (missing stats)                                                                                            ·                                          ·
-·                    table                kv@primary                                                                                                      ·                                          ·
-·                    spans                FULL SCAN                                                                                                       ·                                          ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (k int, stddev decimal)
+│ ordering: +k
+│ estimated row count: 1000 (missing stats)
+│ order: +k
+│
+└── • project
+    │ columns: (k int, stddev decimal)
+    │ estimated row count: 1000 (missing stats)
+    │
+    └── • window
+        │ columns: (k int, v int, d decimal, stddev decimal)
+        │ estimated row count: 1000 (missing stats)
+        │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+        │
+        └── • scan
+              columns: (k int, v int, d decimal)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-·                              distribution         local                                                                                                             ·                                                            ·
-·                              vectorized           true                                                                                                              ·                                                            ·
-project                        ·                    ·                                                                                                                 (k int, "?column?" decimal)                                  ·
- └── sort                      ·                    ·                                                                                                                 ("?column?" decimal, k int, variance decimal)                +variance,+k
-      │                        estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-      │                        order                +variance,+k                                                                                                      ·                                                            ·
-      └── render               ·                    ·                                                                                                                 ("?column?" decimal, k int, variance decimal)                ·
-           │                   estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-           │                   render 0             ((k)[int] + (stddev)[decimal])[decimal]                                                                           ·                                                            ·
-           │                   render 1             (k)[int]                                                                                                          ·                                                            ·
-           │                   render 2             (variance)[decimal]                                                                                               ·                                                            ·
-           └── window          ·                    ·                                                                                                                 (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-                │              window 0             (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·                    ·                                                                                                                 (k int, v int, d decimal, stddev decimal)                    ·
-                     │         estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-                     │         window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·                    ·                                                                                                                 (k int, v int, d decimal)                                    ·
-·                              estimated row count  1000 (missing stats)                                                                                              ·                                                            ·
-·                              table                kv@primary                                                                                                        ·                                                            ·
-·                              spans                FULL SCAN                                                                                                         ·                                                            ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (k int, "?column?" decimal)
+│
+└── • sort
+    │ columns: ("?column?" decimal, k int, variance decimal)
+    │ ordering: +variance,+k
+    │ estimated row count: 1000 (missing stats)
+    │ order: +variance,+k
+    │
+    └── • render
+        │ columns: ("?column?" decimal, k int, variance decimal)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: ((k)[int] + (stddev)[decimal])[decimal]
+        │ render 1: (k)[int]
+        │ render 2: (variance)[decimal]
+        │
+        └── • window
+            │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
+            │ estimated row count: 1000 (missing stats)
+            │ window 0: (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+            │
+            └── • window
+                │ columns: (k int, v int, d decimal, stddev decimal)
+                │ estimated row count: 1000 (missing stats)
+                │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+                │
+                └── • scan
+                      columns: (k int, v int, d decimal)
+                      estimated row count: 1000 (missing stats)
+                      table: kv@primary
+                      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-·                                   distribution         local                                                                                                             ·                                                              ·
-·                                   vectorized           true                                                                                                              ·                                                              ·
-project                             ·                    ·                                                                                                                 (max int, "?column?" decimal)                                  ·
- └── sort                           ·                    ·                                                                                                                 ("?column?" decimal, max int, variance decimal)                +variance
-      │                             estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-      │                             order                +variance                                                                                                         ·                                                              ·
-      └── render                    ·                    ·                                                                                                                 ("?column?" decimal, max int, variance decimal)                ·
-           │                        estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-           │                        render 0             ((max)[int] + (stddev)[decimal])[decimal]                                                                         ·                                                              ·
-           │                        render 1             (max)[int]                                                                                                        ·                                                              ·
-           │                        render 2             (variance)[decimal]                                                                                               ·                                                              ·
-           └── window               ·                    ·                                                                                                                 (v int, d decimal, max int, stddev decimal, variance decimal)  ·
-                │                   estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-                │                   window 0             (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                              ·
-                └── window          ·                    ·                                                                                                                 (v int, d decimal, max int, stddev decimal)                    ·
-                     │              estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-                     │              window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                              ·
-                     └── group      ·                    ·                                                                                                                 (v int, d decimal, max int)                                    ·
-                          │         estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-                          │         aggregate 0          max(k)                                                                                                            ·                                                              ·
-                          │         group by             v, d                                                                                                              ·                                                              ·
-                          └── scan  ·                    ·                                                                                                                 (k int, v int, d decimal)                                      ·
-·                                   estimated row count  1000 (missing stats)                                                                                              ·                                                              ·
-·                                   table                kv@primary                                                                                                        ·                                                              ·
-·                                   spans                FULL SCAN                                                                                                         ·                                                              ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (max int, "?column?" decimal)
+│
+└── • sort
+    │ columns: ("?column?" decimal, max int, variance decimal)
+    │ ordering: +variance
+    │ estimated row count: 1000 (missing stats)
+    │ order: +variance
+    │
+    └── • render
+        │ columns: ("?column?" decimal, max int, variance decimal)
+        │ estimated row count: 1000 (missing stats)
+        │ render 0: ((max)[int] + (stddev)[decimal])[decimal]
+        │ render 1: (max)[int]
+        │ render 2: (variance)[decimal]
+        │
+        └── • window
+            │ columns: (v int, d decimal, max int, stddev decimal, variance decimal)
+            │ estimated row count: 1000 (missing stats)
+            │ window 0: (variance((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+            │
+            └── • window
+                │ columns: (v int, d decimal, max int, stddev decimal)
+                │ estimated row count: 1000 (missing stats)
+                │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+                │
+                └── • group
+                    │ columns: (v int, d decimal, max int)
+                    │ estimated row count: 1000 (missing stats)
+                    │ aggregate 0: max(k)
+                    │ group by: v, d
+                    │
+                    └── • scan
+                          columns: (k int, v int, d decimal)
+                          estimated row count: 1000 (missing stats)
+                          table: kv@primary
+                          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-·                         distribution         local                                                                                                           ·                                            ·
-·                         vectorized           true                                                                                                            ·                                            ·
-sort                      ·                    ·                                                                                                               (max int, stddev decimal)                    +max
- │                        estimated row count  1000 (missing stats)                                                                                            ·                                            ·
- │                        order                +max                                                                                                            ·                                            ·
- └── project              ·                    ·                                                                                                               (max int, stddev decimal)                    ·
-      │                   estimated row count  1000 (missing stats)                                                                                            ·                                            ·
-      └── window          ·                    ·                                                                                                               (v int, d decimal, max int, stddev decimal)  ·
-           │              estimated row count  1000 (missing stats)                                                                                            ·                                            ·
-           │              window 0             (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                            ·
-           └── group      ·                    ·                                                                                                               (v int, d decimal, max int)                  ·
-                │         estimated row count  1000 (missing stats)                                                                                            ·                                            ·
-                │         aggregate 0          max(k)                                                                                                          ·                                            ·
-                │         group by             v, d                                                                                                            ·                                            ·
-                └── scan  ·                    ·                                                                                                               (k int, v int, d decimal)                    ·
-·                         estimated row count  1000 (missing stats)                                                                                            ·                                            ·
-·                         table                kv@primary                                                                                                      ·                                            ·
-·                         spans                FULL SCAN                                                                                                       ·                                            ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (max int, stddev decimal)
+│ ordering: +max
+│ estimated row count: 1000 (missing stats)
+│ order: +max
+│
+└── • project
+    │ columns: (max int, stddev decimal)
+    │ estimated row count: 1000 (missing stats)
+    │
+    └── • window
+        │ columns: (v int, d decimal, max int, stddev decimal)
+        │ estimated row count: 1000 (missing stats)
+        │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
+        │
+        └── • group
+            │ columns: (v int, d decimal, max int)
+            │ estimated row count: 1000 (missing stats)
+            │ aggregate 0: max(k)
+            │ group by: v, d
+            │
+            └── • scan
+                  columns: (k int, v int, d decimal)
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Partition
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT lag(1) OVER (PARTITION BY 2), lead(2) OVER (PARTITION BY 1) FROM kv
 ----
-·                         distribution         local                                                                                                     ·                                                       ·
-·                         vectorized           true                                                                                                      ·                                                       ·
-project                   ·                    ·                                                                                                         (lag, lead)                                             ·
- │                        estimated row count  1000 (missing stats)                                                                                      ·                                                       ·
- └── window               ·                    ·                                                                                                         (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
-      │                   estimated row count  1000 (missing stats)                                                                                      ·                                                       ·
-      │                   window 0             lead(lag_1_partition_1, lag_1_arg1, lag_1_arg3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
-      └── window          ·                    ·                                                                                                         (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
-           │              estimated row count  1000 (missing stats)                                                                                      ·                                                       ·
-           │              window 0             lag(lag_1_arg1, lag_1_arg1, lag_1_arg3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                       ·
-           └── render     ·                    ·                                                                                                         (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
-                │         estimated row count  1000 (missing stats)                                                                                      ·                                                       ·
-                │         render 0             1                                                                                                         ·                                                       ·
-                │         render 1             CAST(NULL AS INT8)                                                                                        ·                                                       ·
-                │         render 2             2                                                                                                         ·                                                       ·
-                └── scan  ·                    ·                                                                                                         ()                                                      ·
-·                         estimated row count  1000 (missing stats)                                                                                      ·                                                       ·
-·                         table                kv@primary                                                                                                ·                                                       ·
-·                         spans                FULL SCAN                                                                                                 ·                                                       ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (lag, lead)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: lead(lag_1_partition_1, lag_1_arg1, lag_1_arg3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • window
+        │ columns: (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)
+        │ estimated row count: 1000 (missing stats)
+        │ window 0: lag(lag_1_arg1, lag_1_arg1, lag_1_arg3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        │
+        └── • render
+            │ columns: (lag_1_arg1, lag_1_arg3, lag_1_partition_1)
+            │ estimated row count: 1000 (missing stats)
+            │ render 0: 1
+            │ render 1: CAST(NULL AS INT8)
+            │ render 2: 2
+            │
+            └── • scan
+                  columns: ()
+                  estimated row count: 1000 (missing stats)
+                  table: kv@primary
+                  spans: FULL SCAN
 
 # Ordering
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-·               distribution         local                                                                           ·             ·
-·               vectorized           true                                                                            ·             ·
-sort            ·                    ·                                                                               (k, v, rank)  +k
- │              estimated row count  1000 (missing stats)                                                            ·             ·
- │              order                +k                                                                              ·             ·
- └── window     ·                    ·                                                                               (k, v, rank)  ·
-      │         estimated row count  1000 (missing stats)                                                            ·             ·
-      │         window 0             rank() OVER (ORDER BY k ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
-      └── scan  ·                    ·                                                                               (k, v)        ·
-·               estimated row count  1000 (missing stats)                                                            ·             ·
-·               table                kv@primary                                                                      ·             ·
-·               spans                FULL SCAN                                                                       ·             ·
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (k, v, rank)
+│ ordering: +k
+│ estimated row count: 1000 (missing stats)
+│ order: +k
+│
+└── • window
+    │ columns: (k, v, rank)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: rank() OVER (ORDER BY k ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • scan
+          columns: (k, v)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
 
 # Frames
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT avg(k) OVER () FROM kv
 ----
-·               distribution         local                                                            ·         ·
-·               vectorized           true                                                             ·         ·
-project         ·                    ·                                                                (avg)     ·
- │              estimated row count  1000 (missing stats)                                             ·         ·
- └── window     ·                    ·                                                                (k, avg)  ·
-      │         estimated row count  1000 (missing stats)                                             ·         ·
-      │         window 0             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·                    ·                                                                (k)       ·
-·               estimated row count  1000 (missing stats)                                             ·         ·
-·               table                kv@primary                                                       ·         ·
-·               spans                FULL SCAN                                                        ·         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (avg)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (k, avg)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • scan
+          columns: (k)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM kv
 ----
-·               distribution         local                                                                    ·         ·
-·               vectorized           true                                                                     ·         ·
-project         ·                    ·                                                                        (avg)     ·
- │              estimated row count  1000 (missing stats)                                                     ·         ·
- └── window     ·                    ·                                                                        (k, avg)  ·
-      │         estimated row count  1000 (missing stats)                                                     ·         ·
-      │         window 0             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
-      └── scan  ·                    ·                                                                        (k)       ·
-·               estimated row count  1000 (missing stats)                                                     ·         ·
-·               table                kv@primary                                                               ·         ·
-·               spans                FULL SCAN                                                                ·         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (avg)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (k, avg)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+    │
+    └── • scan
+          columns: (k)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM kv
 ----
-·               distribution         local                                                            ·         ·
-·               vectorized           true                                                             ·         ·
-project         ·                    ·                                                                (avg)     ·
- │              estimated row count  1000 (missing stats)                                             ·         ·
- └── window     ·                    ·                                                                (k, avg)  ·
-      │         estimated row count  1000 (missing stats)                                             ·         ·
-      │         window 0             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·                    ·                                                                (k)       ·
-·               estimated row count  1000 (missing stats)                                             ·         ·
-·               table                kv@primary                                                       ·         ·
-·               spans                FULL SCAN                                                        ·         ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (avg)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (k, avg)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • scan
+          columns: (k)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
@@ -353,32 +479,40 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·                    distribution         local                                                                                    ·                                                                ·
-·                    vectorized           true                                                                                     ·                                                                ·
-project              ·                    ·                                                                                        (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)     ·
- │                   estimated row count  1000 (missing stats)                                                                     ·                                                                ·
- └── window          ·                    ·                                                                                        (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)  ·
-      │              estimated row count  1000 (missing stats)                                                                     ·                                                                ·
-      │              window 0             avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
-      │              window 1             avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
-      │              window 2             avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
-      │              window 3             avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
-      └── window     ·                    ·                                                                                        (k, avg, avg, avg, avg, avg, avg, avg, avg)                      ·
-           │         estimated row count  1000 (missing stats)                                                                     ·                                                                ·
-           │         window 0             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                  ·                                                                ·
-           │         window 1             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                          ·                                                                ·
-           │         window 2             avg(k) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                          ·                                                                ·
-           │         window 3             avg(k) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                  ·                                                                ·
-           │         window 4             avg(k) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
-           │         window 5             avg(k) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
-           │         window 6             avg(k) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
-           │         window 7             avg(k) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
-           └── scan  ·                    ·                                                                                        (k)                                                              ·
-·                    estimated row count  1000 (missing stats)                                                                     ·                                                                ·
-·                    table                kv@primary                                                                               ·                                                                ·
-·                    spans                FULL SCAN                                                                                ·                                                                ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+    │ window 1: avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │ window 2: avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+    │ window 3: avg(k) OVER (ORDER BY k ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+    │
+    └── • window
+        │ columns: (k, avg, avg, avg, avg, avg, avg, avg, avg)
+        │ estimated row count: 1000 (missing stats)
+        │ window 0: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+        │ window 1: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        │ window 2: avg(k) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+        │ window 3: avg(k) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)
+        │ window 4: avg(k) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+        │ window 5: avg(k) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        │ window 6: avg(k) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+        │ window 7: avg(k) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+        │
+        └── • scan
+              columns: (k)
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         avg(v) OVER (
@@ -390,31 +524,44 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·                         distribution         local                                                                    ·             ·
-·                         vectorized           false                                                                    ·             ·
-root                      ·                    ·                                                                        (avg)         ·
- ├── project              ·                    ·                                                                        (avg)         ·
- │    │                   estimated row count  1000 (missing stats)                                                     ·             ·
- │    └── window          ·                    ·                                                                        (v, w, avg)   ·
- │         │              estimated row count  1000 (missing stats)                                                     ·             ·
- │         │              window 0             avg(v) OVER (PARTITION BY w ROWS BETWEEN @S1 PRECEDING AND 1 FOLLOWING)  ·             ·
- │         └── scan       ·                    ·                                                                        (v, w)        ·
- │                        estimated row count  1000 (missing stats)                                                     ·             ·
- │                        table                kv@primary                                                               ·             ·
- │                        spans                FULL SCAN                                                                ·             ·
- └── subquery             ·                    ·                                                                        ·             ·
-      │                   id                   @S1                                                                      ·             ·
-      │                   original sql         (SELECT count(*) FROM kv)                                                ·             ·
-      │                   exec mode            one row                                                                  ·             ·
-      └── group (scalar)  ·                    ·                                                                        (count_rows)  ·
-           │              estimated row count  1 (missing stats)                                                        ·             ·
-           │              aggregate 0          count_rows()                                                             ·             ·
-           └── scan       ·                    ·                                                                        ()            ·
-·                         estimated row count  1000 (missing stats)                                                     ·             ·
-·                         table                kv@primary                                                               ·             ·
-·                         spans                FULL SCAN                                                                ·             ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (avg)
+│
+├── • project
+│   │ columns: (avg)
+│   │ estimated row count: 1000 (missing stats)
+│   │
+│   └── • window
+│       │ columns: (v, w, avg)
+│       │ estimated row count: 1000 (missing stats)
+│       │ window 0: avg(v) OVER (PARTITION BY w ROWS BETWEEN @S1 PRECEDING AND 1 FOLLOWING)
+│       │
+│       └── • scan
+│             columns: (v, w)
+│             estimated row count: 1000 (missing stats)
+│             table: kv@primary
+│             spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT count(*) FROM kv)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │ columns: (count_rows)
+        │ estimated row count: 1 (missing stats)
+        │ aggregate 0: count_rows()
+        │
+        └── • scan
+              columns: ()
+              estimated row count: 1000 (missing stats)
+              table: kv@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
     SELECT
         avg(k) OVER (RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW),
@@ -424,17 +571,23 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·               distribution         local                                                                                ·                        ·
-·               vectorized           true                                                                                 ·                        ·
-project         ·                    ·                                                                                    (avg, avg, avg, avg)     ·
- │              estimated row count  1000 (missing stats)                                                                 ·                        ·
- └── window     ·                    ·                                                                                    (k, avg, avg, avg, avg)  ·
-      │         estimated row count  1000 (missing stats)                                                                 ·                        ·
-      │         window 0             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
-      │         window 1             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
-      │         window 2             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
-      │         window 3             avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
-      └── scan  ·                    ·                                                                                    (k)                      ·
-·               estimated row count  1000 (missing stats)                                                                 ·                        ·
-·               table                kv@primary                                                                           ·                        ·
-·               spans                FULL SCAN                                                                            ·                        ·
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (avg, avg, avg, avg)
+│ estimated row count: 1000 (missing stats)
+│
+└── • window
+    │ columns: (k, avg, avg, avg, avg)
+    │ estimated row count: 1000 (missing stats)
+    │ window 0: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)
+    │ window 1: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)
+    │ window 2: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+    │ window 3: avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+    │
+    └── • scan
+          columns: (k)
+          estimated row count: 1000 (missing stats)
+          table: kv@primary
+          spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -6,78 +6,108 @@ CREATE TABLE x(a INT)
 statement ok
 CREATE TABLE y(a INT)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
-·                        distribution         local                    ·       ·
-·                        vectorized           false                    ·       ·
-root                     ·                    ·                        (a, a)  ·
- ├── cross join (inner)  ·                    ·                        (a, a)  ·
- │    │                  estimated row count  1000000 (missing stats)  ·       ·
- │    ├── scan buffer    ·                    ·                        (a)     ·
- │    │                  estimated row count  1000 (missing stats)     ·       ·
- │    │                  label                buffer 1 (t)             ·       ·
- │    └── scan buffer    ·                    ·                        (a)     ·
- │                       estimated row count  1000 (missing stats)     ·       ·
- │                       label                buffer 1 (t)             ·       ·
- └── subquery            ·                    ·                        ·       ·
-      │                  id                   @S1                      ·       ·
-      │                  original sql         SELECT a FROM y          ·       ·
-      │                  exec mode            all rows                 ·       ·
-      └── buffer         ·                    ·                        (a)     ·
-           │             label                buffer 1 (t)             ·       ·
-           └── scan      ·                    ·                        (a)     ·
-·                        estimated row count  1000 (missing stats)     ·       ·
-·                        table                y@primary                ·       ·
-·                        spans                FULL SCAN                ·       ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a, a)
+│
+├── • cross join (inner)
+│   │ columns: (a, a)
+│   │ estimated row count: 1000000 (missing stats)
+│   │
+│   ├── • scan buffer
+│   │     columns: (a)
+│   │     estimated row count: 1000 (missing stats)
+│   │     label: buffer 1 (t)
+│   │
+│   └── • scan buffer
+│         columns: (a)
+│         estimated row count: 1000 (missing stats)
+│         label: buffer 1 (t)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: SELECT a FROM y
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1 (t)
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1000 (missing stats)
+              table: y@primary
+              spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t
 ----
-·          distribution         local                 ·    ·
-·          vectorized           true                  ·    ·
-render     ·                    ·                     (a)  ·
- │         estimated row count  1000 (missing stats)  ·    ·
- │         render 0             a                     ·    ·
- └── scan  ·                    ·                     (a)  ·
-·          estimated row count  1000 (missing stats)  ·    ·
-·          table                y@primary             ·    ·
-·          spans                FULL SCAN             ·    ·
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a)
+│ estimated row count: 1000 (missing stats)
+│ render 0: a
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1000 (missing stats)
+      table: y@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   WITH t AS (INSERT INTO x VALUES (1) RETURNING a) SELECT * FROM t
 ----
-·                                distribution         local                                 ·                   ·
-·                                vectorized           false                                 ·                   ·
-root                             ·                    ·                                     (a)                 ·
- ├── scan buffer                 ·                    ·                                     (a)                 ·
- │                               estimated row count  1                                     ·                   ·
- │                               label                buffer 1 (t)                          ·                   ·
- └── subquery                    ·                    ·                                     ·                   ·
-      │                          id                   @S1                                   ·                   ·
-      │                          original sql         INSERT INTO x VALUES (1) RETURNING a  ·                   ·
-      │                          exec mode            all rows                              ·                   ·
-      └── buffer                 ·                    ·                                     (a)                 ·
-           │                     label                buffer 1 (t)                          ·                   ·
-           └── project           ·                    ·                                     (a)                 ·
-                │                estimated row count  1                                     ·                   ·
-                └── insert       ·                    ·                                     (a, rowid)          ·
-                     │           estimated row count  1                                     ·                   ·
-                     │           into                 x(a, rowid)                           ·                   ·
-                     └── values  ·                    ·                                     (column1, column6)  ·
-·                                size                 2 columns, 1 row                      ·                   ·
-·                                row 0, expr 0        1                                     ·                   ·
-·                                row 0, expr 1        unique_rowid()                        ·                   ·
+distribution: local
+vectorized: false
+·
+• root
+│ columns: (a)
+│
+├── • scan buffer
+│     columns: (a)
+│     estimated row count: 1
+│     label: buffer 1 (t)
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO x VALUES (1) RETURNING a
+    │ exec mode: all rows
+    │
+    └── • buffer
+        │ columns: (a)
+        │ label: buffer 1 (t)
+        │
+        └── • project
+            │ columns: (a)
+            │ estimated row count: 1
+            │
+            └── • insert
+                │ columns: (a, rowid)
+                │ estimated row count: 1
+                │ into: x(a, rowid)
+                │
+                └── • values
+                      columns: (column1, column6)
+                      size: 2 columns, 1 row
+                      row 0, expr 0: 1
+                      row 0, expr 1: unique_rowid()
 
 # Regression test for #39010.
 
 statement ok
 CREATE TABLE table39010 (col NAME)
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   WITH
     w AS (SELECT NULL, NULL FROM table39010)
@@ -86,20 +116,26 @@ EXPLAIN (VERBOSE)
   FROM
     w, table39010
 ----
-·                   distribution         local                    ·      ·
-·                   vectorized           true                     ·      ·
-cross join (inner)  ·                    ·                        (col)  ·
- │                  estimated row count  1000000 (missing stats)  ·      ·
- ├── scan           ·                    ·                        ()     ·
- │                  estimated row count  1000 (missing stats)     ·      ·
- │                  table                table39010@primary       ·      ·
- │                  spans                FULL SCAN                ·      ·
- └── scan           ·                    ·                        (col)  ·
-·                   estimated row count  1000 (missing stats)     ·      ·
-·                   table                table39010@primary       ·      ·
-·                   spans                FULL SCAN                ·      ·
+distribution: local
+vectorized: true
+·
+• cross join (inner)
+│ columns: (col)
+│ estimated row count: 1000000 (missing stats)
+│
+├── • scan
+│     columns: ()
+│     estimated row count: 1000 (missing stats)
+│     table: table39010@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (col)
+      estimated row count: 1000 (missing stats)
+      table: table39010@primary
+      spans: FULL SCAN
 
-query TTTTT
+query T
 EXPLAIN (VERBOSE)
   WITH RECURSIVE t(n) AS (
       VALUES (1)
@@ -108,16 +144,24 @@ EXPLAIN (VERBOSE)
   )
   SELECT sum(n) FROM t
 ----
-·                        distribution         local               ·          ·
-·                        vectorized           false               ·          ·
-group (scalar)           ·                    ·                   (sum)      ·
- │                       estimated row count  1 (missing stats)   ·          ·
- │                       aggregate 0          sum(n)              ·          ·
- └── render              ·                    ·                   (n)        ·
-      │                  estimated row count  10 (missing stats)  ·          ·
-      │                  render 0             column1             ·          ·
-      └── recursive cte  ·                    ·                   (column1)  ·
-           │             estimated row count  10 (missing stats)  ·          ·
-           └── values    ·                    ·                   (column1)  ·
-·                        size                 1 column, 1 row     ·          ·
-·                        row 0, expr 0        1                   ·          ·
+distribution: local
+vectorized: false
+·
+• group (scalar)
+│ columns: (sum)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: sum(n)
+│
+└── • render
+    │ columns: (n)
+    │ estimated row count: 10 (missing stats)
+    │ render 0: column1
+    │
+    └── • recursive cte
+        │ columns: (column1)
+        │ estimated row count: 10 (missing stats)
+        │
+        └── • values
+              columns: (column1)
+              size: 1 column, 1 row
+              row 0, expr 0: 1

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -165,9 +165,6 @@ func getResultColumns(
 	case explainOp:
 		switch o := args.(*explainArgs).Options; o.Mode {
 		case tree.ExplainPlan:
-			if o.Flags[tree.ExplainFlagVerbose] || o.Flags[tree.ExplainFlagTypes] {
-				return colinfo.ExplainPlanVerboseColumns, nil
-			}
 			return colinfo.ExplainPlanColumns, nil
 		case tree.ExplainDistSQL:
 			return colinfo.ExplainDistSQLColumns, nil
@@ -178,10 +175,6 @@ func getResultColumns(
 		}
 
 	case explainPlanOp:
-		o := args.(*explainPlanArgs).Options
-		if o.Flags[tree.ExplainFlagVerbose] || o.Flags[tree.ExplainFlagTypes] {
-			return colinfo.ExplainPlanVerboseColumns, nil
-		}
 		return colinfo.ExplainPlanColumns, nil
 
 	case explainOptOp:

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -349,12 +349,12 @@ memo (optimized, ~3KB, required=[presentation: array_agg:4])
  └── G5: (variable x)
 
 memo
-SELECT DISTINCT field FROM [EXPLAIN SELECT 123 AS k]
+SELECT DISTINCT info FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized, ~9KB, required=[presentation: field:6])
- ├── G1: (distinct-on G2 G3 cols=(6))
- │    └── [presentation: field:6]
- │         ├── best: (distinct-on G2 G3 cols=(6))
+memo (optimized, ~7KB, required=[presentation: info:3])
+ ├── G1: (distinct-on G2 G3 cols=(3))
+ │    └── [presentation: info:3]
+ │         ├── best: (distinct-on G2 G3 cols=(3))
  │         └── cost: 0.56
  ├── G2: (project G4 G5)
  │    └── []
@@ -370,7 +370,7 @@ memo (optimized, ~9KB, required=[presentation: field:6])
  │    └── [presentation: k:1]
  │         ├── best: (values G8 id=v1)
  │         └── cost: 0.02
- ├── G7: (variable field)
+ ├── G7: (variable info)
  ├── G8: (scalar-list G9)
  ├── G9: (tuple G10)
  ├── G10: (scalar-list G11)

--- a/pkg/sql/opt/memo/testdata/stats/explain
+++ b/pkg/sql/opt/memo/testdata/stats/explain
@@ -2,7 +2,7 @@ build
 EXPLAIN SELECT 1
 ----
 explain
- ├── columns: tree:2(string) field:3(string) description:4(string)
+ ├── columns: info:2(string)
  ├── stats: [rows=10]
  └── project
       ├── columns: "?column?":1(int!null)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -208,7 +208,7 @@ norm expect=SimplifyExplainOrdering
 EXPLAIN SELECT b, b+1 AS plus, c FROM abcde ORDER BY b, plus, c
 ----
 explain
- ├── columns: tree:8 field:9 description:10
+ ├── columns: info:8
  ├── immutable
  └── sort
       ├── columns: b:2 plus:7 c:3
@@ -231,15 +231,4 @@ explain
 norm
 SELECT field FROM [EXPLAIN SELECT 123 AS k]
 ----
-project
- ├── columns: field:6
- ├── explain
- │    ├── columns: tree:2 field:3 description:4
- │    └── values
- │         ├── columns: k:1!null
- │         ├── cardinality: [1 - 1]
- │         ├── key: ()
- │         ├── fd: ()-->(1)
- │         └── (123,)
- └── projections
-      └── field:3 [as=field:6, outer=(3)]
+error (42703): column "field" does not exist

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -547,25 +547,7 @@ FROM
     OFFSET 1
 )
 ----
-offset
- ├── columns: tree:13 columns:18
- ├── internal-ordering: +13
- ├── sort
- │    ├── columns: tree:13 columns:18
- │    ├── ordering: +13
- │    └── project
- │         ├── columns: tree:13 columns:18
- │         ├── explain
- │         │    ├── columns: tree:6 level:7 node_type:8 field:9 description:10 columns:11 ordering:12
- │         │    ├── mode: verbose
- │         │    └── scan a
- │         │         ├── columns: k:1!null i:2 f:3 s:4
- │         │         ├── key: (1)
- │         │         └── fd: (1)-->(2-4)
- │         └── projections
- │              ├── tree:6 [as=tree:13, outer=(6)]
- │              └── columns:11 [as=columns:18, outer=(11)]
- └── 1
+error (42703): column "tree" does not exist
 
 # --------------------------------------------------
 # PruneLimitCols + PruneOffsetCols
@@ -1599,7 +1581,7 @@ norm expect=PruneExplainCols
 EXPLAIN SELECT a FROM abcde WHERE b=1 AND c IS NOT NULL ORDER BY c, d
 ----
 explain
- ├── columns: tree:7 field:8 description:9
+ ├── columns: info:7
  └── sort
       ├── columns: a:1!null  [hidden: c:3!null]
       ├── key: (1)

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -34,11 +34,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 	switch explain.Mode {
 	case tree.ExplainPlan:
 		telemetry.Inc(sqltelemetry.ExplainPlanUseCounter)
-		if explain.Flags[tree.ExplainFlagVerbose] || explain.Flags[tree.ExplainFlagTypes] {
-			cols = colinfo.ExplainPlanVerboseColumns
-		} else {
-			cols = colinfo.ExplainPlanColumns
-		}
+		cols = colinfo.ExplainPlanColumns
 
 	case tree.ExplainDistSQL:
 		analyze := explain.Flags[tree.ExplainFlagAnalyze]

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -6,7 +6,7 @@ build
 EXPLAIN SELECT * FROM xy
 ----
 explain
- ├── columns: tree:4 field:5 description:6
+ ├── columns: info:4
  └── project
       ├── columns: x:1!null y:2
       └── scan xy
@@ -16,7 +16,7 @@ build
 EXPLAIN (TYPES) SELECT * FROM xy
 ----
 explain
- ├── columns: tree:4 field:7 description:8 columns:9 ordering:10  [hidden: level:5 node_type:6]
+ ├── columns: info:4
  └── project
       ├── columns: x:1!null y:2
       └── scan xy
@@ -26,7 +26,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy
 ----
 explain
- ├── columns: tree:4 field:7 description:8 columns:9 ordering:10  [hidden: level:5 node_type:6]
+ ├── columns: info:4
  ├── mode: verbose
  └── project
       ├── columns: x:1!null y:2
@@ -38,7 +38,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y
 ----
 explain
- ├── columns: tree:4 field:7 description:8 columns:9 ordering:10  [hidden: level:5 node_type:6]
+ ├── columns: info:4
  ├── mode: verbose
  └── sort
       ├── columns: x:1!null y:2
@@ -52,7 +52,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) ON x=u
 ----
 explain
- ├── columns: tree:6 field:9 description:10 columns:11 ordering:12  [hidden: level:7 node_type:8]
+ ├── columns: info:6
  ├── mode: verbose
  └── project
       ├── columns: x:1!null y:2 u:4!null v:5!null
@@ -70,55 +70,12 @@ explain
 build
 SELECT tree FROM [ EXPLAIN (VERBOSE) SELECT * FROM xy ]
 ----
-with &1
- ├── columns: tree:11
- ├── explain
- │    ├── columns: tree:4 level:5 node_type:6 field:7 description:8 columns:9 ordering:10
- │    ├── mode: verbose
- │    └── project
- │         ├── columns: x:1!null y:2
- │         └── scan xy
- │              └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3
- └── project
-      ├── columns: tree:11
-      └── with-scan &1
-           ├── columns: tree:11 level:12 node_type:13 field:14 description:15 columns:16 ordering:17
-           └── mapping:
-                ├──  tree:4 => tree:11
-                ├──  level:5 => level:12
-                ├──  node_type:6 => node_type:13
-                ├──  field:7 => field:14
-                ├──  description:8 => description:15
-                ├──  columns:9 => columns:16
-                └──  ordering:10 => ordering:17
+error (42703): column "tree" does not exist
 
 build
 SELECT tree FROM [ EXPLAIN (VERBOSE) SELECT x, x, y FROM xy ORDER BY y ]
 ----
-with &1
- ├── columns: tree:11
- ├── explain
- │    ├── columns: tree:4 level:5 node_type:6 field:7 description:8 columns:9 ordering:10
- │    ├── mode: verbose
- │    └── sort
- │         ├── columns: x:1!null x:1!null y:2
- │         ├── ordering: +2
- │         └── project
- │              ├── columns: x:1!null y:2
- │              └── scan xy
- │                   └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3
- └── project
-      ├── columns: tree:11
-      └── with-scan &1
-           ├── columns: tree:11 level:12 node_type:13 field:14 description:15 columns:16 ordering:17
-           └── mapping:
-                ├──  tree:4 => tree:11
-                ├──  level:5 => level:12
-                ├──  node_type:6 => node_type:13
-                ├──  field:7 => field:14
-                ├──  description:8 => description:15
-                ├──  columns:9 => columns:16
-                └──  ordering:10 => ordering:17
+error (42703): column "tree" does not exist
 
 build
 SELECT json FROM [EXPLAIN (DISTSQL) SELECT * FROM xy] WHERE false

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -39,7 +39,7 @@ EXPLAIN
     SELECT * FROM x NATURAL JOIN t
 ----
 explain
- ├── columns: tree:9 field:10 description:11
+ ├── columns: info:9
  └── with &1 (t)
       ├── columns: a:4!null b:5
       ├── project
@@ -811,26 +811,20 @@ build
 WITH cte AS (EXPLAIN (VERBOSE) SELECT 1) SELECT * FROM cte
 ----
 with &1 (cte)
- ├── columns: tree:9 field:10 description:11 columns:12 ordering:13
- ├── project
- │    ├── columns: tree:2 field:5 description:6 columns:7 ordering:8
- │    └── explain
- │         ├── columns: tree:2 level:3 node_type:4 field:5 description:6 columns:7 ordering:8
- │         ├── mode: verbose
- │         └── project
- │              ├── columns: "?column?":1!null
- │              ├── values
- │              │    └── ()
- │              └── projections
- │                   └── 1 [as="?column?":1]
+ ├── columns: info:3
+ ├── explain
+ │    ├── columns: info:2
+ │    ├── mode: verbose
+ │    └── project
+ │         ├── columns: "?column?":1!null
+ │         ├── values
+ │         │    └── ()
+ │         └── projections
+ │              └── 1 [as="?column?":1]
  └── with-scan &1 (cte)
-      ├── columns: tree:9 field:10 description:11 columns:12 ordering:13
+      ├── columns: info:3
       └── mapping:
-           ├──  tree:2 => tree:9
-           ├──  field:5 => field:10
-           ├──  description:6 => description:11
-           ├──  columns:7 => columns:12
-           └──  ordering:8 => ordering:13
+           └──  info:2 => info:3
 
 # WITH RECURSIVE examples from postgres docs.
 
@@ -1355,7 +1349,7 @@ build
 EXPLAIN WITH foo AS (INSERT INTO y VALUES (1) RETURNING *) SELECT * FROM foo
 ----
 explain
- ├── columns: tree:7 field:8 description:9
+ ├── columns: info:7
  └── with &1 (foo)
       ├── columns: a:6!null
       ├── project

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -426,7 +426,7 @@ opt
 EXPLAIN SELECT id FROM test ORDER BY id asc LIMIT 10 offset 10000;
 ----
 explain
- ├── columns: tree:5 field:6 description:7
+ ├── columns: info:5
  └── offset
       ├── columns: id:1!null
       ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -621,7 +621,7 @@ opt
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
 ----
 explain
- ├── columns: tree:6 field:9 description:10 columns:11 ordering:12  [hidden: level:7 node_type:8]
+ ├── columns: info:6
  ├── mode: verbose
  └── sort
       ├── columns: x:1!null y:2!null z:3 s:4!null
@@ -636,9 +636,9 @@ explain
 memo
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
 ----
-memo (optimized, ~3KB, required=[presentation: tree:6,field:9,description:10,columns:11,ordering:12])
+memo (optimized, ~3KB, required=[presentation: info:6])
  ├── G1: (explain G2 [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
- │    └── [presentation: tree:6,field:9,description:10,columns:11,ordering:12]
+ │    └── [presentation: info:6]
  │         ├── best: (explain G2="[presentation: x:1,y:2,z:3,s:4] [ordering: +2]" [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
  │         └── cost: 1303.36
  └── G2: (scan a,cols=(1-4))

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -346,7 +346,7 @@ opt
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30 ORDER BY b DESC LIMIT 5
 ----
 explain
- ├── columns: tree:6 field:7 description:8
+ ├── columns: info:6
  └── limit
       ├── columns: a:1!null b:2 c:3 d:4
       ├── internal-ordering: -2
@@ -386,7 +386,7 @@ Initial expression
   Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
 ================================================================================
   explain
-   ├── columns: tree:6 field:7 description:8
+   ├── columns: info:6
    └── sort
         ├── columns: a:1!null b:2 c:3 d:4
         ├── cardinality: [0 - 5]
@@ -429,7 +429,7 @@ SimplifySelectFilters
   Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
 ================================================================================
    explain
-    ├── columns: tree:6 field:7 description:8
+    ├── columns: info:6
     └── sort
          ├── columns: a:1!null b:2 c:3 d:4
          ├── cardinality: [0 - 5]
@@ -474,7 +474,7 @@ ConsolidateSelectFilters
   Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
 ================================================================================
    explain
-    ├── columns: tree:6 field:7 description:8
+    ├── columns: info:6
     └── sort
          ├── columns: a:1!null b:2 c:3 d:4
          ├── cardinality: [0 - 5]
@@ -519,7 +519,7 @@ PruneSelectCols
   Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
 ================================================================================
    explain
-    ├── columns: tree:6 field:7 description:8
+    ├── columns: info:6
     └── sort
          ├── columns: a:1!null b:2 c:3 d:4
          ├── cardinality: [0 - 5]
@@ -566,7 +566,7 @@ EliminateProject
   Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
 ================================================================================
    explain
-    ├── columns: tree:6 field:7 description:8
+    ├── columns: info:6
     └── sort
          ├── columns: a:1!null b:2 c:3 d:4
          ├── cardinality: [0 - 5]
@@ -617,7 +617,7 @@ GenerateIndexScans
   Cost: 4083.92
 ================================================================================
    explain
-    ├── columns: tree:6 field:7 description:8
+    ├── columns: info:6
   - └── sort
   + └── limit
          ├── columns: a:1!null b:2 c:3 d:4
@@ -689,7 +689,7 @@ Final best expression
   Cost: 4083.92
 ================================================================================
   explain
-   ├── columns: tree:6 field:7 description:8
+   ├── columns: info:6
    └── limit
         ├── columns: a:1!null b:2 c:3 d:4
         ├── internal-ordering: -2

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1824,11 +1824,7 @@ func (ef *execFactory) ConstructExplainPlan(
 		flags: flags,
 		plan:  plan.(*explain.Plan),
 	}
-	if flags.Verbose {
-		n.columns = colinfo.ExplainPlanVerboseColumns
-	} else {
-		n.columns = colinfo.ExplainPlanColumns
-	}
+	n.columns = colinfo.ExplainPlanColumns
 	return n, nil
 }
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -735,10 +735,11 @@ func TestPGPreparedQuery(t *testing.T) {
 		// #14238
 		{"EXPLAIN SELECT 1", []preparedQueryTest{
 			baseTest.SetArgs().
-				Results("", "distribution", "local").
-				Results("", "vectorized", "false").
-				Results("values", "", "").
-				Results("", "size", "1 column, 1 row"),
+				Results("distribution: local").
+				Results("vectorized: false").
+				Results("").
+				Results("• values").
+				Results("  size: 1 column, 1 row"),
 		}},
 		// #14245
 		{"SELECT 1::oid = $1", []preparedQueryTest{

--- a/pkg/sql/tests/inverted_index_test.go
+++ b/pkg/sql/tests/inverted_index_test.go
@@ -65,7 +65,7 @@ func TestInvertedIndex(t *testing.T) {
 
 	t.Run("ensure we're using the inverted index", func(t *testing.T) {
 		// Just to make sure we're using the inverted index.
-		explain := db.Query(t, `SELECT count(*) FROM [EXPLAIN SELECT * FROM test.jsons WHERE j @> '{"a": 1}'] WHERE description = 'jsons@jsons_j_idx'`)
+		explain := db.Query(t, `SELECT count(*) FROM [EXPLAIN SELECT * FROM test.jsons WHERE j @> '{"a": 1}'] WHERE info LIKE '%jsons@jsons_j_idx%'`)
 		explain.Next()
 		var c int
 		if err := explain.Scan(&c); err != nil {


### PR DESCRIPTION
#### sql: single-column EXPLAIN output

This change replaces the EXPLAIN columns with a single string column
and shows the information in a tree.

Release note (sql change): New single-column output format for EXPLAIN
and EXPLAIN (VERBOSE).

#### sql: update tests involving EXPLAIN

Release note: None