### PR TITLE
sql: fix object lookup for ALTER TABLE ... RENAME TO ...

### DIFF
--- a/pkg/sql/catalog/catalogkv/namespace.go
+++ b/pkg/sql/catalog/catalogkv/namespace.go
@@ -218,13 +218,6 @@ func LookupObjectID(
 	return false, descpb.InvalidID, nil
 }
 
-// LookupPublicTableID is a wrapper around LookupObjectID for public tables.
-func LookupPublicTableID(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, parentID descpb.ID, name string,
-) (bool, descpb.ID, error) {
-	return LookupObjectID(ctx, txn, codec, parentID, keys.PublicSchemaID, name)
-}
-
 // LookupDatabaseID is  a wrapper around LookupObjectID for databases.
 func LookupDatabaseID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, name string,

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -35,7 +35,7 @@ type createSequenceNode struct {
 
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
 	un := n.Name.ToUnresolvedObjectName()
-	dbDesc, prefix, err := p.ResolveTargetObject(ctx, un)
+	dbDesc, _, prefix, err := p.ResolveTargetObject(ctx, un)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -59,7 +59,7 @@ func resolveNewTypeName(
 	params runParams, name *tree.UnresolvedObjectName,
 ) (*tree.TypeName, catalog.DatabaseDescriptor, error) {
 	// Resolve the target schema and database.
-	db, prefix, err := params.p.ResolveTargetObject(params.ctx, name)
+	db, _, prefix, err := params.p.ResolveTargetObject(params.ctx, name)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -569,3 +569,32 @@ SELECT privilege_type FROM [SHOW GRANTS ON schema s FOR testuser]
 ----
 CREATE
 USAGE
+
+# Verify that a table can be renamed with a schema prefixes
+subtest alter_table_rename
+
+user root
+
+statement ok
+CREATE SCHEMA sch;
+CREATE TABLE sch.table_to_rename();
+CREATE TABLE sch.table_exists();
+CREATE TABLE public_table_to_rename();
+CREATE TABLE public_table_exists();
+
+statement ok
+ALTER TABLE sch.table_to_rename RENAME TO renamed_table;
+
+statement ok
+ALTER TABLE sch.renamed_table RENAME TO sch.renamed_table_2;
+
+statement error pq: relation "table_exists" already exists
+ALTER TABLE sch.renamed_table_2 RENAME TO sch.table_exists;
+
+statement ok
+ALTER TABLE public_table_to_rename RENAME TO public.renamed_public_table;
+
+statement error pq: relation "public_table_exists" already exists
+ALTER TABLE renamed_public_table RENAME TO public_table_exists;
+
+

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -98,6 +98,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	prevDBID := tableDesc.ParentID
 
 	var targetDbDesc catalog.DatabaseDescriptor
+	var targetSchemaDesc catalog.ResolvedSchema
 	// If the target new name has no qualifications, then assume that the table
 	// is intended to be renamed into the same database and schema.
 	newTn := n.newTn
@@ -105,6 +106,11 @@ func (n *renameTableNode) startExec(params runParams) error {
 		newTn.ObjectNamePrefix = oldTn.ObjectNamePrefix
 		var err error
 		targetDbDesc, err = p.ResolveUncachedDatabaseByName(ctx, string(oldTn.CatalogName), true /* required */)
+		if err != nil {
+			return err
+		}
+
+		_, targetSchemaDesc, err = p.ResolveUncachedSchemaDescriptor(ctx, targetDbDesc.GetID(), oldTn.Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -125,7 +131,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		newUn := newTn.ToUnresolvedObjectName()
 		var prefix tree.ObjectNamePrefix
 		var err error
-		targetDbDesc, prefix, err = p.ResolveTargetObject(ctx, newUn)
+		targetDbDesc, targetSchemaDesc, prefix, err = p.ResolveTargetObject(ctx, newUn)
 		if err != nil {
 			return err
 		}
@@ -180,8 +186,8 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return nil
 	}
 
-	exists, id, err := catalogkv.LookupPublicTableID(
-		params.ctx, params.p.txn, p.ExecCfg().Codec, targetDbDesc.GetID(), newTn.Table(),
+	exists, id, err := catalogkv.LookupObjectID(
+		params.ctx, params.p.txn, p.ExecCfg().Codec, targetDbDesc.GetID(), targetSchemaDesc.ID, newTn.Table(),
 	)
 	if err == nil && exists {
 		// Try and see what kind of object we collided with.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -167,15 +167,20 @@ func (p *planner) ResolveUncachedTableDescriptor(
 
 func (p *planner) ResolveTargetObject(
 	ctx context.Context, un *tree.UnresolvedObjectName,
-) (res catalog.DatabaseDescriptor, namePrefix tree.ObjectNamePrefix, err error) {
+) (
+	db catalog.DatabaseDescriptor,
+	schema catalog.ResolvedSchema,
+	namePrefix tree.ObjectNamePrefix,
+	err error,
+) {
 	var prefix *catalog.ResolvedObjectPrefix
 	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		prefix, namePrefix, err = resolver.ResolveTargetObject(ctx, p, un)
 	})
 	if err != nil {
-		return nil, namePrefix, err
+		return nil, catalog.ResolvedSchema{}, namePrefix, err
 	}
-	return prefix.Database, namePrefix, err
+	return prefix.Database, prefix.Schema, namePrefix, err
 }
 
 // LookupSchema implements the tree.ObjectNameTargetResolver interface.

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -123,7 +123,7 @@ func (p *planner) processSerialInColumnDef(
 	// the cache does not work (well) if the txn retries and the
 	// descriptor was written already in an early txn attempt.
 	un := seqName.ToUnresolvedObjectName()
-	dbDesc, prefix, err := p.ResolveTargetObject(ctx, un)
+	dbDesc, _, prefix, err := p.ResolveTargetObject(ctx, un)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
Previously, ALTER TABLE schema.table RENAME TO schema.existing_table
would fail because the statement would look up the destination table in
the public schema only. This commit fixes this behavior by using
the correct destination schema.

Fixes https://github.com/cockroachdb/cockroach/issues/55985

Release note: None
