### PR TITLE
release-20.1: sql: fix planning of distinct stage with mix of (non-)distinct aggregations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1317,18 +1317,50 @@ func (dsp *DistSQLPlanner) addAggregators(
 		orderedGroupColSet.Add(c.ColIdx)
 	}
 
-	// We either have a local stage on each stream followed by a final stage, or
-	// just a final stage. We only use a local stage if:
-	//  - the previous stage is distributed on multiple nodes, and
-	//  - all aggregation functions support it. TODO(radu): we could relax this by
-	//    splitting the aggregation into two different paths and joining on the
-	//    results.
-	//  - we have a mix of aggregations that use distinct and aggregations that
-	//    don't use distinct. TODO(arjun): This would require doing the same as
-	//    the todo as above.
-	multiStage := false
+	// We can have a local stage of distinct processors if all aggregation
+	// functions are distinct.
 	allDistinct := true
-	anyDistinct := false
+	for _, e := range aggregations {
+		if !e.Distinct {
+			allDistinct = false
+			break
+		}
+	}
+	if allDistinct {
+		var distinctColumnsSet util.FastIntSet
+		for _, e := range aggregations {
+			for _, colIdx := range e.ColIdx {
+				distinctColumnsSet.Add(int(colIdx))
+			}
+		}
+		if distinctColumnsSet.Len() > 0 {
+			// We only need to plan distinct processors if we have non-empty
+			// set of argument columns.
+			distinctColumns := make([]uint32, 0, distinctColumnsSet.Len())
+			distinctColumnsSet.ForEach(func(i int) {
+				distinctColumns = append(distinctColumns, uint32(i))
+			})
+			ordering := dsp.convertOrdering(planReqOrdering(n.plan), p.PlanToStreamColMap).Columns
+			orderedColumns := make([]uint32, 0, len(ordering))
+			for _, ord := range ordering {
+				if distinctColumnsSet.Contains(int(ord.ColIdx)) {
+					// Ordered columns must be a subset of distinct columns, so
+					// we only include such into orderedColumns slice.
+					orderedColumns = append(orderedColumns, ord.ColIdx)
+				}
+			}
+			sort.Slice(orderedColumns, func(i, j int) bool { return orderedColumns[i] < orderedColumns[j] })
+			sort.Slice(distinctColumns, func(i, j int) bool { return distinctColumns[i] < distinctColumns[j] })
+			distinctSpec := execinfrapb.ProcessorCoreUnion{
+				Distinct: &execinfrapb.DistinctSpec{
+					OrderedColumns:  orderedColumns,
+					DistinctColumns: distinctColumns,
+				},
+			}
+			// Add distinct processors local to each existing current result processor.
+			p.AddNoGroupingStage(distinctSpec, execinfrapb.PostProcessSpec{}, p.ResultTypes, p.MergeOrdering)
+		}
+	}
 
 	// Check if the previous stage is all on one node.
 	prevStageNode := p.Processors[p.ResultRouters[0]].Node
@@ -1339,73 +1371,30 @@ func (dsp *DistSQLPlanner) addAggregators(
 		}
 	}
 
-	if prevStageNode == 0 {
-		// Check that all aggregation functions support a local stage.
-		multiStage = true
+	// We either have a local stage on each stream followed by a final stage, or
+	// just a final stage. We only use a local stage if:
+	//  - the previous stage is distributed on multiple nodes, and
+	//  - all aggregation functions support it, and
+	//  - no function is performing distinct aggregation.
+	//  TODO(radu): we could relax this by splitting the aggregation into two
+	//  different paths and joining on the results.
+	multiStage := prevStageNode == 0
+	if multiStage {
 		for _, e := range aggregations {
 			if e.Distinct {
-				// We can't do local aggregation for functions with distinct.
 				multiStage = false
-				anyDistinct = true
-			} else {
-				// We can't do local distinct if we have a mix of distinct and
-				// non-distinct aggregations.
-				allDistinct = false
+				break
 			}
+			// Check that the function supports a local stage.
 			if _, ok := physicalplan.DistAggregationTable[e.Func]; !ok {
 				multiStage = false
 				break
 			}
 		}
 	}
-	if !anyDistinct {
-		allDistinct = false
-	}
 
 	var finalAggsSpec execinfrapb.AggregatorSpec
 	var finalAggsPost execinfrapb.PostProcessSpec
-
-	if !multiStage && allDistinct {
-		// We can't do local aggregation, but we can do local distinct processing
-		// to reduce streaming duplicates, and aggregate on the final node.
-
-		ordering := dsp.convertOrdering(planReqOrdering(n.plan), p.PlanToStreamColMap).Columns
-		orderedColsMap := make(map[uint32]struct{})
-		for _, ord := range ordering {
-			orderedColsMap[ord.ColIdx] = struct{}{}
-		}
-		distinctColsMap := make(map[uint32]struct{})
-		for _, agg := range aggregations {
-			for _, c := range agg.ColIdx {
-				distinctColsMap[c] = struct{}{}
-			}
-		}
-		orderedColumns := make([]uint32, len(orderedColsMap))
-		idx := 0
-		for o := range orderedColsMap {
-			orderedColumns[idx] = o
-			idx++
-		}
-		distinctColumns := make([]uint32, len(distinctColsMap))
-		idx = 0
-		for o := range distinctColsMap {
-			distinctColumns[idx] = o
-			idx++
-		}
-
-		sort.Slice(orderedColumns, func(i, j int) bool { return orderedColumns[i] < orderedColumns[j] })
-		sort.Slice(distinctColumns, func(i, j int) bool { return distinctColumns[i] < distinctColumns[j] })
-
-		distinctSpec := execinfrapb.ProcessorCoreUnion{
-			Distinct: &execinfrapb.DistinctSpec{
-				OrderedColumns:  orderedColumns,
-				DistinctColumns: distinctColumns,
-			},
-		}
-
-		// Add distinct processors local to each existing current result processor.
-		p.AddNoGroupingStage(distinctSpec, execinfrapb.PostProcessSpec{}, p.ResultTypes, p.MergeOrdering)
-	}
 
 	// planToStreamMapSet keeps track of whether or not
 	// p.PlanToStreamColMap has been set to its desired mapping or not.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -592,3 +592,24 @@ SELECT sum(v) FROM data INNER LOOKUP JOIN uv ON (a=u) GROUP BY u ORDER BY u
 60000
 70000
 80000
+
+statement ok
+CREATE TABLE t55837 (
+  i  int primary key,
+  y  float,
+  x  float
+);
+INSERT INTO t55837 (i, y, x) VALUES
+  (1, 1.0,   1),
+  (2, 1.0,   1),
+  (3, 2.0,   3),
+  (4, 3.0,   3);
+ALTER TABLE t55837 SPLIT AT VALUES (3);
+ALTER TABLE t55837 EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 2);
+SELECT * FROM t55837 -- make sure that the range cache is populated
+
+# Regression test for incorrectly planning a local distinct stage (#55837).
+query RI
+SELECT corr(DISTINCT y, x), count(y) FROM t55837
+----
+0.866025403784439 4


### PR DESCRIPTION
Backport 1/2 commits from #55780.

/cc @cockroachdb/release

---

**sql: fix planning of distinct stage with mix of (non-)distinct aggregations**

When performing the physical planning of aggregation we have some
optimizations:
- we try to distribute the actual aggregation if all functions support
it, the previous stage is distributed, and no function has DISTINCT
clause
- if we can't do a multi-stage aggregation, then we might plan
a distributed distinct stage if all functions have a DISTINCT clause.

However, previously, we could incorrectly evaluate whether all functions
have a DISTINCT clause if the function that doesn't support distributed
computation is preceding non-distinct function because we broke out of
the loop. As an example, queries like `SELECT corr(DISTINCT y, x),
count(y) ...` would incorrectly think that they can do local distinct
operation, but this would lead to incorrect results.

This is now fixed by separating out the optimization of performing
a local distinct stage (which is always beneficial to do; when all
functions have DISTINCT clause) and then deciding whether we can do
multi-stage aggregation.

Fixes: #55837.

Release note (bug fix): CockroachDB previously could return incorrect
results in rare circumstances when computing the aggregation functions
when some of the functions have DISTINCT clause and some don't (the
latter might not see all the necessary data), and this is now fixed.
This bug has been present for several years.
