### PR TITLE
sql: create event log entry for alter database events

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -31,6 +31,8 @@ const (
 	EventLogDropDatabase EventLogType = "drop_database"
 	// EventLogRenameDatabase is recorded when a database is renamed.
 	EventLogRenameDatabase EventLogType = "rename_database"
+	// EventLogAlterDatabaseOwner is recorded when a database's owner is changed.
+	EventLogAlterDatabaseOwner EventLogType = "alter_database_owner"
 
 	// EventLogCreateSchema is recorded when a schema is created.
 	EventLogCreateSchema EventLogType = "create_schema"
@@ -38,8 +40,10 @@ const (
 	EventLogDropSchema EventLogType = "drop_schema"
 	// EventLogRenameSchema is recorded when a schema is renamed.
 	EventLogRenameSchema EventLogType = "rename_schema"
-	// EventLogChangeSchemaOwner is recorded when a schema's owner is changed.
+	// EventLogAlterSchemaOwner is recorded when a schema's owner is changed.
 	EventLogAlterSchemaOwner EventLogType = "alter_schema_owner"
+	// EventLogConvertToSchema is recorded when a database is converted to a schema.
+	EventLogConvertToSchema EventLogType = "convert_to_schema"
 
 	// EventLogCreateTable is recorded when a table is created.
 	EventLogCreateTable EventLogType = "create_table"

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -383,6 +383,41 @@ WHERE "eventType" = 'rename_database'
 statement ok
 SET DATABASE = test
 
+# set owner of database.
+##################
+
+statement ok
+CREATE USER u
+
+statement ok
+ALTER DATABASE eventlogtonewname OWNER TO u
+
+query ITT
+SELECT "reportingID", info::JSONB->>'DatabaseName', info::JSONB->>'Owner'
+FROM system.eventlog
+WHERE "eventType" = 'alter_database_owner'
+----
+1  eventlogtonewname  u
+
+# convert database to schema
+##################
+
+statement ok
+ALTER DATABASE eventlogtonewname CONVERT TO SCHEMA WITH PARENT test
+
+query ITT
+SELECT "reportingID", info::JSONB->>'DatabaseName', info::JSONB->>'NewDatabaseName'
+FROM system.eventlog
+WHERE "eventType" = 'convert_to_schema'
+----
+1  eventlogtonewname  test
+
+statement ok
+DROP SCHEMA eventlogtonewname
+
+statement ok
+DROP USER u
+
 ##################
 # Cluster Settings
 ##################
@@ -586,5 +621,6 @@ FROM system.eventlog
 WHERE "eventType" = 'drop_schema'
 ORDER BY 2
 ----
+1 eventlogtonewname
 1 s
 1 t

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -22,6 +22,8 @@ export const CREATE_DATABASE = "create_database";
 export const DROP_DATABASE = "drop_database";
 // Recorded when a database is renamed.
 export const RENAME_DATABASE = "rename_database";
+// Recorded when a database's owner is changed.
+export const ALTER_DATABASE_OWNER = "alter_database_owner";
 // Recorded when a table is created.
 export const CREATE_TABLE = "create_table";
 // Recorded when a table is dropped.
@@ -85,6 +87,8 @@ export const DROP_SCHEMA = "drop_schema";
 export const RENAME_SCHEMA = "rename_schema";
 // Recorded when a schema's owner is changed.
 export const ALTER_SCHEMA_OWNER = "alter_schema_owner";
+// Recorded when a database is converted to a schema.
+export const CONVERT_TO_SCHEMA = "convert_to_schema";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONING, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -30,6 +30,8 @@ export function getEventDescription(e: Event$Properties): string {
       return `Database Dropped: User ${info.User} dropped database ${info.DatabaseName}. ${tableDropText}`;
     case eventTypes.RENAME_DATABASE:
       return `Database Renamed: User ${info.User} renamed database ${info.DatabaseName} to ${info.NewDatabaseName}`;
+    case eventTypes.ALTER_DATABASE_OWNER:
+      return `Database Owner Altered: User ${info.User} altered the owner of database ${info.SchemaName} to ${info.Owner}`;
     case eventTypes.CREATE_TABLE:
       return `Table Created: User ${info.User} created table ${info.TableName}`;
     case eventTypes.DROP_TABLE:
@@ -95,6 +97,8 @@ export function getEventDescription(e: Event$Properties): string {
       return `Schema Renamed: User ${info.User} renamed schema ${info.SchemaName} to ${info.NewSchemaName}`;
     case eventTypes.ALTER_SCHEMA_OWNER:
       return `Schema Owner Altered: User ${info.User} altered the owner of schema ${info.SchemaName} to ${info.Owner}`;
+    case eventTypes.CONVERT_TO_SCHEMA:
+      return `Database Converted: User ${info.User} converted database ${info.DatabaseName} to a schema with parent database ${info.NewDatabaseName}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }


### PR DESCRIPTION
The ALTER DATABASE actions for changing a database's owner and
converting a database to a schema are new in v20.2. Events were
not created for these when these new actions were added.

Relates to #55744

Release note (admin ui change): alter database owner and
convert to schema now causes an event to be logged and
displayed in the admin ui



@arulajmani and @jordanlewis could you please review this?