### PR TITLE
importccl: fix INSERT with missing columns with IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -951,6 +951,25 @@ END;
 			skipIssue: 53958,
 		},
 		{
+			name: "INSERT without specifying all column values",
+			typ:  "PGDUMP",
+			data: `
+					SET standard_conforming_strings = OFF;
+					BEGIN;
+					CREATE TABLE "bob" ("a" int, "b" int, c int default 2);
+					INSERT INTO "bob" ("a") VALUES (1), (5);
+					INSERT INTO "bob" ("c", "b") VALUES (3, 2);
+					COMMIT
+			`,
+			query: map[string][][]string{
+				`SELECT * FROM bob`: {
+					{"1", "NULL", "2"},
+					{"5", "NULL", "2"},
+					{"NULL", "2", "3"},
+				},
+			},
+		},
+		{
 			name: "ALTER COLUMN x SET NOT NULL",
 			typ:  "PGDUMP",
 			data: `

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -685,6 +685,14 @@ func (m *pgDumpReader) readFile(
 					conv.IsTargetCol[idx] = struct{}{}
 					targetColMapIdx[j] = idx
 				}
+				// For any missing columns, fill those to NULL.
+				// These will get filled in with the correct default / computed expression
+				// provided conv.IsTargetCol is not set for the given column index.
+				for idx := range conv.VisibleCols {
+					if _, ok := conv.IsTargetCol[idx]; !ok {
+						conv.Datums[idx] = tree.DNull
+					}
+				}
 			}
 			for _, tuple := range values.Rows {
 				count++


### PR DESCRIPTION
We've introduced the functionality in v20.2 to INSERT PGDUMP with
less columns than there are total. As a result, we've introduced a bug
where missing a column in the INSERT would result in a panic.

Release note (bug fix): Fixed a bug where a IMPORTING a PGDUMP with
INSERTs not targeting all columns in the database would panic.

