### PR TITLE
c-deps: remove googletest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "c-deps/protobuf"]
 	path = c-deps/protobuf
 	url = https://github.com/cockroachdb/protobuf.git
-[submodule "c-deps/googletest"]
-	path = c-deps/googletest
-	url = https://github.com/cockroachdb/googletest
 [submodule "pkg/ui/yarn-vendor"]
 	path = pkg/ui/yarn-vendor
 	url = https://github.com/cockroachdb/yarn-vendored


### PR DESCRIPTION
We don't need it anymore. We originally introduced it to support tests
in libroach (#20594), which has since been pared down to something much
simpler (#55509, just DBDumpThreadStacks).

Release note: None