### PR TITLE
storage: rename Iterator to MVCCIterator

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -125,7 +125,7 @@ func loadTestData(
 func runIterate(
 	b *testing.B,
 	loadFactor float32,
-	makeIterator func(storage.Engine, hlc.Timestamp, hlc.Timestamp) storage.Iterator,
+	makeIterator func(storage.Engine, hlc.Timestamp, hlc.Timestamp) storage.MVCCIterator,
 ) {
 	const numKeys = 100000
 	const numBatches = 100
@@ -173,12 +173,12 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 	for _, loadFactor := range []float32{1.0, 0.5, 0.1, 0.05, 0.0} {
 		b.Run(fmt.Sprintf("LoadFactor=%.2f", loadFactor), func(b *testing.B) {
 			b.Run("NormalIterator", func(b *testing.B) {
-				runIterate(b, loadFactor, func(e storage.Engine, _, _ hlc.Timestamp) storage.Iterator {
+				runIterate(b, loadFactor, func(e storage.Engine, _, _ hlc.Timestamp) storage.MVCCIterator {
 					return e.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
 				})
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
-				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) storage.Iterator {
+				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) storage.MVCCIterator {
 					return e.NewIterator(storage.IterOptions{
 						MinTimestampHint: startTime,
 						MaxTimestampHint: endTime,

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -142,7 +142,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	}
 	defer cArgs.EvalCtx.GetLimiters().ConcurrentImportRequests.Finish()
 
-	var iters []storage.SimpleIterator
+	var iters []storage.SimpleMVCCIterator
 	for _, file := range args.Files {
 		log.VEventf(ctx, 2, "import file %s %s", file.Path, args.Key)
 

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -112,10 +112,10 @@ func clearExistingData(
 	}
 
 	log.Eventf(ctx, "target key range not empty, will clear existing data: %+v", existingStats)
-	// If this is a Iterator, we have to unwrap it because
+	// If this is a MVCCIterator, we have to unwrap it because
 	// ClearIterRange needs a plain rocksdb iterator (and can't unwrap
 	// it itself because of import cycles).
-	if ssi, ok := iter.(*spanset.Iterator); ok {
+	if ssi, ok := iter.(*spanset.MVCCIterator); ok {
 		iter = ssi.Iterator()
 	}
 	// TODO(dan): Ideally, this would use `batch.ClearRange` but it doesn't

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -476,7 +476,7 @@ func createSplitSSTable(
 	db SSTSender,
 	start, splitKey roachpb.Key,
 	disallowShadowing bool,
-	iter storage.SimpleIterator,
+	iter storage.SimpleMVCCIterator,
 	settings *cluster.Settings,
 ) (*sstSpan, *sstSpan, error) {
 	sstFile := &storage.MemFile{}

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -181,7 +181,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		iter := batch.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 
-		// Iterators check boundaries on seek and next/prev
+		// MVCCIterators check boundaries on seek and next/prev
 		iter.SeekGE(outsideKey)
 		if _, err := iter.Valid(); !isReadSpanErr(err) {
 			t.Fatalf("Seek: unexpected error %v", err)

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -32,7 +32,7 @@ type instrumentedEngine struct {
 	// ... can be extended ...
 }
 
-func (ie *instrumentedEngine) NewIterator(opts storage.IterOptions) storage.Iterator {
+func (ie *instrumentedEngine) NewIterator(opts storage.IterOptions) storage.MVCCIterator {
 	if ie.onNewIterator != nil {
 		ie.onNewIterator(opts)
 	}

--- a/pkg/kv/kvserver/below_raft_protos_test.go
+++ b/pkg/kv/kvserver/below_raft_protos_test.go
@@ -113,7 +113,7 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 
 func init() {
 	// These are marshaled below Raft by the Pebble merge operator. The Pebble
-	// merge operator can be called below Raft whenever a Pebble Iterator is
+	// merge operator can be called below Raft whenever a Pebble MVCCIterator is
 	// used.
 	belowRaftGoldenProtos[reflect.TypeOf(&roachpb.InternalTimeSeriesData{})] = fixture{
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -179,7 +179,7 @@ func NewProcessor(cfg Config) *Processor {
 
 // IteratorConstructor is used to construct an iterator. It should be called
 // from underneath a stopper task to ensure that the engine has not been closed.
-type IteratorConstructor func() storage.SimpleIterator
+type IteratorConstructor func() storage.SimpleMVCCIterator
 
 // Start launches a goroutine to process rangefeed events and send them to
 // registrations.

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -134,7 +134,7 @@ func rangeFeedCheckpoint(span roachpb.Span, ts hlc.Timestamp) *roachpb.RangeFeed
 const testProcessorEventCCap = 16
 
 func newTestProcessorWithTxnPusher(
-	rtsIter storage.SimpleIterator, txnPusher TxnPusher,
+	rtsIter storage.SimpleMVCCIterator, txnPusher TxnPusher,
 ) (*Processor, *stop.Stopper) {
 	stopper := stop.NewStopper()
 
@@ -158,14 +158,14 @@ func newTestProcessorWithTxnPusher(
 	return p, stopper
 }
 
-func makeIteratorConstructor(rtsIter storage.SimpleIterator) IteratorConstructor {
+func makeIteratorConstructor(rtsIter storage.SimpleMVCCIterator) IteratorConstructor {
 	if rtsIter == nil {
 		return nil
 	}
-	return func() storage.SimpleIterator { return rtsIter }
+	return func() storage.SimpleMVCCIterator { return rtsIter }
 }
 
-func newTestProcessor(rtsIter storage.SimpleIterator) (*Processor, *stop.Stopper) {
+func newTestProcessor(rtsIter storage.SimpleMVCCIterator) (*Processor, *stop.Stopper) {
 	return newTestProcessorWithTxnPusher(rtsIter, nil /* pusher */)
 }
 

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -55,7 +55,7 @@ type registration struct {
 	// Input.
 	span                   roachpb.Span
 	catchupTimestamp       hlc.Timestamp
-	catchupIterConstructor func() storage.SimpleIterator
+	catchupIterConstructor func() storage.SimpleMVCCIterator
 	withDiff               bool
 	metrics                *Metrics
 
@@ -86,7 +86,7 @@ type registration struct {
 func newRegistration(
 	span roachpb.Span,
 	startTS hlc.Timestamp,
-	catchupIterConstructor func() storage.SimpleIterator,
+	catchupIterConstructor func() storage.SimpleMVCCIterator,
 	withDiff bool,
 	bufferSz int,
 	metrics *Metrics,
@@ -295,7 +295,7 @@ func (r *registration) maybeRunCatchupScan() error {
 	startKey := storage.MakeMVCCMetadataKey(r.span.Key)
 	endKey := storage.MakeMVCCMetadataKey(r.span.EndKey)
 
-	// Iterator will encounter historical values for each key in
+	// MVCCIterator will encounter historical values for each key in
 	// reverse-chronological order. To output in chronological order, store
 	// events for the same key until a different key is encountered, then output
 	// the encountered values in reverse. This also allows us to buffer events

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -96,7 +96,7 @@ type testRegistration struct {
 }
 
 func newTestRegistration(
-	span roachpb.Span, ts hlc.Timestamp, catchup storage.SimpleIterator, withDiff bool,
+	span roachpb.Span, ts hlc.Timestamp, catchup storage.SimpleMVCCIterator, withDiff bool,
 ) *testRegistration {
 	s := newTestStream()
 	errC := make(chan *roachpb.Error, 1)

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -37,8 +37,8 @@ type runnable interface {
 // The Processor can initialize its resolvedTimestamp once the scan completes
 // because it knows it is now tracking all intents in its key range.
 //
-// Iterator Contract:
-//   The provided Iterator must observe all intents in the Processor's keyspan.
+// MVCCIterator Contract:
+//   The provided MVCCIterator must observe all intents in the Processor's keyspan.
 //   An important implication of this is that if the iterator is a
 //   TimeBoundIterator, its MinTimestamp cannot be above the keyspan's largest
 //   known resolved timestamp, if one has ever been recorded. If one has never
@@ -46,10 +46,10 @@ type runnable interface {
 //
 type initResolvedTSScan struct {
 	p  *Processor
-	it storage.SimpleIterator
+	it storage.SimpleMVCCIterator
 }
 
-func newInitResolvedTSScan(p *Processor, it storage.SimpleIterator) runnable {
+func newInitResolvedTSScan(p *Processor, it storage.SimpleMVCCIterator) runnable {
 	return &initResolvedTSScan{p: p, it: it}
 }
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -27,7 +27,7 @@ type KeyRange struct {
 // The ranges keyRange slice specifies the key ranges which comprise
 // all of the range's data.
 //
-// A ReplicaDataIterator provides a subset of the engine.Iterator interface.
+// A ReplicaDataIterator provides a subset of the engine.MVCCIterator interface.
 //
 // TODO(tschottdorf): the API is awkward. By default, ReplicaDataIterator uses
 // a byte allocator which needs to be reset manually using `ResetAllocator`.
@@ -37,7 +37,7 @@ type KeyRange struct {
 type ReplicaDataIterator struct {
 	curIndex int
 	ranges   []KeyRange
-	it       storage.Iterator
+	it       storage.MVCCIterator
 	a        bufalloc.ByteAllocator
 }
 

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -18,10 +18,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
-// Iterator wraps an engine.Iterator and ensures that it can
+// MVCCIterator wraps an engine.MVCCIterator and ensures that it can
 // only be used to access spans in a SpanSet.
-type Iterator struct {
-	i     storage.Iterator
+type MVCCIterator struct {
+	i     storage.MVCCIterator
 	spans *SpanSet
 
 	// spansOnly controls whether or not timestamps associated with the
@@ -40,34 +40,33 @@ type Iterator struct {
 	invalid bool
 }
 
-var _ storage.Iterator = &Iterator{}
-var _ storage.MVCCIterator = &Iterator{}
+var _ storage.MVCCIterator = &MVCCIterator{}
 
 // NewIterator constructs an iterator that verifies access of the underlying
 // iterator against the given SpanSet. Timestamps associated with the spans
 // in the spanset are not considered, only the span boundaries are checked.
-func NewIterator(iter storage.Iterator, spans *SpanSet) *Iterator {
-	return &Iterator{i: iter, spans: spans, spansOnly: true}
+func NewIterator(iter storage.MVCCIterator, spans *SpanSet) *MVCCIterator {
+	return &MVCCIterator{i: iter, spans: spans, spansOnly: true}
 }
 
 // NewIteratorAt constructs an iterator that verifies access of the underlying
 // iterator against the given SpanSet at the given timestamp.
-func NewIteratorAt(iter storage.Iterator, spans *SpanSet, ts hlc.Timestamp) *Iterator {
-	return &Iterator{i: iter, spans: spans, ts: ts}
+func NewIteratorAt(iter storage.MVCCIterator, spans *SpanSet, ts hlc.Timestamp) *MVCCIterator {
+	return &MVCCIterator{i: iter, spans: spans, ts: ts}
 }
 
-// Close is part of the engine.Iterator interface.
-func (i *Iterator) Close() {
+// Close is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Close() {
 	i.i.Close()
 }
 
-// Iterator returns the underlying engine.Iterator.
-func (i *Iterator) Iterator() storage.Iterator {
+// Iterator returns the underlying engine.MVCCIterator.
+func (i *MVCCIterator) Iterator() storage.MVCCIterator {
 	return i.i
 }
 
-// Valid is part of the engine.Iterator interface.
-func (i *Iterator) Valid() (bool, error) {
+// Valid is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Valid() (bool, error) {
 	if i.err != nil {
 		return false, i.err
 	}
@@ -78,39 +77,39 @@ func (i *Iterator) Valid() (bool, error) {
 	return ok && !i.invalid, nil
 }
 
-// SeekGE is part of the engine.Iterator interface.
-func (i *Iterator) SeekGE(key storage.MVCCKey) {
+// SeekGE is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) SeekGE(key storage.MVCCKey) {
 	i.i.SeekGE(key)
 	i.checkAllowed(roachpb.Span{Key: key.Key}, true)
 }
 
-// SeekLT is part of the engine.Iterator interface.
-func (i *Iterator) SeekLT(key storage.MVCCKey) {
+// SeekLT is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) SeekLT(key storage.MVCCKey) {
 	i.i.SeekLT(key)
 	// CheckAllowed{At} supports the span representation of [,key), which
 	// corresponds to the span [key.Prev(),).
 	i.checkAllowed(roachpb.Span{EndKey: key.Key}, true)
 }
 
-// Next is part of the engine.Iterator interface.
-func (i *Iterator) Next() {
+// Next is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Next() {
 	i.i.Next()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
 }
 
-// Prev is part of the engine.Iterator interface.
-func (i *Iterator) Prev() {
+// Prev is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Prev() {
 	i.i.Prev()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
 }
 
-// NextKey is part of the engine.Iterator interface.
-func (i *Iterator) NextKey() {
+// NextKey is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) NextKey() {
 	i.i.NextKey()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
 }
 
-func (i *Iterator) checkAllowed(span roachpb.Span, errIfDisallowed bool) {
+func (i *MVCCIterator) checkAllowed(span roachpb.Span, errIfDisallowed bool) {
 	i.invalid = false
 	i.err = nil
 	if ok, _ := i.i.Valid(); !ok {
@@ -132,38 +131,38 @@ func (i *Iterator) checkAllowed(span roachpb.Span, errIfDisallowed bool) {
 	}
 }
 
-// Key is part of the engine.Iterator interface.
-func (i *Iterator) Key() storage.MVCCKey {
+// Key is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Key() storage.MVCCKey {
 	return i.i.Key()
 }
 
-// Value is part of the engine.Iterator interface.
-func (i *Iterator) Value() []byte {
+// Value is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Value() []byte {
 	return i.i.Value()
 }
 
-// ValueProto is part of the engine.Iterator interface.
-func (i *Iterator) ValueProto(msg protoutil.Message) error {
+// ValueProto is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) ValueProto(msg protoutil.Message) error {
 	return i.i.ValueProto(msg)
 }
 
-// UnsafeKey is part of the engine.Iterator interface.
-func (i *Iterator) UnsafeKey() storage.MVCCKey {
+// UnsafeKey is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) UnsafeKey() storage.MVCCKey {
 	return i.i.UnsafeKey()
 }
 
-// UnsafeRawKey is part of the engine.Iterator interface.
-func (i *Iterator) UnsafeRawKey() []byte {
+// UnsafeRawKey is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) UnsafeRawKey() []byte {
 	return i.i.UnsafeRawKey()
 }
 
-// UnsafeValue is part of the engine.Iterator interface.
-func (i *Iterator) UnsafeValue() []byte {
+// UnsafeValue is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
 }
 
-// ComputeStats is part of the engine.Iterator interface.
-func (i *Iterator) ComputeStats(
+// ComputeStats is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	if i.spansOnly {
@@ -178,8 +177,8 @@ func (i *Iterator) ComputeStats(
 	return i.i.ComputeStats(start, end, nowNanos)
 }
 
-// FindSplitKey is part of the engine.Iterator interface.
-func (i *Iterator) FindSplitKey(
+// FindSplitKey is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) FindSplitKey(
 	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (storage.MVCCKey, error) {
 	if i.spansOnly {
@@ -194,66 +193,26 @@ func (i *Iterator) FindSplitKey(
 	return i.i.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
-// CheckForKeyCollisions is part of the engine.Iterator interface.
-func (i *Iterator) CheckForKeyCollisions(
+// CheckForKeyCollisions is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) CheckForKeyCollisions(
 	sstData []byte, start, end roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	return i.i.CheckForKeyCollisions(sstData, start, end)
 }
 
-// SetUpperBound is part of the engine.Iterator interface.
-func (i *Iterator) SetUpperBound(key roachpb.Key) {
+// SetUpperBound is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) SetUpperBound(key roachpb.Key) {
 	i.i.SetUpperBound(key)
 }
 
-// Stats is part of the engine.Iterator interface.
-func (i *Iterator) Stats() storage.IteratorStats {
+// Stats is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) Stats() storage.IteratorStats {
 	return i.i.Stats()
 }
 
-// SupportsPrev is part of the engine.Iterator interface.
-func (i *Iterator) SupportsPrev() bool {
+// SupportsPrev is part of the engine.MVCCIterator interface.
+func (i *MVCCIterator) SupportsPrev() bool {
 	return i.i.SupportsPrev()
-}
-
-// MVCCOpsSpecialized is part of the engine.MVCCIterator interface.
-func (i *Iterator) MVCCOpsSpecialized() bool {
-	if mvccIt, ok := i.i.(storage.MVCCIterator); ok {
-		return mvccIt.MVCCOpsSpecialized()
-	}
-	return false
-}
-
-// MVCCGet is part of the engine.MVCCIterator interface.
-func (i *Iterator) MVCCGet(
-	key roachpb.Key, timestamp hlc.Timestamp, opts storage.MVCCGetOptions,
-) (*roachpb.Value, *roachpb.Intent, error) {
-	if i.spansOnly {
-		if err := i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key}); err != nil {
-			return nil, nil, err
-		}
-	} else {
-		if err := i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: key}, timestamp); err != nil {
-			return nil, nil, err
-		}
-	}
-	return i.i.(storage.MVCCIterator).MVCCGet(key, timestamp, opts)
-}
-
-// MVCCScan is part of the engine.MVCCIterator interface.
-func (i *Iterator) MVCCScan(
-	start, end roachpb.Key, timestamp hlc.Timestamp, opts storage.MVCCScanOptions,
-) (storage.MVCCScanResult, error) {
-	if i.spansOnly {
-		if err := i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
-			return storage.MVCCScanResult{}, err
-		}
-	} else {
-		if err := i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}, timestamp); err != nil {
-			return storage.MVCCScanResult{}, err
-		}
-	}
-	return i.i.(storage.MVCCIterator).MVCCScan(start, end, timestamp, opts)
 }
 
 type spanSetReader struct {
@@ -328,7 +287,7 @@ func (s spanSetReader) Iterate(start, end roachpb.Key, f func(storage.MVCCKeyVal
 	return s.r.Iterate(start, end, f)
 }
 
-func (s spanSetReader) NewIterator(opts storage.IterOptions) storage.Iterator {
+func (s spanSetReader) NewIterator(opts storage.IterOptions) storage.MVCCIterator {
 	if s.spansOnly {
 		return NewIterator(s.r.NewIterator(opts), s.spans)
 	}
@@ -411,7 +370,7 @@ func (s spanSetWriter) ClearRange(start, end storage.MVCCKey) error {
 	return s.w.ClearRange(start, end)
 }
 
-func (s spanSetWriter) ClearIterRange(iter storage.Iterator, start, end roachpb.Key) error {
+func (s spanSetWriter) ClearIterRange(iter storage.MVCCIterator, start, end roachpb.Key) error {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: start, EndKey: end}); err != nil {
 			return err

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1346,7 +1346,7 @@ func IterateRangeDescriptors(
 	ctx context.Context, reader storage.Reader, fn func(desc roachpb.RangeDescriptor) error,
 ) error {
 	log.Event(ctx, "beginning range descriptor iteration")
-	// Iterator over all range-local key-based data.
+	// MVCCIterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -36,10 +36,10 @@ func init() {
 	_ = DefaultStorageEngine.Set(envutil.EnvOrDefaultString("COCKROACH_STORAGE_ENGINE", "pebble"))
 }
 
-// SimpleIterator is an interface for iterating over key/value pairs in an
-// engine. SimpleIterator implementations are thread safe unless otherwise
-// noted. SimpleIterator is a subset of the functionality offered by Iterator.
-type SimpleIterator interface {
+// SimpleMVCCIterator is an interface for iterating over key/value pairs in an
+// engine. SimpleMVCCIterator implementations are thread safe unless otherwise
+// noted. SimpleMVCCIterator is a subset of the functionality offered by MVCCIterator.
+type SimpleMVCCIterator interface {
 	// Close frees up resources held by the iterator.
 	Close()
 	// SeekGE advances the iterator to the first key in the engine which
@@ -70,17 +70,21 @@ type SimpleIterator interface {
 	UnsafeValue() []byte
 }
 
-// IteratorStats is returned from (Iterator).Stats.
+// IteratorStats is returned from (MVCCIterator).Stats.
 type IteratorStats struct {
 	InternalDeleteSkippedCount int
 	TimeBoundNumSSTs           int
 }
 
-// Iterator is an interface for iterating over key/value pairs in an
-// engine. Iterator implementations are thread safe unless otherwise
-// noted.
-type Iterator interface {
-	SimpleIterator
+// MVCCIterator is an interface for iterating over key/value pairs in an
+// engine. It is used for iterating over the key space that can have multiple
+// versions, and if often also used (due to historical reasons) for iterating
+// over the key space that never has multiple versions (i.e.,
+// MVCCKey.Timestamp == hlc.Timestamp{}).
+//
+// MVCCIterator implementations are thread safe unless otherwise noted.
+type MVCCIterator interface {
+	SimpleMVCCIterator
 
 	// SeekLT advances the iterator to the first key in the engine which
 	// is < the provided key.
@@ -111,7 +115,7 @@ type Iterator interface {
 	// chosen from the key ranges listed in keys.NoSplitSpans and will always
 	// sort equal to or after minSplitKey.
 	//
-	// DO NOT CALL directly (except in wrapper Iterator implementations). Use the
+	// DO NOT CALL directly (except in wrapper MVCCIterator implementations). Use the
 	// package-level MVCCFindSplitKey instead. For correct operation, the caller
 	// must set the upper bound on the iterator before calling this method.
 	FindSplitKey(start, end, minSplitKey roachpb.Key, targetSize int64) (MVCCKey, error)
@@ -123,7 +127,7 @@ type Iterator interface {
 	SetUpperBound(roachpb.Key)
 	// Stats returns statistics about the iterator.
 	Stats() IteratorStats
-	// SupportsPrev returns true if Iterator implementation supports reverse
+	// SupportsPrev returns true if MVCCIterator implementation supports reverse
 	// iteration with Prev() or SeekLT().
 	SupportsPrev() bool
 }
@@ -166,33 +170,9 @@ type EngineIterator interface {
 	SetUpperBound(roachpb.Key)
 }
 
-// MVCCIterator is an interface that extends Iterator and provides concrete
-// implementations for MVCCGet and MVCCScan operations. It is used by instances
-// of the interface backed by RocksDB iterators to avoid cgo hops.
-type MVCCIterator interface {
-	Iterator
-	// MVCCOpsSpecialized returns whether the iterator has a specialized
-	// implementation of MVCCGet and MVCCScan. This is exposed as a method
-	// so that wrapper types can defer to their wrapped iterators.
-	MVCCOpsSpecialized() bool
-	// MVCCGet is the internal implementation of the family of package-level
-	// MVCCGet functions.
-	MVCCGet(
-		key roachpb.Key, timestamp hlc.Timestamp, opts MVCCGetOptions,
-	) (*roachpb.Value, *roachpb.Intent, error)
-	// MVCCScan is the internal implementation of the family of package-level
-	// MVCCScan functions. The notable difference is that key/value pairs are
-	// returned raw, as a series of buffers of length-prefixed slices,
-	// alternating from key to value, where numKVs specifies the number of pairs
-	// in the buffer.
-	MVCCScan(
-		start, end roachpb.Key, timestamp hlc.Timestamp, opts MVCCScanOptions,
-	) (MVCCScanResult, error)
-}
-
-// IterOptions contains options used to create an Iterator.
+// IterOptions contains options used to create an MVCCIterator.
 //
-// For performance, every Iterator must specify either Prefix or UpperBound.
+// For performance, every MVCCIterator must specify either Prefix or UpperBound.
 type IterOptions struct {
 	// If Prefix is true, Seek will use the user-key prefix of
 	// the supplied MVCC key to restrict which sstables are searched,
@@ -267,7 +247,7 @@ type Reader interface {
 	// key was not found. On success, returns the length in bytes of the
 	// key and the value.
 	//
-	// Deprecated: use Iterator.ValueProto instead.
+	// Deprecated: use MVCCIterator.ValueProto instead.
 	GetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// Iterate scans from the start key to the end key (exclusive), invoking the
 	// function f on each key value pair. If f returns an error or if the scan
@@ -277,10 +257,10 @@ type Reader interface {
 	// timestamp of the end key; all MVCCKeys at end.Key are considered excluded
 	// in the iteration.
 	Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error
-	// NewIterator returns a new instance of an Iterator over this
-	// engine. The caller must invoke Iterator.Close() when finished
+	// NewIterator returns a new instance of an MVCCIterator over this
+	// engine. The caller must invoke MVCCIterator.Close() when finished
 	// with the iterator to free resources.
-	NewIterator(opts IterOptions) Iterator
+	NewIterator(opts IterOptions) MVCCIterator
 }
 
 // Writer is the write interface to an engine's data.
@@ -333,7 +313,7 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after ClearIterRange
 	// returns.
-	ClearIterRange(iter Iterator, start, end roachpb.Key) error
+	ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"
@@ -422,7 +402,7 @@ type Engine interface {
 	//
 	// TODO(nvanbenschoten): remove this complexity when we're fully on Pebble
 	// and can guarantee that all iterators created from a read-only engine are
-	// consistent. To do this, we will want to add an Iterator.Clone method.
+	// consistent. To do this, we will want to add an MVCCIterator.Clone method.
 	NewReadOnly() ReadWriter
 	// NewWriteOnlyBatch returns a new instance of a batched engine which wraps
 	// this engine. A write-only batch accumulates all mutations and applies them

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -158,7 +158,7 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				// Iterator should not reuse its cached result.
+				// MVCCIterator should not reuse its cached result.
 				iter.SeekGE(key)
 
 				if ok, err := iter.Valid(); err != nil {
@@ -629,7 +629,7 @@ func TestEngineTimeBound(t *testing.T) {
 			batch := engine.NewBatch()
 			defer batch.Close()
 
-			check := func(t *testing.T, tbi Iterator, keys, ssts int) {
+			check := func(t *testing.T, tbi MVCCIterator, keys, ssts int) {
 				defer tbi.Close()
 				tbi.SeekGE(NilKey)
 
@@ -656,7 +656,7 @@ func TestEngineTimeBound(t *testing.T) {
 			}
 
 			testCases := []struct {
-				iter       Iterator
+				iter       MVCCIterator
 				keys, ssts int
 			}{
 				// Completely to the right, not touching.

--- a/pkg/storage/metamorphic/operands.go
+++ b/pkg/storage/metamorphic/operands.go
@@ -379,7 +379,7 @@ func (w *readWriterGenerator) closeAll() {
 type iteratorID string
 type iteratorInfo struct {
 	id          iteratorID
-	iter        storage.Iterator
+	iter        storage.MVCCIterator
 	lowerBound  roachpb.Key
 	isBatchIter bool
 }

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -138,7 +138,7 @@ func generateMVCCScan(
 }
 
 // Prints the key where an iterator is positioned, or valid = false if invalid.
-func printIterState(iter storage.Iterator) string {
+func printIterState(iter storage.MVCCIterator) string {
 	if ok, err := iter.Valid(); !ok || err != nil {
 		if err != nil {
 			return fmt.Sprintf("valid = %v, err = %s", ok, err.Error())

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -18,9 +18,9 @@ import (
 
 const invalidIdxSentinel = -1
 
-// multiIterator multiplexes iteration over a number of Iterators.
+// multiIterator multiplexes iteration over a number of SimpleMVCCIterators.
 type multiIterator struct {
-	iters []SimpleIterator
+	iters []SimpleMVCCIterator
 	// The index into `iters` of the iterator currently being pointed at.
 	currentIdx int
 	// The indexes of every iterator with the same key as the one in currentIdx.
@@ -35,16 +35,16 @@ type multiIterator struct {
 	err error
 }
 
-var _ SimpleIterator = &multiIterator{}
+var _ SimpleMVCCIterator = &multiIterator{}
 
 // MakeMultiIterator creates an iterator that multiplexes
-// SimpleIterators. The caller is responsible for closing the passed
+// SimpleMVCCIterators. The caller is responsible for closing the passed
 // iterators after closing the returned multiIterator.
 //
 // If two iterators have an entry with exactly the same key and timestamp, the
 // one with a higher index in this constructor arg is preferred. The other is
 // skipped.
-func MakeMultiIterator(iters []SimpleIterator) SimpleIterator {
+func MakeMultiIterator(iters []SimpleMVCCIterator) SimpleMVCCIterator {
 	return &multiIterator{
 		iters:                        iters,
 		currentIdx:                   invalidIdxSentinel,

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -79,7 +79,7 @@ func TestMultiIterator(t *testing.T) {
 	for _, test := range tests {
 		name := fmt.Sprintf("%q", test.inputs)
 		t.Run(name, func(t *testing.T) {
-			var iters []SimpleIterator
+			var iters []SimpleMVCCIterator
 			for _, input := range test.inputs {
 				batch := pebble.NewBatch()
 				defer batch.Close()
@@ -112,10 +112,10 @@ func TestMultiIterator(t *testing.T) {
 			subtests := []struct {
 				name     string
 				expected string
-				fn       func(SimpleIterator)
+				fn       func(SimpleMVCCIterator)
 			}{
-				{"NextKey", test.expectedNextKey, (SimpleIterator).NextKey},
-				{"Next", test.expectedNext, (SimpleIterator).Next},
+				{"NextKey", test.expectedNextKey, (SimpleMVCCIterator).NextKey},
+				{"Next", test.expectedNext, (SimpleMVCCIterator).Next},
 			}
 			for _, subtest := range subtests {
 				t.Run(subtest.name, func(t *testing.T) {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -814,7 +814,11 @@ func MVCCGet(
 }
 
 func mvccGet(
-	ctx context.Context, iter Iterator, key roachpb.Key, timestamp hlc.Timestamp, opts MVCCGetOptions,
+	ctx context.Context,
+	iter MVCCIterator,
+	key roachpb.Key,
+	timestamp hlc.Timestamp,
+	opts MVCCGetOptions,
 ) (value *roachpb.Value, intent *roachpb.Intent, err error) {
 	if len(key) == 0 {
 		return nil, nil, emptyKeyError()
@@ -824,11 +828,6 @@ func mvccGet(
 	}
 	if err := opts.validate(); err != nil {
 		return nil, nil, err
-	}
-
-	// If the iterator has a specialized implementation, defer to that.
-	if mvccIter, ok := iter.(MVCCIterator); ok && mvccIter.MVCCOpsSpecialized() {
-		return mvccIter.MVCCGet(key, timestamp, opts)
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
@@ -922,7 +921,7 @@ func MVCCGetAsTxn(
 // used by the Blind{Put,ConditionalPut} operations to avoid seeking when the
 // metadata is known not to exist.
 func mvccGetMetadata(
-	iter Iterator, metaKey MVCCKey, meta *enginepb.MVCCMetadata,
+	iter MVCCIterator, metaKey MVCCKey, meta *enginepb.MVCCMetadata,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	if iter == nil {
 		return false, 0, 0, nil
@@ -980,7 +979,7 @@ const (
 // BenchmarkMVCCConditionalPut_RocksDB/Replace.
 func mvccGetInternal(
 	_ context.Context,
-	iter Iterator,
+	iter MVCCIterator,
 	metaKey MVCCKey,
 	timestamp hlc.Timestamp,
 	consistent bool,
@@ -1232,7 +1231,7 @@ func MVCCPut(
 ) error {
 	// If we're not tracking stats for the key and we're writing a non-versioned
 	// key we can utilize a blind put to avoid reading any existing value.
-	var iter Iterator
+	var iter MVCCIterator
 	blind := ms == nil && timestamp == (hlc.Timestamp{})
 	if !blind {
 		iter = rw.NewIterator(IterOptions{Prefix: true})
@@ -1286,13 +1285,13 @@ func MVCCDelete(
 var noValue = roachpb.Value{}
 
 // mvccPutUsingIter sets the value for a specified key using the provided
-// Iterator. The function takes a value and a valueFn, only one of which
+// MVCCIterator. The function takes a value and a valueFn, only one of which
 // should be provided. If the valueFn is nil, value's raw bytes will be set
 // for the key, else the bytes provided by the valueFn will be used.
 func mvccPutUsingIter(
 	ctx context.Context,
 	writer Writer,
-	iter Iterator,
+	iter MVCCIterator,
 	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -1322,7 +1321,7 @@ func mvccPutUsingIter(
 // the result of calling valueFn on the data read at readTS.
 func maybeGetValue(
 	ctx context.Context,
-	iter Iterator,
+	iter MVCCIterator,
 	metaKey MVCCKey,
 	value []byte,
 	exists bool,
@@ -1396,7 +1395,7 @@ func MVCCScanDecodeKeyValues(repr [][]byte, fn func(key MVCCKey, rawBytes []byte
 func replayTransactionalWrite(
 	ctx context.Context,
 	writer Writer,
-	iter Iterator,
+	iter MVCCIterator,
 	meta *enginepb.MVCCMetadata,
 	ms *enginepb.MVCCStats,
 	key roachpb.Key,
@@ -1515,7 +1514,7 @@ func replayTransactionalWrite(
 func mvccPutInternal(
 	ctx context.Context,
 	writer Writer,
-	iter Iterator,
+	iter MVCCIterator,
 	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -2022,7 +2021,7 @@ func MVCCBlindConditionalPut(
 func mvccConditionalPutUsingIter(
 	ctx context.Context,
 	writer Writer,
-	iter Iterator,
+	iter MVCCIterator,
 	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -2097,7 +2096,7 @@ func MVCCBlindInitPut(
 func mvccInitPutUsingIter(
 	ctx context.Context,
 	rw ReadWriter,
-	iter Iterator,
+	iter MVCCIterator,
 	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
@@ -2422,7 +2421,7 @@ func MVCCDeleteRange(
 
 func mvccScanToBytes(
 	ctx context.Context,
-	iter Iterator,
+	iter MVCCIterator,
 	key, endKey roachpb.Key,
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
@@ -2436,11 +2435,6 @@ func mvccScanToBytes(
 	if opts.MaxKeys < 0 || opts.TargetBytes < 0 {
 		resumeSpan := &roachpb.Span{Key: key, EndKey: endKey}
 		return MVCCScanResult{ResumeSpan: resumeSpan}, nil
-	}
-
-	// If the iterator has a specialized implementation, defer to that.
-	if mvccIter, ok := iter.(MVCCIterator); ok && mvccIter.MVCCOpsSpecialized() {
-		return mvccIter.MVCCScan(key, endKey, timestamp, opts)
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
@@ -2485,11 +2479,11 @@ func mvccScanToBytes(
 	return res, nil
 }
 
-// mvccScanToKvs converts the raw key/value pairs returned by Iterator.MVCCScan
+// mvccScanToKvs converts the raw key/value pairs returned by MVCCIterator.MVCCScan
 // into a slice of roachpb.KeyValues.
 func mvccScanToKvs(
 	ctx context.Context,
-	iter Iterator,
+	iter MVCCIterator,
 	key, endKey roachpb.Key,
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
@@ -2792,7 +2786,7 @@ func MVCCResolveWriteIntentUsingIter(
 // unsafeNextVersion positions the iterator at the successor to latestKey. If this value
 // exists and is a version of the same key, returns the UnsafeKey() and UnsafeValue() of that
 // key-value pair along with `true`.
-func unsafeNextVersion(iter Iterator, latestKey MVCCKey) (MVCCKey, []byte, bool, error) {
+func unsafeNextVersion(iter MVCCIterator, latestKey MVCCKey) (MVCCKey, []byte, bool, error) {
 	// Compute the next possible mvcc value for this key.
 	nextKey := latestKey.Next()
 	iter.SeekGE(nextKey)
@@ -2812,7 +2806,7 @@ func unsafeNextVersion(iter Iterator, latestKey MVCCKey) (MVCCKey, []byte, bool,
 func mvccResolveWriteIntent(
 	ctx context.Context,
 	rw ReadWriter,
-	iter Iterator,
+	iter MVCCIterator,
 	ms *enginepb.MVCCStats,
 	intent roachpb.LockUpdate,
 	buf *putBuffer,
@@ -3132,7 +3126,7 @@ func mvccMaybeRewriteIntentHistory(
 // reuse without the callers needing to know the particulars.
 type IterAndBuf struct {
 	buf  *putBuffer
-	iter Iterator
+	iter MVCCIterator
 }
 
 // GetIterAndBuf returns an IterAndBuf for passing into various MVCC* methods.
@@ -3141,7 +3135,7 @@ func GetIterAndBuf(reader Reader, opts IterOptions) IterAndBuf {
 }
 
 // GetBufUsingIter returns an IterAndBuf using the supplied iterator.
-func GetBufUsingIter(iter Iterator) IterAndBuf {
+func GetBufUsingIter(iter MVCCIterator) IterAndBuf {
 	return IterAndBuf{
 		buf:  newPutBuffer(),
 		iter: iter,
@@ -3573,7 +3567,7 @@ func willOverflow(a, b int64) bool {
 // implemented in c++, so iter.ComputeStats will save several cgo calls per kv
 // processed. (Plus, on equal footing, the c++ implementation is slightly
 // faster.) ComputeStatsGo is here for codepaths that have a pure-go
-// implementation of SimpleIterator.
+// implementation of SimpleMVCCIterator.
 //
 // When optional callbacks are specified, they are invoked for each physical
 // key-value pair (i.e. not for implicit meta records), and iteration is aborted
@@ -3583,7 +3577,7 @@ func willOverflow(a, b int64) bool {
 //
 // This implementation must match engine/db.cc:MVCCComputeStatsInternal.
 func ComputeStatsGo(
-	iter SimpleIterator,
+	iter SimpleMVCCIterator,
 	start, end roachpb.Key,
 	nowNanos int64,
 	callbacks ...func(MVCCKey, []byte) error,
@@ -3841,7 +3835,7 @@ func computeCapacity(path string, maxSizeBytes int64) (roachpb.StoreCapacity, er
 // is not considered a collision and we continue iteration from the next key in
 // the existing data.
 func checkForKeyCollisionsGo(
-	existingIter Iterator, sstData []byte, start, end roachpb.Key,
+	existingIter MVCCIterator, sstData []byte, start, end roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	var skippedKVStats enginepb.MVCCStats
 	sstIter, err := NewMemSSTIterator(sstData, false)

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -68,7 +68,7 @@ import (
 // NOTE: This is not used by CockroachDB and has been preserved to serve as an
 // oracle to prove the correctness of the new export logic.
 type MVCCIncrementalIterator struct {
-	iter Iterator
+	iter MVCCIterator
 
 	// A time-bound iterator cannot be used by itself due to a bug in the time-
 	// bound iterator (#28358). This was historically augmented with an iterator
@@ -76,7 +76,7 @@ type MVCCIncrementalIterator struct {
 	// issues remained (#43799), so now the iterator above is the main iterator
 	// the timeBoundIter is used to check if any keys can be skipped by the main
 	// iterator.
-	timeBoundIter Iterator
+	timeBoundIter MVCCIterator
 
 	startTime hlc.Timestamp
 	endTime   hlc.Timestamp
@@ -88,7 +88,7 @@ type MVCCIncrementalIterator struct {
 	meta enginepb.MVCCMetadata
 }
 
-var _ SimpleIterator = &MVCCIncrementalIterator{}
+var _ SimpleMVCCIterator = &MVCCIncrementalIterator{}
 
 // MVCCIncrementalIterOptions bundles options for NewMVCCIncrementalIterator.
 type MVCCIncrementalIterOptions struct {
@@ -110,8 +110,8 @@ type MVCCIncrementalIterOptions struct {
 func NewMVCCIncrementalIterator(
 	reader Reader, opts MVCCIncrementalIterOptions,
 ) *MVCCIncrementalIterator {
-	var iter Iterator
-	var timeBoundIter Iterator
+	var iter MVCCIterator
+	var timeBoundIter MVCCIterator
 	if !opts.IterOptions.MinTimestampHint.IsEmpty() && !opts.IterOptions.MaxTimestampHint.IsEmpty() {
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -651,7 +651,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	db2 := NewInMem(ctx, roachpb.Attributes{}, 10<<20)
 	defer db2.Close()
 
-	ingest := func(it Iterator, count int) {
+	ingest := func(it MVCCIterator, count int) {
 		memFile := &MemFile{}
 		sst := MakeIngestionSSTWriter(memFile)
 		defer sst.Close()

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1326,17 +1326,17 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 
 var mvccStatsTests = []struct {
 	name string
-	fn   func(Iterator, roachpb.Key, roachpb.Key, int64) (enginepb.MVCCStats, error)
+	fn   func(MVCCIterator, roachpb.Key, roachpb.Key, int64) (enginepb.MVCCStats, error)
 }{
 	{
 		name: "ComputeStats",
-		fn: func(iter Iterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
+		fn: func(iter MVCCIterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
 			return iter.ComputeStats(start, end, nowNanos)
 		},
 	},
 	{
 		name: "ComputeStatsGo",
-		fn: func(iter Iterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
+		fn: func(iter MVCCIterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
 			return ComputeStatsGo(iter, start, end, nowNanos)
 		},
 	},

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -111,7 +111,7 @@ func (n mvccKeys) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n mvccKeys) Less(i, j int) bool { return n[i].Less(n[j]) }
 
 // mvccGetGo is identical to MVCCGet except that it uses mvccGetInternal
-// instead of the C++ Iterator.MVCCGet. It is used to test mvccGetInternal
+// instead of the C++ MVCCIterator.MVCCGet. It is used to test mvccGetInternal
 // which is used by mvccPutInternal to avoid Cgo crossings. Simply using the
 // C++ MVCCGet in mvccPutInternal causes a significant performance hit to
 // conditional put operations.
@@ -5019,8 +5019,8 @@ type readWriterReturningSeekLTTrackingIterator struct {
 }
 
 // NewIterator injects a seekLTTrackingIterator over the engine's real iterator.
-func (rw *readWriterReturningSeekLTTrackingIterator) NewIterator(opts IterOptions) Iterator {
-	rw.it.Iterator = rw.ReadWriter.NewIterator(opts)
+func (rw *readWriterReturningSeekLTTrackingIterator) NewIterator(opts IterOptions) MVCCIterator {
+	rw.it.MVCCIterator = rw.ReadWriter.NewIterator(opts)
 	return &rw.it
 }
 
@@ -5028,12 +5028,12 @@ func (rw *readWriterReturningSeekLTTrackingIterator) NewIterator(opts IterOption
 // called.
 type seekLTTrackingIterator struct {
 	seekLTCalled int
-	Iterator
+	MVCCIterator
 }
 
 func (it *seekLTTrackingIterator) SeekLT(k MVCCKey) {
 	it.seekLTCalled++
-	it.Iterator.SeekLT(k)
+	it.MVCCIterator.SeekLT(k)
 }
 
 // TestMVCCGarbageCollectUsesSeekLTAppropriately ensures that the garbage

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -693,7 +693,7 @@ func (p *Pebble) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) err
 }
 
 // NewIterator implements the Engine interface.
-func (p *Pebble) NewIterator(opts IterOptions) Iterator {
+func (p *Pebble) NewIterator(opts IterOptions) MVCCIterator {
 	iter := newPebbleIterator(p.db, opts)
 	if iter == nil {
 		panic("couldn't create a new iterator")
@@ -743,7 +743,7 @@ func (p *Pebble) ClearRange(start, end MVCCKey) error {
 }
 
 // ClearIterRange implements the Engine interface.
-func (p *Pebble) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+func (p *Pebble) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
 	// Write all the tombstones in one batch.
 	batch := p.NewWriteOnlyBatch()
 	defer batch.Close()
@@ -1149,13 +1149,13 @@ func (p *pebbleReadOnly) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) er
 	return iterateOnReader(p, start, end, f)
 }
 
-func (p *pebbleReadOnly) NewIterator(opts IterOptions) Iterator {
+func (p *pebbleReadOnly) NewIterator(opts IterOptions) MVCCIterator {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
 
 	if opts.MinTimestampHint != (hlc.Timestamp{}) {
-		// Iterators that specify timestamp bounds cannot be cached.
+		// MVCCIterators that specify timestamp bounds cannot be cached.
 		return newPebbleIterator(p.parent.db, opts)
 	}
 
@@ -1198,7 +1198,7 @@ func (p *pebbleReadOnly) ClearRange(start, end MVCCKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+func (p *pebbleReadOnly) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
 	panic("not implemented")
 }
 
@@ -1297,7 +1297,7 @@ func (p *pebbleSnapshot) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) er
 }
 
 // NewIterator implements the Reader interface.
-func (p pebbleSnapshot) NewIterator(opts IterOptions) Iterator {
+func (p pebbleSnapshot) NewIterator(opts IterOptions) MVCCIterator {
 	return newPebbleIterator(p.snapshot, opts)
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -174,7 +174,7 @@ func (p *pebbleBatch) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error
 }
 
 // NewIterator implements the Batch interface.
-func (p *pebbleBatch) NewIterator(opts IterOptions) Iterator {
+func (p *pebbleBatch) NewIterator(opts IterOptions) MVCCIterator {
 	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
 		panic("iterator must set prefix or upper bound or lower bound")
 	}
@@ -187,7 +187,7 @@ func (p *pebbleBatch) NewIterator(opts IterOptions) Iterator {
 	}
 
 	if opts.MinTimestampHint != (hlc.Timestamp{}) {
-		// Iterators that specify timestamp bounds cannot be cached.
+		// MVCCIterators that specify timestamp bounds cannot be cached.
 		return newPebbleIterator(p.batch, opts)
 	}
 
@@ -263,7 +263,7 @@ func (p *pebbleBatch) ClearRange(start, end MVCCKey) error {
 }
 
 // Clear implements the Batch interface.
-func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+func (p *pebbleBatch) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
 	}

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -90,7 +90,7 @@ func (p *pebbleResults) finish() [][]byte {
 // Go port of mvccScanner in libroach/mvcc.h. Stores all variables relating to
 // one MVCCGet / MVCCScan call.
 type pebbleMVCCScanner struct {
-	parent  Iterator
+	parent  MVCCIterator
 	reverse bool
 	peeked  bool
 	// Iteration bounds. Does not contain MVCC timestamp.

--- a/pkg/storage/sst_iterator_test.go
+++ b/pkg/storage/sst_iterator_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-func runTestSSTIterator(t *testing.T, iter SimpleIterator, allKVs []MVCCKeyValue) {
+func runTestSSTIterator(t *testing.T, iter SimpleMVCCIterator, allKVs []MVCCKeyValue) {
 	// Drop the first kv so we can test Seek.
 	expected := allKVs[1:]
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -114,7 +114,7 @@ func (fw *SSTWriter) SingleClear(key MVCCKey) error {
 }
 
 // ClearIterRange implements the Writer interface.
-func (fw *SSTWriter) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+func (fw *SSTWriter) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearIterRange on a closed writer")
 	}


### PR DESCRIPTION

Also remove MVCCIterator, which was implemented for RocksDB.

Release note: None