### PR TITLE
logictest: fix comparison logic

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2725,24 +2725,25 @@ func (t *logicTest) execQuery(query logicQuery) error {
 			}
 			return errors.Newf("%s", buf.String())
 		}
-		if len(query.expectedResults) == 0 || len(actualResults) == 0 {
-			if len(query.expectedResults) != len(actualResults) {
-				return makeError()
+		if len(query.expectedResults) != len(actualResults) {
+			return makeError()
+		}
+		for i := range query.expectedResults {
+			expected, actual := query.expectedResults[i], actualResults[i]
+			resultMatches := expected == actual
+			// Results are flattened into columns for each row.
+			// To find the coltype for the given result, mod the result number
+			// by the number of coltypes.
+			colT := query.colTypes[i%len(query.colTypes)]
+			if !resultMatches && colT == 'F' {
+				var err error
+				resultMatches, err = floatsMatch(expected, actual)
+				if err != nil {
+					return errors.CombineErrors(makeError(), err)
+				}
 			}
-		} else {
-			for i, colT := range query.colTypes {
-				expected, actual := query.expectedResults[i], actualResults[i]
-				resultMatches := expected == actual
-				if !resultMatches && colT == 'F' {
-					var err error
-					resultMatches, err = floatsMatch(expected, actual)
-					if err != nil {
-						return errors.CombineErrors(makeError(), err)
-					}
-				}
-				if !resultMatches {
-					return makeError()
-				}
+			if !resultMatches {
+				return makeError()
 			}
 		}
 	}


### PR DESCRIPTION
`9d2c054fd3e9e8c6a7d73f4e464ebd32ee82b8a2` introduced a bug in the
commit logic where it would only check logic test errors for the first
line, since it only compares the first column of results. This is now
fixed to compare every row.

Release note: None