### PR TITLE
storage: renaming functions in the Reader interface

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -244,7 +244,7 @@ func TestPebbleEncryption(t *testing.T) {
 	require.NoError(t, batch.Put(storage.MVCCKey{Key: roachpb.Key("a")}, []byte("a")))
 	require.NoError(t, batch.Commit(true))
 	require.NoError(t, db.Flush())
-	val, err := db.Get(storage.MVCCKey{Key: roachpb.Key("a")})
+	val, err := db.MVCCGet(storage.MVCCKey{Key: roachpb.Key("a")})
 	require.NoError(t, err)
 	require.Equal(t, "a", string(val))
 	db.Close()
@@ -266,7 +266,7 @@ func TestPebbleEncryption(t *testing.T) {
 			Opts: opts2,
 		})
 	require.NoError(t, err)
-	val, err = db.Get(storage.MVCCKey{Key: roachpb.Key("a")})
+	val, err = db.MVCCGet(storage.MVCCKey{Key: roachpb.Key("a")})
 	require.NoError(t, err)
 	require.Equal(t, "a", string(val))
 

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -156,7 +156,7 @@ func evalExport(
 		maxSize = targetSize + uint64(allowedOverage)
 	}
 	for start := args.Key; start != nil; {
-		data, summary, resume, err := e.ExportToSst(start, args.EndKey, args.StartTime,
+		data, summary, resume, err := e.ExportMVCCToSst(start, args.EndKey, args.StartTime,
 			h.Timestamp, exportAllRevisions, targetSize, maxSize, io)
 		if err != nil {
 			return result.Result{}, err

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -433,7 +433,7 @@ func assertEqualKVs(
 			var summary roachpb.BulkOpSummary
 			maxSize := uint64(0)
 			prevStart := start
-			sst, summary, start, err = e.ExportToSst(start, endKey, startTime, endTime,
+			sst, summary, start, err = e.ExportMVCCToSst(start, endKey, startTime, endTime,
 				exportAllRevisions, targetSize, maxSize, io)
 			require.NoError(t, err)
 			loaded := loadSST(t, sst, startKey, endKey)
@@ -472,7 +472,7 @@ func assertEqualKVs(
 				if dataSizeWhenExceeded == maxSize {
 					maxSize--
 				}
-				_, _, _, err = e.ExportToSst(prevStart, endKey, startTime, endTime,
+				_, _, _, err = e.ExportMVCCToSst(prevStart, endKey, startTime, endTime,
 					exportAllRevisions, targetSize, maxSize, io)
 				require.Regexp(t, fmt.Sprintf("export size \\(%d bytes\\) exceeds max size \\(%d bytes\\)",
 					dataSizeWhenExceeded, maxSize), err)

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -84,7 +84,7 @@ func clearExistingData(
 ) (enginepb.MVCCStats, error) {
 	{
 		isEmpty := true
-		if err := batch.Iterate(start, end, func(_ storage.MVCCKeyValue) error {
+		if err := batch.MVCCIterate(start, end, func(_ storage.MVCCKeyValue) error {
 			isEmpty = false
 			return iterutil.StopIteration() // stop right away
 		}); err != nil {

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -215,7 +215,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 	}
 
 	results := 0
-	return db.Iterate(debugCtx.startKey.Key, debugCtx.endKey.Key, func(kv storage.MVCCKeyValue) error {
+	return db.MVCCIterate(debugCtx.startKey.Key, debugCtx.endKey.Key, func(kv storage.MVCCKeyValue) error {
 		done, err := printer(kv)
 		if err != nil {
 			return err
@@ -380,7 +380,7 @@ func loadRangeDescriptor(
 	start := keys.LocalRangePrefix
 	end := keys.LocalRangeMax
 
-	if err := db.Iterate(start, end, handleKV); err != nil {
+	if err := db.MVCCIterate(start, end, handleKV); err != nil {
 		return roachpb.RangeDescriptor{}, err
 	}
 	if desc.RangeID == rangeID {
@@ -401,7 +401,7 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	start := keys.LocalRangePrefix
 	end := keys.LocalRangeMax
 
-	return db.Iterate(start, end, func(kv storage.MVCCKeyValue) error {
+	return db.MVCCIterate(start, end, func(kv storage.MVCCKeyValue) error {
 		if kvserver.IsRangeDescriptorKey(kv.Key) != nil {
 			return nil
 		}
@@ -531,7 +531,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		string(storage.EncodeKey(storage.MakeMVCCMetadataKey(start))),
 		string(storage.EncodeKey(storage.MakeMVCCMetadataKey(end))))
 
-	return db.Iterate(start, end, func(kv storage.MVCCKeyValue) error {
+	return db.MVCCIterate(start, end, func(kv storage.MVCCKeyValue) error {
 		kvserver.PrintKeyValue(kv)
 		return nil
 	})

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -224,7 +224,7 @@ func checkStoreRaftState(
 		return err
 	}
 
-	// Iterate over the entire range-id-local space.
+	// MVCCIterate over the entire range-id-local space.
 	start := roachpb.Key(keys.LocalRangeIDPrefix)
 	end := start.PrefixEnd()
 

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -144,7 +144,7 @@ func runSyncer(
 	}
 
 	fmt.Fprintf(stderr, "verifying existing sequence numbers...")
-	if err := db.Iterate(roachpb.KeyMin, roachpb.KeyMax, check); err != nil {
+	if err := db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, check); err != nil {
 		return 0, err
 	}
 	// We must not lose writes, but sometimes we get extra ones (i.e. we caught an

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -414,8 +414,8 @@ func verifyCleanup(key roachpb.Key, eng storage.Engine, t *testing.T, coords ...
 			}
 		}
 		meta := &enginepb.MVCCMetadata{}
-		//lint:ignore SA1019 historical usage of deprecated eng.GetProto is OK
-		ok, _, _, err := eng.GetProto(storage.MakeMVCCMetadataKey(key), meta)
+		//lint:ignore SA1019 historical usage of deprecated eng.MVCCGetProto is OK
+		ok, _, _, err := eng.MVCCGetProto(storage.MakeMVCCMetadataKey(key), meta)
 		if err != nil {
 			return fmt.Errorf("error getting MVCC metadata: %s", err)
 		}

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -118,21 +118,21 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 
 	t.Run("reads inside range", func(t *testing.T) {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if value, err := batch.Get(insideKey); err != nil {
+		if value, err := batch.MVCCGet(insideKey); err != nil {
 			t.Errorf("failed to read inside the range: %+v", err)
 		} else if !bytes.Equal(value, []byte("value")) {
 			t.Errorf("failed to read previously written value, got %q", value)
 		}
-		//lint:ignore SA1019 historical usage of deprecated batch.GetProto is OK
-		if _, _, _, err := batch.GetProto(insideKey, nil); err != nil {
-			t.Errorf("GetProto: unexpected error %v", err)
+		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
+		if _, _, _, err := batch.MVCCGetProto(insideKey, nil); err != nil {
+			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.Iterate(insideKey.Key, insideKey2.Key,
+		if err := batch.MVCCIterate(insideKey.Key, insideKey2.Key,
 			func(v storage.MVCCKeyValue) error {
 				return nil
 			},
 		); err != nil {
-			t.Errorf("Iterate: unexpected error %v", err)
+			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
 
@@ -143,37 +143,37 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 
 	t.Run("reads before range", func(t *testing.T) {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.Get(outsideKey); !isReadSpanErr(err) {
+		if _, err := batch.MVCCGet(outsideKey); !isReadSpanErr(err) {
 			t.Errorf("Get: unexpected error %v", err)
 		}
-		//lint:ignore SA1019 historical usage of deprecated batch.GetProto is OK
-		if _, _, _, err := batch.GetProto(outsideKey, nil); !isReadSpanErr(err) {
-			t.Errorf("GetProto: unexpected error %v", err)
+		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
+		if _, _, _, err := batch.MVCCGetProto(outsideKey, nil); !isReadSpanErr(err) {
+			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.Iterate(outsideKey.Key, insideKey2.Key,
+		if err := batch.MVCCIterate(outsideKey.Key, insideKey2.Key,
 			func(v storage.MVCCKeyValue) error {
 				return errors.Errorf("unexpected callback: %v", v)
 			},
 		); !isReadSpanErr(err) {
-			t.Errorf("Iterate: unexpected error %v", err)
+			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
 
 	t.Run("reads after range", func(t *testing.T) {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.Get(outsideKey3); !isReadSpanErr(err) {
+		if _, err := batch.MVCCGet(outsideKey3); !isReadSpanErr(err) {
 			t.Errorf("Get: unexpected error %v", err)
 		}
-		//lint:ignore SA1019 historical usage of deprecated batch.GetProto is OK
-		if _, _, _, err := batch.GetProto(outsideKey3, nil); !isReadSpanErr(err) {
-			t.Errorf("GetProto: unexpected error %v", err)
+		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
+		if _, _, _, err := batch.MVCCGetProto(outsideKey3, nil); !isReadSpanErr(err) {
+			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.Iterate(insideKey2.Key, outsideKey4.Key,
+		if err := batch.MVCCIterate(insideKey2.Key, outsideKey4.Key,
 			func(v storage.MVCCKeyValue) error {
 				return errors.Errorf("unexpected callback: %v", v)
 			},
 		); !isReadSpanErr(err) {
-			t.Errorf("Iterate: unexpected error %v", err)
+			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
 
@@ -349,7 +349,7 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 	// Reads.
 	for _, batch := range []storage.Batch{batchBefore, batchDuring} {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if res, err := batch.Get(rkey); err != nil {
+		if res, err := batch.MVCCGet(rkey); err != nil {
 			t.Errorf("failed to read inside the range: %+v", err)
 		} else if !bytes.Equal(res, value) {
 			t.Errorf("failed to read previously written value, got %q", res)
@@ -362,20 +362,20 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 
 	for _, batch := range []storage.Batch{batchAfter, batchNonMVCC} {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.Get(rkey); !isReadSpanErr(err) {
+		if _, err := batch.MVCCGet(rkey); !isReadSpanErr(err) {
 			t.Errorf("Get: unexpected error %v", err)
 		}
 
-		//lint:ignore SA1019 historical usage of deprecated batch.GetProto is OK
-		if _, _, _, err := batch.GetProto(rkey, nil); !isReadSpanErr(err) {
-			t.Errorf("GetProto: unexpected error %v", err)
+		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
+		if _, _, _, err := batch.MVCCGetProto(rkey, nil); !isReadSpanErr(err) {
+			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.Iterate(rkey.Key, rkey.Key,
+		if err := batch.MVCCIterate(rkey.Key, rkey.Key,
 			func(v storage.MVCCKeyValue) error {
 				return errors.Errorf("unexpected callback: %v", v)
 			},
 		); !isReadSpanErr(err) {
-			t.Errorf("Iterate: unexpected error %v", err)
+			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	}
 }
@@ -510,7 +510,7 @@ func TestSpanSetNonMVCCBatch(t *testing.T) {
 	// Reads.
 	for _, batch := range []storage.Batch{batchNonMVCC, batchMVCC} {
 		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if res, err := batch.Get(rkey); err != nil {
+		if res, err := batch.MVCCGet(rkey); err != nil {
 			t.Errorf("read disallowed through non-MVCC latch: %+v", err)
 		} else if !bytes.Equal(res, value) {
 			t.Errorf("failed to read previously written value, got %q", res)

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -87,7 +87,7 @@ func ClearRange(
 	// instead of using a range tombstone (inefficient for small ranges).
 	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
-		if err := readWriter.Iterate(from, to,
+		if err := readWriter.MVCCIterate(from, to,
 			func(kv storage.MVCCKeyValue) error {
 				return readWriter.Clear(kv.Key)
 			},

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -142,7 +142,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			if err := batch.Commit(true /* commit */); err != nil {
 				t.Fatal(err)
 			}
-			if err := eng.Iterate(startKey, endKey,
+			if err := eng.MVCCIterate(startKey, endKey,
 				func(kv storage.MVCCKeyValue) error {
 					return errors.New("expected no data in underlying engine")
 				},

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -30,7 +30,7 @@ import (
 func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []byte {
 	t.Helper()
 	h := sha256.New()
-	if err := reader.Iterate(start, end,
+	if err := reader.MVCCIterate(start, end,
 		func(kv storage.MVCCKeyValue) error {
 			h.Write(kv.Key.Key)
 			h.Write(kv.Value)

--- a/pkg/kv/kvserver/compactor/compactor.go
+++ b/pkg/kv/kvserver/compactor/compactor.go
@@ -294,7 +294,7 @@ func (c *Compactor) fetchSuggestions(
 	delBatch := c.eng.NewBatch()
 	defer delBatch.Close()
 
-	err = c.eng.Iterate(
+	err = c.eng.MVCCIterate(
 		keys.LocalStoreSuggestedCompactionsMin,
 		keys.LocalStoreSuggestedCompactionsMax,
 		func(kv storage.MVCCKeyValue) error {
@@ -462,7 +462,7 @@ func (c *Compactor) aggregateCompaction(
 // BytesQueued gauge.
 func (c *Compactor) examineQueue(ctx context.Context) (int64, error) {
 	var totalBytes int64
-	if err := c.eng.Iterate(
+	if err := c.eng.MVCCIterate(
 		keys.LocalStoreSuggestedCompactionsMin,
 		keys.LocalStoreSuggestedCompactionsMax,
 		func(kv storage.MVCCKeyValue) error {
@@ -488,8 +488,8 @@ func (c *Compactor) Suggest(ctx context.Context, sc kvserverpb.SuggestedCompacti
 	// Check whether a suggested compaction already exists for this key span.
 	key := keys.StoreSuggestedCompactionKey(sc.StartKey, sc.EndKey)
 	var existing kvserverpb.Compaction
-	//lint:ignore SA1019 historical usage of deprecated c.eng.GetProto is OK
-	ok, _, _, err := c.eng.GetProto(storage.MVCCKey{Key: key}, &existing)
+	//lint:ignore SA1019 historical usage of deprecated c.eng.MVCCGetProto is OK
+	ok, _, _, err := c.eng.MVCCGetProto(storage.MVCCKey{Key: key}, &existing)
 	if err != nil {
 		log.VErrEventf(ctx, 2, "unable to record suggested compaction: %s", err)
 		return

--- a/pkg/kv/kvserver/compactor/compactor_test.go
+++ b/pkg/kv/kvserver/compactor/compactor_test.go
@@ -568,7 +568,7 @@ func TestCompactorThresholds(t *testing.T) {
 				// Read the remaining suggestions in the queue; verify compacted
 				// spans have been cleared and uncompacted spans remain.
 				var idx int
-				return we.Iterate(
+				return we.MVCCIterate(
 					keys.LocalStoreSuggestedCompactionsMin,
 					keys.LocalStoreSuggestedCompactionsMax,
 					func(kv storage.MVCCKeyValue) error {

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -967,12 +967,12 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	}
 	assert.True(t, processed, "queue not processed")
 
-	// Iterate through all values to ensure intents have been fully resolved.
+	// MVCCIterate through all values to ensure intents have been fully resolved.
 	// This must be done in a SucceedsSoon loop because intent resolution
 	// is initiated asynchronously from the GC queue.
 	testutils.SucceedsSoon(t, func() error {
 		meta := &enginepb.MVCCMetadata{}
-		return tc.store.Engine().Iterate(roachpb.KeyMin, roachpb.KeyMax,
+		return tc.store.Engine().MVCCIterate(roachpb.KeyMin, roachpb.KeyMax,
 			func(kv storage.MVCCKeyValue) error {
 				if !kv.Key.IsValue() {
 					if err := protoutil.Unmarshal(kv.Value, meta); err != nil {

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -199,9 +199,9 @@ func TestReadOnlyBasics(t *testing.T) {
 			a := mvccKey("a")
 			getVal := &roachpb.Value{}
 			successTestCases := []func(){
-				func() { _, _ = ro.Get(a) },
-				func() { _, _, _, _ = ro.GetProto(a, getVal) },
-				func() { _ = ro.Iterate(a.Key, a.Key, func(MVCCKeyValue) error { return iterutil.StopIteration() }) },
+				func() { _, _ = ro.MVCCGet(a) },
+				func() { _, _, _, _ = ro.MVCCGetProto(a, getVal) },
+				func() { _ = ro.MVCCIterate(a.Key, a.Key, func(MVCCKeyValue) error { return iterutil.StopIteration() }) },
 				func() { ro.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}).Close() },
 				func() {
 					ro.NewIterator(IterOptions{
@@ -409,7 +409,7 @@ func TestApplyBatchRepr(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				if b, err := e.Get(key); err != nil {
+				if b, err := e.MVCCGet(key); err != nil {
 					t.Fatal(err)
 				} else if !reflect.DeepEqual(b, val) {
 					t.Fatalf("read %q from engine, expected %q", b, val)
@@ -465,7 +465,7 @@ func TestBatchGet(t *testing.T) {
 				{Key: mvccKey("d"), Value: []byte("after")},
 			}
 			for i, expKV := range expValues {
-				kv, err := b.Get(expKV.Key)
+				kv, err := b.MVCCGet(expKV.Key)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -523,7 +523,7 @@ func TestBatchMerge(t *testing.T) {
 			}
 
 			// Verify values.
-			val, err := b.Get(mvccKey("a"))
+			val, err := b.MVCCGet(mvccKey("a"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -531,7 +531,7 @@ func TestBatchMerge(t *testing.T) {
 				t.Error("mismatch of \"a\"")
 			}
 
-			val, err = b.Get(mvccKey("b"))
+			val, err = b.MVCCGet(mvccKey("b"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -539,7 +539,7 @@ func TestBatchMerge(t *testing.T) {
 				t.Error("mismatch of \"b\"")
 			}
 
-			val, err = b.Get(mvccKey("c"))
+			val, err = b.MVCCGet(mvccKey("c"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -567,9 +567,9 @@ func TestBatchProto(t *testing.T) {
 				t.Fatal(err)
 			}
 			getVal := &roachpb.Value{}
-			ok, keySize, valSize, err := b.GetProto(mvccKey("proto"), getVal)
+			ok, keySize, valSize, err := b.MVCCGetProto(mvccKey("proto"), getVal)
 			if !ok || err != nil {
-				t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
+				t.Fatalf("expected MVCCGetProto to success ok=%t: %+v", ok, err)
 			}
 			if keySize != 6 {
 				t.Errorf("expected key size 6; got %d", keySize)
@@ -586,16 +586,16 @@ func TestBatchProto(t *testing.T) {
 			}
 			// Before commit, proto will not be available via engine.
 			fmt.Printf("before\n")
-			if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
+			if ok, _, _, err := e.MVCCGetProto(mvccKey("proto"), getVal); ok || err != nil {
 				fmt.Printf("after\n")
-				t.Fatalf("expected GetProto to fail ok=%t: %+v", ok, err)
+				t.Fatalf("expected MVCCGetProto to fail ok=%t: %+v", ok, err)
 			}
 			// Commit and verify the proto can be read directly from the engine.
 			if err := b.Commit(false /* sync */); err != nil {
 				t.Fatal(err)
 			}
-			if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
-				t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
+			if ok, _, _, err := e.MVCCGetProto(mvccKey("proto"), getVal); !ok || err != nil {
+				t.Fatalf("expected MVCCGetProto to success ok=%t: %+v", ok, err)
 			}
 			if !proto.Equal(getVal, &val) {
 				t.Errorf("expected %v; got %v", &val, getVal)
@@ -790,7 +790,7 @@ func TestBatchConcurrency(t *testing.T) {
 			if err := b.Merge(mvccKey("a"), appender("bar")); err != nil {
 				t.Fatal(err)
 			}
-			val, err := b.Get(mvccKey("a"))
+			val, err := b.MVCCGet(mvccKey("a"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -802,7 +802,7 @@ func TestBatchConcurrency(t *testing.T) {
 				t.Fatal(err)
 			}
 			// Now, read again and verify that the merge happens on top of the mod.
-			val, err = b.Get(mvccKey("a"))
+			val, err = b.MVCCGet(mvccKey("a"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -842,7 +842,7 @@ func TestBatchDistinctAfterApplyBatchRepr(t *testing.T) {
 			defer distinct.Close()
 
 			// The distinct batch can see the earlier write to the batch.
-			v, err := distinct.Get(mvccKey("batchkey"))
+			v, err := distinct.MVCCGet(mvccKey("batchkey"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -875,7 +875,7 @@ func TestBatchDistinct(t *testing.T) {
 			}
 
 			// The original batch can see the writes to the batch.
-			if v, err := batch.Get(mvccKey("a")); err != nil {
+			if v, err := batch.MVCCGet(mvccKey("a")); err != nil {
 				t.Fatal(err)
 			} else if string(v) != "a" {
 				t.Fatalf("expected a, but got %s", v)
@@ -883,12 +883,12 @@ func TestBatchDistinct(t *testing.T) {
 
 			// The distinct batch will see previous writes to the batch.
 			distinct := batch.Distinct()
-			if v, err := distinct.Get(mvccKey("a")); err != nil {
+			if v, err := distinct.MVCCGet(mvccKey("a")); err != nil {
 				t.Fatal(err)
 			} else if string(v) != "a" {
 				t.Fatalf("expected a, but got %s", v)
 			}
-			if v, err := distinct.Get(mvccKey("b")); err != nil {
+			if v, err := distinct.MVCCGet(mvccKey("b")); err != nil {
 				t.Fatal(err)
 			} else if v != nil {
 				t.Fatalf("expected nothing, but got %s", v)
@@ -909,7 +909,7 @@ func TestBatchDistinct(t *testing.T) {
 			if err := distinct.Put(mvccKey("c"), []byte("c")); err != nil {
 				t.Fatal(err)
 			}
-			if v, err := distinct.Get(mvccKey("c")); err != nil {
+			if v, err := distinct.MVCCGet(mvccKey("c")); err != nil {
 				t.Fatal(err)
 			} else {
 				switch engineImpl.name {
@@ -931,7 +931,7 @@ func TestBatchDistinct(t *testing.T) {
 			distinct.Close()
 
 			// Writes to the distinct batch are reflected in the original batch.
-			if v, err := batch.Get(mvccKey("c")); err != nil {
+			if v, err := batch.MVCCGet(mvccKey("c")); err != nil {
 				t.Fatal(err)
 			} else if string(v) != "c" {
 				t.Fatalf("expected c, but got %s", v)
@@ -974,14 +974,14 @@ func TestWriteOnlyBatchDistinct(t *testing.T) {
 			}
 			iter.Close()
 
-			if v, err := distinct.Get(mvccKey("b")); err != nil {
+			if v, err := distinct.MVCCGet(mvccKey("b")); err != nil {
 				t.Fatal(err)
 			} else if string(v) != "b" {
 				t.Fatalf("expected b, but got %s", v)
 			}
 
 			val := &roachpb.Value{}
-			if _, _, _, err := distinct.GetProto(mvccKey("c"), val); err != nil {
+			if _, _, _, err := distinct.MVCCGetProto(mvccKey("c"), val); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1012,9 +1012,9 @@ func TestBatchDistinctPanics(t *testing.T) {
 				func() { _ = batch.Clear(a) },
 				func() { _ = batch.SingleClear(a) },
 				func() { _ = batch.ApplyBatchRepr(nil, false) },
-				func() { _, _ = batch.Get(a) },
-				func() { _, _, _, _ = batch.GetProto(a, nil) },
-				func() { _ = batch.Iterate(a.Key, a.Key, nil) },
+				func() { _, _ = batch.MVCCGet(a) },
+				func() { _, _, _, _ = batch.MVCCGetProto(a, nil) },
+				func() { _ = batch.MVCCIterate(a.Key, a.Key, nil) },
 				func() { _ = batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}) },
 			}
 			for i, f := range testCases {
@@ -1173,7 +1173,7 @@ func TestBatchCombine(t *testing.T) {
 						}
 
 						// Verify we can read the key we just wrote immediately.
-						if v, err := e.Get(mvccKey(k)); err != nil {
+						if v, err := e.MVCCGet(mvccKey(k)); err != nil {
 							errs <- errors.Wrap(err, "get failed")
 							return
 						} else if string(v) != k {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1065,7 +1065,7 @@ func runExportToSst(
 	for i := 0; i < b.N; i++ {
 		startTS := hlc.Timestamp{WallTime: int64(numRevisions / 2)}
 		endTS := hlc.Timestamp{WallTime: int64(numRevisions + 2)}
-		_, _, _, err := engine.ExportToSst(roachpb.KeyMin, roachpb.KeyMax, startTS, endTS, exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, IterOptions{
+		_, _, _, err := engine.ExportMVCCToSst(roachpb.KeyMin, roachpb.KeyMax, startTS, endTS, exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, IterOptions{
 			LowerBound: roachpb.KeyMin,
 			UpperBound: roachpb.KeyMax,
 		})

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -97,7 +97,7 @@ func TestMVCCHistories(t *testing.T) {
 
 				reportDataEntries := func(buf *bytes.Buffer) error {
 					hasData := false
-					err := engine.Iterate(
+					err := engine.MVCCIterate(
 						span.Key,
 						span.EndKey,
 						func(r MVCCKeyValue) error {
@@ -521,7 +521,7 @@ func cmdCheckIntent(e *evalCtx) error {
 	}
 	metaKey := mvccKey(key)
 	var meta enginepb.MVCCMetadata
-	ok, _, _, err := e.engine.GetProto(metaKey, &meta)
+	ok, _, _, err := e.engine.MVCCGetProto(metaKey, &meta)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -79,7 +79,7 @@ func assertExportedKVs(
 	expected []MVCCKeyValue,
 ) {
 	const big = 1 << 30
-	data, _, _, err := e.ExportToSst(startKey, endKey, startTime, endTime, revisions, big, big, io)
+	data, _, _, err := e.ExportMVCCToSst(startKey, endKey, startTime, endTime, revisions, big, big, io)
 	require.NoError(t, err)
 
 	if data == nil {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -867,7 +867,7 @@ func TestMVCCDeleteMissingKey(t *testing.T) {
 				t.Fatal(err)
 			}
 			// Verify nothing is written to the engine.
-			if val, err := engine.Get(mvccKey(testKey1)); err != nil || val != nil {
+			if val, err := engine.MVCCGet(mvccKey(testKey1)); err != nil || val != nil {
 				t.Fatalf("expected no mvcc metadata after delete of a missing key; got %q: %+v", val, err)
 			}
 		})
@@ -1170,7 +1170,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 }
 
-// TestMVCCGetProtoInconsistent verifies the behavior of GetProto with
+// TestMVCCGetProtoInconsistent verifies the behavior of MVCCGetProto with
 // consistent set to false.
 func TestMVCCGetProtoInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -3470,7 +3470,7 @@ func TestMVCCAbortTxn(t *testing.T) {
 			} else if value != nil {
 				t.Fatalf("expected the value to be empty: %s", value)
 			}
-			if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+			if meta, err := engine.MVCCGet(mvccKey(testKey1)); err != nil {
 				t.Fatal(err)
 			} else if len(meta) != 0 {
 				t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
@@ -3509,7 +3509,7 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+			if meta, err := engine.MVCCGet(mvccKey(testKey1)); err != nil {
 				t.Fatal(err)
 			} else if len(meta) != 0 {
 				t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
@@ -5230,7 +5230,7 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 			// Check that the intent was not cleared.
 			metaKey := mvccKey(testKey1)
 			meta := &enginepb.MVCCMetadata{}
-			ok, _, _, err := engine.GetProto(metaKey, meta)
+			ok, _, _, err := engine.MVCCGetProto(metaKey, meta)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -626,8 +626,8 @@ func (p *Pebble) Closed() bool {
 	return p.closed
 }
 
-// ExportToSst is part of the engine.Reader interface.
-func (p *Pebble) ExportToSst(
+// ExportMVCCToSst is part of the engine.Reader interface.
+func (p *Pebble) ExportMVCCToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -637,8 +637,8 @@ func (p *Pebble) ExportToSst(
 	return pebbleExportToSst(p, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 }
 
-// Get implements the Engine interface.
-func (p *Pebble) Get(key MVCCKey) ([]byte, error) {
+// MVCCGet implements the Engine interface.
+func (p *Pebble) MVCCGet(key MVCCKey) ([]byte, error) {
 	if len(key.Key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -663,8 +663,8 @@ func (p *Pebble) GetCompactionStats() string {
 	return "\n" + p.db.Metrics().String()
 }
 
-// GetProto implements the Engine interface.
-func (p *Pebble) GetProto(
+// MVCCGetProto implements the Engine interface.
+func (p *Pebble) MVCCGetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	if len(key.Key) == 0 {
@@ -687,8 +687,8 @@ func (p *Pebble) GetProto(
 	return false, 0, 0, err
 }
 
-// Iterate implements the Engine interface.
-func (p *Pebble) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+// MVCCIterate implements the Engine interface.
+func (p *Pebble) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
 	return iterateOnReader(p, start, end, f)
 }
 
@@ -1115,8 +1115,8 @@ func (p *pebbleReadOnly) Closed() bool {
 	return p.closed
 }
 
-// ExportToSst is part of the engine.Reader interface.
-func (p *pebbleReadOnly) ExportToSst(
+// ExportMVCCToSst is part of the engine.Reader interface.
+func (p *pebbleReadOnly) ExportMVCCToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -1126,23 +1126,23 @@ func (p *pebbleReadOnly) ExportToSst(
 	return pebbleExportToSst(p, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 }
 
-func (p *pebbleReadOnly) Get(key MVCCKey) ([]byte, error) {
+func (p *pebbleReadOnly) MVCCGet(key MVCCKey) ([]byte, error) {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
-	return p.parent.Get(key)
+	return p.parent.MVCCGet(key)
 }
 
-func (p *pebbleReadOnly) GetProto(
+func (p *pebbleReadOnly) MVCCGetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
-	return p.parent.GetProto(key, msg)
+	return p.parent.MVCCGetProto(key, msg)
 }
 
-func (p *pebbleReadOnly) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+func (p *pebbleReadOnly) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
@@ -1237,8 +1237,8 @@ func (p *pebbleSnapshot) Closed() bool {
 	return p.closed
 }
 
-// ExportToSst is part of the engine.Reader interface.
-func (p *pebbleSnapshot) ExportToSst(
+// ExportMVCCToSst is part of the engine.Reader interface.
+func (p *pebbleSnapshot) ExportMVCCToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -1249,7 +1249,7 @@ func (p *pebbleSnapshot) ExportToSst(
 }
 
 // Get implements the Reader interface.
-func (p *pebbleSnapshot) Get(key MVCCKey) ([]byte, error) {
+func (p *pebbleSnapshot) MVCCGet(key MVCCKey) ([]byte, error) {
 	if len(key.Key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -1267,8 +1267,8 @@ func (p *pebbleSnapshot) Get(key MVCCKey) ([]byte, error) {
 	return ret, err
 }
 
-// GetProto implements the Reader interface.
-func (p *pebbleSnapshot) GetProto(
+// MVCCGetProto implements the Reader interface.
+func (p *pebbleSnapshot) MVCCGetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	if len(key.Key) == 0 {
@@ -1291,8 +1291,8 @@ func (p *pebbleSnapshot) GetProto(
 	return false, 0, 0, err
 }
 
-// Iterate implements the Reader interface.
-func (p *pebbleSnapshot) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+// MVCCIterate implements the Reader interface.
+func (p *pebbleSnapshot) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
 	return iterateOnReader(p, start, end, f)
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -89,8 +89,8 @@ func (p *pebbleBatch) Closed() bool {
 	return p.closed
 }
 
-// ExportToSst is part of the engine.Reader interface.
-func (p *pebbleBatch) ExportToSst(
+// ExportMVCCToSst is part of the engine.Reader interface.
+func (p *pebbleBatch) ExportMVCCToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -101,7 +101,7 @@ func (p *pebbleBatch) ExportToSst(
 }
 
 // Get implements the Batch interface.
-func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
+func (p *pebbleBatch) MVCCGet(key MVCCKey) ([]byte, error) {
 	r := pebble.Reader(p.batch)
 	if !p.isDistinct {
 		if !p.batch.Indexed() {
@@ -130,8 +130,8 @@ func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
 	return ret, err
 }
 
-// GetProto implements the Batch interface.
-func (p *pebbleBatch) GetProto(
+// MVCCGetProto implements the Batch interface.
+func (p *pebbleBatch) MVCCGetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	r := pebble.Reader(p.batch)
@@ -165,8 +165,8 @@ func (p *pebbleBatch) GetProto(
 	return false, 0, 0, err
 }
 
-// Iterate implements the Batch interface.
-func (p *pebbleBatch) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+// MVCCIterate implements the Batch interface.
+func (p *pebbleBatch) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
 	}


### PR DESCRIPTION
- Get to MVCCGet
- GetProto to MVCCGetProto
- Iterate to MVCCIterate
- ExportToSst to ExportMVCCToSst

Also added MVCCIterKind.

Release note: None
