### PR TITLE
release-20.1: rowexec: fix metadata propagation in zigzag joiner

### DIFF
--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -32,6 +32,75 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+// TestColBatchScanMeta makes sure that the ColBatchScan propagates the leaf
+// txn final state metadata which is necessary to notify the kvCoordSender
+// about the spans that have been read.
+func TestColBatchScanMeta(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlutils.CreateTable(t, sqlDB, "t",
+		"num INT PRIMARY KEY",
+		3, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	st := s.ClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
+	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), &leafInputState)
+	flowCtx := execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+		Txn:    leafTxn,
+		Local:  true,
+		NodeID: s.NodeID(),
+	}
+	spec := execinfrapb.ProcessorSpec{
+		Core: execinfrapb.ProcessorCoreUnion{
+			TableReader: &execinfrapb.TableReaderSpec{
+				Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+				Table: *td,
+			}},
+		Post: execinfrapb.PostProcessSpec{
+			Projection:    true,
+			OutputColumns: []uint32{0},
+		},
+	}
+
+	args := colexec.NewColOperatorArgs{
+		Spec:                &spec,
+		StreamingMemAccount: testMemAcc,
+	}
+	args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+	res, err := colexec.NewColOperator(ctx, &flowCtx, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := res.Op
+	tr.Init()
+	meta := tr.(*colexec.CancelChecker).Input().(execinfrapb.MetadataSource).DrainMeta(ctx)
+	var txnFinalStateSeen bool
+	for _, m := range meta {
+		if m.LeafTxnFinalState != nil {
+			txnFinalStateSeen = true
+			break
+		}
+	}
+	if !txnFinalStateSeen {
+		t.Fatal("missing txn final state")
+	}
+}
+
 func BenchmarkColBatchScan(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 	logScope := log.Scope(b)

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -293,6 +293,53 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 	})
 }
 
+func TestTableReaderDrain(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlutils.CreateTable(t, sqlDB, "t",
+		"num INT PRIMARY KEY",
+		3, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	// Run the flow in a snowball trace so that we can test for tracing info.
+	tracer := tracing.NewTracer()
+	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	defer sp.Finish()
+	st := s.ClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
+	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), &leafInputState)
+	flowCtx := execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+		Txn:    leafTxn,
+		Local:  true,
+		NodeID: s.NodeID(),
+	}
+	spec := execinfrapb.TableReaderSpec{
+		Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+		Table: *td,
+	}
+	post := execinfrapb.PostProcessSpec{
+		Projection:    true,
+		OutputColumns: []uint32{0},
+	}
+
+	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+		return newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, out)
+	})
+}
+
 // Test that a scan with a limit doesn't touch more ranges than necessary (i.e.
 // we properly set the limit on the underlying Fetcher/KVFetcher).
 func TestLimitScans(t *testing.T) {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -907,11 +907,11 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 
 // Next is part of the RowSource interface.
 func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	if err := z.maybeFetchInitialRow(); err != nil {
-		z.MoveToDraining(err)
-	}
-
 	for z.State == execinfra.StateRunning {
+		if err := z.maybeFetchInitialRow(); err != nil {
+			z.MoveToDraining(err)
+			break
+		}
 		row, err := z.nextRow(z.Ctx, z.FlowCtx.Txn)
 		if err != nil {
 			z.MoveToDraining(err)

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -135,7 +135,7 @@ import (
 //
 // When Should a Zigzag Join Be Planned:
 //
-// The intuition behind when a zigzag join should be used is when the carnality
+// The intuition behind when a zigzag join should be used is when the cardinality
 // of the output is much smaller than the size of either side of the join. If
 // this is not the case, it may end up being slower than other joins because it
 // is constantly alternating between sides of the join. Alternatively, the
@@ -224,10 +224,9 @@ import (
 type zigzagJoiner struct {
 	joinerBase
 
-	evalCtx       *tree.EvalContext
 	cancelChecker *sqlbase.CancelChecker
 
-	// numTables stored the number of tables involved in the join.
+	// numTables stores the number of tables involved in the join.
 	numTables int
 	// side keeps track of which side is being processed.
 	side int
@@ -237,24 +236,18 @@ type zigzagJoiner struct {
 	// more information.
 	infos []*zigzagJoinerInfo
 
-	// Base row stores the that the algorithm is compared against and is updated
-	// with every change of side.
+	// baseRow stores the row that the algorithm is compared against and is
+	// updated with every change of side.
 	baseRow sqlbase.EncDatumRow
 
-	rowAlloc sqlbase.EncDatumRowAlloc
-
-	// TODO(andrei): get rid of this field and move the actions it gates into the
-	// Start() method.
-	started bool
-
-	// returnedMeta contains all the metadata that zigzag joiner has emitted.
-	returnedMeta []execinfrapb.ProducerMetadata
+	rowAlloc           sqlbase.EncDatumRowAlloc
+	fetchedInititalRow bool
 }
 
-// Batch size is a parameter which determines how many rows should be fetched
-// at a time. Increasing this will improve performance for when matched rows
-// are grouped together, but increasing this too much will result in fetching
-// too many rows and therefore skipping less rows.
+// zigzagJoinerBatchSize is a parameter which determines how many rows should
+// be fetched at a time. Increasing this will improve performance for when
+// matched rows are grouped together, but increasing this too much will result
+// in fetching too many rows and therefore skipping less rows.
 const zigzagJoinerBatchSize = 5
 
 var _ execinfra.Processor = &zigzagJoiner{}
@@ -274,6 +267,12 @@ func newZigzagJoiner(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (*zigzagJoiner, error) {
+	if len(spec.Tables) != 2 {
+		return nil, errors.Errorf("zigzag joins only of two tables (or indexes) are supported, %d requested", len(spec.Tables))
+	}
+	if spec.Type != sqlbase.InnerJoin {
+		return nil, errors.Errorf("only inner zigzag joins are supported, %s requested", spec.Type)
+	}
 	z := &zigzagJoiner{}
 
 	leftColumnTypes := spec.Tables[0].ColumnTypes()
@@ -293,7 +292,12 @@ func newZigzagJoiner(
 		0, /* numMerged */
 		post,
 		output,
-		execinfra.ProcStateOpts{}, // zigzagJoiner doesn't have any inputs to drain.
+		execinfra.ProcStateOpts{
+			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+				z.close()
+				return z.generateMeta(ctx)
+			},
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -301,8 +305,6 @@ func newZigzagJoiner(
 
 	z.numTables = len(spec.Tables)
 	z.infos = make([]*zigzagJoinerInfo, z.numTables)
-	z.returnedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
-
 	for i := range z.infos {
 		z.infos[i] = &zigzagJoinerInfo{}
 	}
@@ -349,7 +351,6 @@ func valuesSpecToEncDatum(
 // Start is part of the RowSource interface.
 func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
 	ctx = z.StartInternal(ctx, zigzagJoinerProcName)
-	z.evalCtx = z.FlowCtx.NewEvalCtx()
 	z.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	log.VEventf(ctx, 2, "starting zigzag joiner run")
 	return ctx
@@ -474,28 +475,6 @@ func (z *zigzagJoiner) close() {
 	if z.InternalClose() {
 		log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
 	}
-}
-
-// producerMeta constructs the ProducerMetadata after consumption of rows has
-// terminated, either due to being indicated by the consumer, or because the
-// processor ran out of rows or encountered an error. It is ok for err to be
-// nil indicating that we're done producing rows even though no error occurred.
-func (z *zigzagJoiner) producerMeta(err error) *execinfrapb.ProducerMetadata {
-	var meta *execinfrapb.ProducerMetadata
-	if !z.Closed {
-		if err != nil {
-			meta = &execinfrapb.ProducerMetadata{Err: err}
-		} else if trace := execinfra.GetTraceData(z.Ctx); trace != nil {
-			meta = &execinfrapb.ProducerMetadata{TraceData: trace}
-		}
-		// We need to close as soon as we send producer metadata as we're done
-		// sending rows. The consumer is allowed to not call ConsumerDone().
-		z.close()
-	}
-	if meta != nil {
-		z.returnedMeta = append(z.returnedMeta, *meta)
-	}
-	return meta
 }
 
 func findColumnID(s []sqlbase.ColumnID, t sqlbase.ColumnID) int {
@@ -728,18 +707,16 @@ func (z *zigzagJoiner) emitFromContainers() (sqlbase.EncDatumRow, error) {
 // nextRow fetches the nextRow to emit from the join. It iterates through all
 // sides until a match is found then emits the results of the match one result
 // at a time.
-func (z *zigzagJoiner) nextRow(
-	ctx context.Context, txn *kv.Txn,
-) (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
+func (z *zigzagJoiner) nextRow(ctx context.Context, txn *kv.Txn) (sqlbase.EncDatumRow, error) {
 	for {
 		if err := z.cancelChecker.Check(); err != nil {
-			return nil, &execinfrapb.ProducerMetadata{Err: err}
+			return nil, err
 		}
 
 		// Check if there are any rows built up in the containers that need to be
 		// emitted.
 		if rowToEmit, err := z.emitFromContainers(); err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		} else if rowToEmit != nil {
 			return rowToEmit, nil
 		}
@@ -757,7 +734,7 @@ func (z *zigzagJoiner) nextRow(
 		// use it to jump to the next possible match on the current side.
 		span, err := z.produceSpanFromBaseRow()
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		curInfo.key = span.Key
 
@@ -770,12 +747,12 @@ func (z *zigzagJoiner) nextRow(
 			z.FlowCtx.TraceKV,
 		)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 
 		fetchedRow, err := z.fetchRow(ctx)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		// If the next possible match on the current side that matches the previous
 		// row is `nil`, that means that there are no more matches in the join so
@@ -786,7 +763,7 @@ func (z *zigzagJoiner) nextRow(
 
 		matched, err := z.matchBase(fetchedRow, z.side)
 		if err != nil {
-			return nil, z.producerMeta(err)
+			return nil, err
 		}
 		if matched {
 			// We've detected a match! Now, we collect all subsequent matches on both
@@ -808,11 +785,11 @@ func (z *zigzagJoiner) nextRow(
 			// of the two rows.
 			prevNext, err := z.collectAllMatches(ctx, prevSide)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			curNext, err := z.collectAllMatches(ctx, z.side)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 
 			// No more matches, so set the baseRow to nil to indicate that we should
@@ -827,12 +804,12 @@ func (z *zigzagJoiner) nextRow(
 			eqColTypes := curInfo.eqColTypes()
 			ordering, err := curInfo.eqOrdering()
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			da := &sqlbase.DatumAlloc{}
 			cmp, err := prevEqCols.Compare(eqColTypes, da, ordering, z.FlowCtx.EvalCtx, currentEqCols)
 			if err != nil {
-				return nil, z.producerMeta(err)
+				return nil, err
 			}
 			// We want the new current side to be the one that has the latest key
 			// since we know that this key will not be able to match any previous
@@ -898,18 +875,16 @@ func (z *zigzagJoiner) collectAllMatches(
 	return row, nil
 }
 
-// Next is part of the RowSource interface.
-func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	txn := z.FlowCtx.Txn
-
-	if !z.started {
-		z.started = true
+// maybeFetchInitialRow checks whether we have already fetched an initial row
+// from one of the inputs and does so if we haven't.
+func (z *zigzagJoiner) maybeFetchInitialRow() error {
+	if !z.fetchedInititalRow {
+		z.fetchedInititalRow = true
 
 		curInfo := z.infos[z.side]
-		// Fetch initial batch.
 		err := curInfo.fetcher.StartScan(
 			z.Ctx,
-			txn,
+			z.FlowCtx.Txn,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			true, /* batch limit */
 			zigzagJoinerBatchSize,
@@ -917,57 +892,59 @@ func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 		)
 		if err != nil {
 			log.Errorf(z.Ctx, "scan error: %s", err)
-			return nil, z.producerMeta(err)
+			return err
 		}
 		fetchedRow, err := z.fetchRow(z.Ctx)
 		if err != nil {
-			err = scrub.UnwrapScrubError(err)
-			return nil, z.producerMeta(err)
+			return scrub.UnwrapScrubError(err)
 		}
 		z.baseRow = z.rowAlloc.AllocRow(len(fetchedRow))
 		copy(z.baseRow, fetchedRow)
 		z.side = z.nextSide()
 	}
+	return nil
+}
 
-	if z.Closed {
-		return nil, z.producerMeta(nil /* err */)
+// Next is part of the RowSource interface.
+func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if err := z.maybeFetchInitialRow(); err != nil {
+		z.MoveToDraining(err)
 	}
 
-	for {
-		row, meta := z.nextRow(z.Ctx, txn)
-		if z.Closed || meta != nil {
-			if meta != nil {
-				z.returnedMeta = append(z.returnedMeta, *meta)
-			}
-			return nil, meta
+	for z.State == execinfra.StateRunning {
+		row, err := z.nextRow(z.Ctx, z.FlowCtx.Txn)
+		if err != nil {
+			z.MoveToDraining(err)
+			break
 		}
 		if row == nil {
 			z.MoveToDraining(nil /* err */)
 			break
 		}
 
-		outRow := z.ProcessRowHelper(row)
-		if outRow == nil {
-			continue
+		if outRow := z.ProcessRowHelper(row); outRow != nil {
+			return outRow, nil
 		}
-		return outRow, nil
 	}
-	meta := z.DrainHelper()
-	if meta != nil {
-		z.returnedMeta = append(z.returnedMeta, *meta)
-	}
-	return nil, meta
+
+	return nil, z.DrainHelper()
 }
 
 // ConsumerClosed is part of the RowSource interface.
 func (z *zigzagJoiner) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
 	z.close()
 }
 
+func (z *zigzagJoiner) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	if tfs := execinfra.GetLeafTxnFinalState(ctx, z.FlowCtx.Txn); tfs != nil {
+		return []execinfrapb.ProducerMetadata{{LeafTxnFinalState: tfs}}
+	}
+	return nil
+}
+
 // DrainMeta is part of the MetadataSource interface.
-func (z *zigzagJoiner) DrainMeta(_ context.Context) []execinfrapb.ProducerMetadata {
-	return z.returnedMeta
+func (z *zigzagJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	return z.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.

--- a/pkg/sql/sqlbase/cancel_checker.go
+++ b/pkg/sql/sqlbase/cancel_checker.go
@@ -28,6 +28,8 @@ type CancelChecker struct {
 }
 
 // NewCancelChecker returns a new CancelChecker.
+// TODO(yuzefovich): audit all processors to make sure that the ones that
+// should use the cancel checker actually do so.
 func NewCancelChecker(ctx context.Context) *CancelChecker {
 	return &CancelChecker{
 		ctx: ctx,


### PR DESCRIPTION
Backport 1/3 commits from #54377.
Backport 1/1 commits from #55610.

/cc @cockroachdb/release

---

**rowexec: fix metadata propagation in zigzag joiner**

This commit refactors the zigzag joiner slightly to be more similar to
other processors. Most notable change is the removal of `producerMeta`
method and switching to returning an error and moving to draining
instead. In fact, previous behavior of metadata propagation was
incorrect in some cases when two or more metadata records needed to be
returned, and this is now fixed.

This commit also fixes an issue of zigzag joiner not propagating a leaf
txn final state metadata which could lead to a write skew. Additionally,
this commit adds low-level tests that verify that all reader-processors
output the leaf txn final state meta as well as trace meta.

Release note (bug fix): Fixed possible write skew in distributed queries
that have both zigzag joins and table readers with the zigzag joins
reading keys not read by the table readers. Note that although this
sounds scary, the bug itself is very rare.

**rowexec: fix recent refactor of zigzag joiner**

In a recent refactor of zigzag joiner I introduced a helper method that
could emit an error which would force the processor to move to draining.
The issue is that this could happen regardless of the current state of
the processor which breaks the contract (namely, we could try to move to
draining state twice). This is now fixed.

Release note: None (no release with the bug)