### PR TITLE
keys,storage: add lock table key space, EngineKey, and LockTableKey

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -52,8 +52,9 @@ var (
 	// key suffixes.
 	localSuffixLength = 4
 
-	// There are four types of local key data enumerated below: replicated
-	// range-ID, unreplicated range-ID, range local, and store-local keys.
+	// There are five types of local key data enumerated below: replicated
+	// range-ID, unreplicated range-ID, range local, range lock, and
+	// store-local keys.
 
 	// 1. Replicated Range-ID keys
 	//
@@ -155,7 +156,26 @@ var (
 	// (storage/engine/rocksdb/db.cc).
 	LocalTransactionSuffix = roachpb.RKey("txn-")
 
-	// 4. Store local keys
+	// 4. Lock table keys
+	//
+	// LocalRangeLockTablePrefix specifies the key prefix for the lock
+	// table. It is immediately followed by the LockTableSingleKeyInfix,
+	// and then the key being locked.
+	//
+	// The lock strength and txn UUID are not in the part of the key that
+	// the keys package deals with. They are in the versioned part of the
+	// key (see EngineKey.Version). This permits the storage engine to use
+	// bloom filters when searching for all locks for a lockable key.
+	//
+	// Different lock strengths may use different value types. The exclusive
+	// lock strength uses MVCCMetadata as the value type, since it does
+	// double duty as a reference to a provisional MVCC value.
+	// TODO(sumeer): remember to adjust this comment when adding locks of
+	// other strengths, or range locks.
+	LocalRangeLockTablePrefix = roachpb.Key(makeKey(localPrefix, roachpb.RKey("l")))
+	LockTableSingleKeyInfix   = []byte("k")
+
+	// 5. Store local keys
 	//
 	// localStorePrefix is the prefix identifying per-store data.
 	localStorePrefix = makeKey(localPrefix, roachpb.Key("s"))

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -155,8 +155,9 @@ package keys
 var _ = [...]interface{}{
 	MinKey,
 
-	// There are four types of local key data enumerated below: replicated
-	// range-ID, unreplicated range-ID, range local, and store-local keys.
+	// There are five types of local key data enumerated below: replicated
+	// range-ID, unreplicated range-ID, range local, range lock, and
+	// store-local keys.
 	// Local keys are constructed using a prefix, an optional infix, and a
 	// suffix. The prefix and infix are used to disambiguate between the four
 	// types of local keys listed above, and determines inter-group ordering.
@@ -167,12 +168,14 @@ var _ = [...]interface{}{
 	// 	  - RangeID unreplicated keys all share `LocalRangeIDPrefix` and
 	// 		`localRangeIDUnreplicatedInfix`.
 	// 	  - Range local keys all share `LocalRangePrefix`.
+	// 	  - Range lock (which are also local keys) all share
+	//	  `LocalRangeLockTablePrefix`.
 	//	  - Store keys all share `localStorePrefix`.
 	//
-	// `LocalRangeIDPrefix`, `localRangePrefix` and `localStorePrefix` all in
-	// turn share `localPrefix`. `localPrefix` was chosen arbitrarily. Local
-	// keys would work just as well with a different prefix, like 0xff, or even
-	// with a suffix.
+	// `LocalRangeIDPrefix`, `localRangePrefix`, `LocalRangeLockTablePrefix`,
+	// and `localStorePrefix` all in turn share `localPrefix`. `localPrefix` was
+	// chosen arbitrarily. Local keys would work just as well with a different
+	// prefix, like 0xff, or even with a suffix.
 
 	//   1. Replicated range-ID local keys: These store metadata pertaining to a
 	//   range as a whole. Though they are replicated, they are unaddressable.
@@ -206,7 +209,17 @@ var _ = [...]interface{}{
 	RangeDescriptorKey,      // "rdsc"
 	TransactionKey,          // "txn-"
 
-	//   4. Store local keys: These contain metadata about an individual store.
+	//   4. Range lock keys for all replicated locks. All range locks share
+	//   LocalRangeLockTablePrefix. Locks can be acquired on global keys and on
+	//   range local keys. Currently, locks are only on single keys, i.e., not
+	//   on a range of keys. Only exclusive locks are currently supported, and
+	//   these additionally function as pointers to the provisional MVCC values.
+	//   Single key locks use a byte, LockTableSingleKeyInfix, that follows
+	//   the LocalRangeLockTablePrefix. This is to keep the single-key locks
+	//   separate from (future) range locks.
+	LockTableSingleKey,
+
+	//   5. Store local keys: These contain metadata about an individual store.
 	//   They are unreplicated and unaddressable. The typical example is the
 	//   store 'ident' record. They all share `localStorePrefix`.
 	StoreSuggestedCompactionKey, // "comp"

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -128,6 +128,44 @@ type Iterator interface {
 	SupportsPrev() bool
 }
 
+// EngineIterator is an iterator over key-value pairs where the key is
+// an EngineKey.
+//lint:ignore U1001 unused
+type EngineIterator interface {
+	// Close frees up resources held by the iterator.
+	Close()
+	// SeekGE advances the iterator to the first key in the engine which
+	// is >= the provided key.
+	SeekGE(key EngineKey) (valid bool, err error)
+	// SeekLT advances the iterator to the first key in the engine which
+	// is < the provided key.
+	SeekLT(key EngineKey) (valid bool, err error)
+	// Next advances the iterator to the next key/value in the
+	// iteration. After this call, valid will be true if the
+	// iterator was not originally positioned at the last key.
+	Next() (valid bool, err error)
+	// Prev moves the iterator backward to the previous key/value
+	// in the iteration. After this call, valid will be true if the
+	// iterator was not originally positioned at the first key.
+	Prev() (valid bool, err error)
+	// UnsafeKey returns the same value as Key, but the memory is invalidated on
+	// the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
+	// REQUIRES: latest positioning function returned valid=true.
+	UnsafeKey() EngineKey
+	// UnsafeValue returns the same value as Value, but the memory is
+	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
+	// REQUIRES: latest positioning function returned valid=true.
+	UnsafeValue() []byte
+	// Key returns the current key.
+	// REQUIRES: latest positioning function returned valid=true.
+	Key() EngineKey
+	// Value returns the current value as a byte slice.
+	// REQUIRES: latest positioning function returned valid=true.
+	Value() []byte
+	// SetUpperBound installs a new upper bound for this iterator.
+	SetUpperBound(roachpb.Key)
+}
+
 // MVCCIterator is an interface that extends Iterator and provides concrete
 // implementations for MVCCGet and MVCCScan operations. It is used by instances
 // of the interface backed by RocksDB iterators to avoid cgo hops.

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -1,0 +1,225 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// EngineKey is the general key type that is stored in the engine. It consists
+// of a roachpb.Key followed by an optional "version". The term "version" is
+// a loose one: often the version is a real version represented as an hlc.Timestamp,
+// but it can also be the suffix of a lock table key containing the lock strength
+// and txn UUID. These special cases have their own types, MVCCKey and LockTableKey.
+// For key kinds that will never have a version, the code has historically used
+// MVCCKey, though future code may be better served by using EngineKey (and we
+// should consider changing all the legacy code).
+//
+// The version can have the following lengths in addition to 0 length.
+// - Timestamp of MVCC keys: 8 or 12 bytes.
+// - Lock table key: 17 bytes.
+type EngineKey struct {
+	Key     roachpb.Key
+	Version []byte
+}
+
+const (
+	engineKeyNoVersion                    = 0
+	engineKeyVersionWallTimeLen           = 8
+	engineKeyVersionWallAndLogicalTimeLen = 12
+	engineKeyVersionLockTableLen          = 17
+)
+
+// Format implements the fmt.Formatter interface
+func (k EngineKey) Format(f fmt.State, c rune) {
+	fmt.Fprintf(f, "%s/%x", k.Key, k.Version)
+}
+
+// Encoding:
+// Key + \x00 (sentinel) [+ Version + <byte representing length of Version>]
+//
+// The motivation for the sentinel is that we configure the underlying storage
+// engine (Pebble) with a Split function that can be used for constructing
+// Bloom filters over just the Key field. However, the encoded Key must also
+// look like an encoded EngineKey. By splitting, at Key + \x00, the Key looks
+// like an EngineKey with no Version.
+const (
+	sentinelLen            = 1
+	suffixEncodedLengthLen = 1
+)
+
+// EncodedLen returns the encoded length of k.
+func (k EngineKey) EncodedLen() int {
+	n := len(k.Key) + suffixEncodedLengthLen
+	versionLen := len(k.Version)
+	if versionLen > 0 {
+		n += sentinelLen + versionLen
+	}
+	return n
+}
+
+// Encode encoded the key.
+func (k EngineKey) Encode() []byte {
+	encodedLen := k.EncodedLen()
+	buf := make([]byte, encodedLen)
+	k.encodeToSizedBuf(buf)
+	return buf
+}
+
+// EncodeToBuf attempts to reuse buf for encoding the key, and if undersized,
+// allocates a new buffer.
+func (k EngineKey) EncodeToBuf(buf []byte) []byte {
+	encodedLen := k.EncodedLen()
+	if cap(buf) < encodedLen {
+		buf = make([]byte, encodedLen)
+	} else {
+		buf = buf[:encodedLen]
+	}
+	k.encodeToSizedBuf(buf)
+	return buf
+}
+
+func (k EngineKey) encodeToSizedBuf(buf []byte) {
+	copy(buf, k.Key)
+	pos := len(k.Key)
+	suffixLen := len(k.Version)
+	if suffixLen > 0 {
+		buf[pos] = 0
+		pos += sentinelLen
+		copy(buf[pos:], k.Version)
+	}
+	buf[len(buf)-1] = byte(suffixLen)
+}
+
+// IsMVCCKey returns true if the key can be decoded as an MVCCKey.
+// This includes the case of an empty timestamp.
+func (k EngineKey) IsMVCCKey() bool {
+	l := len(k.Version)
+	return l == engineKeyNoVersion || l == engineKeyVersionWallTimeLen ||
+		l == engineKeyVersionWallAndLogicalTimeLen
+}
+
+// IsLockTableKey returns true if the key can be decoded as a LockTableKey.
+func (k EngineKey) IsLockTableKey() bool {
+	return len(k.Version) == engineKeyVersionLockTableLen
+}
+
+// ToMVCCKey constructs a MVCCKey from the EngineKey.
+func (k EngineKey) ToMVCCKey() (MVCCKey, error) {
+	key := MVCCKey{Key: k.Key}
+	switch len(k.Version) {
+	case engineKeyNoVersion:
+		// No-op.
+	case engineKeyVersionWallTimeLen:
+		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(k.Version[0:8]))
+	case engineKeyVersionWallAndLogicalTimeLen:
+		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(k.Version[0:8]))
+		key.Timestamp.Logical = int32(binary.BigEndian.Uint32(k.Version[8:12]))
+	default:
+		return MVCCKey{}, errors.Errorf("version is not an encoded timestamp %x", k.Version)
+	}
+	return key, nil
+}
+
+// ToLockTableKey constructs a LockTableKey from the EngineKey.
+func (k EngineKey) ToLockTableKey() (LockTableKey, error) {
+	lockedKey, err := keys.DecodeLockTableSingleKey(k.Key)
+	if err != nil {
+		return LockTableKey{}, err
+	}
+	key := LockTableKey{Key: lockedKey}
+	switch len(k.Version) {
+	case engineKeyVersionLockTableLen:
+		key.Strength = lock.Strength(k.Version[0])
+		if key.Strength < lock.None || key.Strength > lock.Exclusive {
+			return LockTableKey{}, errors.Errorf("unknown strength %d", key.Strength)
+		}
+		key.TxnUUID = k.Version[1:]
+	default:
+		return LockTableKey{}, errors.Errorf("version is not valid for a LockTableKey %x", k.Version)
+	}
+	return key, nil
+}
+
+// DecodeEngineKey decodes the given bytes as an EngineKey. This function is
+// similar to enginepb.SplitMVCCKey.
+// TODO(sumeer): consider removing SplitMVCCKey.
+func DecodeEngineKey(b []byte) (key EngineKey, ok bool) {
+	if len(b) == 0 {
+		return EngineKey{}, false
+	}
+	// Last byte is the version length.
+	versionLen := int(b[len(b)-1])
+	// keyPartEnd points to the sentinel byte.
+	keyPartEnd := len(b) - 1
+	if versionLen > 0 {
+		keyPartEnd = len(b) - 1 - versionLen - 1
+	}
+	if keyPartEnd < 0 {
+		return EngineKey{}, false
+	}
+
+	// Key excludes the sentinel byte.
+	key.Key = b[:keyPartEnd]
+	if versionLen > 0 {
+		// Version consists of the bytes after the sentinel and before the length.
+		key.Version = b[keyPartEnd+1 : len(b)-1]
+	}
+	return key, true
+}
+
+// EngineKeyFormatter is a fmt.Formatter for EngineKeys.
+type EngineKeyFormatter struct {
+	key EngineKey
+}
+
+var _ fmt.Formatter = EngineKeyFormatter{}
+
+// Format implements the fmt.Formatter interface.
+func (m EngineKeyFormatter) Format(f fmt.State, c rune) {
+	m.key.Format(f, c)
+}
+
+// LockTableKey is a key representing a lock in the lock table.
+type LockTableKey struct {
+	Key      roachpb.Key
+	Strength lock.Strength
+	// Slice is of length uuid.Size. We use a slice instead of a byte array, to
+	// avoid copying a slice when decoding.
+	TxnUUID []byte
+}
+
+// ToEngineKey converts a lock table key to an EngineKey.
+//
+// TODO(sumeer): if this function is needed for non-test code, change
+// it to use a buffer passed in by the caller, to avoid the allocation.
+func (lk LockTableKey) ToEngineKey() EngineKey {
+	if len(lk.TxnUUID) != uuid.Size {
+		panic("invalid TxnUUID")
+	}
+	if lk.Strength != lock.Exclusive {
+		panic("unsupported lock strength")
+	}
+	k := EngineKey{
+		Key:     keys.LockTableSingleKey(lk.Key),
+		Version: make([]byte, engineKeyVersionLockTableLen),
+	}
+	k.Version[0] = byte(lk.Strength)
+	copy(k.Version[1:], lk.TxnUUID)
+	return k
+}

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockTableKeyEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	uuid1 := uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	uuid2 := uuid.Must(uuid.FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	testCases := []struct {
+		key LockTableKey
+	}{
+		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Exclusive, TxnUUID: uuid1[:]}},
+		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: uuid2[:]}},
+		// Causes a doubly-local range local key.
+		{key: LockTableKey{
+			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")),
+			Strength: lock.Exclusive,
+			TxnUUID:  uuid1[:]}},
+	}
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			eKey := test.key.ToEngineKey()
+			b1 := eKey.Encode()
+			require.Equal(t, len(b1), eKey.EncodedLen())
+			var b2 []byte
+			if rand.Intn(2) == 0 {
+				b2 = make([]byte, len(b1)*2)
+			}
+			b2 = eKey.EncodeToBuf(b2)
+			require.Equal(t, b1, b2)
+			require.True(t, eKey.IsLockTableKey())
+			require.False(t, eKey.IsMVCCKey())
+			eKeyDecoded, ok := DecodeEngineKey(b2)
+			require.True(t, ok)
+			require.True(t, eKeyDecoded.IsLockTableKey())
+			require.False(t, eKeyDecoded.IsMVCCKey())
+			keyDecoded, err := eKeyDecoded.ToLockTableKey()
+			require.NoError(t, err)
+			require.Equal(t, test.key, keyDecoded)
+		})
+	}
+}
+
+func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		key MVCCKey
+	}{
+		{key: MVCCKey{Key: roachpb.Key("foo"), Timestamp: hlc.Timestamp{WallTime: 99, Logical: 45}}},
+		{key: MVCCKey{Key: roachpb.Key("glue"), Timestamp: hlc.Timestamp{WallTime: 89999}}},
+		{key: MVCCKey{Key: roachpb.Key("a")}},
+	}
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			var encodedTS []byte
+			if !(test.key.Timestamp == hlc.Timestamp{}) {
+				if test.key.Timestamp.Logical == 0 {
+					encodedTS = make([]byte, 8)
+				} else {
+					encodedTS = make([]byte, 12)
+				}
+				binary.BigEndian.PutUint64(encodedTS, uint64(test.key.Timestamp.WallTime))
+				if test.key.Timestamp.Logical != 0 {
+					binary.BigEndian.PutUint32(encodedTS[8:], uint32(test.key.Timestamp.Logical))
+				}
+			}
+			eKey := EngineKey{Key: test.key.Key, Version: encodedTS}
+			b1 := eKey.Encode()
+			require.Equal(t, len(b1), eKey.EncodedLen())
+			var b2 []byte
+			if rand.Intn(2) == 0 {
+				b2 = make([]byte, len(b1)*2)
+			}
+			b2 = eKey.EncodeToBuf(b2)
+			require.Equal(t, b1, b2)
+			require.False(t, eKey.IsLockTableKey())
+			require.True(t, eKey.IsMVCCKey())
+			eKeyDecoded, ok := DecodeEngineKey(b2)
+			require.True(t, ok)
+			require.False(t, eKeyDecoded.IsLockTableKey())
+			require.True(t, eKeyDecoded.IsMVCCKey())
+			keyDecoded, err := eKeyDecoded.ToMVCCKey()
+			require.NoError(t, err)
+			require.Equal(t, test.key, keyDecoded)
+		})
+	}
+}


### PR DESCRIPTION
This includes an EngineIterator interface that currently has no
implementation.

The next PR will rename Iterator to MVCCIterator.

Release note: None