### PR TITLE
build: increase logictest stress timeout to 2h

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -19,6 +19,7 @@ env=(
   "GOFLAGS=${GOFLAGS:-}"
   "TAGS=${TAGS:-}"
   "STRESSFLAGS=${STRESSFLAGS:-}"
+  "TESTTIMEOUT=${TESTTIMEOUT:-}"
   "TZ=America/New_York"
 )
 
@@ -47,7 +48,7 @@ go install ./pkg/cmd/github-post
 # are test failures.
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 if ! stdbuf -oL -eL \
-  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-stderr $STRESSFLAGS" 2>&1 \
+  make stress PKG="$PKG" TESTTIMEOUT="$TESTTIMEOUT" GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
   exit_status=${PIPESTATUS[0]}
   go tool test2json -t -p "${PKG}" < artifacts/stress.log | github-post

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -67,6 +67,9 @@ func runTC(queueBuild func(string, map[string]string)) {
 		// By default, fail the stress run on the first test failure.
 		maxFails := 1
 
+		// By default, a single test times out after 40 minutes.
+		testTimeout := 40 * time.Minute
+
 		// The stress program by default runs as many instances in parallel as there
 		// are CPUs. Each instance itself can run tests in parallel. The amount of
 		// parallelism needs to be reduced, or we can run into OOM issues,
@@ -87,11 +90,16 @@ func runTC(queueBuild func(string, map[string]string)) {
 			// Stress logic tests with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2
+			// Increase logic test timeout.
+			testTimeout = 2 * time.Hour
+			maxTime = 3 * time.Hour
 		}
 
 		opts := map[string]string{
 			"env.PKG": importPath,
 		}
+
+		opts["env.TESTTIMEOUT"] = testTimeout.String()
 
 		// Run non-race build.
 		opts["env.GOFLAGS"] = fmt.Sprintf("-parallel=%d", parallelism)

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -66,24 +66,30 @@ func Example_runTC() {
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
+	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
 	//   env.GOFLAGS:     -race -parallel=2
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 2
+	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
 	//   env.GOFLAGS:     -parallel=2
-	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 2
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 3h0m0s -maxfails 1 -p 2
+	//   env.TESTTIMEOUT: 2h0m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
 	//   env.GOFLAGS:     -race -parallel=1
-	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 1
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 3h0m0s -maxfails 1 -p 1
+	//   env.TESTTIMEOUT: 2h0m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 4
+	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage
 	//   env.GOFLAGS:     -race -parallel=2
 	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 2
+	//   env.TESTTIMEOUT: 40m0s
 }


### PR DESCRIPTION
The default 40 minutes timeout is not enough.

Release note: None (testing change)

Closes #53729

cc @yuzefovich 