### PR TITLE
sql/tenant: synch clear range data on tenant drop request

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -233,4 +233,8 @@ type TestTenantArgs struct {
 	// TenantIDCodecOverride overrides the tenant ID used to construct the SQL
 	// server's codec, but nothing else (e.g. its certs). Used for testing.
 	TenantIDCodecOverride roachpb.TenantID
+
+	// Stopper, if not nil, is used to stop the tenant manually otherwise the
+	// TestServer stopper will be used.
+	Stopper *stop.Stopper
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1491,9 +1491,8 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}
 	return descs.Txn(ctx, execCfg.Settings, execCfg.LeaseManager, execCfg.InternalExecutor,
 		execCfg.DB, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
 			for _, tenant := range details.Tenants {
-				// TODO(dt): this is a noop since the tenant is already active=false but
-				// that should be fixed in DestroyTenant.
-				if err := sql.DestroyTenant(ctx, execCfg, txn, tenant.ID); err != nil {
+				tenant.State = descpb.TenantInfo_DROP
+				if err := sql.GCTenant(ctx, execCfg, &tenant); err != nil {
 					return err
 				}
 			}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -598,9 +598,13 @@ func (ts *TestServer) StartTenant(
 			ClusterSettingsUpdater: st.MakeUpdater(),
 		}
 	}
+	stopper := params.Stopper
+	if stopper == nil {
+		stopper = ts.Stopper()
+	}
 	return StartTenant(
 		ctx,
-		ts.Stopper(),
+		stopper,
 		ts.Cfg.ClusterName,
 		baseCfg,
 		sqlCfg,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -212,3 +212,8 @@ func (c *DummyTenantOperator) CreateTenant(_ context.Context, _ uint64) error {
 func (c *DummyTenantOperator) DestroyTenant(_ context.Context, _ uint64) error {
 	return errors.WithStack(errEvalTenant)
 }
+
+// GCTenant is part of the tree.TenantOperator interface.
+func (c *DummyTenantOperator) GCTenant(_ context.Context, _ uint64) error {
+	return errors.WithStack(errEvalTenant)
+}

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -27,6 +27,9 @@ id  active  crdb_internal.pb_to_json
 
 # Destroy a tenant.
 
+query error tenant 5 is not in state DROP
+SELECT crdb_internal.gc_tenant(5)
+
 query I
 SELECT crdb_internal.destroy_tenant(5)
 ----
@@ -45,6 +48,19 @@ id  active  crdb_internal.pb_to_json
 
 query error pgcode 42710 tenant "5" already exists
 SELECT crdb_internal.create_tenant(5)
+
+query I
+SELECT crdb_internal.gc_tenant(5)
+----
+5
+
+query error pgcode 42704 tenant "5" does not exist
+SELECT crdb_internal.gc_tenant(5)
+
+query I
+SELECT crdb_internal.create_tenant(5)
+----
+5
 
 query error pgcode 42710 tenant "10" already exists
 SELECT crdb_internal.create_tenant(10)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4293,6 +4293,31 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.gc_tenant": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     categoryMultiTenancy,
+			Undocumented: true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				sTenID := int64(tree.MustBeDInt(args[0]))
+				if sTenID <= 0 {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "tenant ID must be positive")
+				}
+				if err := ctx.Tenant.GCTenant(ctx.Context, uint64(sTenID)); err != nil {
+					return nil, err
+				}
+				return args[0], nil
+			},
+			Info:       "Garbage collects a tenant with the provided ID. Must be run by the System tenant.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	"num_nulls": makeBuiltin(
 		tree.FunctionProperties{
 			Category:     categoryComparison,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3120,6 +3120,11 @@ type TenantOperator interface {
 	// DestroyTenant attempts to uninstall an existing tenant from the system.
 	// It returns an error if the tenant does not exist.
 	DestroyTenant(ctx context.Context, tenantID uint64) error
+
+	// GCTenant attempts to garbage collect a DROP tenant from the system. Upon
+	// success it also removes the tenant record.
+	// It returns an error if the tenant does not exist.
+	GCTenant(ctx context.Context, tenantID uint64) error
 }
 
 // EvalContextTestingKnobs contains test knobs.

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -323,7 +323,11 @@ func StartTenant(t testing.TB, ts TestServerInterface, params base.TestTenantArg
 	if err != nil {
 		t.Fatal(err)
 	}
-	ts.Stopper().AddCloser(stop.CloserFn(func() {
+	stopper := params.Stopper
+	if stopper == nil {
+		stopper = ts.Stopper()
+	}
+	stopper.AddCloser(stop.CloserFn(func() {
 		cleanupGoDB()
 	}))
 	return db


### PR DESCRIPTION
Informs #47904.

This is a stop gap solution that will perform the operation
synchronously inside the transaction that marks the tenant row
as DROP and finally deletes the row.

This PR is intended to be backported to 20.2 release branch.
The long-term solution that implements #48775 is done in #55756
and will be our long term approach for release 21.0 and beyond.

Release note: none.