### PR TITLE
testutils: backport the test skip util from master

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1461,6 +1461,9 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* const .* is unused`),
 				// The methods in exprgen.customFuncs are used via reflection.
 				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
+				// TODO(adityamaru): Delete this in work being done for #51897
+				stream.GrepNot(`pkg/testutils/skip/skip.go`),
+				stream.GrepNot(`pkg/testutils/skip/stress.go`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -1,0 +1,72 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package skip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// SkippableTest is a testing.TB with Skip methods.
+type SkippableTest interface {
+	Skip(...interface{})
+	Skipf(string, ...interface{})
+}
+
+// WithIssue skips this test, logging the given issue ID as the reason.
+func WithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Skip(append([]interface{}{
+		fmt.Sprintf("https://github.com/cockroachdb/cockroach/issue/%d", githubIssueID)},
+		args...))
+}
+
+// IgnoreLint skips this test, explicitly marking it as not a test that
+// should be tracked as a "skipped test" by external tools. You should use this
+// if, for example, your test should only be run in Race mode.
+func IgnoreLint(t SkippableTest, args ...interface{}) {
+	t.Skip(args...)
+}
+
+// IgnoreLintf is like IgnoreLint, and it also takes a format string.
+func IgnoreLintf(t SkippableTest, format string, args ...interface{}) {
+	t.Skipf(format, args...)
+}
+
+// UnderRace skips this test if the race detector is enabled.
+func UnderRace(t SkippableTest, args ...interface{}) {
+	if util.RaceEnabled {
+		t.Skip(append([]interface{}{"disabled under race"}, args...))
+	}
+}
+
+// UnderShort skips this test if the -short flag is specified.
+func UnderShort(t SkippableTest, args ...interface{}) {
+	if testing.Short() {
+		t.Skip(append([]interface{}{"disabled under -short"}, args...))
+	}
+}
+
+// UnderStress skips this test when running under stress.
+func UnderStress(t SkippableTest, args ...interface{}) {
+	if NightlyStress() {
+		t.Skip(append([]interface{}{"disabled under stress"}, args...))
+	}
+}
+
+// UnderStressRace skips this test during stressrace runs, which are tests
+// run under stress with the -race flag.
+func UnderStressRace(t SkippableTest, args ...interface{}) {
+	if NightlyStress() && util.RaceEnabled {
+		t.Skip(append([]interface{}{"disabled under stressrace"}, args...))
+	}
+}

--- a/pkg/testutils/skip/stress.go
+++ b/pkg/testutils/skip/stress.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package skip
+
+import "github.com/cockroachdb/cockroach/pkg/util/envutil"
+
+var stress = envutil.EnvOrDefaultBool("COCKROACH_NIGHTLY_STRESS", false)
+
+// NightlyStress returns true iff the process is running as part of CockroachDB's
+// nightly stress tests.
+func NightlyStress() bool {
+	return stress
+}


### PR DESCRIPTION
This is in preparation for the work being done in #51897

Release note: None