### PR TITLE
cli: support \connect DATABASE and \c DATABASE

### DIFF
--- a/pkg/cli/interactive_tests/test_connection.tcl
+++ b/pkg/cli/interactive_tests/test_connection.tcl
@@ -1,0 +1,19 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Check \c and \connect to connect another DB"
+
+spawn $argv demo movr
+
+eexpect "movr"
+
+send "\\c postgres \r"
+eexpect "SET"
+eexpect "postgres"
+
+send "\\connect movr \r"
+eexpect "SET"
+eexpect "movr"
+
+end_test

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -64,6 +64,9 @@ Query Buffer
   \r                during a multi-line statement, erase all the SQL entered so far.
   \| CMD            run an external command and run its output as SQL statements.
 
+Connection
+  \c, \connect [DB] connect to a new database
+
 Input/Output
   \echo [STRING]    write the provided string to standard output.
   \i                execute commands from the specified file.
@@ -1112,6 +1115,14 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 			return cliRunStatement
 		}
 		return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
+
+	case `\connect`, `\c`:
+		if len(cmd) == 2 {
+			c.concatLines = `USE ` + cmd[1]
+			return cliRunStatement
+
+		}
+		return c.invalidSyntax(errState, `%s. Try \? for help`, c.lastInputLine)
 
 	case `\demo`:
 		return c.handleDemo(cmd[1:], loopState, errState)


### PR DESCRIPTION
Add \connect DATABASE and \c DATABASE for aliasing `USE DATABASE`

Fixes #55613.

Release note (cli change): support \connect DATABASE and \c DATABASE.