### PR TITLE
opt: transform InnerJoin + Values to Project

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -75,54 +75,39 @@ SELECT (SELECT (VALUES (x), (y))) FROM xysd
 project
  ├── columns: column1:8(int)
  ├── prune: (8)
- ├── inner-join-apply
- │    ├── columns: x:1(int!null) y:2(int) column1:6(int) column1:7(int)
+ ├── ensure-distinct-on
+ │    ├── columns: x:1(int!null) column1:6(int)
+ │    ├── grouping columns: x:1(int!null)
+ │    ├── error: "more than one row returned by a subquery used as an expression"
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,6,7)
- │    ├── prune: (7)
- │    ├── interesting orderings: (+1)
- │    ├── scan xysd
- │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    ├── prune: (1,2)
- │    │    └── interesting orderings: (+1)
+ │    ├── fd: (1)-->(6)
+ │    ├── prune: (6)
  │    ├── inner-join-apply
- │    │    ├── columns: column1:6(int) column1:7(int)
- │    │    ├── outer: (1,2)
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(6,7)
- │    │    ├── prune: (7)
- │    │    ├── max1-row
- │    │    │    ├── columns: column1:6(int)
- │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
- │    │    │    ├── outer: (1,2)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(6)
- │    │    │    └── values
- │    │    │         ├── columns: column1:6(int)
- │    │    │         ├── outer: (1,2)
- │    │    │         ├── cardinality: [2 - 2]
- │    │    │         ├── prune: (6)
- │    │    │         ├── tuple [type=tuple{int}]
- │    │    │         │    └── variable: x:1 [type=int]
- │    │    │         └── tuple [type=tuple{int}]
- │    │    │              └── variable: y:2 [type=int]
+ │    │    ├── columns: x:1(int!null) y:2(int) column1:6(int)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── prune: (6)
+ │    │    ├── interesting orderings: (+1)
+ │    │    ├── scan xysd
+ │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── prune: (1,2)
+ │    │    │    └── interesting orderings: (+1)
  │    │    ├── values
- │    │    │    ├── columns: column1:7(int)
- │    │    │    ├── outer: (6)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(7)
- │    │    │    ├── prune: (7)
+ │    │    │    ├── columns: column1:6(int)
+ │    │    │    ├── outer: (1,2)
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── prune: (6)
+ │    │    │    ├── tuple [type=tuple{int}]
+ │    │    │    │    └── variable: x:1 [type=int]
  │    │    │    └── tuple [type=tuple{int}]
- │    │    │         └── variable: column1:6 [type=int]
+ │    │    │         └── variable: y:2 [type=int]
  │    │    └── filters (true)
- │    └── filters (true)
+ │    └── aggregations
+ │         └── const-agg [as=column1:6, type=int, outer=(6)]
+ │              └── variable: column1:6 [type=int]
  └── projections
-      └── variable: column1:7 [as=column1:8, type=int, outer=(7)]
+      └── variable: column1:6 [as=column1:8, type=int, outer=(6)]
 
 # Inner-join-apply nested in inner-join-apply with outer column references to
 # each parent.

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1175,27 +1175,40 @@ left-join (cross)
  └── filters (true)
 
 norm
-SELECT * FROM (SELECT 1) FULL JOIN (VALUES (1), (2)) ON true
+SELECT * FROM (SELECT 1 UNION SELECT 2) FULL JOIN (VALUES (1), (2)) ON true
 ----
 inner-join (cross)
- ├── columns: "?column?":1(int!null) column1:2(int!null)
- ├── cardinality: [2 - 2]
- ├── multiplicity: left-rows(exactly-one), right-rows(one-or-more)
- ├── stats: [rows=2]
- ├── fd: ()-->(1)
+ ├── columns: "?column?":3(int!null) column1:4(int!null)
+ ├── cardinality: [2 - 4]
+ ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
+ ├── stats: [rows=4]
  ├── values
- │    ├── columns: column1:2(int!null)
+ │    ├── columns: column1:4(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── stats: [rows=2]
  │    ├── (1,) [type=tuple{int}]
  │    └── (2,) [type=tuple{int}]
- ├── values
- │    ├── columns: "?column?":1(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
- │    ├── key: ()
- │    ├── fd: ()-->(1)
- │    └── (1,) [type=tuple{int}]
+ ├── union
+ │    ├── columns: "?column?":3(int!null)
+ │    ├── left columns: "?column?":1(int)
+ │    ├── right columns: "?column?":2(int)
+ │    ├── cardinality: [1 - 2]
+ │    ├── stats: [rows=2, distinct(3)=2, null(3)=0]
+ │    ├── key: (3)
+ │    ├── values
+ │    │    ├── columns: "?column?":1(int!null)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,) [type=tuple{int}]
+ │    └── values
+ │         ├── columns: "?column?":2(int!null)
+ │         ├── cardinality: [1 - 1]
+ │         ├── stats: [rows=1, distinct(2)=1, null(2)=0]
+ │         ├── key: ()
+ │         ├── fd: ()-->(2)
+ │         └── (2,) [type=tuple{int}]
  └── filters (true)
 
 exec-ddl

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -769,3 +769,25 @@ $left
 )
 =>
 ((OpName) $left $right (RemoveFiltersItem $on $item) $private)
+
+# ProjectInnerJoinValues transforms an inner join with a single-row Values
+# operator to a Project operator. This allows decorrelation of e.g.:
+#
+#   SELECT (SELECT CASE WHEN ord.approved THEN 'Approved' ELSE '---' END)
+#   FROM (VALUES (1, true), (2, false)) ord(id, approved)
+#
+[ProjectInnerJoinValues, Normalize]
+(InnerJoin | InnerJoinApply
+    $left:*
+    $right:(Values) & (HasOneRow $right)
+    $on:*
+)
+=>
+(Select
+    (Project
+        $left
+        (MakeProjectionsFromValues $right)
+        (OutputCols $left)
+    )
+    $on
+)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4477,37 +4477,26 @@ SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = x
 project
  ├── columns: i:2 y:8
  ├── immutable
- └── inner-join-apply
-      ├── columns: k:1!null i:2 x:7!null y:8 "?column?":10
+ └── inner-join (hash)
+      ├── columns: i:2 x:7!null y:8 column11:11!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       ├── immutable
-      ├── key: (1,7)
-      ├── fd: (1)-->(2), (1,7)-->(8,10), (7)==(10), (10)==(7)
-      ├── scan a
-      │    ├── columns: k:1!null i:2
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2)
-      ├── inner-join (cross)
-      │    ├── columns: x:7!null y:8 "?column?":10
-      │    ├── outer: (1)
-      │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      ├── fd: (7)-->(8), (7)==(11), (11)==(7)
+      ├── project
+      │    ├── columns: column11:11!null i:2
       │    ├── immutable
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections
+      │         └── k:1 + 1 [as=column11:11, outer=(1), immutable]
+      ├── scan xy
+      │    ├── columns: x:7!null y:8
       │    ├── key: (7)
-      │    ├── fd: ()-->(10), (7)-->(8)
-      │    ├── scan xy
-      │    │    ├── columns: x:7!null y:8
-      │    │    ├── key: (7)
-      │    │    └── fd: (7)-->(8)
-      │    ├── values
-      │    │    ├── columns: "?column?":10
-      │    │    ├── outer: (1)
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── immutable
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(10)
-      │    │    └── (k:1 + 1,)
-      │    └── filters (true)
+      │    └── fd: (7)-->(8)
       └── filters
-           └── x:7 = "?column?":10 [outer=(7,10), constraints=(/7: (/NULL - ]; /10: (/NULL - ]), fd=(7)==(10), (10)==(7)]
+           └── column11:11 = x:7 [outer=(7,11), constraints=(/7: (/NULL - ]; /11: (/NULL - ]), fd=(7)==(11), (11)==(7)]
 
 # Hoist Exists in join filter disjunction.
 norm expect=HoistJoinSubquery
@@ -4652,31 +4641,14 @@ project
  │    │    │    ├── cardinality: [3 - 3]
  │    │    │    ├── immutable
  │    │    │    ├── fd: ()-->(7,8)
- │    │    │    ├── inner-join (cross)
+ │    │    │    ├── values
  │    │    │    │    ├── columns: r:7 s:8
  │    │    │    │    ├── outer: (1,2)
  │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(7,8)
- │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: r:7
- │    │    │    │    │    ├── outer: (2)
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(7)
- │    │    │    │    │    └── (i:2 + 1,)
- │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: s:8
- │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(8)
- │    │    │    │    │    └── (k:1 + 1,)
- │    │    │    │    └── filters (true)
+ │    │    │    │    └── (i:2 + 1, k:1 + 1)
  │    │    │    ├── values
  │    │    │    │    ├── columns: column1:9
  │    │    │    │    ├── outer: (7,8)
@@ -4697,79 +4669,36 @@ norm expect=HoistValuesSubquery
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
- ├── columns: column1:14
- ├── inner-join-apply
- │    ├── columns: k:1!null column1:10 exists:13!null
+ ├── columns: column1:14!null
+ ├── group-by
+ │    ├── columns: k:1!null true_agg:12
+ │    ├── grouping columns: k:1!null
  │    ├── key: (1)
- │    ├── fd: (1)-->(10,13)
- │    ├── scan a
- │    │    ├── columns: k:1!null
- │    │    └── key: (1)
- │    ├── inner-join-apply
- │    │    ├── columns: column1:10 exists:13!null
- │    │    ├── outer: (1)
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(10,13)
+ │    ├── fd: (1)-->(12)
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1!null x:7 true:11
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(7,11)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null
+ │    │    │    └── key: (1)
  │    │    ├── project
- │    │    │    ├── columns: exists:13!null
- │    │    │    ├── outer: (1)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(13)
- │    │    │    ├── group-by
- │    │    │    │    ├── columns: true_agg:12
- │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(12)
- │    │    │    │    ├── left-join (cross)
- │    │    │    │    │    ├── columns: true:11
- │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(11)
- │    │    │    │    │    ├── values
- │    │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    └── ()
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: true:11!null
- │    │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    ├── fd: ()-->(11)
- │    │    │    │    │    │    ├── select
- │    │    │    │    │    │    │    ├── columns: x:7!null
- │    │    │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    │    ├── fd: ()-->(7)
- │    │    │    │    │    │    │    ├── scan xy
- │    │    │    │    │    │    │    │    ├── columns: x:7!null
- │    │    │    │    │    │    │    │    └── key: (7)
- │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │         └── x:7 = k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
- │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── true [as=true:11]
- │    │    │    │    │    └── filters (true)
- │    │    │    │    └── aggregations
- │    │    │    │         └── const-not-null-agg [as=true_agg:12, outer=(11)]
- │    │    │    │              └── true:11
+ │    │    │    ├── columns: true:11!null x:7!null
+ │    │    │    ├── key: (7)
+ │    │    │    ├── fd: ()-->(11)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:7!null
+ │    │    │    │    └── key: (7)
  │    │    │    └── projections
- │    │    │         └── true_agg:12 IS NOT NULL [as=exists:13, outer=(12)]
- │    │    ├── values
- │    │    │    ├── columns: column1:10
- │    │    │    ├── outer: (13)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(10)
- │    │    │    └── (exists:13,)
- │    │    └── filters (true)
- │    └── filters (true)
+ │    │    │         └── true [as=true:11]
+ │    │    └── filters
+ │    │         └── x:7 = k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ │    └── aggregations
+ │         └── const-not-null-agg [as=true_agg:12, outer=(11)]
+ │              └── true:11
  └── projections
-      └── column1:10 [as=column1:14, outer=(10)]
+      └── true_agg:12 IS NOT NULL [as=column1:14, outer=(12)]
 
 # Any in values row.
 norm expect=HoistValuesSubquery
@@ -4777,80 +4706,42 @@ SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
  ├── columns: column1:14
- ├── inner-join-apply
- │    ├── columns: k:1!null column1:10 case:13
+ ├── group-by
+ │    ├── columns: k:1!null bool_or:12
+ │    ├── grouping columns: k:1!null
  │    ├── key: (1)
- │    ├── fd: (1)-->(10,13)
- │    ├── scan a
- │    │    ├── columns: k:1!null
- │    │    └── key: (1)
- │    ├── inner-join-apply
- │    │    ├── columns: column1:10 case:13
- │    │    ├── outer: (1)
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(10,13)
+ │    ├── fd: (1)-->(12)
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1!null x:7 notnull:11
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (7)-->(11), (1)-->(7,11)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null
+ │    │    │    └── key: (1)
  │    │    ├── project
- │    │    │    ├── columns: case:13
- │    │    │    ├── outer: (1)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(13)
- │    │    │    ├── group-by
- │    │    │    │    ├── columns: bool_or:12
- │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(12)
- │    │    │    │    ├── left-join (cross)
- │    │    │    │    │    ├── columns: notnull:11
- │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(11)
- │    │    │    │    │    ├── values
- │    │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    └── ()
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: notnull:11!null
- │    │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    ├── fd: ()-->(11)
- │    │    │    │    │    │    ├── select
- │    │    │    │    │    │    │    ├── columns: x:7!null y:8
- │    │    │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    │    ├── fd: ()-->(7,8)
- │    │    │    │    │    │    │    ├── scan xy
- │    │    │    │    │    │    │    │    ├── columns: x:7!null y:8
- │    │    │    │    │    │    │    │    ├── key: (7)
- │    │    │    │    │    │    │    │    └── fd: (7)-->(8)
- │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │         ├── x:7 = k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
- │    │    │    │    │    │    │         └── (y:8 = 5) IS NOT false [outer=(8)]
- │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── y:8 IS NOT NULL [as=notnull:11, outer=(8)]
- │    │    │    │    │    └── filters (true)
- │    │    │    │    └── aggregations
- │    │    │    │         └── bool-or [as=bool_or:12, outer=(11)]
- │    │    │    │              └── notnull:11
+ │    │    │    ├── columns: notnull:11!null x:7!null
+ │    │    │    ├── key: (7)
+ │    │    │    ├── fd: (7)-->(11)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: x:7!null y:8
+ │    │    │    │    ├── key: (7)
+ │    │    │    │    ├── fd: (7)-->(8)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:7!null y:8
+ │    │    │    │    │    ├── key: (7)
+ │    │    │    │    │    └── fd: (7)-->(8)
+ │    │    │    │    └── filters
+ │    │    │    │         └── (y:8 = 5) IS NOT false [outer=(8)]
  │    │    │    └── projections
- │    │    │         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:13, outer=(12)]
- │    │    ├── values
- │    │    │    ├── columns: column1:10
- │    │    │    ├── outer: (13)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(10)
- │    │    │    └── (case:13,)
- │    │    └── filters (true)
- │    └── filters (true)
+ │    │    │         └── y:8 IS NOT NULL [as=notnull:11, outer=(8)]
+ │    │    └── filters
+ │    │         └── x:7 = k:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ │    └── aggregations
+ │         └── bool-or [as=bool_or:12, outer=(11)]
+ │              └── notnull:11
  └── projections
-      └── column1:10 [as=column1:14, outer=(10)]
+      └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=column1:14, outer=(12)]
 
 # ---------------------------------------------------
 # HoistProjectSetSubquery + TryDecorrelateProjectSet
@@ -5015,28 +4906,15 @@ project
  ├── immutable
  ├── fd: ()-->(1)
  └── project-set
-      ├── columns: column1:1!null a:2 generate_series:3
+      ├── columns: column1:1!null a:2!null generate_series:3
       ├── immutable
       ├── fd: ()-->(1,2)
-      ├── inner-join-apply
-      │    ├── columns: column1:1!null a:2
+      ├── values
+      │    ├── columns: column1:1!null a:2!null
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2)
-      │    ├── values
-      │    │    ├── columns: column1:1!null
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1)
-      │    │    └── (1,)
-      │    ├── values
-      │    │    ├── columns: a:2
-      │    │    ├── outer: (1)
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(2)
-      │    │    └── (column1:1,)
-      │    └── filters (true)
+      │    └── (1, 1)
       └── zip
            └── generate_series(1, a:2) [outer=(2), immutable]
 
@@ -5048,41 +4926,15 @@ project
  ├── immutable
  ├── fd: ()-->(1)
  └── project-set
-      ├── columns: column1:1!null a:2 generate_series:3 a:4 generate_series:5
+      ├── columns: column1:1!null a:2!null generate_series:3 a:4!null generate_series:5
       ├── immutable
       ├── fd: ()-->(1,2,4)
-      ├── inner-join-apply
-      │    ├── columns: column1:1!null a:2 a:4
+      ├── values
+      │    ├── columns: column1:1!null a:2!null a:4!null
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2,4)
-      │    ├── inner-join-apply
-      │    │    ├── columns: column1:1!null a:2
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1,2)
-      │    │    ├── values
-      │    │    │    ├── columns: column1:1!null
-      │    │    │    ├── cardinality: [1 - 1]
-      │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1)
-      │    │    │    └── (1,)
-      │    │    ├── values
-      │    │    │    ├── columns: a:2
-      │    │    │    ├── outer: (1)
-      │    │    │    ├── cardinality: [1 - 1]
-      │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(2)
-      │    │    │    └── (column1:1,)
-      │    │    └── filters (true)
-      │    ├── values
-      │    │    ├── columns: a:4
-      │    │    ├── outer: (1)
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(4)
-      │    │    └── (column1:1,)
-      │    └── filters (true)
+      │    └── (1, 1, 1)
       └── zip
            ├── generate_series(1, a:2) [outer=(2), immutable]
            └── generate_series(1, a:4) [outer=(4), immutable]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -487,12 +487,11 @@ INNER MERGE JOIN (SELECT k2, v2 FROM kv2) ON k2 = lookup_k;
 project
  └── inner-join (merge)
       ├── flags: force merge join
-      ├── inner-join (merge)
-      │    ├── flags: force merge join
+      ├── project
       │    ├── scan kv
-      │    ├── values
-      │    │    └── (1,)
-      │    └── filters (true)
+      │    │    └── constraint: /1: [/1 - /1]
+      │    └── projections
+      │         └── 1
       ├── scan kv2
       └── filters (true)
 

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -3520,3 +3520,196 @@ project
       ├── scan xy
       └── filters
            └── (i:2 + k:1) IS NOT NULL [outer=(1,2), immutable]
+
+# --------------------------------------------------
+# ProjectInnerJoinValues
+# --------------------------------------------------
+norm expect=ProjectInnerJoinValues
+SELECT (SELECT CASE WHEN ord.approved THEN 'Approved' ELSE '---' END)
+FROM (VALUES (1, true), (2, false)) ord(id, approved)
+----
+project
+ ├── columns: case:4!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column2:2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (true,)
+ │    └── (false,)
+ └── projections
+      └── CASE WHEN column2:2 THEN 'Approved' ELSE '---' END [as=case:4, outer=(2)]
+
+norm expect=ProjectInnerJoinValues
+SELECT k, i - (SELECT f::int + i) FROM a
+----
+project
+ ├── columns: k:1!null "?column?":8
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(8)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── projections
+      └── i:2 - (i:2 + f:3::INT8) [as="?column?":8, outer=(2,3), immutable]
+
+# Correlated subquery with 0 rows.
+norm expect-not=ProjectInnerJoinValues
+SELECT k, i - (SELECT f::int LIMIT 0) FROM a
+----
+project
+ ├── columns: k:1!null "?column?":8
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(8)
+ ├── left-join-apply
+ │    ├── columns: k:1!null i:2 a.f:3!null f:7
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3,7)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 a.f:3!null
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    ├── limit
+ │    │    ├── columns: f:7
+ │    │    ├── outer: (3)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── immutable
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(7)
+ │    │    ├── values
+ │    │    │    ├── columns: f:7
+ │    │    │    ├── outer: (3)
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── immutable
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(7)
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── (a.f:3::INT8,)
+ │    │    └── 0
+ │    └── filters (true)
+ └── projections
+      └── i:2 - f:7 [as="?column?":8, outer=(2,7), immutable]
+
+# Inner join with single-row values.
+norm expect=ProjectInnerJoinValues
+SELECT a.k, vals.value
+FROM a INNER JOIN (SELECT 1, 9) vals(k, value) ON a.k = vals.k
+----
+project
+ ├── columns: k:1!null value:8!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,8)
+ ├── select
+ │    ├── columns: k:1!null
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ └── projections
+      └── 9 [as="?column?":8]
+
+# Inner join with zero-row values.
+norm expect-not=ProjectInnerJoinValues
+SELECT a.k, vals.value
+FROM a INNER JOIN (SELECT 1, 9 LIMIT 0) vals(k, value) ON a.k = vals.k
+----
+values
+ ├── columns: k:1!null value:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,8)
+
+# Inner join with multi-row values.
+norm expect-not=ProjectInnerJoinValues
+SELECT a.k, vals.value
+FROM a
+INNER JOIN (SELECT 1, 10 UNION SELECT 2, 20) vals(k, value)
+ON a.k = vals.k
+----
+project
+ ├── columns: k:1!null value:12!null
+ ├── cardinality: [0 - 2]
+ ├── key: (1,12)
+ └── inner-join (hash)
+      ├── columns: k:1!null "?column?":11!null "?column?":12!null
+      ├── cardinality: [0 - 2]
+      ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      ├── key: (11,12)
+      ├── fd: (1)==(11), (11)==(1)
+      ├── scan a
+      │    ├── columns: k:1!null
+      │    └── key: (1)
+      ├── union
+      │    ├── columns: "?column?":11!null "?column?":12!null
+      │    ├── left columns: "?column?":7 "?column?":8
+      │    ├── right columns: "?column?":9 "?column?":10
+      │    ├── cardinality: [1 - 2]
+      │    ├── key: (11,12)
+      │    ├── values
+      │    │    ├── columns: "?column?":7!null "?column?":8!null
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7,8)
+      │    │    └── (1, 10)
+      │    └── values
+      │         ├── columns: "?column?":9!null "?column?":10!null
+      │         ├── cardinality: [1 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(9,10)
+      │         └── (2, 20)
+      └── filters
+           └── k:1 = "?column?":11 [outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
+
+# Lateral inner join with single-row values.
+norm expect=ProjectInnerJoinValues
+SELECT *
+FROM a
+INNER JOIN LATERAL (VALUES (a.k, a.k + 1, a.s, 10)) vals(c1, c2, c3, c4)
+ON a.k = c1
+----
+project
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 c1:7!null c2:8!null c3:9 c4:10!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(10), (1)-->(2-5,8), (1)==(7), (7)==(1), (4)==(9), (9)==(4)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── projections
+      ├── k:1 [as=column1:7, outer=(1)]
+      ├── k:1 + 1 [as=column2:8, outer=(1), immutable]
+      ├── s:4 [as=column3:9, outer=(4)]
+      └── 10 [as=column4:10]
+
+# Lateral inner join with hidden single-row values (passed through for sort).
+norm expect=ProjectInnerJoinValues
+SELECT a.k
+FROM a
+INNER JOIN LATERAL (VALUES (a.k, a.k + 1, a.s, 10)) vals(c1, c2, c3, c4)
+ON a.k = c1
+ORDER BY c3 DESC
+----
+sort
+ ├── columns: k:1!null  [hidden: column3:9]
+ ├── key: (1)
+ ├── fd: (1)-->(9)
+ ├── ordering: -9
+ └── project
+      ├── columns: column3:9 k:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(9)
+      ├── scan a
+      │    ├── columns: k:1!null s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── projections
+           └── s:4 [as=column3:9, outer=(4)]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1483,14 +1483,11 @@ ON True
 distinct-on
  ├── left-join-apply
  │    ├── scan uv
- │    ├── inner-join (cross)
- │    │    ├── project
- │    │    │    ├── scan ab
- │    │    │    └── projections
- │    │    │         └── a * u
- │    │    ├── values
- │    │    │    └── (1,)
- │    │    └── filters (true)
+ │    ├── project
+ │    │    ├── scan ab
+ │    │    └── projections
+ │    │         ├── 1
+ │    │         └── a * u
  │    └── filters (true)
  └── aggregations
       ├── const-agg

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -917,7 +917,7 @@ inner-join (hash)
       └── u:1 = y:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
 
 # InnerJoinApply case.
-norm expect=RejectNullsUnderJoinLeft
+norm expect=RejectNullsUnderJoinLeft disable=ProjectInnerJoinValues
 SELECT * FROM a
 LEFT JOIN xy ON k = x
 INNER JOIN LATERAL (VALUES (x)) f(v) ON v = y

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1642,73 +1642,51 @@ FROM pg_class AS rel
 project
  ├── columns: array:69
  ├── inner-join-apply
- │    ├── columns: rel.oid:1 array_agg:66 array:67
+ │    ├── columns: rel.oid:1 inhrelid:31 array_agg:68
  │    ├── scan pg_class [as=rel]
  │    │    └── columns: rel.oid:1
- │    ├── inner-join-apply
- │    │    ├── columns: array_agg:66 array:67
+ │    ├── group-by
+ │    │    ├── columns: inhrelid:31 array_agg:68
+ │    │    ├── internal-ordering: +33 opt(31)
  │    │    ├── outer: (1)
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
- │    │    ├── fd: ()-->(66,67)
- │    │    ├── project
- │    │    │    ├── columns: array_agg:66
+ │    │    ├── fd: ()-->(31,68)
+ │    │    ├── sort
+ │    │    │    ├── columns: inhrelid:31 inhparent:32 inhseqno:33 c.oid:36 c.relname:37
  │    │    │    ├── outer: (1)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(66)
- │    │    │    ├── group-by
- │    │    │    │    ├── columns: inhrelid:31 array_agg:68
- │    │    │    │    ├── internal-ordering: +33 opt(31)
- │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(31,68)
- │    │    │    │    ├── sort
- │    │    │    │    │    ├── columns: inhrelid:31 inhparent:32 inhseqno:33 c.oid:36 c.relname:37
- │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    ├── cardinality: [1 - ]
- │    │    │    │    │    ├── fd: (32)==(36), (36)==(32)
- │    │    │    │    │    ├── ordering: +33 opt(31) [actual: +33]
- │    │    │    │    │    └── left-join (cross)
- │    │    │    │    │         ├── columns: inhrelid:31 inhparent:32 inhseqno:33 c.oid:36 c.relname:37
- │    │    │    │    │         ├── outer: (1)
- │    │    │    │    │         ├── cardinality: [1 - ]
- │    │    │    │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
- │    │    │    │    │         ├── fd: (32)==(36), (36)==(32)
- │    │    │    │    │         ├── values
- │    │    │    │    │         │    ├── cardinality: [1 - 1]
- │    │    │    │    │         │    ├── key: ()
- │    │    │    │    │         │    └── ()
- │    │    │    │    │         ├── inner-join (hash)
- │    │    │    │    │         │    ├── columns: inhrelid:31 inhparent:32!null inhseqno:33 c.oid:36!null c.relname:37!null
- │    │    │    │    │         │    ├── fd: (32)==(36), (36)==(32)
- │    │    │    │    │         │    ├── scan pg_inherits [as=i]
- │    │    │    │    │         │    │    └── columns: inhrelid:31 inhparent:32 inhseqno:33
- │    │    │    │    │         │    ├── scan pg_class [as=c]
- │    │    │    │    │         │    │    └── columns: c.oid:36 c.relname:37!null
- │    │    │    │    │         │    └── filters
- │    │    │    │    │         │         └── c.oid:36 = inhparent:32 [outer=(32,36), constraints=(/32: (/NULL - ]; /36: (/NULL - ]), fd=(32)==(36), (36)==(32)]
- │    │    │    │    │         └── filters
- │    │    │    │    │              └── inhrelid:31 = rel.oid:1 [outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │    │    │    │    └── aggregations
- │    │    │    │         ├── array-agg [as=array_agg:68, outer=(37)]
- │    │    │    │         │    └── c.relname:37
- │    │    │    │         └── any-not-null-agg [as=inhrelid:31, outer=(31)]
- │    │    │    │              └── inhrelid:31
- │    │    │    └── projections
- │    │    │         └── CASE WHEN inhrelid:31 IS NOT NULL THEN array_agg:68 ELSE CAST(NULL AS NAME[]) END [as=array_agg:66, outer=(31,68)]
- │    │    ├── values
- │    │    │    ├── columns: array:67
- │    │    │    ├── outer: (66)
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(67)
- │    │    │    └── (COALESCE(array_agg:66, ARRAY[]),)
- │    │    └── filters (true)
+ │    │    │    ├── cardinality: [1 - ]
+ │    │    │    ├── fd: (32)==(36), (36)==(32)
+ │    │    │    ├── ordering: +33 opt(31) [actual: +33]
+ │    │    │    └── left-join (cross)
+ │    │    │         ├── columns: inhrelid:31 inhparent:32 inhseqno:33 c.oid:36 c.relname:37
+ │    │    │         ├── outer: (1)
+ │    │    │         ├── cardinality: [1 - ]
+ │    │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │    │    │         ├── fd: (32)==(36), (36)==(32)
+ │    │    │         ├── values
+ │    │    │         │    ├── cardinality: [1 - 1]
+ │    │    │         │    ├── key: ()
+ │    │    │         │    └── ()
+ │    │    │         ├── inner-join (hash)
+ │    │    │         │    ├── columns: inhrelid:31 inhparent:32!null inhseqno:33 c.oid:36!null c.relname:37!null
+ │    │    │         │    ├── fd: (32)==(36), (36)==(32)
+ │    │    │         │    ├── scan pg_inherits [as=i]
+ │    │    │         │    │    └── columns: inhrelid:31 inhparent:32 inhseqno:33
+ │    │    │         │    ├── scan pg_class [as=c]
+ │    │    │         │    │    └── columns: c.oid:36 c.relname:37!null
+ │    │    │         │    └── filters
+ │    │    │         │         └── c.oid:36 = inhparent:32 [outer=(32,36), constraints=(/32: (/NULL - ]; /36: (/NULL - ]), fd=(32)==(36), (36)==(32)]
+ │    │    │         └── filters
+ │    │    │              └── inhrelid:31 = rel.oid:1 [outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+ │    │    └── aggregations
+ │    │         ├── array-agg [as=array_agg:68, outer=(37)]
+ │    │         │    └── c.relname:37
+ │    │         └── any-not-null-agg [as=inhrelid:31, outer=(31)]
+ │    │              └── inhrelid:31
  │    └── filters (true)
  └── projections
-      └── array:67 [as=array:69, outer=(67)]
+      └── COALESCE(CASE WHEN inhrelid:31 IS NOT NULL THEN array_agg:68 ELSE CAST(NULL AS NAME[]) END, ARRAY[]) [as=array:69, outer=(31,68)]
 
 # --------------------------------------------------
 # SimplifySameVarEqualities

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -75,59 +75,27 @@ values
 norm format=show-all expect=InlineWith
 WITH foo AS (SELECT 1) SELECT * FROM foo CROSS JOIN (VALUES (2))
 ----
-inner-join (cross)
+values
  ├── columns: "?column?":2(int!null) column1:3(int!null)
  ├── cardinality: [1 - 1]
- ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  ├── stats: [rows=1]
- ├── cost: 0.09
+ ├── cost: 0.02
  ├── key: ()
  ├── fd: ()-->(2,3)
  ├── prune: (2,3)
- ├── values
- │    ├── columns: "?column?":2(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
- │    ├── cost: 0.02
- │    ├── key: ()
- │    ├── fd: ()-->(2)
- │    ├── prune: (2)
- │    └── tuple [type=tuple{int}]
- │         └── const: 1 [type=int]
- ├── values
- │    ├── columns: column1:3(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
- │    ├── cost: 0.02
- │    ├── key: ()
- │    ├── fd: ()-->(3)
- │    ├── prune: (3)
- │    └── tuple [type=tuple{int}]
- │         └── const: 2 [type=int]
- └── filters (true)
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
 
 norm expect=InlineWith
 WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT * FROM foo CROSS JOIN bar
 ----
-inner-join (cross)
+values
  ├── columns: "?column?":3!null "?column?":4!null
  ├── cardinality: [1 - 1]
- ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  ├── key: ()
  ├── fd: ()-->(3,4)
- ├── values
- │    ├── columns: "?column?":3!null
- │    ├── cardinality: [1 - 1]
- │    ├── key: ()
- │    ├── fd: ()-->(3)
- │    └── (1,)
- ├── values
- │    ├── columns: "?column?":4!null
- │    ├── cardinality: [1 - 1]
- │    ├── key: ()
- │    ├── fd: ()-->(4)
- │    └── (2,)
- └── filters (true)
+ └── (1, 2)
 
 # Descend into scalar expressions.
 


### PR DESCRIPTION
This commit adds an optimizer normalization rule that transforms
inner joins with single-row `Values` into a projection, for
decorrelating subqueries that only reference variables from the outer
query.
    
It also adds the optgen helper `MakeProjectionsFromValues` to convert a
single-row `Values` into `Projections`.
    
Release note (performance improvement): The optimizer now converts
inner joins with single-row values expressions into projections. This
allows decorrelation of subqueries that only reference variables from
the outer query, such as `SELECT (SELECT value + 10) FROM table`.

Resolves #45853.

I would appreciate an extra pair of eyes on the new test case plans - the changes appear to make sense to me, but I'm not too familiar with the query engine just yet.