### PR TITLE
release-20.2: sql,colexec: fix distinct aggregation

### DIFF
--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -353,6 +353,10 @@ func (b *distinctAggregatorHelperBase) selectDistinctTuples(
 			}
 		}
 		for _, colIdx := range inputIdxs {
+			// Note that we don't need to explicitly unset ed because encoded
+			// field is never set during fingerprinting - we'll compute the
+			// encoding and return it without updating the EncDatum; therefore,
+			// simply setting Datum field to the argument is sufficient.
 			b.scratch.ed.Datum = b.aggColsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
 			b.scratch.encoded, err = b.scratch.ed.Fingerprint(
 				b.inputTypes[colIdx], b.datumAlloc, b.scratch.encoded,

--- a/pkg/sql/colexec/default_agg_tmpl.go
+++ b/pkg/sql/colexec/default_agg_tmpl.go
@@ -84,43 +84,36 @@ func (a *default_AGGKINDAgg) Compute(
 	// function itself does the latter.
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
-		if sel != nil {
-			for convertedTupleIdx, origTupleIdx := range sel[:inputLen] {
-				_ADD_TUPLE(a, a.groups, a.nulls, convertedTupleIdx, origTupleIdx)
+		if sel == nil {
+			for tupleIdx := 0; tupleIdx < inputLen; tupleIdx++ {
+				_ADD_TUPLE(a, a.groups, a.nulls, tupleIdx)
 			}
-		} else {
-			for convertedTupleIdx, origTupleIdx := 0, 0; origTupleIdx < inputLen; {
-				_ADD_TUPLE(a, a.groups, a.nulls, convertedTupleIdx, origTupleIdx)
-				convertedTupleIdx++
-				origTupleIdx++
-			}
-		}
-		// {{else}}
-		// We don't need to check whether sel is non-nil because the hash
-		// aggregator always uses non-nil sel to specify the tuples to be
-		// aggregated. Also, the hash aggregator converts the batch "sparsely",
-		// so converted values are at the same positions as the original ones.
-		var convertedTupleIdx int
-		for _, origTupleIdx := range sel[:inputLen] {
-			convertedTupleIdx = origTupleIdx
-			_ADD_TUPLE(a, a.groups, a.nulls, convertedTupleIdx, origTupleIdx)
-		}
+		} else
 		// {{end}}
+		{
+			// {{if eq "_AGGKIND" "Hash"}}
+			// We don't need to check whether sel is non-nil in case of the
+			// hash aggregator because it always uses non-nil sel to specify
+			// the tuples to be aggregated.
+			// {{end}}
+			// Both aggregators convert the batch "sparsely" - without
+			// deselection - so converted values are at the same positions as
+			// the original ones.
+			for _, tupleIdx := range sel[:inputLen] {
+				_ADD_TUPLE(a, a.groups, a.nulls, tupleIdx)
+			}
+		}
 	})
 }
 
 // {{/*
-// _ADD_TUPLE aggregates the tuple that is at position 'origTupleIdx' in the
-// original batch but has the converted tree.Datum values at position
-// 'convertedTupleIdx'. These indices are the same when there is no selection
-// vector but could be different if there is one.
-func _ADD_TUPLE(
-	a *default_AGGKINDAgg, groups []bool, nulls *coldata.Nulls, convertedTupleIdx, origTupleIdx int,
-) { // */}}
+// _ADD_TUPLE aggregates the tuple that is at position 'tupleIdx' in the
+// original batch and has the converted tree.Datum values at the same position.
+func _ADD_TUPLE(a *default_AGGKINDAgg, groups []bool, nulls *coldata.Nulls, tupleIdx int) { // */}}
 	// {{define "addTuple" -}}
 
 	// {{if eq "_AGGKIND" "Ordered"}}
-	if a.groups[origTupleIdx] {
+	if a.groups[tupleIdx] {
 		res, err := a.fn.Result()
 		if err != nil {
 			colexecerror.ExpectedError(err)
@@ -133,16 +126,13 @@ func _ADD_TUPLE(
 		a.curIdx++
 		a.fn.Reset(a.ctx)
 	}
-	// {{else}}
-	// Go around unused warning.
-	_ = origTupleIdx
 	// {{end}}
 	// Note that the only function that takes no arguments is COUNT_ROWS, and
 	// it has an optimized implementation, so we don't need to check whether
 	// len(inputIdxs) is at least 1.
-	firstArg := a.inputArgsConverter.GetDatumColumn(int(inputIdxs[0]))[convertedTupleIdx]
+	firstArg := a.inputArgsConverter.GetDatumColumn(int(inputIdxs[0]))[tupleIdx]
 	for j, colIdx := range inputIdxs[1:] {
-		a.scratch.otherArgs[j] = a.inputArgsConverter.GetDatumColumn(int(colIdx))[convertedTupleIdx]
+		a.scratch.otherArgs[j] = a.inputArgsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
 	}
 	if err := a.fn.Add(a.ctx, firstArg, a.scratch.otherArgs...); err != nil {
 		colexecerror.ExpectedError(err)

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
@@ -18,7 +18,7 @@ import (
 const defaultAggTmpl = "pkg/sql/colexec/default_agg_tmpl.go"
 
 func genDefaultAgg(inputFileContents string, wr io.Writer) error {
-	addTuple := makeFunctionRegex("_ADD_TUPLE", 5)
+	addTuple := makeFunctionRegex("_ADD_TUPLE", 4)
 	s := addTuple.ReplaceAllString(inputFileContents, `{{template "addTuple"}}`)
 
 	tmpl, err := template.New("default_agg").Parse(s)

--- a/pkg/sql/colexec/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/hash_default_agg.eg.go
@@ -61,26 +61,26 @@ func (a *defaultHashAgg) Compute(
 	// and not for the intermediate results of aggregation since the aggregate
 	// function itself does the latter.
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// We don't need to check whether sel is non-nil because the hash
-		// aggregator always uses non-nil sel to specify the tuples to be
-		// aggregated. Also, the hash aggregator converts the batch "sparsely",
-		// so converted values are at the same positions as the original ones.
-		var convertedTupleIdx int
-		for _, origTupleIdx := range sel[:inputLen] {
-			convertedTupleIdx = origTupleIdx
-			// Go around unused warning.
-			_ = origTupleIdx
-			// Note that the only function that takes no arguments is COUNT_ROWS, and
-			// it has an optimized implementation, so we don't need to check whether
-			// len(inputIdxs) is at least 1.
-			firstArg := a.inputArgsConverter.GetDatumColumn(int(inputIdxs[0]))[convertedTupleIdx]
-			for j, colIdx := range inputIdxs[1:] {
-				a.scratch.otherArgs[j] = a.inputArgsConverter.GetDatumColumn(int(colIdx))[convertedTupleIdx]
-			}
-			if err := a.fn.Add(a.ctx, firstArg, a.scratch.otherArgs...); err != nil {
-				colexecerror.ExpectedError(err)
-			}
+		{
+			// We don't need to check whether sel is non-nil in case of the
+			// hash aggregator because it always uses non-nil sel to specify
+			// the tuples to be aggregated.
+			// Both aggregators convert the batch "sparsely" - without
+			// deselection - so converted values are at the same positions as
+			// the original ones.
+			for _, tupleIdx := range sel[:inputLen] {
+				// Note that the only function that takes no arguments is COUNT_ROWS, and
+				// it has an optimized implementation, so we don't need to check whether
+				// len(inputIdxs) is at least 1.
+				firstArg := a.inputArgsConverter.GetDatumColumn(int(inputIdxs[0]))[tupleIdx]
+				for j, colIdx := range inputIdxs[1:] {
+					a.scratch.otherArgs[j] = a.inputArgsConverter.GetDatumColumn(int(colIdx))[tupleIdx]
+				}
+				if err := a.fn.Add(a.ctx, firstArg, a.scratch.otherArgs...); err != nil {
+					colexecerror.ExpectedError(err)
+				}
 
+			}
 		}
 	})
 }

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -241,7 +241,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			if batchLength > 0 {
-				a.inputArgsConverter.ConvertBatchAndDeselect(batch)
+				a.inputArgsConverter.ConvertBatch(batch)
 				a.aggHelper.performAggregation(
 					ctx, batch.ColVecs(), batchLength, batch.Selection(), &a.bucket, a.groupCol,
 				)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1431,18 +1431,51 @@ func (dsp *DistSQLPlanner) planAggregators(
 		orderedGroupColSet.Add(c.ColIdx)
 	}
 
-	// We either have a local stage on each stream followed by a final stage, or
-	// just a final stage. We only use a local stage if:
-	//  - the previous stage is distributed on multiple nodes, and
-	//  - all aggregation functions support it. TODO(radu): we could relax this by
-	//    splitting the aggregation into two different paths and joining on the
-	//    results.
-	//  - we have a mix of aggregations that use distinct and aggregations that
-	//    don't use distinct. TODO(arjun): This would require doing the same as
-	//    the todo as above.
-	multiStage := false
+	// We can have a local stage of distinct processors if all aggregation
+	// functions are distinct.
 	allDistinct := true
-	anyDistinct := false
+	for _, e := range info.aggregations {
+		if !e.Distinct {
+			allDistinct = false
+			break
+		}
+	}
+	if allDistinct {
+		var distinctColumnsSet util.FastIntSet
+		for _, e := range info.aggregations {
+			for _, colIdx := range e.ColIdx {
+				distinctColumnsSet.Add(int(colIdx))
+			}
+		}
+		if distinctColumnsSet.Len() > 0 {
+			// We only need to plan distinct processors if we have non-empty
+			// set of argument columns.
+			distinctColumns := make([]uint32, 0, distinctColumnsSet.Len())
+			distinctColumnsSet.ForEach(func(i int) {
+				distinctColumns = append(distinctColumns, uint32(i))
+			})
+			ordering := info.inputMergeOrdering.Columns
+			orderedColumns := make([]uint32, 0, len(ordering))
+			for _, ord := range ordering {
+				if distinctColumnsSet.Contains(int(ord.ColIdx)) {
+					// Ordered columns must be a subset of distinct columns, so
+					// we only include such into orderedColumns slice.
+					orderedColumns = append(orderedColumns, ord.ColIdx)
+				}
+			}
+			sort.Slice(orderedColumns, func(i, j int) bool { return orderedColumns[i] < orderedColumns[j] })
+			sort.Slice(distinctColumns, func(i, j int) bool { return distinctColumns[i] < distinctColumns[j] })
+			distinctSpec := execinfrapb.ProcessorCoreUnion{
+				Distinct: &execinfrapb.DistinctSpec{
+					OrderedColumns:  orderedColumns,
+					DistinctColumns: distinctColumns,
+				},
+			}
+			// Add distinct processors local to each existing current result
+			// processor.
+			p.AddNoGroupingStage(distinctSpec, execinfrapb.PostProcessSpec{}, p.ResultTypes, p.MergeOrdering)
+		}
+	}
 
 	// Check if the previous stage is all on one node.
 	prevStageNode := p.Processors[p.ResultRouters[0]].Node
@@ -1453,73 +1486,30 @@ func (dsp *DistSQLPlanner) planAggregators(
 		}
 	}
 
-	if prevStageNode == 0 {
-		// Check that all aggregation functions support a local stage.
-		multiStage = true
+	// We either have a local stage on each stream followed by a final stage, or
+	// just a final stage. We only use a local stage if:
+	//  - the previous stage is distributed on multiple nodes, and
+	//  - all aggregation functions support it, and
+	//  - no function is performing distinct aggregation.
+	//  TODO(radu): we could relax this by splitting the aggregation into two
+	//  different paths and joining on the results.
+	multiStage := prevStageNode == 0
+	if multiStage {
 		for _, e := range info.aggregations {
 			if e.Distinct {
-				// We can't do local aggregation for functions with distinct.
 				multiStage = false
-				anyDistinct = true
-			} else {
-				// We can't do local distinct if we have a mix of distinct and
-				// non-distinct aggregations.
-				allDistinct = false
+				break
 			}
+			// Check that the function supports a local stage.
 			if _, ok := physicalplan.DistAggregationTable[e.Func]; !ok {
 				multiStage = false
 				break
 			}
 		}
 	}
-	if !anyDistinct {
-		allDistinct = false
-	}
 
 	var finalAggsSpec execinfrapb.AggregatorSpec
 	var finalAggsPost execinfrapb.PostProcessSpec
-
-	if !multiStage && allDistinct {
-		// We can't do local aggregation, but we can do local distinct processing
-		// to reduce streaming duplicates, and aggregate on the final node.
-
-		ordering := info.inputMergeOrdering.Columns
-		orderedColsMap := make(map[uint32]struct{})
-		for _, ord := range ordering {
-			orderedColsMap[ord.ColIdx] = struct{}{}
-		}
-		distinctColsMap := make(map[uint32]struct{})
-		for _, agg := range info.aggregations {
-			for _, c := range agg.ColIdx {
-				distinctColsMap[c] = struct{}{}
-			}
-		}
-		orderedColumns := make([]uint32, len(orderedColsMap))
-		idx := 0
-		for o := range orderedColsMap {
-			orderedColumns[idx] = o
-			idx++
-		}
-		distinctColumns := make([]uint32, len(distinctColsMap))
-		idx = 0
-		for o := range distinctColsMap {
-			distinctColumns[idx] = o
-			idx++
-		}
-
-		sort.Slice(orderedColumns, func(i, j int) bool { return orderedColumns[i] < orderedColumns[j] })
-		sort.Slice(distinctColumns, func(i, j int) bool { return distinctColumns[i] < distinctColumns[j] })
-
-		distinctSpec := execinfrapb.ProcessorCoreUnion{
-			Distinct: &execinfrapb.DistinctSpec{
-				OrderedColumns:  orderedColumns,
-				DistinctColumns: distinctColumns,
-			},
-		}
-
-		// Add distinct processors local to each existing current result processor.
-		p.AddNoGroupingStage(distinctSpec, execinfrapb.PostProcessSpec{}, p.ResultTypes, p.MergeOrdering)
-	}
 
 	// planToStreamMapSet keeps track of whether or not
 	// p.PlanToStreamColMap has been set to its desired mapping or not.

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2801,3 +2801,19 @@ FROM blog b, blog_properties p WHERE b.id = p.blog_id
 GROUP BY b.name
 ----
 {"Test Blog": {"Admin Email": "admin@email.com", "Application Name": "Twitter", "Blog Name": "Wordpress Blog", "KeepAlive": "true", "Session Timeout": "1000ms"}}
+
+# Regression test for incorrectly handling DISTINCT ordered aggregation in the
+# vectorized engine (#55776).
+statement ok
+CREATE TABLE t55776 (i INT8 PRIMARY KEY, y FLOAT8, x FLOAT8);
+INSERT INTO t55776 (i, y, x) VALUES
+  (1, 1.0, 1),
+  (2, 2.0, 2),
+  (3, 1.0, 2),
+  (4, 1.0, 2),
+  (5, 3.0, 2);
+
+query RI
+SELECT corr(DISTINCT y, x), count(DISTINCT y) FROM t55776
+----
+0.522232967867094 3

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -592,3 +592,24 @@ SELECT sum(v) FROM data INNER LOOKUP JOIN uv ON (a=u) GROUP BY u ORDER BY u
 60000
 70000
 80000
+
+statement ok
+CREATE TABLE t55837 (
+  i  int primary key,
+  y  float,
+  x  float
+);
+INSERT INTO t55837 (i, y, x) VALUES
+  (1, 1.0,   1),
+  (2, 1.0,   1),
+  (3, 2.0,   3),
+  (4, 3.0,   3);
+ALTER TABLE t55837 SPLIT AT VALUES (3);
+ALTER TABLE t55837 EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 2);
+SELECT * FROM t55837 -- make sure that the range cache is populated
+
+# Regression test for incorrectly planning a local distinct stage (#55837).
+query RI
+SELECT corr(DISTINCT y, x), count(y) FROM t55837
+----
+0.866025403784439 4


### PR DESCRIPTION
Backport 2/2 commits from #55780.

/cc @cockroachdb/release

---

**colexec: fix tuple index mismatch in ordered distinct aggregation**

We're handling the DISTINCT aggregations by populating new selection
vector to include only the tuples that are distinct to be aggregated by
a particular function. Previously, we would convert the arguments to
default aggregate function in case of ordered aggregation "with
deselection" step (this is a minor optimization). However, combining
these two things makes it very hard to know at which position in the
converted []tree.Datum vectors the arguments of a tuple actually live
which would result in us using the wrong ones. As a result, when
actually performing the aggregation we could see that there is
a selection vector (populated by the distinctness helper), yet there was
no original selection vector on the batch itself, so we would use
incorrect indices to look up the arguments in the converted []tree.Datum
slices.

Now this is fixed by following the pattern of the hash aggregator -
converting the input argument vectors without the deselection. In order
for the bug to be triggered we need to have at least two aggregate
functions with one of them handled by the default aggregate function (i.e.
it doesn't have an optimized implementation) with DISTINCT clause (if
the projection contains only that function, then the distinct operation
is pushed out of the aggregation into a distinct stage).

Fixes: #55776.

Release note (bug fix): CockroachDB could previously incorrectly compute
some aggregate functions with DISTINCT clauses when the query projects
other columns/functions and the vectorized engine was used. This bug was
introduced in 20.2.0.alpha.3 release.

**sql: fix planning of distinct stage with mix of (non-)distinct aggregations**

When performing the physical planning of aggregation we have some
optimizations:
- we try to distribute the actual aggregation if all functions support
it, the previous stage is distributed, and no function has DISTINCT
clause
- if we can't do a multi-stage aggregation, then we might plan
a distributed distinct stage if all functions have a DISTINCT clause.

However, previously, we could incorrectly evaluate whether all functions
have a DISTINCT clause if the function that doesn't support distributed
computation is preceding non-distinct function because we broke out of
the loop. As an example, queries like `SELECT corr(DISTINCT y, x),
count(y) ...` would incorrectly think that they can do local distinct
operation, but this would lead to incorrect results.

This is now fixed by separating out the optimization of performing
a local distinct stage (which is always beneficial to do; when all
functions have DISTINCT clause) and then deciding whether we can do
multi-stage aggregation.

Fixes: #55837.

Release note (bug fix): CockroachDB previously could return incorrect
results in rare circumstances when computing the aggregation functions
when some of the functions have DISTINCT clause and some don't (the
latter might not see all the necessary data), and this is now fixed.
This bug has been present for several years.
