### PR TITLE
kvserver: remove the replica.mu.draining field

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1034,12 +1034,6 @@ func (s *Store) AnnotateCtx(ctx context.Context) context.Context {
 func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 	s.draining.Store(drain)
 	if !drain {
-		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
-			r.mu.Lock()
-			r.mu.draining = false
-			r.mu.Unlock()
-			return true
-		})
 		return
 	}
 
@@ -1109,10 +1103,6 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 						return
 					default:
 					}
-
-					r.mu.Lock()
-					r.mu.draining = true
-					r.mu.Unlock()
 
 					var drainingLease roachpb.Lease
 					for {


### PR DESCRIPTION
It was only used in one rando place. Generally everybody looks at the
store's draing status.

Release note: None