### PR TITLE
sql: add support for CTAS AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1115,12 +1115,29 @@ func ParseHLC(s string) (hlc.Timestamp, error) {
 	return tree.DecimalToHLC(dec)
 }
 
+// asOfTimestampType is used during processing of AOST clauses: depending on the
+// context of an AOST clause, we should either set the main user's transaction
+// timestamp or use the timestamp for a historical backfill (in the case of
+// CREATE TABLE AS and other such statements).
+type asOfTimestampType int
+
+const (
+	// transactionTimestamp indicates that the AOST clause should apply to the
+	// user's transaction.
+	transactionTimestamp asOfTimestampType = iota + 1
+	// backfillTimestamp indicates that the AOST clause should apply to a backfill
+	// operation.
+	backfillTimestamp
+)
+
 // isAsOf analyzes a statement to bypass the logic in newPlan(), since
 // that requires the transaction to be started already. If the returned
 // timestamp is not nil, it is the timestamp to which a transaction
 // should be set. The statements that will be checked are Select,
 // ShowTrace (of a Select statement), Scrub, Export, and CreateStats.
-func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*hlc.Timestamp, error) {
+func (p *planner) isAsOf(
+	ctx context.Context, stmt tree.Statement,
+) (*hlc.Timestamp, asOfTimestampType, error) {
 	var asOf tree.AsOfClause
 	switch s := stmt.(type) {
 	case *tree.Select:
@@ -1133,32 +1150,38 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*hlc.Timesta
 
 		sc, ok := selStmt.(*tree.SelectClause)
 		if !ok {
-			return nil, nil
+			return nil, 0, nil
 		}
 		if sc.From.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 
 		asOf = sc.From.AsOf
 	case *tree.Scrub:
 		if s.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 		asOf = s.AsOf
 	case *tree.Export:
 		return p.isAsOf(ctx, s.Query)
 	case *tree.CreateStats:
 		if s.Options.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 		asOf = s.Options.AsOf
 	case *tree.Explain:
 		return p.isAsOf(ctx, s.Statement)
+	case *tree.CreateTable:
+		if !s.As() {
+			return nil, 0, nil
+		}
+		ts, _, err := p.isAsOf(ctx, s.AsSource)
+		return ts, backfillTimestamp, err
 	default:
-		return nil, nil
+		return nil, 0, nil
 	}
 	ts, err := p.EvalAsOfTimestamp(ctx, asOf)
-	return &ts, err
+	return &ts, transactionTimestamp, err
 }
 
 // isSavepoint returns true if ast is a SAVEPOINT statement.

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,3 +1,6 @@
+let $ts
+SELECT now()
+
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 
@@ -40,8 +43,8 @@ forks blue
 forks red
 forks green
 
-statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
+statement error pgcode 42P01 relation "stock" does not exist
+CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns
 CREATE TABLE t2 (col1, col2, col3) AS SELECT * FROM stock
@@ -362,3 +365,79 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Test CTAS as of system time.
+
+# Sleep for a millisecond to guarantee that the statement below will have
+# occurred at least a millisecond after the insert into the stock table.
+statement ok
+SELECT pg_sleep(0.001)
+
+statement ok
+CREATE TABLE stockcopy AS SELECT * FROM stock AS OF SYSTEM TIME '-1 ms'
+
+statement count 3
+SELECT * FROM stockcopy
+
+statement ok
+INSERT INTO stock VALUES ('spoons', 10)
+
+# Run a CTAS at a timestamp before we inserted the new value, and make sure
+# that the newly-created table does not contain the new value.
+let $ts
+SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) -
+  '1ms'::interval FROM stock WHERE item = 'spoons';
+
+statement ok
+CREATE TABLE stocknospoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query I
+SELECT count(*) FROM stocknospoons WHERE item = 'spoons'
+----
+0
+
+# Make sure that testing after the timestamp produces a result that
+# includes the new row.
+
+let $ts
+SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) +
+  '1ms'::interval FROM stock WHERE item = 'spoons';
+
+statement ok
+CREATE TABLE stockwithspoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query I
+SELECT count(*) FROM stockwithspoons WHERE item = 'spoons'
+----
+1
+
+statement ok
+ALTER TABLE stock ADD COLUMN newcol INT DEFAULT 1
+
+statement ok
+CREATE TABLE stockafterschemachange AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query error column "newcol" does not exist
+SELECT newcol FROM stockafterschemachange
+
+query I
+SELECT count(*) FROM stockafterschemachange WHERE item = 'spoons'
+----
+1
+
+## Test that CTAS AOST doesn't mix with explicit txns.
+statement ok
+BEGIN
+
+statement error unimplemented: historical CREATE TABLE AS unsupported in explicit transaction
+CREATE TABLE willfail AS SELECT * FROM stock AS OF SYSTEM TIME '-1s'
+
+statement ok
+ROLLBACK
+
+statement error syntax error
+CREATE TABLE willfail (a INT) AS OF SYSTEM TIME '-1s'
+
+statement error unimplemented: cannot specify AS OF SYSTEM TIME with different timestamps
+CREATE TABLE willfail AS SELECT *, (SELECT count(1) FROM STOCK AS OF SYSTEM TIME '-2s')
+                                    FROM stock AS OF SYSTEM TIME '-1s'

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -454,7 +454,7 @@ statement ok
 CREATE VIEW v AS SELECT d, t FROM t
 
 statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
+INSERT INTO t SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok
 DROP TABLE t CASCADE

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1299,14 +1299,19 @@ func (b *Builder) validateAsOf(asOf tree.AsOfClause) {
 		panic(err)
 	}
 
-	if b.semaCtx.AsOfTimestamp == nil {
+	if b.semaCtx.AsOfTimestamp != nil {
+		if *b.semaCtx.AsOfTimestamp != ts {
+			panic(unimplementedWithIssueDetailf(35712, "",
+				"cannot specify AS OF SYSTEM TIME with different timestamps"))
+		}
+	} else if b.semaCtx.AsOfTimestampForBackfill != nil {
+		if *b.semaCtx.AsOfTimestampForBackfill != ts {
+			panic(unimplementedWithIssueDetailf(35712, "",
+				"cannot specify AS OF SYSTEM TIME with different timestamps"))
+		}
+	} else {
 		panic(pgerror.Newf(pgcode.Syntax,
 			"AS OF SYSTEM TIME must be provided on a top-level statement"))
-	}
-
-	if *b.semaCtx.AsOfTimestamp != ts {
-		panic(unimplementedWithIssueDetailf(35712, "",
-			"cannot specify AS OF SYSTEM TIME with different timestamps"))
 	}
 }
 

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -137,6 +137,10 @@ const (
 	// rather than string literals. For example, the bytes \x40 will be formatted
 	// as b'\x40' rather than '\x40'.
 	fmtFormatByteLiterals
+
+	// FmtSkipAsOfSystemTimeClauses prevents the formatter from printing AS OF
+	// SYSTEM TIME clauses.
+	FmtSkipAsOfSystemTimeClauses
 )
 
 // Composite/derived flag definitions follow.

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -201,8 +201,10 @@ type AsOfClause struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AsOfClause) Format(ctx *FmtCtx) {
-	ctx.WriteString("AS OF SYSTEM TIME ")
-	ctx.FormatNode(a.Expr)
+	if !ctx.flags.HasFlags(FmtSkipAsOfSystemTimeClauses) {
+		ctx.WriteString("AS OF SYSTEM TIME ")
+		ctx.FormatNode(a.Expr)
+	}
 }
 
 // From represents a FROM clause.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -49,6 +49,8 @@ type SemaContext struct {
 	// TypeResolver manages resolving type names into *types.T's.
 	TypeResolver TypeReferenceResolver
 
+	// Only one of the following two AOST-related fields can be set at a time.
+
 	// AsOfTimestamp denotes the explicit AS OF SYSTEM TIME timestamp for the
 	// query, if any. If the query is not an AS OF SYSTEM TIME query,
 	// AsOfTimestamp is nil.
@@ -57,6 +59,12 @@ type SemaContext struct {
 	// timestamp. In that case, the timestamp would not be set
 	// globally for the entire txn and this field would not be needed.
 	AsOfTimestamp *hlc.Timestamp
+
+	// AsOfTimestampForBackfill is set to non-nil if the query contains a backfill
+	// operation that is expected to perform at a user-defined timestamp. It's
+	// distinct from AsOfTimestamp above, which is used to denote a user-defined
+	// *transaction* timestamp.
+	AsOfTimestampForBackfill *hlc.Timestamp
 
 	Properties SemaProperties
 }


### PR DESCRIPTION
Previously, running a statement of the form

    CREATE TABLE t AS SELECT ... FROM ... AS OF SYSTEM TIME x

was not supported.

Now, it is supported. The semantics are that the table creation happens
at the transaction timestamp, but the backfill that's performed to fetch
the data from the `SELECT` is performed at the user-specified timestamp
x.

This is useful for copying data from tables that are experiencing write
traffic. Reading the contended table's data at a historical timestamp
avoids contention on the CREATE TABLE AS.

Release note (sql change): CREATE TABLE AS SELECT ... FROM ... AS OF
SYSTEM TIME x is now supported.