### PR TITLE
opt/idxconstraint: recognize stored column expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0
-	github.com/cockroachdb/datadriven v1.0.1-0.20200826112548-92602d883b11
+	github.com/cockroachdb/datadriven v1.0.1-0.20201022032720-3e27adf87325
 	github.com/cockroachdb/errors v1.7.5
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0/go.mod h1:uY/PY
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v1.0.0 h1:uhZrAfEayBecH2w2tZmhe20HJ7hDvrrA4x2Bg9YdZKM=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
-github.com/cockroachdb/datadriven v1.0.1-0.20200826112548-92602d883b11 h1:KQqSlwJmTr7NmxtVOl6nPNSZQEk8XuLoLyNDYcmniBo=
-github.com/cockroachdb/datadriven v1.0.1-0.20200826112548-92602d883b11/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
+github.com/cockroachdb/datadriven v1.0.1-0.20201022032720-3e27adf87325 h1:p4AOBShzCogHTl1n5Ff16j5a24tvk1lc7fzRqduSpKM=
+github.com/cockroachdb/datadriven v1.0.1-0.20201022032720-3e27adf87325/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
 github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcKDqs=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1288,6 +1288,7 @@ func (ic *Instance) Init(
 	optionalFilters memo.FiltersExpr,
 	columns []opt.OrderingColumn,
 	notNullCols opt.ColSet,
+	computedCols map[opt.ColumnID]opt.ScalarExpr,
 	isInverted bool,
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
@@ -1302,7 +1303,7 @@ func (ic *Instance) Init(
 		ic.allFilters = requiredFilters[:len(requiredFilters):len(requiredFilters)]
 		ic.allFilters = append(ic.allFilters, optionalFilters...)
 	}
-	ic.indexConstraintCtx.init(columns, notNullCols, isInverted, evalCtx, factory)
+	ic.indexConstraintCtx.init(columns, notNullCols, computedCols, isInverted, evalCtx, factory)
 	if isInverted {
 		tight, constraints := ic.makeInvertedIndexSpansForExpr(
 			&ic.allFilters, nil /* constraints */, false,
@@ -1384,6 +1385,8 @@ type indexConstraintCtx struct {
 
 	notNullCols opt.ColSet
 
+	computedCols map[opt.ColumnID]opt.ScalarExpr
+
 	// isInverted indicates if the index is an inverted index (e.g. JSONB).
 	// An inverted index behaves differently than a normal index because a PK
 	// can appear in multiple index entries. For example, `a @> x AND a @> y` is
@@ -1402,6 +1405,7 @@ type indexConstraintCtx struct {
 func (c *indexConstraintCtx) init(
 	columns []opt.OrderingColumn,
 	notNullCols opt.ColSet,
+	computedCols map[opt.ColumnID]opt.ScalarExpr,
 	isInverted bool,
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
@@ -1409,6 +1413,7 @@ func (c *indexConstraintCtx) init(
 	c.md = factory.Metadata()
 	c.columns = columns
 	c.notNullCols = notNullCols
+	c.computedCols = computedCols
 	c.isInverted = isInverted
 	c.evalCtx = evalCtx
 	c.factory = factory
@@ -1420,10 +1425,17 @@ func (c *indexConstraintCtx) init(
 	}
 }
 
-// isIndexColumn returns true if ev is a variable on the n indexed var that
-// corresponds to index column <offset>.
-func (c *indexConstraintCtx) isIndexColumn(nd opt.Expr, offset int) bool {
-	if v, ok := nd.(*memo.VariableExpr); ok && v.Col == c.columns[offset].ID() {
+// isIndexColumn returns true if e is an expression that corresponds to index
+// column <offset>. The expression can be either
+//  - a variable on the index column, or
+//  - an expression that matches the computed column expression (if the index
+//    column is computed).
+//
+func (c *indexConstraintCtx) isIndexColumn(e opt.Expr, offset int) bool {
+	if v, ok := e.(*memo.VariableExpr); ok && v.Col == c.columns[offset].ID() {
+		return true
+	}
+	if c.computedCols != nil && e == c.computedCols[c.columns[offset].ID()] {
 		return true
 	}
 	return false

--- a/pkg/sql/opt/idxconstraint/testdata/computed
+++ b/pkg/sql/opt/idxconstraint/testdata/computed
@@ -1,0 +1,36 @@
+# We recognize lower(s) as equivalent to c.
+index-constraints vars=(s string, c string as (lower(s)) stored) index=(c)
+lower(s) = 'foo'
+----
+[/'foo' - /'foo']
+
+# Make sure that using the column directly still works.
+index-constraints vars=(s string, c string as (lower(s)) stored) index=(c)
+c = 'foo'
+----
+[/'foo' - /'foo']
+
+index-constraints vars=(s string, c string as (lower(s)) stored, x int) index=(x,c)
+x = 1 AND lower(s) LIKE 'foo%'
+----
+[/1/'foo' - /1/'fop')
+
+index-constraints vars=(s string, c string as (lower(s)) stored, x int) index=(c,x)
+x >= 1 AND x <= 10 AND lower(s) = 'foo'
+----
+[/'foo'/1 - /'foo'/10]
+
+index-constraints vars=(a int, b int, c int as (a+b) stored) index=(c)
+a+b > 0
+----
+[/1 - ]
+
+index-constraints vars=(j json, field int as ((j->'foo')::string::int) stored) index=(field)
+(j->'foo')::string::int = 10
+----
+[/10 - /10]
+
+index-constraints vars=(j json, field int as (j->'foo') stored) inverted-index=(field)
+j->'foo' @> '{"a": 1}'
+----
+[/'{"a": 1}' - /'{"a": 1}']

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -123,8 +123,8 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 	// which does not take part in an index scan). Note that the OrderingColumn
 	// slice cannot be reused, as Instance.Init can use it in the constraint.
 	md := c.e.mem.Metadata()
-	tab := md.Table(tabID)
-	index := tab.Index(indexOrd)
+	tabMeta := md.TableMeta(tabID)
+	index := tabMeta.Table.Index(indexOrd)
 	columns := make([]opt.OrderingColumn, index.LaxKeyColumnCount())
 	var notNullCols opt.ColSet
 	for i := range columns {
@@ -147,6 +147,10 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 	}
 
 	// Generate index constraints.
-	ic.Init(requiredFilters, optionalFilters, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
+	ic.Init(
+		requiredFilters, optionalFilters,
+		columns, notNullCols, tabMeta.ComputedCols,
+		isInverted, c.e.evalCtx, c.e.f,
+	)
 	return ic
 }

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -102,6 +102,20 @@ CREATE TABLE no_explicit_primary_key
 )
 ----
 
+exec-ddl
+CREATE TABLE computed (
+    k INT PRIMARY KEY,
+    s STRING,
+    l STRING AS (lower(s)) STORED,
+    j JSON,
+    field JSON AS (j->'foo') STORED,
+    fieldstr STRING AS ((j->'foo')::string) STORED,
+    INDEX l_idx (l),
+    INDEX fieldstr_idx (fieldstr),
+    INVERTED INDEX field_inv_idx (field)
+)
+----
+
 # --------------------------------------------------
 # GeneratePartialIndexScans
 # --------------------------------------------------
@@ -1618,6 +1632,32 @@ project
       └── filters
            └── a:2 > 1 [outer=(2), constraints=(/2: [/2 - ]; tight)]
 
+# Check that we can generate constraints by recognizing computed column
+# expressions.
+opt
+SELECT k FROM computed WHERE lower(s) = 'foo'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan computed@l_idx
+      ├── columns: k:1!null
+      ├── constraint: /3/1: [/'foo' - /'foo']
+      └── key: (1)
+
+opt
+SELECT k FROM computed WHERE (j->'foo')::string LIKE 'bar%'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan computed@fieldstr_idx
+      ├── columns: k:1!null
+      ├── constraint: /6/1: [/'bar' - /'bas')
+      └── key: (1)
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------
@@ -2903,6 +2943,20 @@ memo (optimized, ~6KB, required=[presentation: k:1,s:2,j:3])
 exec-ddl
 DROP INDEX idx
 ----
+
+# Check that we can generate constraints by recognizing computed column
+# expressions.
+opt
+SELECT k FROM computed WHERE (j->'foo') @> '{"a": "b"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan computed@field_inv_idx
+      ├── columns: k:1!null
+      ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
 
 # --------------------------------------------------
 # GenerateZigzagJoins


### PR DESCRIPTION
#### deps: update datadriven

Release note: None

#### opt/idxconstraint: recognize stored column expressions

This change makes the index constraint generator aware of computed
column expressions so it can substitute them for the computed column
if it is indexed.

Release note (performance improvement): indexes on computed columns
can now be utilized when filters reference the computed expression and
not the computed column directly.