### PR TITLE
roachtest: increase slowness threshold to 50% for tpchvec/perf

### DIFF
--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -86,16 +86,6 @@ func scatterTables(t *test, conn *gosql.DB, tableNames []string) {
 	}
 }
 
-// disableRangeMerges disables the range merge queue on the cluster.
-func disableRangeMerges(t *test, conn *gosql.DB) {
-	t.Status("disabling range merges")
-	if _, err := conn.Exec(
-		`SET CLUSTER SETTING kv.range_merge.queue_enabled = false`,
-	); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // disableAutoStats disables automatic collection of statistics on the cluster.
 func disableAutoStats(t *test, conn *gosql.DB) {
 	t.Status("disabling automatic collection of stats")

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -98,9 +98,6 @@ func registerTPCDSVec(r *testRegistry) {
 		c.Start(ctx, t)
 
 		clusterConn := c.Conn(ctx, 1)
-		// We will disable range merges in order to remove a possible source of
-		// random query latency spikes during perf runs.
-		disableRangeMerges(t, clusterConn)
 		disableAutoStats(t, clusterConn)
 		disableVectorizeRowCountThresholdHeuristic(t, clusterConn)
 		t.Status("restoring TPCDS dataset for Scale Factor 1")

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -75,20 +75,7 @@ var queriesToSkipByVersion = map[crdbVersion]map[int]string{
 	},
 }
 
-// getSlownessThreshold returns the threshold at which we fail the test if vec
-// ON is slower that vec OFF, meaning that if
-//   vec_on_time >= slownessThreshold * vec_off_time
-// the test is failed. This will help catch any regressions.
-func getSlownessThreshold(version crdbVersion) float64 {
-	switch version {
-	// Note that for 19.2 version the threshold is higher in order to reduce
-	// the noise.
-	case tpchVecVersion19_2:
-		return 1.5
-	default:
-		return 1.2
-	}
-}
+const tpchVecPerfSlownessThreshold = 1.5
 
 var tpchTables = []string{
 	"nation", "region", "part", "supplier",
@@ -324,7 +311,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 					queryNum, 100*(vecOffTime-vecOnTime)/vecOnTime,
 					vecOnTime, vecOffTime, vecOnTimes, vecOffTimes))
 		}
-		if vecOnTime >= getSlownessThreshold(version)*vecOffTime {
+		if vecOnTime >= tpchVecPerfSlownessThreshold*vecOffTime {
 			// For some reason, the vectorized engine executed the query a lot
 			// slower than the row-by-row engine which is unexpected. In order
 			// to understand where the slowness comes from, we will run EXPLAIN
@@ -658,9 +645,6 @@ func runTPCHVec(
 	c.Start(ctx, t)
 
 	conn := c.Conn(ctx, 1)
-	// We will disable range merges in order to remove a possible source of
-	// random query latency spikes during perf runs.
-	disableRangeMerges(t, conn)
 	disableAutoStats(t, conn)
 	disableVectorizeRowCountThresholdHeuristic(t, conn)
 	t.Status("restoring TPCH dataset for Scale Factor 1")


### PR DESCRIPTION
We have seen many false positives from tpchvec/perf test that are due to
the variation of the runtime of join readers, so this commit increases
the slowness threshold from 20% to 50%. Additionally, it removes the
range merge disabling that was introduced in hopes to reduce the noise.

Fixes: #55955.

Release note: None