### PR TITLE
Revert "tpcc: use multiple column families to avoid contention"

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -21,14 +21,14 @@ SELECT w_tax FROM warehouse WHERE w_id = 1
 ----
 project
  ├── save-table-name: new_order_01_project_1
- ├── columns: w_tax:8(decimal!null)
+ ├── columns: w_tax:8(decimal)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(8)=1, null(8)=0]
  ├── key: ()
  ├── fd: ()-->(8)
  └── scan warehouse
       ├── save-table-name: new_order_01_scan_2
-      ├── columns: w_id:1(int!null) w_tax:8(decimal!null)
+      ├── columns: w_id:1(int!null) w_tax:8(decimal)
       ├── constraint: /1: [/1 - /1]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(8)=1, null(8)=0]
@@ -54,14 +54,14 @@ WHERE c_w_id = 1 AND c_d_id = 1 AND c_id = 50
 ----
 project
  ├── save-table-name: new_order_02_project_1
- ├── columns: c_discount:16(decimal!null) c_last:6(varchar!null) c_credit:14(char!null)
+ ├── columns: c_discount:16(decimal) c_last:6(varchar) c_credit:14(char)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(6)=0.999501832, null(6)=0, distinct(14)=0.786939691, null(14)=0, distinct(16)=0.999901673, null(16)=0]
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  └── scan customer
       ├── save-table-name: new_order_02_scan_2
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar!null) c_credit:14(char!null) c_discount:16(decimal!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar) c_credit:14(char) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/1/1/50 - /1/1/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=0.999501832, null(6)=0, distinct(14)=0.786939691, null(14)=0, distinct(16)=0.999901673, null(16)=0, distinct(1-3)=1, null(1-3)=0]
@@ -202,14 +202,14 @@ ORDER BY c_first ASC
 ----
 project
  ├── save-table-name: payment_01_project_1
- ├── columns: c_id:1(int!null)  [hidden: c_first:4(varchar!null)]
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(varchar)]
  ├── stats: [rows=2.05079862, distinct(1)=2.05010459, null(1)=0, distinct(4)=2.0470416, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
  └── scan customer@customer_idx
       ├── save-table-name: payment_01_scan_2
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar!null) c_last:6(varchar!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
       ├── constraint: /3/2/6/4/1: [/1/1/'ANTIABLEABLE' - /1/1/'ANTIABLEABLE']
       ├── stats: [rows=2.05079862, distinct(1)=2.05010459, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=2.0470416, null(4)=0, distinct(6)=1, null(6)=0, distinct(2,3,6)=1, null(2,3,6)=0]
       │   histogram(2)=  0 2.0508
@@ -256,14 +256,14 @@ WHERE c_w_id = 1 AND c_d_id = 1 AND c_id = 50
 ----
 project
  ├── save-table-name: order_status_01_project_1
- ├── columns: c_balance:17(decimal!null) c_first:4(varchar!null) c_middle:5(char!null) c_last:6(varchar!null)
+ ├── columns: c_balance:17(decimal) c_first:4(varchar) c_middle:5(char) c_last:6(varchar)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(4)=0.999106141, null(4)=0, distinct(5)=0.632121172, null(5)=0, distinct(6)=0.999501832, null(6)=0, distinct(17)=0.632121172, null(17)=0]
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  └── scan customer
       ├── save-table-name: order_status_01_scan_2
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar!null) c_middle:5(char!null) c_last:6(varchar!null) c_balance:17(decimal!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/1/1/50 - /1/1/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=0.999106141, null(4)=0, distinct(5)=0.632121172, null(5)=0, distinct(6)=0.999501832, null(6)=0, distinct(17)=0.632121172, null(17)=0, distinct(1-3)=1, null(1-3)=0]
@@ -300,14 +300,14 @@ ORDER BY c_first ASC
 ----
 project
  ├── save-table-name: order_status_02_project_1
- ├── columns: c_id:1(int!null) c_balance:17(decimal!null) c_first:4(varchar!null) c_middle:5(char!null)
+ ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(varchar) c_middle:5(char)
  ├── stats: [rows=2.12233702, distinct(1)=2.12159373, null(1)=0, distinct(4)=2.11831349, null(4)=0, distinct(5)=0.880249459, null(5)=0, distinct(17)=0.880249459, null(17)=0]
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  └── index-join customer
       ├── save-table-name: order_status_02_index_join_2
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar!null) c_middle:5(char!null) c_last:6(varchar!null) c_balance:17(decimal!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar!null) c_balance:17(decimal)
       ├── stats: [rows=2.12233702, distinct(1)=2.12159373, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=2.11831349, null(4)=0, distinct(5)=0.880249459, null(5)=0, distinct(6)=1, null(6)=0, distinct(17)=0.880249459, null(17)=0, distinct(2,3,6)=1, null(2,3,6)=0]
       │   histogram(2)=  0 2.1223
       │                <---- 2 --
@@ -320,7 +320,7 @@ project
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       └── scan customer@customer_idx
            ├── save-table-name: order_status_02_scan_3
-           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar!null) c_last:6(varchar!null)
+           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
            ├── constraint: /3/2/6/4/1: [/2/2/'ANTIBARESE' - /2/2/'ANTIBARESE']
            ├── stats: [rows=2.12233702, distinct(1)=2.12159373, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=2.11831349, null(4)=0, distinct(6)=1, null(6)=0, distinct(2,3,6)=1, null(2,3,6)=0]
            │   histogram(1)=  0 0.00042447 0.0097628 0.00084893 0.010399 0.00084893 0.010399 0.00021223 0.009975 0.00084893 0.009975 0.0010612 0.010187 0.0010612 0.009975 0.0006367 0.010187 0.0012734 0.0097628 0.00084893 0.0097628 0.00084893 0.010399 0.0006367 0.010399 0.00042447 0.010187 0.0012734 0.010187 0.00084893 0.010399 0.0016979 0.010399 0.00084893 0.010399 0.0006367 0.009975 0.0006367 0.010187 0.00042447 0.010187 0.00084893 0.010399 0.0006367 0.010399 0.0012734 0.010399 0.00021223 0.009975 0.0006367 0.010187 0.0006367 0.010187 0.00084893 0.010399 0.00084893 0.0093383 0.0019101 0.0089138 0.0016979 0.010187 0.0014856 0.010187 0.0019101 0.0089138 0.0014856 0.009975 0.0010612 0.009975 0.0006367 0.0097628 0.0010612 0.0089138 0.0014856 0.010187 0.0006367 0.0097628 0.0006367 0.0097628 0.0010612 0.0097628 0.0006367 0.0097628 0.0006367 0.010187 0.00084893 0.010187 0.00042447 0.010187 0.00042447 0.009975 0.0006367 0.009975 0.00084893 0.009975 0.0010612 0.0097628 0.0012734 0.010187 0.0014856 0.010187 0.00021223 0.010187 0.0010612 0.0095505 0.0010612 0.0093383 0.0016979 0.0097628 0.0010612 0.010187 0.0006367 0.0095505 0.00084893 0.010187 0.00042447 0.0089138 0.0014856 0.010187 0.0010612 0.0097628 0.0010612 0.0095505 0.0010612 0.010187 0.0012734 0.0095505 0.00084893 0.0095505 0.00084893 0.009975 0.00084893 0.010187 0.0010612 0.009975 0.0010612 0.009975 0.0006367 0.009975 0.00084893 0.010187 0.0006367 0.0097628 0.0006367 0.009975 0.0006367 0.0093383 0.0014856 0.0095505 0.00084893 0.0097628 0.0006367 0.010187 0.0006367 0.010187 0.0006367 0.010187 0.00042447 0.0093383 0.0014856 0.010187 0.00042447 0.0097628 0.0014856 0.009975 0.0006367 0.0095505 0.0014856 0.010187 0.0012734 0.009975 0.00084893 0.009975 0.00084893 0.0097628 0.0010612 0.0097628 0.00084893 0.009975 0.0006367 0.010187 0.00084893 0.010187 0.00021223 0.010187 0.00021223 0.010187 0.0006367 0.009975 0.0010612 0.0095505 0.0010612 0.009126 0.0012734 0.0093383 0.0016979 0.0097628 0.0006367 0.0097628 0.0006367 0.009975 0.00042447 0.010187 0.00021223 0.009975 0.00084893 0.0097628 0.0016979 0.0095505 0.0012734 0.009975 0.00084893 0.009975 0.00042447 0.0097628 0.0012734 0.0095505 0.00084893 0.0093383 0.0010612 0.0097628 0.0006367 0.010187 0.00042447 0.0097628 0.0010612 0.009975 0.00084893 0.0097628 0.0006367 0.010187 0.00042447 0.0095505 0.00084893 0.010187 0.0006367 0.0093383 0.0010612 0.010187 0.0006367 0.0089138 0.0014856 0.010187 0.00084893 0.010187 0.0012734 0.009975 0.00042447 0.009126 0.0016979 0.010187 0.00042447 0.010187 0.0012734 0.0097628 0.0006367 0.009975 0.0006367 0.009975 0.00021223 0.0095505 0.0006367 0.009126 0.0014856 0.009975 0.00021223 0.0097628 0.0010612 0.009975 0.0006367 0.0093383 0.00084893 0.0097628 0.00084893 0.0093383 0.00084893 0.0097628 0.0012734 0.009975 0.00042447 0.009975 0.0010612 0.0087016 0.0019101 0.0087016 0.0023346 0.009126 0.0010612 0.0097628 0.00042447 0.009975 0.00084893 0.009975 0.00021223 0.0097628 0.0010612 0.0093383 0.00084893 0.0093383 0.00084893 0.0093383 0.0010612 0.009975 0.0006367 0.0097628 0.0006367 0.0097628 0.00042447 0.0097628 0.0014856 0.0095505 0.0006367 0.0097628 0.0006367 0.0097628 0.0006367 0.009126 0.0010612 0.0097628 0.00084893 0.0095505 0.0010612 0.0097628 0.0006367 0.009975 0.0006367 0.009975 0.00084893 0.009126 0.0012734 0.0095505 0.00084893 0.0095505 0.0010612 0.009126 0.0010612 0.0095505 0.0010612 0.0095505 0.0014856 0.009975 0.0014856 0.0095505 0.0006367 0.0097628 0.0014856 0.0097628 0.0010612 0.0093383 0.0006367 0.0095505 0.0006367 0.0097628 0.0006367 0.0097628 0.0006367 0.0087016 0.0012734 0.0095505 0.0014856 0.0097628 0.00021223 0.0089138 0.0014856 0.0095505 0.0010612 0.0087016 0.0012734 0.0097628 0.00084893 0.0095505 0.0012734 0.009126 0.0012734 0.0089138 0.00084893 0.0095505 0.00021223 0.0095505 0.0006367 0.0095505 0.00042447 0.0093383 0.0010612 0.0093383 0.00084893 0.0089138 0.0010612 0.0093383 0.00042447 0.0087016 0.0010612 0.0082771 0.0016979 0.0089138 0.0012734 0.0089138 0.00042447 0.0087016 0.00084893
@@ -567,14 +567,14 @@ WHERE d_w_id = 4 AND d_id = 9
 ----
 project
  ├── save-table-name: stock_level_01_project_1
- ├── columns: d_next_o_id:11(int!null)
+ ├── columns: d_next_o_id:11(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(11)=0.633967659, null(11)=0]
  ├── key: ()
  ├── fd: ()-->(11)
  └── scan district
       ├── save-table-name: stock_level_01_scan_2
-      ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_next_o_id:11(int!null)
+      ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_next_o_id:11(int)
       ├── constraint: /2/1: [/4/9 - /4/9]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(11)=0.633967659, null(11)=0, distinct(1,2)=1, null(1,2)=0]
@@ -729,7 +729,7 @@ scalar-group-by
  │    ├── fd: (1)-->(9), (12)-->(23), (1)==(12), (12)==(1)
  │    ├── scan warehouse
  │    │    ├── save-table-name: consistency_01_scan_3
- │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null)
+ │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal)
  │    │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(9)=1, null(9)=0]
  │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1
  │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
@@ -740,7 +740,7 @@ scalar-group-by
  │    │    └── ordering: +1
  │    ├── group-by
  │    │    ├── save-table-name: consistency_01_group_by_4
- │    │    ├── columns: d_w_id:12(int!null) sum:23(decimal!null)
+ │    │    ├── columns: d_w_id:12(int!null) sum:23(decimal)
  │    │    ├── grouping columns: d_w_id:12(int!null)
  │    │    ├── stats: [rows=10, distinct(12)=10, null(12)=0, distinct(23)=10, null(23)=0]
  │    │    ├── key: (12)
@@ -748,7 +748,7 @@ scalar-group-by
  │    │    ├── ordering: +12
  │    │    ├── scan district
  │    │    │    ├── save-table-name: consistency_01_scan_5
- │    │    │    ├── columns: d_w_id:12(int!null) d_ytd:20(decimal!null)
+ │    │    │    ├── columns: d_w_id:12(int!null) d_ytd:20(decimal)
  │    │    │    ├── stats: [rows=100, distinct(12)=10, null(12)=0, distinct(20)=1, null(20)=0]
  │    │    │    │   histogram(12)=  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0 10
  │    │    │    │                 <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
@@ -820,7 +820,7 @@ ORDER BY d_w_id, d_id
 ----
 scan district
  ├── save-table-name: consistency_02_scan_1
- ├── columns: d_next_o_id:11(int!null)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
+ ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
  ├── stats: [rows=100, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0, distinct(11)=1, null(11)=0]
  │   histogram(1)=  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0 10  0  10
  │                <--- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10

--- a/pkg/sql/opt/testutils/opttester/testfixtures/tpcc_schema
+++ b/pkg/sql/opt/testutils/opttester/testfixtures/tpcc_schema
@@ -1,17 +1,15 @@
 exec-ddl
 CREATE TABLE warehouse
 (
-    w_id        integer       not null primary key,
-    w_name      varchar(10)   not null,
-    w_street_1  varchar(20)   not null,
-    w_street_2  varchar(20)   not null,
-    w_city      varchar(20)   not null,
-    w_state     char(2)       not null,
-    w_zip       char(9)       not null,
-    w_tax       decimal(4,4)  not null,
-    w_ytd       decimal(12,2) not null,
-    family      f1 (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_ytd),
-    family      f2 (w_tax)
+    w_id        integer   not null primary key,
+    w_name      varchar(10),
+    w_street_1  varchar(20),
+    w_street_2  varchar(20),
+    w_city      varchar(20),
+    w_state     char(2),
+    w_zip       char(9),
+    w_tax       decimal(4,4),
+    w_ytd       decimal(12,2)
 )
 ----
 
@@ -20,55 +18,47 @@ CREATE TABLE district
 (
     d_id         integer       not null,
     d_w_id       integer       not null,
-    d_name       varchar(10)   not null,
-    d_street_1   varchar(20)   not null,
-    d_street_2   varchar(20)   not null,
-    d_city       varchar(20)   not null,
-    d_state      char(2)       not null,
-    d_zip        char(9)       not null,
-    d_tax        decimal(4,4)  not null,
-    d_ytd        decimal(12,2) not null,
-    d_next_o_id  integer       not null,
-    primary key  (d_w_id, d_id),
-    foreign key  (d_w_id) references warehouse (w_id),
-    family       static    (d_w_id, d_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip),
-    family       dynamic_1 (d_ytd),
-    family       dynamic_2 (d_next_o_id, d_tax)
+    d_name       varchar(10),
+    d_street_1   varchar(20),
+    d_street_2   varchar(20),
+    d_city       varchar(20),
+    d_state      char(2),
+    d_zip        char(9),
+    d_tax        decimal(4,4),
+    d_ytd        decimal(12,2),
+    d_next_o_id  integer,
+    primary key (d_w_id, d_id),
+    foreign key (d_w_id) references warehouse (w_id)
 ) interleave in parent warehouse (d_w_id)
 ----
 
 exec-ddl
 CREATE TABLE customer
 (
-    c_id           integer       not null,
-    c_d_id         integer       not null,
-    c_w_id         integer       not null,
-    c_first        varchar(16)   not null,
-    c_middle       char(2)       not null,
-    c_last         varchar(16)   not null,
-    c_street_1     varchar(20)   not null,
-    c_street_2     varchar(20)   not null,
-    c_city         varchar(20)   not null,
-    c_state        char(2)       not null,
-    c_zip          char(9)       not null,
-    c_phone        char(16)      not null,
-    c_since        timestamp     not null,
-    c_credit       char(2)       not null,
-    c_credit_lim   decimal(12,2) not null,
-    c_discount     decimal(4,4)  not null,
-    c_balance      decimal(12,2) not null,
-    c_ytd_payment  decimal(12,2) not null,
-    c_payment_cnt  integer       not null,
-    c_delivery_cnt integer       not null,
-    c_data         varchar(500)  not null,
-    primary key        (c_w_id, c_d_id, c_id),
+    c_id           integer        not null,
+    c_d_id         integer        not null,
+    c_w_id         integer        not null,
+    c_first        varchar(16),
+    c_middle       char(2),
+    c_last         varchar(16),
+    c_street_1     varchar(20),
+    c_street_2     varchar(20),
+    c_city         varchar(20),
+    c_state        char(2),
+    c_zip          char(9),
+    c_phone        char(16),
+    c_since        timestamp,
+    c_credit       char(2),
+    c_credit_lim   decimal(12,2),
+    c_discount     decimal(4,4),
+    c_balance      decimal(12,2),
+    c_ytd_payment  decimal(12,2),
+    c_payment_cnt  integer,
+    c_delivery_cnt integer,
+    c_data         varchar(500),
+    primary key (c_w_id, c_d_id, c_id),
     index customer_idx (c_w_id, c_d_id, c_last, c_first),
-    foreign key        (c_w_id, c_d_id) references district (d_w_id, d_id),
-    family static      (
-        c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2,
-        c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount
-    ),
-    family dynamic (c_balance, c_ytd_payment, c_payment_cnt, c_data, c_delivery_cnt)
+    foreign key (c_w_id, c_d_id) references district (d_w_id, d_id)
 ) interleave in parent district (c_w_id, c_d_id)
 ----
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -22,14 +22,14 @@ WHERE d_w_id = 10 AND d_id = 5
 RETURNING d_tax, d_next_o_id
 ----
 project
- ├── columns: d_tax:9!null d_next_o_id:11!null
+ ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_tax:9!null d_next_o_id:11!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_tax:21 d_next_o_id:23
+      ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_next_o_id_new:25 => d_next_o_id:11
       ├── cardinality: [0 - 1]
@@ -37,17 +37,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: d_next_o_id_new:25!null d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           ├── columns: d_next_o_id_new:25 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13,14,21,23,25)
+           ├── fd: ()-->(13-23,25)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13,14,21,23)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── d_next_o_id:23 + 1 [as=d_next_o_id_new:25, outer=(23), immutable]
 
@@ -55,12 +55,12 @@ opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
 ----
 project
- ├── columns: w_tax:8!null
+ ├── columns: w_tax:8
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(8)
  └── scan warehouse
-      ├── columns: w_id:1!null w_tax:8!null
+      ├── columns: w_id:1!null w_tax:8
       ├── constraint: /1: [/10 - /10]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -72,12 +72,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16!null c_last:6!null c_credit:14!null
+ ├── columns: c_discount:16 c_last:6 c_credit:14
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6!null c_credit:14!null c_discount:16!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6 c_credit:14 c_discount:16
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -431,14 +431,14 @@ UPDATE warehouse SET w_ytd = w_ytd + 3860.61 WHERE w_id = 10
 RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 ----
 project
- ├── columns: w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
+ ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
-      ├── columns: w_id:1!null w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 warehouse.w_ytd:19
+      ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
       ├── update-mapping:
       │    └── w_ytd:22 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
@@ -446,17 +446,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(11-17,19,22)
+           ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(11-17,19)
+           │    └── fd: ()-->(11-19)
            └── projections
                 └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
 
@@ -465,14 +465,14 @@ UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
 RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 ----
 project
- ├── columns: d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
+ ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 district.d_ytd:22
+      ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_ytd:26 => district.d_ytd:10
       ├── cardinality: [0 - 1]
@@ -480,17 +480,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13-20,22,26)
+           ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13-20,22)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
 
@@ -501,12 +501,12 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1!null  [hidden: c_first:4!null]
+ ├── columns: c_id:1!null  [hidden: c_first:4]
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
  └── scan customer@customer_idx
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_last:6!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
@@ -554,13 +554,13 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null c_balance:17!null case:51
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:51
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null customer.c_balance:17!null c_data:21!null
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
  │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
  │    │    ├── c_balance:49 => customer.c_balance:17
@@ -572,13 +572,13 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47!null c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
@@ -671,12 +671,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17!null c_first:4!null c_middle:5!null c_last:6!null
+ ├── columns: c_balance:17 c_first:4 c_middle:5 c_last:6
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -689,17 +689,17 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1!null c_balance:17!null c_first:4!null c_middle:5!null
+ ├── columns: c_id:1!null c_balance:17 c_first:4 c_middle:5
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  └── index-join customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       └── scan customer@customer_idx
-           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_last:6!null
+           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
@@ -877,20 +877,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
  │    ├── c_balance:47 => customer.c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45!null c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
-      ├── fd: ()-->(25), (23,24)-->(39-43,47), (42)-->(45)
+      ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -904,7 +904,7 @@ update customer
       │    │    └── [/10/10/417 - /10/10/417]
       │    ├── cardinality: [0 - 10]
       │    ├── key: (23,24)
-      │    └── fd: ()-->(25), (23,24)-->(39-43)
+      │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
@@ -1006,12 +1006,12 @@ FROM district
 WHERE d_w_id = 10 AND d_id = 100
 ----
 project
- ├── columns: d_next_o_id:11!null
+ ├── columns: d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(11)
  └── scan district
-      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11!null
+      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -1083,18 +1083,18 @@ scalar-group-by
  │    ├── key: (12)
  │    ├── fd: (1)-->(9), (12)-->(23), (1)==(12), (12)==(1)
  │    ├── scan warehouse
- │    │    ├── columns: w_id:1!null w_ytd:9!null
+ │    │    ├── columns: w_id:1!null w_ytd:9
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    └── ordering: +1
  │    ├── group-by
- │    │    ├── columns: d_w_id:12!null sum:23!null
+ │    │    ├── columns: d_w_id:12!null sum:23
  │    │    ├── grouping columns: d_w_id:12!null
  │    │    ├── key: (12)
  │    │    ├── fd: (12)-->(23)
  │    │    ├── ordering: +12
  │    │    ├── scan district
- │    │    │    ├── columns: d_w_id:12!null d_ytd:20!null
+ │    │    │    ├── columns: d_w_id:12!null d_ytd:20
  │    │    │    └── ordering: +12
  │    │    └── aggregations
  │    │         └── sum [as=sum:23, outer=(20)]
@@ -1110,7 +1110,7 @@ FROM district
 ORDER BY d_w_id, d_id
 ----
 scan district
- ├── columns: d_next_o_id:11!null  [hidden: d_id:1!null d_w_id:2!null]
+ ├── columns: d_next_o_id:11  [hidden: d_id:1!null d_w_id:2!null]
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  └── ordering: +2,+1

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -25,14 +25,14 @@ WHERE d_w_id = 10 AND d_id = 5
 RETURNING d_tax, d_next_o_id
 ----
 project
- ├── columns: d_tax:9!null d_next_o_id:11!null
+ ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_tax:9!null d_next_o_id:11!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_tax:21 d_next_o_id:23
+      ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_next_o_id_new:25 => d_next_o_id:11
       ├── cardinality: [0 - 1]
@@ -40,17 +40,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: d_next_o_id_new:25!null d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           ├── columns: d_next_o_id_new:25 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13,14,21,23,25)
+           ├── fd: ()-->(13-23,25)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13,14,21,23)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── d_next_o_id:23 + 1 [as=d_next_o_id_new:25, outer=(23), immutable]
 
@@ -58,12 +58,12 @@ opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
 ----
 project
- ├── columns: w_tax:8!null
+ ├── columns: w_tax:8
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(8)
  └── scan warehouse
-      ├── columns: w_id:1!null w_tax:8!null
+      ├── columns: w_id:1!null w_tax:8
       ├── constraint: /1: [/10 - /10]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -75,12 +75,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16!null c_last:6!null c_credit:14!null
+ ├── columns: c_discount:16 c_last:6 c_credit:14
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6!null c_credit:14!null c_discount:16!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6 c_credit:14 c_discount:16
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -434,14 +434,14 @@ UPDATE warehouse SET w_ytd = w_ytd + 3860.61 WHERE w_id = 10
 RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 ----
 project
- ├── columns: w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
+ ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
-      ├── columns: w_id:1!null w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 warehouse.w_ytd:19
+      ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
       ├── update-mapping:
       │    └── w_ytd:22 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
@@ -449,17 +449,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(11-17,19,22)
+           ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(11-17,19)
+           │    └── fd: ()-->(11-19)
            └── projections
                 └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
 
@@ -468,14 +468,14 @@ UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
 RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 ----
 project
- ├── columns: d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
+ ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 district.d_ytd:22
+      ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_ytd:26 => district.d_ytd:10
       ├── cardinality: [0 - 1]
@@ -483,17 +483,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13-20,22,26)
+           ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13-20,22)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
 
@@ -504,12 +504,12 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1!null  [hidden: c_first:4!null]
+ ├── columns: c_id:1!null  [hidden: c_first:4]
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
  └── scan customer@customer_idx
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_last:6!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
@@ -557,13 +557,13 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null c_balance:17!null case:51
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:51
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null customer.c_balance:17!null c_data:21!null
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
  │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
  │    │    ├── c_balance:49 => customer.c_balance:17
@@ -575,13 +575,13 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47!null c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
@@ -674,12 +674,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17!null c_first:4!null c_middle:5!null c_last:6!null
+ ├── columns: c_balance:17 c_first:4 c_middle:5 c_last:6
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -692,17 +692,17 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1!null c_balance:17!null c_first:4!null c_middle:5!null
+ ├── columns: c_id:1!null c_balance:17 c_first:4 c_middle:5
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  └── index-join customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       └── scan customer@customer_idx
-           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_last:6!null
+           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
@@ -880,20 +880,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
  │    ├── c_balance:47 => customer.c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45!null c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
-      ├── fd: ()-->(25), (23,24)-->(39-43,47), (42)-->(45)
+      ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -907,7 +907,7 @@ update customer
       │    │    └── [/10/10/417 - /10/10/417]
       │    ├── cardinality: [0 - 10]
       │    ├── key: (23,24)
-      │    └── fd: ()-->(25), (23,24)-->(39-43)
+      │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
@@ -1008,12 +1008,12 @@ FROM district
 WHERE d_w_id = 10 AND d_id = 100
 ----
 project
- ├── columns: d_next_o_id:11!null
+ ├── columns: d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(11)
  └── scan district
-      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11!null
+      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -1085,18 +1085,18 @@ scalar-group-by
  │    ├── key: (12)
  │    ├── fd: (1)-->(9), (12)-->(23), (1)==(12), (12)==(1)
  │    ├── scan warehouse
- │    │    ├── columns: w_id:1!null w_ytd:9!null
+ │    │    ├── columns: w_id:1!null w_ytd:9
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    └── ordering: +1
  │    ├── group-by
- │    │    ├── columns: d_w_id:12!null sum:23!null
+ │    │    ├── columns: d_w_id:12!null sum:23
  │    │    ├── grouping columns: d_w_id:12!null
  │    │    ├── key: (12)
  │    │    ├── fd: (12)-->(23)
  │    │    ├── ordering: +12
  │    │    ├── scan district
- │    │    │    ├── columns: d_w_id:12!null d_ytd:20!null
+ │    │    │    ├── columns: d_w_id:12!null d_ytd:20
  │    │    │    └── ordering: +12
  │    │    └── aggregations
  │    │         └── sum [as=sum:23, outer=(20)]
@@ -1112,7 +1112,7 @@ FROM district
 ORDER BY d_w_id, d_id
 ----
 scan district
- ├── columns: d_next_o_id:11!null  [hidden: d_id:1!null d_w_id:2!null]
+ ├── columns: d_next_o_id:11  [hidden: d_id:1!null d_w_id:2!null]
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  └── ordering: +2,+1

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -19,14 +19,14 @@ WHERE d_w_id = 10 AND d_id = 5
 RETURNING d_tax, d_next_o_id
 ----
 project
- ├── columns: d_tax:9!null d_next_o_id:11!null
+ ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_tax:9!null d_next_o_id:11!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_tax:21 d_next_o_id:23
+      ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_next_o_id_new:25 => d_next_o_id:11
       ├── cardinality: [0 - 1]
@@ -34,17 +34,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: d_next_o_id_new:25!null d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           ├── columns: d_next_o_id_new:25 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13,14,21,23,25)
+           ├── fd: ()-->(13-23,25)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_tax:21!null d_next_o_id:23!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13,14,21,23)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── d_next_o_id:23 + 1 [as=d_next_o_id_new:25, outer=(23), immutable]
 
@@ -52,12 +52,12 @@ opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
 ----
 project
- ├── columns: w_tax:8!null
+ ├── columns: w_tax:8
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(8)
  └── scan warehouse
-      ├── columns: w_id:1!null w_tax:8!null
+      ├── columns: w_id:1!null w_tax:8
       ├── constraint: /1: [/10 - /10]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -69,12 +69,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16!null c_last:6!null c_credit:14!null
+ ├── columns: c_discount:16 c_last:6 c_credit:14
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6!null c_credit:14!null c_discount:16!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6 c_credit:14 c_discount:16
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -428,14 +428,14 @@ UPDATE warehouse SET w_ytd = w_ytd + 3860.61 WHERE w_id = 10
 RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 ----
 project
- ├── columns: w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
+ ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
-      ├── columns: w_id:1!null w_name:2!null w_street_1:3!null w_street_2:4!null w_city:5!null w_state:6!null w_zip:7!null
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 warehouse.w_ytd:19
+      ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
       ├── update-mapping:
       │    └── w_ytd:22 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
@@ -443,17 +443,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(11-17,19,22)
+           ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12!null w_street_1:13!null w_street_2:14!null w_city:15!null w_state:16!null w_zip:17!null warehouse.w_ytd:19!null
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(11-17,19)
+           │    └── fd: ()-->(11-19)
            └── projections
                 └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
 
@@ -462,14 +462,14 @@ UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
 RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 ----
 project
- ├── columns: d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
+ ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
-      ├── columns: d_id:1!null d_w_id:2!null d_name:3!null d_street_1:4!null d_street_2:5!null d_city:6!null d_state:7!null d_zip:8!null
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 district.d_ytd:22
+      ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
       ├── update-mapping:
       │    └── d_ytd:26 => district.d_ytd:10
       ├── cardinality: [0 - 1]
@@ -477,17 +477,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
-           ├── fd: ()-->(13-20,22,26)
+           ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15!null d_street_1:16!null d_street_2:17!null d_city:18!null d_state:19!null d_zip:20!null district.d_ytd:22!null
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    └── fd: ()-->(13-20,22)
+           │    └── fd: ()-->(13-23)
            └── projections
                 └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
 
@@ -498,12 +498,12 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1!null  [hidden: c_first:4!null]
+ ├── columns: c_id:1!null  [hidden: c_first:4]
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
  └── scan customer@customer_idx
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_last:6!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
@@ -551,13 +551,13 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null c_balance:17!null case:51
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:51
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_street_1:7!null c_street_2:8!null c_city:9!null c_state:10!null c_zip:11!null c_phone:12!null c_since:13!null c_credit:14!null c_credit_lim:15!null c_discount:16!null customer.c_balance:17!null c_data:21!null
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
  │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
  │    │    ├── c_balance:49 => customer.c_balance:17
@@ -569,13 +569,13 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47!null c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26!null c_middle:27!null c_last:28!null c_street_1:29!null c_street_2:30!null c_city:31!null c_state:32!null c_zip:33!null c_phone:34!null c_since:35!null c_credit:36!null c_credit_lim:37!null c_discount:38!null customer.c_balance:39!null customer.c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
@@ -668,12 +668,12 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17!null c_first:4!null c_middle:5!null c_last:6!null
+ ├── columns: c_balance:17 c_first:4 c_middle:5 c_last:6
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  └── scan customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -686,20 +686,20 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 sort
- ├── columns: c_id:1!null c_balance:17!null c_first:4!null c_middle:5!null
+ ├── columns: c_id:1!null c_balance:17 c_first:4 c_middle:5
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  └── project
-      ├── columns: c_id:1!null c_first:4!null c_middle:5!null c_balance:17!null
+      ├── columns: c_id:1!null c_first:4 c_middle:5 c_balance:17
       ├── key: (1)
       ├── fd: (1)-->(4,5,17)
       └── select
-           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
            ├── scan customer
-           │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4!null c_middle:5!null c_last:6!null c_balance:17!null
+           │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
            │    ├── constraint: /3/2/1: [/10/100 - /10/100]
            │    ├── key: (1)
            │    └── fd: ()-->(2,3), (1)-->(4-6,17)
@@ -879,20 +879,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
  │    ├── c_balance:47 => customer.c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45!null c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
-      ├── fd: ()-->(25), (23,24)-->(39-43,47), (42)-->(45)
+      ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null customer.c_balance:39!null c_ytd_payment:40!null c_payment_cnt:41!null c_delivery_cnt:42!null c_data:43!null
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -906,7 +906,7 @@ update customer
       │    │    └── [/10/10/417 - /10/10/417]
       │    ├── cardinality: [0 - 10]
       │    ├── key: (23,24)
-      │    └── fd: ()-->(25), (23,24)-->(39-43)
+      │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
@@ -1007,12 +1007,12 @@ FROM district
 WHERE d_w_id = 10 AND d_id = 100
 ----
 project
- ├── columns: d_next_o_id:11!null
+ ├── columns: d_next_o_id:11
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(11)
  └── scan district
-      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11!null
+      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
       ├── key: ()
@@ -1084,13 +1084,13 @@ scalar-group-by
  │    ├── key: (12)
  │    ├── fd: (1)-->(9), (12)-->(23), (1)==(12), (12)==(1)
  │    ├── group-by
- │    │    ├── columns: d_w_id:12!null sum:23!null
+ │    │    ├── columns: d_w_id:12!null sum:23
  │    │    ├── grouping columns: d_w_id:12!null
  │    │    ├── internal-ordering: +12
  │    │    ├── key: (12)
  │    │    ├── fd: (12)-->(23)
  │    │    ├── scan district
- │    │    │    ├── columns: d_w_id:12!null d_ytd:20!null
+ │    │    │    ├── columns: d_w_id:12!null d_ytd:20
  │    │    │    └── ordering: +12
  │    │    └── aggregations
  │    │         └── sum [as=sum:23, outer=(20)]
@@ -1106,7 +1106,7 @@ FROM district
 ORDER BY d_w_id, d_id
 ----
 scan district
- ├── columns: d_next_o_id:11!null  [hidden: d_id:1!null d_w_id:2!null]
+ ├── columns: d_next_o_id:11  [hidden: d_id:1!null d_w_id:2!null]
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  └── ordering: +2,+1

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -21,70 +21,60 @@ import (
 const (
 	// WAREHOUSE table.
 	tpccWarehouseSchema = `(
-		w_id        integer       not null primary key,
-		w_name      varchar(10)   not null,
-		w_street_1  varchar(20)   not null,
-		w_street_2  varchar(20)   not null,
-		w_city      varchar(20)   not null,
-		w_state     char(2)       not null,
-		w_zip       char(9)       not null,
-		w_tax       decimal(4,4)  not null,
-		w_ytd       decimal(12,2) not null,
-		family      f1 (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_ytd),
-		family      f2 (w_tax)
+		w_id        integer   not null primary key,
+		w_name      varchar(10),
+		w_street_1  varchar(20),
+		w_street_2  varchar(20),
+		w_city      varchar(20),
+		w_state     char(2),
+		w_zip       char(9),
+		w_tax       decimal(4,4),
+		w_ytd       decimal(12,2)
 	)`
 
 	// DISTRICT table.
 	tpccDistrictSchemaBase = `(
 		d_id         integer       not null,
 		d_w_id       integer       not null,
-		d_name       varchar(10)   not null,
-		d_street_1   varchar(20)   not null,
-		d_street_2   varchar(20)   not null,
-		d_city       varchar(20)   not null,
-		d_state      char(2)       not null,
-		d_zip        char(9)       not null,
-		d_tax        decimal(4,4)  not null,
-		d_ytd        decimal(12,2) not null,
-		d_next_o_id  integer       not null,
-		primary key  (d_w_id, d_id),
-		family       static    (d_w_id, d_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip),
-		family       dynamic_1 (d_ytd),
-		family       dynamic_2 (d_next_o_id, d_tax)
+		d_name       varchar(10),
+		d_street_1   varchar(20),
+		d_street_2   varchar(20),
+		d_city       varchar(20),
+		d_state      char(2),
+		d_zip        char(9),
+		d_tax        decimal(4,4),
+		d_ytd        decimal(12,2),
+		d_next_o_id  integer,
+		primary key (d_w_id, d_id)
 	)`
 	tpccDistrictSchemaInterleaveSuffix = `
 		interleave in parent warehouse (d_w_id)`
 
 	// CUSTOMER table.
 	tpccCustomerSchemaBase = `(
-		c_id           integer       not null,
-		c_d_id         integer       not null,
-		c_w_id         integer       not null,
-		c_first        varchar(16)   not null,
-		c_middle       char(2)       not null,
-		c_last         varchar(16)   not null,
-		c_street_1     varchar(20)   not null,
-		c_street_2     varchar(20)   not null,
-		c_city         varchar(20)   not null,
-		c_state        char(2)       not null,
-		c_zip          char(9)       not null,
-		c_phone        char(16)      not null,
-		c_since        timestamp     not null,
-		c_credit       char(2)       not null,
-		c_credit_lim   decimal(12,2) not null,
-		c_discount     decimal(4,4)  not null,
-		c_balance      decimal(12,2) not null,
-		c_ytd_payment  decimal(12,2) not null,
-		c_payment_cnt  integer       not null,
-		c_delivery_cnt integer       not null,
-		c_data         varchar(500)  not null,
-		primary key        (c_w_id, c_d_id, c_id),
-		index customer_idx (c_w_id, c_d_id, c_last, c_first),
-		family static      (
-			c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2,
-			c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount
-		),
-		family dynamic (c_balance, c_ytd_payment, c_payment_cnt, c_data, c_delivery_cnt)
+		c_id           integer        not null,
+		c_d_id         integer        not null,
+		c_w_id         integer        not null,
+		c_first        varchar(16),
+		c_middle       char(2),
+		c_last         varchar(16),
+		c_street_1     varchar(20),
+		c_street_2     varchar(20),
+		c_city         varchar(20),
+		c_state        char(2),
+		c_zip          char(9),
+		c_phone        char(16),
+		c_since        timestamp,
+		c_credit       char(2),
+		c_credit_lim   decimal(12,2),
+		c_discount     decimal(4,4),
+		c_balance      decimal(12,2),
+		c_ytd_payment  decimal(12,2),
+		c_payment_cnt  integer,
+		c_delivery_cnt integer,
+		c_data         varchar(500),
+		primary key (c_w_id, c_d_id, c_id),
+		index customer_idx (c_w_id, c_d_id, c_last, c_first)
 	)`
 	tpccCustomerSchemaInterleaveSuffix = `
 		interleave in parent district (c_w_id, c_d_id)`


### PR DESCRIPTION
This reverts commit 6b119183540ea6378418aaf6cff61b67ec1e0536.

Fixes #55954.
Fixes #55953.
Fixes #55952.
Fixes #55951.
Fixes #55949.

In #30624, we split various column families up in the TPC-C workload. This
had the unintended consequence of breaking CDC roachtests, because CDC
does not support multiple column families per row:
```
CHANGEFEEDs are currently supported on tables with exactly 1 column family: warehouse has 2
```

This PR reverts that commit. I intend to come back to this and introduce
a `--families` flag to TPC-C (like we have to YCSB) that can be used to
selectively toggle column families on or off. However, I'll do this
after #51897 lands, because it's going to be more effort than it's worth
to conditionally set this flag based on whether the version of workload
used in the test supports it or not.