### PR TITLE
sql: create event log entry for role events

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1019,8 +1019,11 @@ func TestAdminAPIEvents(t *testing.T) {
 				}
 
 				isSettingChange := e.EventType == string(sql.EventLogSetClusterSetting)
+				isRoleChange := e.EventType == string(sql.EventLogCreateRole) ||
+					e.EventType == string(sql.EventLogDropRole) ||
+					e.EventType == string(sql.EventLogAlterRole)
 
-				if e.TargetID == 0 && !isSettingChange {
+				if e.TargetID == 0 && !isSettingChange && !isRoleChange {
 					t.Errorf("%d: missing/empty TargetID", i)
 				}
 				if e.ReportingID == 0 {

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -245,7 +245,17 @@ func (n *alterRoleNode) startExec(params runParams) error {
 		}
 	}
 
-	return nil
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		EventLogAlterRole,
+		0, /* no target */
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
+		struct {
+			RoleName string
+			User     string
+		}{normalizedUsername.Normalized(), params.p.User().Normalized()},
+	)
 }
 
 func (*alterRoleNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -228,7 +228,17 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 		}
 	}
 
-	return nil
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		EventLogCreateRole,
+		0, /* no target */
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
+		struct {
+			RoleName string
+			User     string
+		}{normalizedUsername.Normalized(), params.p.User().Normalized()},
+	)
 }
 
 // Next implements the planNode interface.

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -134,6 +134,13 @@ const (
 	// EventLogRevokePrivilege is recorded when privileges are removed from a
 	// user for a database object.
 	EventLogRevokePrivilege EventLogType = "revoke_privilege"
+
+	// EventLogCreateRole is recorded when a role is created.
+	EventLogCreateRole EventLogType = "create_role"
+	// EventLogDropRole is recorded when a role is dropped.
+	EventLogDropRole EventLogType = "drop_role"
+	// EventLogAlterRole is recorded when a role is altered.
+	EventLogAlterRole EventLogType = "alter_role"
 )
 
 // EventLogSetClusterSettingDetail is the json details for a settings change.

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -3,6 +3,33 @@
 # TABLE DDL
 ##################
 
+# Verify events related to roles
+##################
+
+statement ok
+CREATE ROLE r
+
+statement ok
+CREATE ROLE IF NOT EXISTS r2
+
+statement ok
+ALTER ROLE r WITH CONTROLCHANGEFEED
+
+statement ok
+DROP ROLE r, r2
+
+query ITTT
+SELECT "reportingID", info::JSONB->>'RoleName', "eventType", user
+FROM system.eventlog
+WHERE "eventType" IN ('create_role', 'drop_role', 'alter_role')
+ORDER BY "eventType", 2
+----
+1 r          alter_role    root
+1 r          create_role   root
+1 r2         create_role   root
+1 testuser   create_role   root
+1 r, r2        drop_role   root
+
 # Create two tables + superfluous "IF NOT EXISTS"
 ##################
 

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -89,6 +89,12 @@ export const RENAME_SCHEMA = "rename_schema";
 export const ALTER_SCHEMA_OWNER = "alter_schema_owner";
 // Recorded when a database is converted to a schema.
 export const CONVERT_TO_SCHEMA = "convert_to_schema";
+// Recorded when a role is created.
+export const CREATE_ROLE = "create_role";
+// Recorded when a role is dropped.
+export const DROP_ROLE = "drop_role";
+// Recorded when a role is altered.
+export const ALTER_ROLE = "alter_role";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONING, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -31,7 +31,7 @@ export function getEventDescription(e: Event$Properties): string {
     case eventTypes.RENAME_DATABASE:
       return `Database Renamed: User ${info.User} renamed database ${info.DatabaseName} to ${info.NewDatabaseName}`;
     case eventTypes.ALTER_DATABASE_OWNER:
-      return `Database Owner Altered: User ${info.User} altered the owner of database ${info.SchemaName} to ${info.Owner}`;
+      return `Database Owner Altered: User ${info.User} altered the owner of database ${info.DatabaseName} to ${info.Owner}`;
     case eventTypes.CREATE_TABLE:
       return `Table Created: User ${info.User} created table ${info.TableName}`;
     case eventTypes.DROP_TABLE:
@@ -99,6 +99,12 @@ export function getEventDescription(e: Event$Properties): string {
       return `Schema Owner Altered: User ${info.User} altered the owner of schema ${info.SchemaName} to ${info.Owner}`;
     case eventTypes.CONVERT_TO_SCHEMA:
       return `Database Converted: User ${info.User} converted database ${info.DatabaseName} to a schema with parent database ${info.NewDatabaseName}`;
+    case eventTypes.CREATE_ROLE:
+      return `Role Created: User ${info.User} created role ${info.RoleName}`;
+    case eventTypes.DROP_ROLE:
+      return `Role Dropped: User ${info.User} dropped role(s) ${info.RoleName}`;
+    case eventTypes.ALTER_ROLE:
+      return `Role Altered: User ${info.User} altered role ${info.RoleName}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }
@@ -126,6 +132,7 @@ export interface EventInfo {
   SchemaName?: string;
   NewSchemaName?: string;
   Owner?: string;
+  RoleName?: string;
   // The following are three names for the same key (it was renamed twice).
   // All ar included for backwards compatibility.
   DroppedTables?: string[];


### PR DESCRIPTION
Add event log entries when a role is created, dropped
or altered. These actions previously did not create
an entry.

Relates to #55744

Release note (admin ui change): creating, dropping and
altering roles or users now causes an event to be logged
and displayed in the admin ui