### PR TITLE
{kv,}server: prune out a few cluster version helpers

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2760,20 +2760,16 @@ func (s *Store) ManuallyEnqueue(
 	return collect(), processErr, nil
 }
 
-// GetClusterVersion reads the the cluster version from the store-local version
-// key. Returns an empty version if the key is not found.
-func (s *Store) GetClusterVersion(ctx context.Context) (clusterversion.ClusterVersion, error) {
-	return ReadClusterVersion(ctx, s.engine)
-}
-
-// WriteClusterVersion writes the given cluster version to the store-local cluster version key.
+// WriteClusterVersion writes the given cluster version to the store-local
+// cluster version key.
 func WriteClusterVersion(
 	ctx context.Context, writer storage.ReadWriter, cv clusterversion.ClusterVersion,
 ) error {
 	return storage.MVCCPutProto(ctx, writer, nil, keys.StoreClusterVersionKey(), hlc.Timestamp{}, nil, &cv)
 }
 
-// ReadClusterVersion reads the the cluster version from the store-local version key.
+// ReadClusterVersion reads the the cluster version from the store-local version
+// key. Returns an empty version if the key is not found.
 func ReadClusterVersion(
 	ctx context.Context, reader storage.Reader,
 ) (clusterversion.ClusterVersion, error) {

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -274,24 +274,12 @@ func (ls *Stores) updateBootstrapInfoLocked(bi *gossip.BootstrapInfo) error {
 	return err
 }
 
-// ReadVersionFromEngineOrZero reads the persisted cluster version from the
-// engine, falling back to the zero value.
-func ReadVersionFromEngineOrZero(
-	ctx context.Context, reader storage.Reader,
-) (clusterversion.ClusterVersion, error) {
-	var cv clusterversion.ClusterVersion
-	cv, err := ReadClusterVersion(ctx, reader)
-	if err != nil {
-		return clusterversion.ClusterVersion{}, err
-	}
-	return cv, nil
-}
-
 // WriteClusterVersionToEngines writes the given version to the given engines,
 // Returns nil on success; otherwise returns first error encountered writing to
-// the stores.
+// the stores. It makes no attempt to validate the supplied version.
 //
-// WriteClusterVersion makes no attempt to validate the supplied version.
+// At the time of writing this is used during bootstrap, initial server start
+// (to perhaps fill into additional stores), and during cluster version bumps.
 func WriteClusterVersionToEngines(
 	ctx context.Context, engines []storage.Engine, cv clusterversion.ClusterVersion,
 ) error {
@@ -341,7 +329,7 @@ func SynthesizeClusterVersionFromEngines(
 	for _, eng := range engines {
 		eng := eng.(storage.Reader) // we're read only
 		var cv clusterversion.ClusterVersion
-		cv, err := ReadVersionFromEngineOrZero(ctx, eng)
+		cv, err := ReadClusterVersion(ctx, eng)
 		if err != nil {
 			return clusterversion.ClusterVersion{}, err
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -526,7 +526,7 @@ func (n *Node) SetHLCUpperBound(ctx context.Context, hlcUpperBound int64) error 
 }
 
 func (n *Node) addStore(ctx context.Context, store *kvserver.Store) {
-	cv, err := store.GetClusterVersion(context.TODO())
+	cv, err := kvserver.ReadClusterVersion(context.TODO(), store.Engine())
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -328,7 +328,7 @@ func TestClusterVersionUpgrade(t *testing.T) {
 	// Since the wrapped version setting exposes the new versions, it must
 	// definitely be present on all stores on the first try.
 	if err := tc.Servers[1].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
-		cv, err := kvserver.ReadVersionFromEngineOrZero(ctx, s.Engine())
+		cv, err := kvserver.ReadClusterVersion(ctx, s.Engine())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
These helpers don't really add anything, they're just different ways to
read/write to the store local cluster version key. This is an area we're
looking to coalesce/repurpose in future PRs, so sending out this
drive-by clean up + documentation early.

Release note: None