### PR TITLE
Updated help text for crdb_internal.force_retry

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3779,7 +3779,7 @@ may increase either contention or retry errors, or both.`,
 				}
 				return tree.DZero, nil
 			},
-			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Info:       "This function triggers a transaction retry, which can be useful for testing purposes.",
 			Volatility: tree.VolatilityVolatile,
 		},
 	),


### PR DESCRIPTION
Related to https://github.com/cockroachdb/docs/issues/5538.

Release justification: Non-production code changes

Release note: None