### PR TITLE
sql: support SQL parse dollar-quoted strings with digit

### DIFF
--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -944,7 +944,7 @@ outer:
 
 		default:
 			// If we haven't found a start tag yet, check whether the current characters is a valid for a tag.
-			if !foundStartTag && !lexbase.IsIdentStart(ch) {
+			if !foundStartTag && !lexbase.IsIdentStart(ch) && !lexbase.IsDigit(ch) {
 				return false
 			}
 			s.pos++

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -89,6 +89,8 @@ func TestScanner(t *testing.T) {
 		{`$a$1$$3$a$`, []int{SCONST}},
 		{`$a$1$3$a$`, []int{SCONST}},
 		{`$ab$1$a$ab$`, []int{SCONST}},
+		{`$ab1$ab$ab1$`, []int{SCONST}},
+		{`$ab1$ab12$ab1$`, []int{SCONST}},
 		{`$$~!@#$%^&*()_+:",./<>?;'$$`, []int{SCONST}},
 		{`$$hello
 world$$`, []int{SCONST}},
@@ -312,6 +314,8 @@ world`},
 		{`$a$1$$3$a$`, "1$$3"},
 		{`$a$1$3$a$`, "1$3"},
 		{`$ab$1$a$ab$`, "1$a"},
+		{`$ab1$ab$ab1$`, "ab"},
+		{`$ab1$ab12$ab1$`, "ab12"},
 		{`$$~!@#$%^&*()_+:",./<>?;'$$`, "~!@#$%^&*()_+:\",./<>?;'"},
 		{`$$hello
 world$$`, `hello


### PR DESCRIPTION
Support SQL parse dollar-quoted strings with digit

Fixes #54676.

Release note (sql change): support SQL parse dollar-quoted strings with digit.