### PR TITLE
release-20.2: ui: fix tooltip in database grants page

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
@@ -82,7 +82,7 @@ export class DatabaseSummaryGrants extends DatabaseSummaryBase {
             <SummaryCard>
                 <SummaryHeadlineStat
                   title="Total Users"
-                  tooltip="Total users that have been granted permissions on this table."
+                  tooltip="Total users that have been granted permissions on this database."
                   value={this.totalUsers()}
                 />
             </SummaryCard>


### PR DESCRIPTION
Backport 1/1 commits from #55066.

/cc @cockroachdb/release

---

It referred to grants on a table, but it was actually showing grants on
a database.

Release note: None
