### PR TITLE
bulkio: Ensure correct descriptor used when restoring.

### DIFF
--- a/pkg/ccl/backupccl/restore_test.go
+++ b/pkg/ccl/backupccl/restore_test.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// A special jobs.Resumer that simulates interrupted resume by
+// aborting resume after restore descriptors are published, and then
+// resuming execution again.
+var _ jobs.Resumer = &restartAfterPublishDescriptorsResumer{}
+
+type restartAfterPublishDescriptorsResumer struct {
+	t       *testing.T
+	wrapped *restoreResumer
+}
+
+func (r *restartAfterPublishDescriptorsResumer) Resume(
+	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
+) error {
+	e := errors.New("bail out")
+	r.wrapped.testingKnobs.afterPublishingDescriptors = func() error {
+		return e
+	}
+	require.Equal(r.t, e, r.wrapped.Resume(ctx, phs, resultsCh))
+	r.wrapped.testingKnobs.afterPublishingDescriptors = nil
+	return r.wrapped.Resume(ctx, phs, resultsCh)
+}
+
+func (r *restartAfterPublishDescriptorsResumer) OnFailOrCancel(
+	ctx context.Context, phs interface{},
+) error {
+	return nil
+}
+
+func TestRestorePrivilegesChanged(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	params := base.TestClusterArgs{}
+	params.ServerArgs.ExternalIODir = dir
+	tc := testcluster.StartTestCluster(t, 1, params)
+	defer tc.Stopper().Stop(ctx)
+
+	tc.Server(0).JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+		// Arrange for our special job resumer to be returned.
+		jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			return &restartAfterPublishDescriptorsResumer{
+				t:       t,
+				wrapped: raw.(*restoreResumer),
+			}
+		},
+	}
+
+	runner := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	runner.Exec(t, `
+CREATE USER user_to_drop;
+CREATE TABLE foo (k INT PRIMARY KEY, v BYTES);
+GRANT SELECT ON TABLE foo TO user_to_drop;
+BACKUP TABLE foo TO 'nodelocal://0/foo';
+DROP TABLE foo;
+DROP ROLE user_to_drop;
+RESTORE TABLE foo FROM 'nodelocal://0/foo';
+`)
+}


### PR DESCRIPTION
Fixes #55642

Prior to this change, a copy of descriptors being restored could
become out of sync with the copy stored in the jobs table.

The divergence could occur when restoring into a cluster (or db) with
a different set of privileges than the privileges stored in the descriptors
when the backup was created.

In such a case, when we attempt to restore into a database with different
set of priveleges, we would override descriptor privileges with correct
permissions, and then commit the modified descriptors to KV (and system.jobs table).
Subsequently, if the restore process gets restarted, we would ignore
the privilege updates performed before and our in-memory descriptor would be
different from the descriptor stored in KV.  This would result in an
error when attempting to mark descriptor PUBLIC:
`validating table descriptor has not changed, expected:....`

This change ensures that if we resume restore execution, then we would use
the descriptors stored in the jobs details as opposed to the ones we compute.

Release Notes: Fix a bug which could result in a failed restore when restoring
into a database with a different set of privileges than the backup privileges.

Release Justifications: Bug fix: ensure we can restore even if restoring into
a database with different set of permissions.