### PR TITLE
sql,colexec: add support for wrapping LocalPlanNode

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -42,6 +42,7 @@ import (
 
 type changeAggregator struct {
 	execinfra.ProcessorBase
+	execinfra.StreamingProcessor
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.ChangeAggregatorSpec
@@ -407,6 +408,7 @@ const (
 
 type changeFrontier struct {
 	execinfra.ProcessorBase
+	execinfra.StreamingProcessor
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.ChangeFrontierSpec

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -529,6 +529,7 @@ go_test(
         "//pkg/sql/tests",
         "//pkg/sql/types",
         "//pkg/sqlmigrations",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/buildutil",
         "//pkg/testutils/diagutils",

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -24,6 +24,22 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// columnarizerMode indicates the mode of operation of the Columnarizer.
+type columnarizerMode int
+
+const (
+	// columnarizerBufferingMode is the mode of operation in which the
+	// Columnarizer will be buffering up rows (dynamically, up to
+	// coldata.BatchSize()) before emitting the output batch.
+	// TODO(jordan): evaluate whether it's more efficient to skip the buffer
+	// phase.
+	columnarizerBufferingMode columnarizerMode = iota
+	// columnarizerStreamingMode is the mode of operation in which the
+	// Columnarizer will always emit batches with a single tuple (until it is
+	// done).
+	columnarizerStreamingMode
+)
+
 // Columnarizer turns an execinfra.RowSource input into an Operator output, by
 // reading the input in chunks of size coldata.BatchSize() and converting each
 // chunk into a coldata.Batch column by column.
@@ -31,6 +47,7 @@ type Columnarizer struct {
 	execinfra.ProcessorBase
 	NonExplainable
 
+	mode       columnarizerMode
 	allocator  *colmem.Allocator
 	input      execinfra.RowSource
 	da         rowenc.DatumAlloc
@@ -45,19 +62,50 @@ type Columnarizer struct {
 
 var _ colexecbase.Operator = &Columnarizer{}
 
-// NewColumnarizer returns a new Columnarizer.
-func NewColumnarizer(
+// NewBufferingColumnarizer returns a new Columnarizer that will be buffering up
+// rows before emitting them as output batches.
+func NewBufferingColumnarizer(
 	ctx context.Context,
 	allocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
 ) (*Columnarizer, error) {
+	return newColumnarizer(ctx, allocator, flowCtx, processorID, input, columnarizerBufferingMode)
+}
+
+// NewStreamingColumnarizer returns a new Columnarizer that emits every input
+// row as a separate batch.
+func NewStreamingColumnarizer(
+	ctx context.Context,
+	allocator *colmem.Allocator,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	input execinfra.RowSource,
+) (*Columnarizer, error) {
+	return newColumnarizer(ctx, allocator, flowCtx, processorID, input, columnarizerStreamingMode)
+}
+
+// newColumnarizer returns a new Columnarizer.
+func newColumnarizer(
+	ctx context.Context,
+	allocator *colmem.Allocator,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	input execinfra.RowSource,
+	mode columnarizerMode,
+) (*Columnarizer, error) {
 	var err error
+	switch mode {
+	case columnarizerBufferingMode, columnarizerStreamingMode:
+	default:
+		return nil, errors.AssertionFailedf("unexpected columnarizerMode %d", mode)
+	}
 	c := &Columnarizer{
 		allocator: allocator,
 		input:     input,
 		ctx:       ctx,
+		mode:      mode,
 	}
 	if err = c.ProcessorBase.Init(
 		nil,
@@ -90,7 +138,19 @@ func (c *Columnarizer) Init() {
 // Next is part of the Operator interface.
 func (c *Columnarizer) Next(context.Context) coldata.Batch {
 	var reallocated bool
-	c.batch, reallocated = c.allocator.ResetMaybeReallocate(c.typs, c.batch, 1 /* minCapacity */)
+	switch c.mode {
+	case columnarizerBufferingMode:
+		c.batch, reallocated = c.allocator.ResetMaybeReallocate(c.typs, c.batch, 1 /* minCapacity */)
+	case columnarizerStreamingMode:
+		// Note that we're not using ResetMaybeReallocate because we will
+		// always have at most one tuple in the batch.
+		if c.batch == nil {
+			c.batch = c.allocator.NewMemBatchWithFixedCapacity(c.typs, 1 /* minCapacity */)
+			reallocated = true
+		} else {
+			c.batch.ResetInternalBatch()
+		}
+	}
 	if reallocated {
 		oldRows := c.buffered
 		c.buffered = make(rowenc.EncDatumRows, c.batch.Capacity())
@@ -103,9 +163,8 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 			}
 		}
 	}
-	// Buffer up n rows.
+	// Buffer up rows up to the capacity of the batch.
 	nRows := 0
-	columnTypes := c.OutputTypes()
 	for ; nRows < c.batch.Capacity(); nRows++ {
 		row, meta := c.input.Next()
 		if meta != nil {
@@ -120,8 +179,6 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 		if row == nil {
 			break
 		}
-		// TODO(jordan): evaluate whether it's more efficient to skip the buffer
-		// phase.
 		copy(c.buffered[nRows], row)
 	}
 
@@ -132,7 +189,7 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 	}
 
 	// Write each column into the output batch.
-	for idx, ct := range columnTypes {
+	for idx, ct := range c.typs {
 		err := EncDatumRowsToColVec(c.allocator, c.buffered[:nRows], c.batch.ColVec(idx), idx, ct, &c.da)
 		if err != nil {
 			colexecerror.InternalError(err)

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -51,7 +51,7 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 		EvalCtx: &evalCtx,
 	}
 
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 
 	const errMsg = "artificial error"
 	rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
+	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
 	require.NoError(t, err)
 
 	c.Init()
@@ -125,7 +125,7 @@ func BenchmarkColumnarize(b *testing.B) {
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -56,7 +56,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/op_creation.go
+++ b/pkg/sql/colexec/op_creation.go
@@ -37,6 +37,7 @@ type NewColOperatorArgs struct {
 	Inputs               []colexecbase.Operator
 	StreamingMemAccount  *mon.BoundAccount
 	ProcessorConstructor execinfra.ProcessorConstructor
+	LocalProcessors      []execinfra.LocalProcessor
 	DiskQueueCfg         colcontainer.DiskQueueCfg
 	FDSemaphore          semaphore.Semaphore
 	ExprHelper           *ExprHelper

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -76,7 +76,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 			typs := []*types.T{typ}
 			source := execinfra.NewRepeatableRowSource(typs, rows)
 
-			columnarizer, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, source)
+			columnarizer, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, source)
 			require.NoError(t, err)
 
 			c, err := colserde.NewArrowBatchConverter(typs)

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1231,7 +1231,7 @@ func (rf *cFetcher) processValueSingle(
 	if needDecode {
 		if idx, ok := table.colIdxMap.get(colID); ok {
 			if rf.traceKV {
-				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.GetColumnAtIdx(idx).Name)
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
 			}
 			val := rf.machine.nextKV.Value
 			if len(val.RawBytes) == 0 {
@@ -1332,7 +1332,7 @@ func (rf *cFetcher) processValueBytes(
 		}
 
 		if rf.traceKV {
-			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.GetColumnAtIdx(idx).Name)
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
 		}
 
 		vec := rf.machine.colvecs[idx]

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -232,7 +232,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 		nil /* fdSemaphore */, descs.DistSQLTypeResolver{},
 	)
 
-	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
+	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, nil /* localProcessors */, flowinfra.FuseNormally)
 	defer vfc.cleanup(ctx)
 	require.NoError(t, err)
 

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -65,7 +65,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 1, mts)
+	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 1, mts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -48,7 +48,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	types := rowenc.OneIntCol
 	input := execinfra.NewRepeatableRowSource(types, rowenc.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	types := rowenc.OneIntCol
 	input := execinfra.NewRepeatableRowSource(types, rowenc.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -127,7 +127,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	testAllocator := colmem.NewAllocator(ctx, &acc, coldataext.NewExtendedColumnFactory(&evalCtx))
 	columnarizers := make([]colexecbase.Operator, len(args.inputs))
 	for i, input := range inputsColOp {
-		c, err := colexec.NewColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)
+		c, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -936,10 +936,18 @@ func NewLimitedMonitor(
 // these objects at creation time.
 type LocalProcessor interface {
 	RowSourcedProcessor
+	StreamingProcessor
 	// InitWithOutput initializes this processor.
 	InitWithOutput(flowCtx *FlowCtx, post *execinfrapb.PostProcessSpec, output RowReceiver) error
 	// SetInput initializes this LocalProcessor with an input RowSource. Not all
 	// LocalProcessors need inputs, but this needs to be called if a
 	// LocalProcessor expects to get its data from another RowSource.
 	SetInput(ctx context.Context, input RowSource) error
+}
+
+// StreamingProcessor is a marker interface that indicates that the processor is
+// of "streaming" nature and is expected to emit the output one tuple at a time
+// (in both row-by-row and the vectorized engines).
+type StreamingProcessor interface {
+	mustBeStreaming()
 }

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -98,7 +98,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	verbose := n.options.Flags[tree.ExplainFlagVerbose]
 	for _, flow := range sortedFlows {
 		node := root.Childf("Node %d", flow.nodeID)
-		opChains, cleanup, err := colflow.ConvertToVecTree(params.ctx, flowCtx, flow.flow, !willDistribute)
+		opChains, cleanup, err := colflow.ConvertToVecTree(params.ctx, flowCtx, flow.flow, physPlan.LocalProcessors, !willDistribute)
 		defer cleanup()
 		if err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -252,6 +252,7 @@ vectorized: <hidden>
 • root
 │
 ├── • insert
+│   │ actual row count: 1
 │   │ into: child(c, p)
 │   │
 │   └── • buffer
@@ -280,6 +281,7 @@ vectorized: <hidden>
 └── • fk-check
     │
     └── • error if rows
+        │ actual row count: 0
         │
         └── • lookup join (anti)
             │ actual row count: 0
@@ -293,10 +295,11 @@ vectorized: <hidden>
                 │ filter: column2 IS NOT NULL
                 │
                 └── • scan buffer
+                      actual row count: 1
                       label: buffer 1
 ·
 Diagram 1 (subquery): https://cockroachdb.github.io/distsqlplan/decode.html#eJy0UtGK2zoQfb9fIeYpAS2xs1woetq0pBA2dUriDZRiFkUevKK2pErj7qYhn9Uf6JcV2-sQszRlKX2cMzqac2bOAcLXEgQsks18nbJFkq6YetBlzraz5d18w0YxZ6PNfDl_l7JKm5Ebs_fr1QfmpEdD4zFwMDbHRFYYQHyGGDj8DxkH563CEKxv4EP7aJE_gYg4aONqauCMg7IeQRyANJUIAhJ7Zd1kChxyJKnL9lN8QlWTtoaRrlCw6OePABx2ktQDBmZrcjUJFgEHql15BsWQHTl01fPEQLJAENdHfqYqvqwqlbsS1yhz9JNoqK1bxI3zupJ-Dxw2Tpog2BVwWOpKE2tWcrsdSr_dMmUNoXnpqnnamfAoc9HTd3s6QW_Y27-1H7_G_qwoPBaSrJ_EQ_ez5NN9skrvk7vlcnQTN3H4F8eaDtT-IUJrDM6agAOlv_s5OmYcMC-wi2mwtVf40VvVjunKVctrgRwDdd3rrliYrtUIPCfHF8nTy-TpRXI0JLdWWldgkB6t_8JKSWjU_rT7Hn-UmoZXyTGg17LU3-XLk_W0UxwV6m_4HMm-2eey770qm9nxv18BAAD__1R7fzs=
-Diagram 2 (main-query): https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj8FqtEAQhO__UzR1Uhj49Tq3EAwIGw1qcgkeZKbZCLPTZmaEgPjuYfWQ6x7rq6ouekP8dtCom77qBqqboSXzNTtLH0-X96qnrFSU9dWleh7oNvtsyemla19pmQL7lOdQ8GK5mW4coT9RYlRYghiOUcIdbUegtj_QhcLslzXd8ahgJDD0hjQnx9BwYiZHRlafqPhfQMFymmZ3xHcFWdNfOabpytDlrh4f6Dgu4iM_dLnYRwW2Vz6fiLIGw29BzDFzyvboHcByTKdbnqL2p7WP-7_fAAAA__93xnPL
-Diagram 3 (postquery): https://cockroachdb.github.io/distsqlplan/decode.html#eJyUU01u2zwQ3X-nGMzKBghYtLPiysEHGVCqSoWtZFNowUrjlC1NqiSFNjB8rF6gJyskBm2dwEK8nMd5P3wSj-i_aRSYFbt0W0FWVCU0n5Vu4eE2v093MOMMZrs0T_-v4KDMrJvDZlu-h046MmE-R4bGtlTIA3kUH5FjzbBztiHvrRug47iQtT9QJAyV6fowwDXDxjpCccSggiYUqG0jNfhGGvjU7_fkIFkkyLClIJUe5cs-CFgvsT4xtH34q-WDfCQU_MTe7rdROpAjt-DnJhEXsOaQ7aAoKyju8xyfxSD0nSYvgP9BfJBaQ1AHEpD8-umRYVyCmHHYvZR4eU3iO6vMlmRLbrE8z1w9dSQgTzcV3BZVBndlViDD-JnWnVMH6Z6QYW7t176DL1YZsGa4I7LnVvl1N3z38GpurAlkgrLm9Wrsw5Fso-6LgpKLBa2uKSj-QuScdaD24Ox3D3yxOuvqktHNNUZb8p01nt6knJxqhtQ-UnwP3vauoQ_ONqNNHMuRNwIt-RBPeRwyE4-GgP-S-SR5OU1eTpJX0-TVJPnmBbk-_fc7AAD__yVxcZc=
+Diagram 2 (main-query): https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkM1KAzEUhfc-xeWsWgg4s81OZISB2kpb3cgsxsylDaRJnNxAocxj-QI-mXTiQheCy_PdnB9yQXp30GjXu2a7p3a935A5WjfQy93qudnRola02DWr5n5PJ-sXcUkP280jxX5kL8slFHwYeN2fOEG_okanEMdgOKUwXtFlftAOZ-hKwfqY5Yo7BRNGhr5ArDiGhgumd2RC9kLVbQWFgaW3bg7mM5ssNngSe2JN1edHgsJbL-bIiUKWmEXT1SU5uh-oRjcpFPXdnKQ_MHQ9qf-v23KKwSf-Neuv5GrqFHg4cPmBFPJo-GkMZq4pcjP7ZjBwknKti2h9OU3ddPMVAAD__4OeiTQ=
+Diagram 3 (postquery): https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k9Fq2zAUhu_3FIdzlYAgdtIrXaWMBNx59kjc3oxcqPJJq02RNElmLSGPtRfYkw1bHTQrDUuhdz6_zn_06Ze1x_BDI8eiWi9WDRRVU4O8V7qFm8vyerGGUc5gtF6Ui48N7JQZuTEsV_VncMKTieMxMjS2pUrsKCD_ijluGDpvJYVgfS_th4aifUCeMVTGdbGXNwyl9YR8j1FFTchRWyk0BCkM3HbbLXnIJhkybCkKpYfxdRc5zKfIkB5IdlFZA1HtiEP2-1dAhrciynsKYLvo-t7eHzunn0k5bg4MU_VEEqK4I-T5gf0_7VLpSJ78JD9GTDqHeQ7FGqq6geq6LN-JeHoO8ZVVZkWiJT-ZHjM3j444lItlA5dVU8BVXVTIMF3y3Hm1E_4RGZbWfu8cfLPKgDX9GZE93Un_NWwOCb6n_quEKLQ-PvWnmxe1tCaSeRlQ35ry8CTaNPftWWavZjk7J8v0r5L31oPagrc_A-ST2XGs70F5cQ7lioKzJtAR1muTs8OGIbV3lF5tsJ2X9MVbOWyTynrwDUJLIabVPBWFSUs94HNzftI8PW2enjTPTptnJ80X_5g3hw9_AgAA__8n-Kvh
 ·
 WARNING: this statement is experimental!

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -39,7 +39,7 @@ CREATE TABLE xy (x INT, y INT)
 statement ok
 INSERT INTO xy VALUES (4, 4), (5, 5), (6, 6)
 
-statement error insert on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(4\) is not present in table "parent"\.
+statement error insert on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\([4-6]\) is not present in table "parent"\.
 INSERT INTO child SELECT x,y FROM xy
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -1,3 +1,5 @@
+# LogicTest: !fakedist-metadata
+
 statement ok
 CREATE TABLE users (
   uid    INT PRIMARY KEY,
@@ -111,27 +113,33 @@ statement ok
 DROP VIEW v2
 
 query T
-SELECT column_name FROM [SHOW COLUMNS FROM users]
+SELECT column_name FROM [SHOW COLUMNS FROM users] ORDER BY column_name
 ----
 id
-username
 species
+username
+
+statement ok
+SET vectorize=on
 
 query T
 EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • alter table
 
+statement ok
+RESET vectorize
+
 # Verify that EXPLAIN did not actually rename the column
 query T
-SELECT column_name FROM [SHOW COLUMNS FROM users]
+SELECT column_name FROM [SHOW COLUMNS FROM users] ORDER BY column_name
 ----
 id
-username
 species
+username
 
 # Check that a column can be added and renamed in the same statement
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -1,3 +1,5 @@
+# LogicTest: !fakedist-metadata
+
 statement ok
 SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
 
@@ -173,13 +175,19 @@ system     node  NULL  {}  NULL
 t          root  NULL  {}  NULL
 v          root  NULL  {}  NULL
 
+statement ok
+SET vectorize=on
+
 query T
 EXPLAIN ALTER DATABASE v RENAME TO x
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • rename database
+
+statement ok
+RESET vectorize
 
 # Verify that the EXPLAIN above does not actually rename the database (#30543)
 query TTTTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -1,3 +1,5 @@
+# LogicTest: !fakedist-metadata
+
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,
@@ -138,13 +140,19 @@ SELECT * FROM users@pk
 1 tom   cat
 2 jerry rat
 
+statement ok
+SET vectorize=on
+
 query T
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • rename index
+
+statement ok
+RESET vectorize
 
 # Verify that EXPLAIN did not actually rename the index (#30543)
 query T rowsort

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,3 +1,5 @@
+# LogicTest: !fakedist-metadata
+
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 
@@ -249,13 +251,19 @@ SHOW TABLES
 ----
 public  kv  table  root  0  NULL
 
+statement ok
+SET vectorize=on
+
 query T
 EXPLAIN ALTER TABLE kv RENAME TO kv2
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • rename table
+
+statement ok
+RESET vectorize
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
 query TTTTIT

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -792,7 +792,7 @@ CREATE SCHEMA sc1;
 statement ok;
 CREATE TABLE sc1.t1 (i INT PRIMARY KEY);
 
-query TT
+query TT rowsort
 SELECT schema_name, table_name FROM [SHOW TABLES]
 ----
 public t1
@@ -806,7 +806,7 @@ sc1    t1
 statement ok
 USE test
 
-query TT
+query TT rowsort
 SELECT schema_name, table_name FROM [SHOW TABLES FROM for_show]
 ----
 public t1

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,3 +1,5 @@
+# LogicTest: !fakedist-metadata
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,
@@ -160,13 +162,19 @@ subtest truncate_30547
 statement ok
 CREATE TABLE tt AS SELECT 'foo'
 
+statement ok
+SET vectorize=on
+
 query T
 EXPLAIN TRUNCATE TABLE tt
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • truncate
+
+statement ok
+RESET vectorize
 
 # Verify that EXPLAIN did not cause the truncate to be performed.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -122,7 +122,7 @@ regr_intercept(1, 1), regr_r2(1, 1), regr_slope(1, 1), regr_sxx(1, 1), regr_sxy(
 regr_count(1, 1), regr_avgx(1, 1), regr_avgy(1, 1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string, corr float, covar_pop float, covar_samp float, sqrdiff decimal, regr_intercept float, regr_r2 float, regr_slope float, regr_sxx float, regr_sxy float, regr_syy float, regr_count int, regr_avgx float, regr_avgy float)

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -827,7 +827,7 @@ query T
 EXPLAIN DELETE FROM delrng1 WHERE p = 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -22,7 +22,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t9 SET b = b + 1 WHERE a = 5
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -56,7 +56,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -96,7 +96,7 @@ query T
 EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • split
 │ columns: (key, pretty, split_enforced_until)

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -61,7 +61,7 @@ query T
 EXPLAIN DELETE FROM unindexed
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: unindexed
@@ -71,7 +71,7 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -93,7 +93,7 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -115,7 +115,7 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: unindexed
@@ -130,7 +130,7 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0 LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -146,7 +146,7 @@ query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: indexed
@@ -162,7 +162,7 @@ query T
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: indexed
@@ -179,7 +179,7 @@ query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: indexed
@@ -200,7 +200,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM t38799@foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ columns: ()
@@ -261,7 +261,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: parent
@@ -280,7 +280,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: parent
@@ -291,7 +291,7 @@ query T
 EXPLAIN DELETE FROM child WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ from: child
@@ -318,7 +318,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: parent
@@ -338,7 +338,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: parent
@@ -357,7 +357,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -393,7 +393,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -453,7 +453,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -512,7 +512,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -551,7 +551,7 @@ query T
 EXPLAIN DELETE FROM ab WHERE a = 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -47,7 +47,7 @@ query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • union
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -33,7 +33,7 @@ query T
 EXPLAIN (PLAN, VERBOSE) SELECT 1 a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a)
@@ -44,7 +44,7 @@ query T
 EXPLAIN (VERBOSE,PLAN) SELECT 1 a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a)
@@ -56,7 +56,7 @@ query T
 EXPLAIN (TYPES) SELECT 1 a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a int)
@@ -90,7 +90,7 @@ query T
 EXPLAIN CREATE DATABASE foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • create database
 
@@ -98,7 +98,7 @@ query T
 EXPLAIN CREATE TABLE foo (x INT)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • create table
 
@@ -109,7 +109,7 @@ query T
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • create index
 
@@ -120,7 +120,7 @@ query T
 EXPLAIN DROP DATABASE foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • drop database
 
@@ -131,7 +131,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW JOBS] WHERE info NOT LIKE '%size%' AND info NOT LIKE '%filter%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: -column18,-started
@@ -149,7 +149,7 @@ query T
 EXPLAIN DROP INDEX foo@a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • drop index
 
@@ -157,7 +157,7 @@ query T
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • alter table
 
@@ -165,7 +165,7 @@ query T
 EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • split
 │ columns: (key, pretty, split_enforced_until)
@@ -180,7 +180,7 @@ query T
 EXPLAIN DROP TABLE foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • drop table
 
@@ -188,7 +188,7 @@ query T
 EXPLAIN SHOW DATABASES
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +name
@@ -200,7 +200,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +nspname,+relname
@@ -249,7 +249,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +nspname,+relname
@@ -306,7 +306,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'database'
@@ -318,7 +318,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW SCHEMAS] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +nspname
@@ -345,7 +345,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'timezone'
@@ -357,7 +357,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'default_transaction_isolation'
@@ -369,7 +369,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'default_transaction_priority'
@@ -381,7 +381,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'default_transaction_use_follower_reads'
@@ -393,7 +393,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'transaction_isolation'
@@ -405,7 +405,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: variable = 'transaction_priority'
@@ -417,7 +417,7 @@ query T
 EXPLAIN SHOW COLUMNS FROM foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +ordinal_position,+column_name,+crdb_sql_type,+is_nullable,+column_default,+generation_expression,+indices,+is_hidden
@@ -448,7 +448,7 @@ query T
 SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +grantee,+privilege_type
@@ -463,7 +463,7 @@ query T
 EXPLAIN SHOW INDEX FROM foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +index_name,+non_unique,+seq_in_index,+column_name,+direction,+storing,+implicit
@@ -480,7 +480,7 @@ query T
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +conname,+constraint_type,+condef,+convalidated
@@ -561,7 +561,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM select_test
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sequence select
   columns: (last_value, log_cnt, is_called)
@@ -571,7 +571,7 @@ query T
 EXPLAIN (VERBOSE) SELECT @1 FROM select_test
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: ("?column?")
@@ -593,7 +593,7 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   into: t(k, v)
@@ -677,7 +677,7 @@ query T
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   size: 3 columns, 2 rows
@@ -686,7 +686,7 @@ query T
 EXPLAIN VALUES (1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   size: 1 column, 1 row
@@ -785,7 +785,7 @@ query T
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   columns: ()
@@ -800,7 +800,7 @@ query T
 EXPLAIN (TYPES) SELECT 42 AS a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a int)
@@ -852,7 +852,7 @@ query T
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (column1 int, column2 int, column3 int)
@@ -883,7 +883,7 @@ query T
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ columns: ()
@@ -909,7 +909,7 @@ query T
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -940,7 +940,7 @@ query T
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • union
 │ columns: (column1 int)
@@ -1031,7 +1031,7 @@ query T
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a int)
@@ -1043,7 +1043,7 @@ query T
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (x int)
@@ -1307,7 +1307,7 @@ query T
 EXPLAIN SELECT string_agg(x, y) FROM (VALUES ('foo', 'foo'), ('bar', 'bar')) t(x, y)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • group (scalar)
 │
@@ -1348,7 +1348,7 @@ query T
 EXPLAIN EXPLAIN SELECT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • explain
 
@@ -1382,7 +1382,7 @@ query T
 EXPLAIN UPSERT INTO u VALUES (1, 1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ into: u(k, v)
@@ -1404,7 +1404,7 @@ query T
 EXPLAIN INSERT INTO u VALUES (1, 1) ON CONFLICT DO NOTHING
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: u(k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -16,7 +16,7 @@ query T
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -49,7 +49,7 @@ query T
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -89,7 +89,7 @@ query T
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -133,7 +133,7 @@ query T
 EXPLAIN INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -181,7 +181,7 @@ query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL), (2, 3, 4, 5)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -229,7 +229,7 @@ query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: multi_ref_child(k, a, b, c)
@@ -244,7 +244,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -288,7 +288,7 @@ query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -352,7 +352,7 @@ query T
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -384,7 +384,7 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -423,7 +423,7 @@ query T
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -458,7 +458,7 @@ query T
 EXPLAIN UPDATE parent SET p = p+1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -533,7 +533,7 @@ query T
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -591,7 +591,7 @@ query T
 EXPLAIN UPDATE child SET c = 4
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -640,7 +640,7 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -679,7 +679,7 @@ query T
 EXPLAIN UPDATE child SET p = p
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -716,7 +716,7 @@ query T
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -784,7 +784,7 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -826,7 +826,7 @@ query T
 EXPLAIN UPDATE self SET y = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -865,7 +865,7 @@ query T
 EXPLAIN UPDATE self SET x = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -918,7 +918,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   columns: ()
@@ -999,7 +999,7 @@ query T
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   into: nonunique_idx_child(k, ref1, ref2)
@@ -1044,7 +1044,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: ()
@@ -1062,7 +1062,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1 AND data > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: ()
@@ -1192,7 +1192,7 @@ query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1225,7 +1225,7 @@ query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1267,7 +1267,7 @@ query T
 EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1311,7 +1311,7 @@ query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1350,7 +1350,7 @@ query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3);
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   into: c(c, p)
@@ -1362,7 +1362,7 @@ query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1400,7 +1400,7 @@ query T
 EXPLAIN UPDATE p SET p=p+1 WHERE p > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1439,7 +1439,7 @@ query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -1489,7 +1489,7 @@ query T
 EXPLAIN INSERT INTO large_child SELECT i, i % 10 + 1 FROM generate_series(1, 10000) AS i
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -10,7 +10,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()
@@ -44,7 +44,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -4,7 +4,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table
   columns: (catalog_name, schema_name, default_character_set_name, sql_path, crdb_is_user_defined)
@@ -15,7 +15,7 @@ query T
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: table_name = 'foo'

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -306,7 +306,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()
@@ -343,7 +343,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()
@@ -370,7 +370,7 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -388,7 +388,7 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -409,7 +409,7 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -430,7 +430,7 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -453,7 +453,7 @@ EXPLAIN (VERBOSE)
 INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETURNING x+v
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: ("?column?")
@@ -511,7 +511,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (x)
@@ -537,7 +537,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   columns: ()
@@ -564,7 +564,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM [INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -292,7 +292,7 @@ SELECT count(*), (SELECT count(*) FROM q) FROM (
 ) GROUP BY lk
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (count, count)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -300,7 +300,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, 
                   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ columns: (k, u, w)
@@ -402,7 +402,7 @@ EXPLAIN (VERBOSE) SELECT
            pos.n
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (pktable_cat, pktable_schem, pktable_name, pkcolumn_name, fktable_cat, fktable_schem, fktable_name, fkcolumn_name, key_seq, update_rule, delete_rule, fk_name, pk_name, deferrability)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -637,7 +637,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (x)
@@ -650,7 +650,7 @@ query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • ordinality
 │
@@ -661,7 +661,7 @@ query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: -"ordinality"
@@ -675,7 +675,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • ordinality
 │ columns: (x, "ordinality")
@@ -692,7 +692,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • ordinality
 │ columns: (x, "ordinality")
@@ -716,7 +716,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (b)
@@ -736,7 +736,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (b)
@@ -758,7 +758,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (b)
@@ -1099,7 +1099,7 @@ EXPLAIN (VERBOSE)
 SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -11,7 +11,7 @@ query T
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (r)
@@ -22,7 +22,7 @@ query T
 EXPLAIN (VERBOSE) SELECT true AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (r)
@@ -33,7 +33,7 @@ query T
 EXPLAIN (VERBOSE) SELECT false AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (r)
@@ -44,7 +44,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (1, 2) AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (r)
@@ -55,7 +55,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (true, false) AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (r)
@@ -810,7 +810,7 @@ query T
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: ("coalesce")
@@ -833,7 +833,7 @@ query T
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: ("coalesce")
@@ -1055,7 +1055,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='t'::regclass
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table
   columns: (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)
@@ -1067,7 +1067,7 @@ query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: ("case")
@@ -1079,7 +1079,7 @@ query T
 EXPLAIN (VERBOSE) SELECT random(), current_database()
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (random, current_database)
@@ -1111,7 +1111,7 @@ query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: ("array")
@@ -1144,7 +1144,7 @@ query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT a FROM t ORDER BY b)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: ("array")

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -7,7 +7,7 @@ CREATE TABLE t (
   c TEXT COLLATE en_US DEFAULT('empty' COLLATE en_US),
   d DECIMAL(10,2) NOT NULL,
   e TIME,
-  f DECIMAL AS (a + b + d) STORED,
+  f DECIMAL(10,1) AS (a + b + d) STORED,
   --UNIQUE INDEX t_secondary (c, d), -- Fails due to #46276
   FAMILY (a, b, c),
   FAMILY (d, e, f)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -2,8 +2,10 @@
 
 # Prepare a trace to be inspected below.
 
+# TODO(yuzefovich): clean up the tracing in the vectorized engine and remove
+# adjustment of vectorize mode (#55821).
 statement ok
-SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off
+SET vectorize=off; SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off; RESET vectorize
 
 # Inspect the trace: we exclude messages containing newlines as these
 # may contain non-deterministic txn object descriptions.

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -524,7 +524,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) FOR UPDATE
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -553,7 +553,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -586,7 +586,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -616,7 +616,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t) AS r FOR UPDATE
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (r)
@@ -645,7 +645,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE) AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (r)
@@ -678,7 +678,7 @@ query T
 EXPLAIN (VERBOSE) SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (r)
@@ -867,7 +867,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -897,7 +897,7 @@ query T
 EXPLAIN (VERBOSE) WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1842,7 +1842,7 @@ query T
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: t4
@@ -1862,7 +1862,7 @@ query T
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete range
   from: t4

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -12,7 +12,7 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -43,7 +43,7 @@ EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -75,7 +75,7 @@ EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -110,7 +110,7 @@ EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -139,7 +139,7 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -169,7 +169,7 @@ query T
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -199,7 +199,7 @@ query T
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -233,7 +233,7 @@ query T
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -262,7 +262,7 @@ query T
 EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -291,7 +291,7 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -330,7 +330,7 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
         SELECT * FROM b LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -377,7 +377,7 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -406,7 +406,7 @@ query T
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -439,7 +439,7 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -475,7 +475,7 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -15,7 +15,7 @@ query T
 EXPLAIN (VERBOSE) SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT',2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (addgeometrycolumn)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -469,7 +469,7 @@ EXPLAIN (VERBOSE)
         (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (generate_series)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -10,7 +10,7 @@ query T
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -34,7 +34,7 @@ query T
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -160,7 +160,7 @@ query T
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +foo1
@@ -173,7 +173,7 @@ query T
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │
@@ -353,7 +353,7 @@ query T
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: ("array")
@@ -379,7 +379,7 @@ query T
 EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • apply join (semi)
 │ columns: (a, b, c)

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -226,7 +226,7 @@ FROM (
 )
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (e int, f string, g bool)

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -47,7 +47,7 @@ query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • union
 │
@@ -99,7 +99,7 @@ query T
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (a)
@@ -129,7 +129,7 @@ EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: ("?column?", "?column?", "?column?")

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -102,7 +102,7 @@ query T
 EXPLAIN UPDATE xyz SET y = x
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: xyz
@@ -119,7 +119,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -148,7 +148,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -171,7 +171,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -245,7 +245,7 @@ query T
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -270,7 +270,7 @@ query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -298,7 +298,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE tu SET c=c+1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -363,7 +363,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -440,7 +440,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -483,7 +483,7 @@ query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -502,7 +502,7 @@ query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -519,7 +519,7 @@ query T
 EXPLAIN UPDATE kv SET v = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -547,7 +547,7 @@ query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv3
@@ -569,7 +569,7 @@ query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv3
@@ -592,7 +592,7 @@ query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -610,7 +610,7 @@ query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -626,7 +626,7 @@ query T
 EXPLAIN UPDATE kv SET v = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -644,7 +644,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -672,7 +672,7 @@ query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv
@@ -691,7 +691,7 @@ query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv3
@@ -712,7 +712,7 @@ query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: kv3
@@ -732,7 +732,7 @@ query T
 EXPLAIN UPDATE tu SET c=c+1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: tu

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -8,7 +8,7 @@ query T
 EXPLAIN UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc
@@ -40,7 +40,7 @@ query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc
@@ -77,7 +77,7 @@ RETURNING
   abc.a, abc.b AS new_b, old.b as old_b, abc.c as new_c, old.c as old_c
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc
@@ -106,7 +106,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: (a, b, c, a, b, c)
@@ -154,7 +154,7 @@ query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as other ("a", "b", "c") WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc
@@ -183,7 +183,7 @@ query T
 EXPLAIN UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc
@@ -229,7 +229,7 @@ RETURNING
   *
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ table: abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -11,7 +11,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC LIMIT 2
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -44,7 +44,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -77,7 +77,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2 RETURNING *
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: (k, v)
@@ -110,7 +110,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO kv (k) SELECT k FROM kv ORDER BY v DESC LIMIT 2
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -174,7 +174,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -222,7 +222,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1), (2), (3), (4)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -279,7 +279,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1) RETURNING *
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: (a, b, c, d)
@@ -337,7 +337,7 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader                          Scan /Table/57/1/2{-/#}
+materializer                          Scan /Table/57/1/2{-/#}
 flow                                  CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/57/2/3/0 -> /BYTES/0x8a
 kv.DistSender: sending partial batch  r35: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
@@ -351,7 +351,7 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader                          Scan /Table/57/1/1{-/#}
+materializer                          Scan /Table/57/1/1{-/#}
 flow                                  CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/57/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r35: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
@@ -366,8 +366,8 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader                          Scan /Table/57/1/2{-/#}
-table reader                          fetched: /kv/primary/2/v -> /3
+materializer                          Scan /Table/57/1/2{-/#}
+materializer                          fetched: /kv/primary/2/v -> /3
 flow                                  Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/57/2/3/0
 flow                                  CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
@@ -435,7 +435,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM [UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (z)
@@ -533,7 +533,7 @@ query T
 EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -574,7 +574,7 @@ EXPLAIN (VERBOSE)
 INSERT INTO tdup VALUES (2, 2, 2), (3, 2, 2) ON CONFLICT (z, y) DO UPDATE SET z=1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()
@@ -635,7 +635,7 @@ INSERT INTO target SELECT x, y, z FROM source WHERE (y IS NULL OR y > 0) AND x <
 ON CONFLICT (b, c) DO UPDATE SET b=5
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • upsert
 │ columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -5,7 +5,7 @@ query T
 EXPLAIN (VERBOSE) SELECT 1 a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a)
@@ -16,7 +16,7 @@ query T
 EXPLAIN (VERBOSE) SELECT 1 + 2 a
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (a)
@@ -27,7 +27,7 @@ query T
 EXPLAIN (VERBOSE) VALUES (1, 2, 3), (4, 5, 6)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (column1, column2, column3)
@@ -43,7 +43,7 @@ query T
 EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (length('ab') * 2)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • values
   columns: (column1)
@@ -57,7 +57,7 @@ query T
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • render
 │ columns: (r)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -1,12 +1,10 @@
-# LogicTest: !local-spec-planning !fakedist-spec-planning !3node-tenant
-# Note that the new factory currently has limited support of EXPLAIN (PLAN)
-# statements, so spec-planning configurations are currently skipped.
+# LogicTest: local
 
 query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table
   table: pg_class@pg_class_oid_idx
@@ -16,7 +14,7 @@ query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE relname = 'blah'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: relname = 'blah'
@@ -31,7 +29,7 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: table_name = 'blah'
@@ -46,7 +44,7 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name > 'blah' ORDER BY table_name
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +table_name
@@ -63,7 +61,7 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah' AND table_type = 'foo'
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • filter
 │ filter: (table_name = 'blah') AND (table_type = 'foo')
@@ -77,7 +75,7 @@ query T
 EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table lookup join
 │ table: pg_class@pg_class_oid_idx
@@ -90,7 +88,7 @@ query T
 EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table lookup join (left outer)
 │ table: pg_class@pg_class_oid_idx
@@ -130,7 +128,7 @@ ORDER BY
         c.conname
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • sort
 │ order: +conname
@@ -189,7 +187,7 @@ query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50 LIMIT 1
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • virtual table
   table: pg_class@pg_class_oid_idx

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -129,7 +129,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   columns: ()
@@ -145,7 +145,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 1) RETURNING v
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (v)
@@ -165,7 +165,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t_idx VALUES (1, 1)
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert fast path
   columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -11,7 +11,7 @@ EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a, a)
@@ -68,7 +68,7 @@ EXPLAIN (VERBOSE)
   WITH t AS (INSERT INTO x VALUES (1) RETURNING a) SELECT * FROM t
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • root
 │ columns: (a)
@@ -145,7 +145,7 @@ EXPLAIN (VERBOSE)
   SELECT sum(n) FROM t
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • group (scalar)
 │ columns: (sum)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -736,7 +736,7 @@ func TestPGPreparedQuery(t *testing.T) {
 		{"EXPLAIN SELECT 1", []preparedQueryTest{
 			baseTest.SetArgs().
 				Results("distribution: local").
-				Results("vectorized: false").
+				Results("vectorized: true").
 				Results("").
 				Results("• values").
 				Results("  size: 1 column, 1 row"),

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 type metadataForwarder interface {
@@ -29,6 +30,7 @@ type planNodeToRowSource struct {
 	execinfra.ProcessorBase
 	execinfra.StreamingProcessor
 
+	input   execinfra.RowSource
 	started bool
 
 	fastPath bool
@@ -42,6 +44,8 @@ type planNodeToRowSource struct {
 	// run time state machine values
 	row rowenc.EncDatumRow
 }
+
+var _ execinfra.OpNode = &planNodeToRowSource{}
 
 func makePlanNodeToRowSource(
 	source planNode, params runParams, fastPath bool,
@@ -96,6 +100,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 		// tree had no DistSQL-plannable subtrees.
 		return nil
 	}
+	p.input = input
 	p.AddInputToDrain(input)
 	// Search the plan we're wrapping for firstNotWrapped, which is the planNode
 	// that DistSQL planning resumed in. Replace that planNode with input,
@@ -196,24 +201,31 @@ func (p *planNodeToRowSource) ConsumerClosed() {
 	p.InternalClose()
 }
 
-// IsException implements the VectorizeAlwaysException interface.
-func (p *planNodeToRowSource) IsException() bool {
-	if _, ok := p.node.(*setVarNode); ok {
-		// We need to make an exception for changing a session variable.
-		return true
-	}
-	if d, ok := p.node.(*delayedNode); ok {
-		// We want to make an exception for retrieving the current database
-		// name (which is done via a scan of 'session_variables' virtual table.
-		return d.name == "session_variables@primary"
-	}
-	return false
-}
-
 // forwardMetadata will be called by any upstream rowSourceToPlanNode processors
 // that need to forward metadata to the end of the flow. They can't pass
 // metadata through local processors, so they instead add the metadata to our
 // trailing metadata and expect us to forward it further.
 func (p *planNodeToRowSource) forwardMetadata(metadata *execinfrapb.ProducerMetadata) {
 	p.ProcessorBase.AppendTrailingMeta(*metadata)
+}
+
+// ChildCount is part of the execinfra.OpNode interface.
+func (p *planNodeToRowSource) ChildCount(verbose bool) int {
+	if _, ok := p.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
+}
+
+// Child is part of the execinfra.OpNode interface.
+func (p *planNodeToRowSource) Child(nth int, verbose bool) execinfra.OpNode {
+	switch nth {
+	case 0:
+		if n, ok := p.input.(execinfra.OpNode); ok {
+			return n
+		}
+		panic("input to planNodeToRowSource is not an execinfra.OpNode")
+	default:
+		panic(errors.AssertionFailedf("invalid index %d", nth))
+	}
 }

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -27,6 +27,7 @@ type metadataForwarder interface {
 
 type planNodeToRowSource struct {
 	execinfra.ProcessorBase
+	execinfra.StreamingProcessor
 
 	started bool
 

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -577,13 +577,18 @@ func formatBitArrayToType(d *DBitArray, t *types.T) *DBitArray {
 	return &DBitArray{a}
 }
 
-// performCastWithoutPrecisionTruncation performs the cast, but does not do a check on whether
-// the datum fits the type.
+// performCastWithoutPrecisionTruncation performs the cast, but does not do a
+// check on whether the datum fits the type.
 // In an ideal state, components of AdjustValueToType should be embedded into
 // this function, but the code base needs a general refactor of parsing
 // and casting logic before this can happen.
 // See also: #55094.
 func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
+	// If we're casting a DOidWrapper, then we want to cast the wrapped datum.
+	// It is also reasonable to lose the old Oid value too.
+	// Note that we pass in nil as the first argument since we're not interested
+	// in evaluating the placeholders.
+	d = UnwrapDatum(nil /* evalCtx */, d)
 	switch t.Family() {
 	case types.BitFamily:
 		switch v := d.(type) {

--- a/pkg/util/log/logcrash/crash_reporting_packet_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_packet_test.go
@@ -257,6 +257,7 @@ func TestInternalErrorReporting(t *testing.T) {
 		`\*errutil.withPrefix: crdb_internal.force_assertion_error\(\) \(2\)\n`+
 		`eval.go:\d+: \*withstack.withStack \(3\)\n`+
 		`\*telemetrykeys.withTelemetry: crdb_internal.force_assertion_error\(\) \(4\)\n`+
+		`\*colexecerror.notInternalError\n`+
 		`\(check the extra data payloads\)`, p.Message)
 
 	expectedExtra := []struct {


### PR DESCRIPTION
**tree: unwrap DOidWrapper before casting**

When performing a cast from `DOidWrapper`, we're interested in casting
the wrapped datum, so this commit adds the unwrapping to the top of
`performCast`.

Release note: None

**colexec: introduce streaming mode to the columnarizer**

Previously, the columnarizer would always buffer up tuples (dynamically,
up to `coldata.BatchSize()`) before emitting them as output; however,
there are several processors which are of "streaming" nature and such
buffering approach is not compatible when wrapping them. This commit
introduces a streaming mode of operation to the columnarizer which is
used when wrapping a streaming processor (newly introduced marker
interface that currently is implemented by the `planNodeToRowSource` and
the changefeed processors).

Note that there are still some unresolved issues around the changefeed
processors, so they aren't being wrapped into the vectorized flows.

Release note: None

**colexec: add support for wrapping LocalPlanNode**

This commit adds the support for wrapping `LocalPlanNode` core. It also
changes the meaning of `experimental_always` to allow wrapping of
JoinReader and LocalPlanNode cores. The latter allows us to remove
VectorizeAlwaysException.

Notable change is that now the materializer created when wrapping
row-execution processors are no longer added to the set of releasables
at the flow cleanup because in some cases it could be released before
being closed. Namely, this would occur if we have a subquery with
LocalPlanNode core and a materializer is added in order to wrap that
core - what will happen is that all releasables are put back into their
pools upon the subquery's flow cleanup, yet the subquery planNode tree
isn't closed yet since its closure is down when the main planNode tree
is being closed.

Another change is fixing the tracing in the cFetcher during mutations
(we were accessing public only columns whereas we should have been
accessing deletable ones - that's what row.Fetcher does in two places
that needed a fix).

Addresses: #57268.

Release note: None