### PR TITLE
storage: add MVCCIterKind parameter to Reader functions

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -174,12 +174,12 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 		b.Run(fmt.Sprintf("LoadFactor=%.2f", loadFactor), func(b *testing.B) {
 			b.Run("NormalIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, _, _ hlc.Timestamp) storage.MVCCIterator {
-					return e.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+					return e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				})
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) storage.MVCCIterator {
-					return e.NewIterator(storage.IterOptions{
+					return e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 						MinTimestampHint: startTime,
 						MaxTimestampHint: endTime,
 						UpperBound:       roachpb.KeyMax,

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -110,7 +110,7 @@ func slurpSSTablesLatestKey(
 	}
 
 	var kvs []storage.MVCCKeyValue
-	it := batch.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+	it := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 	for it.SeekGE(start); ; it.NextKey() {
 		if ok, err := it.Valid(); err != nil {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -84,7 +84,7 @@ func clearExistingData(
 ) (enginepb.MVCCStats, error) {
 	{
 		isEmpty := true
-		if err := batch.MVCCIterate(start, end, func(_ storage.MVCCKeyValue) error {
+		if err := batch.MVCCIterate(start, end, storage.MVCCKeyAndIntentsIterKind, func(_ storage.MVCCKeyValue) error {
 			isEmpty = false
 			return iterutil.StopIteration() // stop right away
 		}); err != nil {
@@ -96,7 +96,7 @@ func clearExistingData(
 		}
 	}
 
-	iter := batch.NewIterator(storage.IterOptions{UpperBound: end})
+	iter := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end})
 	defer iter.Close()
 
 	iter.SeekGE(storage.MakeMVCCMetadataKey(start))

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -144,7 +144,7 @@ func runSyncer(
 	}
 
 	fmt.Fprintf(stderr, "verifying existing sequence numbers...")
-	if err := db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, check); err != nil {
+	if err := db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind, check); err != nil {
 		return 0, err
 	}
 	// We must not lose writes, but sometimes we get extra ones (i.e. we caught an

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -125,7 +125,8 @@
 // be the target of KV operations, unaddressable keys can only be written as a
 // side-effect of other KV operations. This can often makes the choice between
 // the two clear (range descriptor keys needing to be addressable, and therefore
-// being a range local key is one example of this).
+// being a range local key is one example of this). Not being addressable also
+// implies not having multiple versions, and therefore never having intents.
 //
 // The "behavioral" difference between range local keys and range-id local keys
 // is that range local keys split and merge along range boundaries while

--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -76,7 +76,8 @@ func (sc *AbortSpan) max() roachpb.Key {
 
 // ClearData removes all persisted items stored in the cache.
 func (sc *AbortSpan) ClearData(e storage.Engine) error {
-	iter := e.NewIterator(storage.IterOptions{UpperBound: sc.max()})
+	// NB: The abort span is a Range-ID local key which has no versions or intents.
+	iter := e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: sc.max()})
 	defer iter.Close()
 	b := e.NewWriteOnlyBatch()
 	defer b.Close()

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -225,7 +225,7 @@ func checkForKeyCollisions(
 	emptyMVCCStats := enginepb.MVCCStats{}
 
 	// Create iterator over the existing data.
-	existingDataIter := dbEngine.NewIterator(storage.IterOptions{UpperBound: mvccEndKey.Key})
+	existingDataIter := dbEngine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: mvccEndKey.Key})
 	defer existingDataIter.Close()
 	existingDataIter.SeekGE(mvccStartKey)
 	if ok, err := existingDataIter.Valid(); err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -390,7 +390,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			// stats. Make sure recomputing from scratch gets the same answer as
 			// applying the diff to the stats
 			beforeStats := func() enginepb.MVCCStats {
-				iter := e.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
 				beforeStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {
@@ -441,7 +441,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			}
 
 			afterStats := func() enginepb.MVCCStats {
-				iter := e.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
 				afterStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -142,11 +142,9 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			if err := batch.Commit(true /* commit */); err != nil {
 				t.Fatal(err)
 			}
-			if err := eng.MVCCIterate(startKey, endKey,
-				func(kv storage.MVCCKeyValue) error {
-					return errors.New("expected no data in underlying engine")
-				},
-			); err != nil {
+			if err := eng.MVCCIterate(startKey, endKey, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
+				return errors.New("expected no data in underlying engine")
+			}); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -442,7 +442,7 @@ func resolveLocalLocks(
 		desc = &mergeTrigger.LeftDesc
 	}
 
-	iter := readWriter.NewIterator(storage.IterOptions{
+	iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		UpperBound: desc.EndKey.AsRawKey(),
 	})
 	iterAndBuf := storage.GetBufUsingIter(iter)
@@ -1063,7 +1063,8 @@ func mergeTrigger(
 	ms.Add(merge.RightMVCCStats)
 	{
 		ridPrefix := keys.MakeRangeIDReplicatedPrefix(merge.RightDesc.RangeID)
-		iter := batch.NewIterator(storage.IterOptions{UpperBound: ridPrefix.PrefixEnd()})
+		// NB: Range-ID local keys have no versions and no intents.
+		iter := batch.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: ridPrefix.PrefixEnd()})
 		defer iter.Close()
 		sysMS, err := iter.ComputeStats(ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -48,7 +48,7 @@ func isEmptyKeyTimeRange(
 	// may not be in the time range but the fact the TBI found any key indicates
 	// that there is *a* key in the SST that is in the time range. Thus we should
 	// proceed to iteration that actually checks timestamps on each key.
-	iter := readWriter.NewIterator(storage.IterOptions{
+	iter := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound: from, UpperBound: to,
 		MinTimestampHint: since.Next() /* make exclusive */, MaxTimestampHint: until,
 	})

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -30,13 +30,11 @@ import (
 func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []byte {
 	t.Helper()
 	h := sha256.New()
-	if err := reader.MVCCIterate(start, end,
-		func(kv storage.MVCCKeyValue) error {
-			h.Write(kv.Key.Key)
-			h.Write(kv.Value)
-			return nil
-		},
-	); err != nil {
+	if err := reader.MVCCIterate(start, end, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
+		h.Write(kv.Key.Key)
+		h.Write(kv.Value)
+		return nil
+	}); err != nil {
 		t.Fatal(err)
 	}
 	return h.Sum(nil)
@@ -44,7 +42,7 @@ func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []by
 
 func getStats(t *testing.T, reader storage.Reader) enginepb.MVCCStats {
 	t.Helper()
-	iter := reader.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 	s, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
 	if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -113,7 +113,7 @@ func TruncateLog(
 	// bugs that let it diverge. It might be easier to compute the stats
 	// from scratch, stopping when 4mb (defaultRaftLogTruncationThreshold)
 	// is reached as at that point we'll truncate aggressively anyway.
-	iter := readWriter.NewIterator(storage.IterOptions{UpperBound: end})
+	iter := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: end})
 	defer iter.Close()
 	// We can pass zero as nowNanos because we're only interested in SysBytes.
 	ms, err := iter.ComputeStats(start, end, 0 /* nowNanos */)

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -32,11 +32,13 @@ type instrumentedEngine struct {
 	// ... can be extended ...
 }
 
-func (ie *instrumentedEngine) NewIterator(opts storage.IterOptions) storage.MVCCIterator {
+func (ie *instrumentedEngine) NewMVCCIterator(
+	iterKind storage.MVCCIterKind, opts storage.IterOptions,
+) storage.MVCCIterator {
 	if ie.onNewIterator != nil {
 		ie.onNewIterator(opts)
 	}
-	return ie.Engine.NewIterator(opts)
+	return ie.Engine.NewMVCCIterator(iterKind, opts)
 }
 
 // TestCollectIntentsUsesSameIterator tests that all uses of CollectIntents

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -409,7 +409,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	// Verify the transaction record is gone.
 	start := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMin))
 	end := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMax))
-	iter := store.Engine().NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+	iter := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 
 	defer iter.Close()
 	for iter.SeekGE(start); ; iter.Next() {

--- a/pkg/kv/kvserver/compactor/compactor_test.go
+++ b/pkg/kv/kvserver/compactor/compactor_test.go
@@ -568,25 +568,21 @@ func TestCompactorThresholds(t *testing.T) {
 				// Read the remaining suggestions in the queue; verify compacted
 				// spans have been cleared and uncompacted spans remain.
 				var idx int
-				return we.MVCCIterate(
-					keys.LocalStoreSuggestedCompactionsMin,
-					keys.LocalStoreSuggestedCompactionsMax,
-					func(kv storage.MVCCKeyValue) error {
-						start, end, err := keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
-						if err != nil {
-							t.Fatalf("failed to decode suggested compaction key: %+v", err)
-						}
-						if idx >= len(test.expUncompacted) {
-							return fmt.Errorf("found unexpected uncompacted span %s-%s", start, end)
-						}
-						if !start.Equal(test.expUncompacted[idx].Key) || !end.Equal(test.expUncompacted[idx].EndKey) {
-							return fmt.Errorf("found unexpected uncompacted span %s-%s; expected %s-%s",
-								start, end, test.expUncompacted[idx].Key, test.expUncompacted[idx].EndKey)
-						}
-						idx++
-						return nil // continue iteration
-					},
-				)
+				return we.MVCCIterate(keys.LocalStoreSuggestedCompactionsMin, keys.LocalStoreSuggestedCompactionsMax, storage.MVCCKeyIterKind, func(kv storage.MVCCKeyValue) error {
+					start, end, err := keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
+					if err != nil {
+						t.Fatalf("failed to decode suggested compaction key: %+v", err)
+					}
+					if idx >= len(test.expUncompacted) {
+						return fmt.Errorf("found unexpected uncompacted span %s-%s", start, end)
+					}
+					if !start.Equal(test.expUncompacted[idx].Key) || !end.Equal(test.expUncompacted[idx].EndKey) {
+						return fmt.Errorf("found unexpected uncompacted span %s-%s; expected %s-%s",
+							start, end, test.expUncompacted[idx].Key, test.expUncompacted[idx].EndKey)
+					}
+					idx++
+					return nil // continue iteration
+				})
 			})
 		})
 	}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -439,7 +439,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		assert.NoError(t, err)
 		defer cpEng.Close()
 
-		iter := cpEng.NewIterator(storage.IterOptions{UpperBound: []byte("\xff")})
+		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})
 		defer iter.Close()
 
 		ms, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -114,7 +114,8 @@ func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 func NewReplicaDataIterator(
 	d *roachpb.RangeDescriptor, reader storage.Reader, replicatedOnly bool, seekEnd bool,
 ) *ReplicaDataIterator {
-	it := reader.NewIterator(storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
+	// TODO(sumeer): use an EngineIterator.
+	it := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 
 	rangeFunc := MakeAllKeyRanges
 	if replicatedOnly {

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -22,7 +22,7 @@ import (
 func ComputeStatsForRange(
 	d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	iter := reader.NewIterator(storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
+	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 	defer iter.Close()
 
 	ms := enginepb.MVCCStats{}

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -89,7 +89,10 @@ func optimizePuts(
 	if firstUnoptimizedIndex < optimizePutThreshold { // don't bother if below this threshold
 		return origReqs
 	}
-	iter := reader.NewIterator(storage.IterOptions{
+	// iter is being used to find the parts of the key range that is empty. We
+	// don't need to see intents for this purpose since intents also have
+	// provisional values that we will see.
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		// We want to include maxKey in our scan. Since UpperBound is exclusive, we
 		// need to set it to the key after maxKey.
 		UpperBound: maxKey.Next(),

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1739,7 +1739,7 @@ func ComputeRaftLogSize(
 ) (int64, error) {
 	prefix := keys.RaftLogPrefix(rangeID)
 	prefixEnd := prefix.PrefixEnd()
-	iter := reader.NewIterator(storage.IterOptions{
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound: prefix,
 		UpperBound: prefixEnd,
 	})

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -201,7 +201,7 @@ func (r *Replica) RangeFeed(
 	if usingCatchupIter {
 		catchUpIterFunc = func() storage.SimpleMVCCIterator {
 
-			innerIter := r.Engine().NewIterator(storage.IterOptions{
+			innerIter := r.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 				UpperBound: args.Span.EndKey,
 				// RangeFeed originally intended to use the time-bound iterator
 				// performance optimization. However, they've had correctness issues in
@@ -347,7 +347,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 	// Start it with an iterator to initialize the resolved timestamp.
 	rtsIter := func() storage.SimpleMVCCIterator {
-		return r.Engine().NewIterator(storage.IterOptions{
+		return r.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 			UpperBound: desc.EndKey.AsRawKey(),
 			// TODO(nvanbenschoten): To facilitate fast restarts of rangefeed
 			// we should periodically persist the resolved timestamp so that we

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2921,7 +2921,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 			if _, pErr := tc.SendWrappedWith(roachpb.Header{Txn: txnOld}, &pArgs); pErr != nil {
 				t.Fatal(pErr)
 			}
-			iter := tc.engine.NewIterator(storage.IterOptions{Prefix: true})
+			iter := tc.engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
 			defer iter.Close()
 			mvccKey := storage.MakeMVCCMetadataKey(key)
 			iter.SeekGE(mvccKey)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -275,7 +275,7 @@ func (s spanSetReader) MVCCGetProto(
 }
 
 func (s spanSetReader) MVCCIterate(
-	start, end roachpb.Key, f func(storage.MVCCKeyValue) error,
+	start, end roachpb.Key, iterKind storage.MVCCIterKind, f func(storage.MVCCKeyValue) error,
 ) error {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
@@ -286,14 +286,16 @@ func (s spanSetReader) MVCCIterate(
 			return err
 		}
 	}
-	return s.r.MVCCIterate(start, end, f)
+	return s.r.MVCCIterate(start, end, iterKind, f)
 }
 
-func (s spanSetReader) NewIterator(opts storage.IterOptions) storage.MVCCIterator {
+func (s spanSetReader) NewMVCCIterator(
+	iterKind storage.MVCCIterKind, opts storage.IterOptions,
+) storage.MVCCIterator {
 	if s.spansOnly {
-		return NewIterator(s.r.NewIterator(opts), s.spans)
+		return NewIterator(s.r.NewMVCCIterator(iterKind, opts), s.spans)
 	}
-	return NewIteratorAt(s.r.NewIterator(opts), s.spans, s.ts)
+	return NewIteratorAt(s.r.NewMVCCIterator(iterKind, opts), s.spans, s.ts)
 }
 
 // GetDBEngine recursively searches for the underlying rocksDB engine.

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -510,7 +510,8 @@ func (rsl StateLoader) SetGCThreshold(
 // LoadLastIndex loads the last index.
 func (rsl StateLoader) LoadLastIndex(ctx context.Context, reader storage.Reader) (uint64, error) {
 	prefix := rsl.RaftLogPrefix()
-	iter := reader.NewIterator(storage.IterOptions{LowerBound: prefix})
+	// NB: raft log has no intents.
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{LowerBound: prefix})
 	defer iter.Close()
 
 	var lastIndex uint64

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1265,7 +1265,8 @@ func IterateIDPrefixKeys(
 	f func(_ roachpb.RangeID) error,
 ) error {
 	rangeID := roachpb.RangeID(1)
-	iter := reader.NewIterator(storage.IterOptions{
+	// NB: Range-ID local keys have no versions and no intents.
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey(),
 	})
 	defer iter.Close()

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -44,7 +44,7 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine) []roachpb.KeyValue {
 	var kvs []roachpb.KeyValue
 	testutils.SucceedsSoon(t, func() error {
 		kvs = nil
-		it := e.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax})
+		it := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
 		for it.SeekGE(storage.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
 			ok, err := it.Valid()

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -317,7 +317,7 @@ func BenchmarkClearRange_Pebble(b *testing.B) {
 func BenchmarkClearIterRange_Pebble(b *testing.B) {
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
-		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 		return batch.ClearIterRange(iter, start.Key, end.Key)
 	})

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -408,7 +408,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 		// Pull all of the sstables into the RocksDB cache in order to make the
 		// timings more stable. Otherwise, the first run will be penalized pulling
 		// data into the cache while later runs will not.
-		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 		_, _ = iter.ComputeStats(roachpb.KeyMin, roachpb.KeyMax, 0)
 		iter.Close()
 	}
@@ -829,7 +829,7 @@ func runClearRange(
 	//
 	// TODO(benesch): when those hacks are removed, don't bother computing the
 	// first key and simply ClearRange(NilKey, MVCCKeyMax).
-	iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+	iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 	iter.SeekGE(NilKey)
 	if ok, err := iter.Valid(); !ok {
@@ -872,7 +872,7 @@ func runMVCCComputeStats(ctx context.Context, b *testing.B, emk engineMaker, val
 	var stats enginepb.MVCCStats
 	var err error
 	for i := 0; i < b.N; i++ {
-		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 		stats, err = iter.ComputeStats(roachpb.KeyMin, roachpb.KeyMax, 0)
 		iter.Close()
 		if err != nil {

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -464,7 +464,7 @@ type iterOpenOp struct {
 
 func (i iterOpenOp) run(ctx context.Context) string {
 	rw := i.m.getReadWriter(i.rw)
-	iter := rw.NewIterator(storage.IterOptions{
+	iter := rw.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		Prefix:     false,
 		LowerBound: i.key,
 		UpperBound: i.endKey.Next(),

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -104,7 +104,7 @@ func TestMultiIterator(t *testing.T) {
 						t.Fatalf("%+v", err)
 					}
 				}
-				iter := batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+				iter := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
 				iters = append(iters, iter)
 			}

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -115,12 +115,14 @@ func NewMVCCIncrementalIterator(
 	if !opts.IterOptions.MinTimestampHint.IsEmpty() && !opts.IterOptions.MaxTimestampHint.IsEmpty() {
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.
-		iter = reader.NewIterator(IterOptions{
+		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 			UpperBound: opts.IterOptions.UpperBound,
 		})
-		timeBoundIter = reader.NewIterator(opts.IterOptions)
+		// The timeBoundIter is only required to see versioned keys, since the
+		// intents will be found by iter.
+		timeBoundIter = reader.NewMVCCIterator(MVCCKeyIterKind, opts.IterOptions)
 	} else {
-		iter = reader.NewIterator(opts.IterOptions)
+		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, opts.IterOptions)
 	}
 
 	return &MVCCIncrementalIterator{

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -683,7 +683,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	{
 		// Iterate over the entries in the first DB, ingesting them into SSTables
 		// in the second DB.
-		it := db1.NewIterator(IterOptions{
+		it := db1.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 			UpperBound: keys.MaxKey,
 		})
 		defer it.Close()
@@ -766,7 +766,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 			defer leaktest.AfterTest(t)()
 
 			var expectedKVs []MVCCKeyValue
-			iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
 			iter.SeekGE(MVCCKey{})
 			for {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -44,7 +44,7 @@ func assertEq(t *testing.T, rw ReadWriter, debug string, ms, expMS *enginepb.MVC
 		t.Errorf("%s: diff(ms, expMS) nontrivial", debug)
 	}
 
-	it := rw.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+	it := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 
 	for _, mvccStatsTest := range mvccStatsTests {
@@ -1597,7 +1597,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			iter := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
 			for _, mvccStatsTest := range mvccStatsTests {
 				t.Run(mvccStatsTest.name, func(t *testing.T) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -688,12 +688,14 @@ func (p *Pebble) MVCCGetProto(
 }
 
 // MVCCIterate implements the Engine interface.
-func (p *Pebble) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
-	return iterateOnReader(p, start, end, f)
+func (p *Pebble) MVCCIterate(
+	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+) error {
+	return iterateOnReader(p, start, end, iterKind, f)
 }
 
-// NewIterator implements the Engine interface.
-func (p *Pebble) NewIterator(opts IterOptions) MVCCIterator {
+// NewMVCCIterator implements the Engine interface.
+func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
 	iter := newPebbleIterator(p.db, opts)
 	if iter == nil {
 		panic("couldn't create a new iterator")
@@ -1142,14 +1144,16 @@ func (p *pebbleReadOnly) MVCCGetProto(
 	return p.parent.MVCCGetProto(key, msg)
 }
 
-func (p *pebbleReadOnly) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+func (p *pebbleReadOnly) MVCCIterate(
+	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+) error {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
-	return iterateOnReader(p, start, end, f)
+	return iterateOnReader(p, start, end, iterKind, f)
 }
 
-func (p *pebbleReadOnly) NewIterator(opts IterOptions) MVCCIterator {
+func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
@@ -1292,12 +1296,14 @@ func (p *pebbleSnapshot) MVCCGetProto(
 }
 
 // MVCCIterate implements the Reader interface.
-func (p *pebbleSnapshot) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
-	return iterateOnReader(p, start, end, f)
+func (p *pebbleSnapshot) MVCCIterate(
+	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+) error {
+	return iterateOnReader(p, start, end, iterKind, f)
 }
 
-// NewIterator implements the Reader interface.
-func (p pebbleSnapshot) NewIterator(opts IterOptions) MVCCIterator {
+// NewMVCCIterator implements the Reader interface.
+func (p pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
 	return newPebbleIterator(p.snapshot, opts)
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -166,15 +166,17 @@ func (p *pebbleBatch) MVCCGetProto(
 }
 
 // MVCCIterate implements the Batch interface.
-func (p *pebbleBatch) MVCCIterate(start, end roachpb.Key, f func(MVCCKeyValue) error) error {
+func (p *pebbleBatch) MVCCIterate(
+	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
 	}
-	return iterateOnReader(p, start, end, f)
+	return iterateOnReader(p, start, end, iterKind, f)
 }
 
-// NewIterator implements the Batch interface.
-func (p *pebbleBatch) NewIterator(opts IterOptions) MVCCIterator {
+// NewMVCCIterator implements the Batch interface.
+func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
 	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
 		panic("iterator must set prefix or upper bound or lower bound")
 	}
@@ -211,7 +213,7 @@ func (p *pebbleBatch) NewIterator(opts IterOptions) MVCCIterator {
 	return iter
 }
 
-// NewIterator implements the Batch interface.
+// NewMVCCIterator implements the Batch interface.
 func (p *pebbleBatch) ApplyBatchRepr(repr []byte, sync bool) error {
 	if p.distinctOpen {
 		panic("distinct batch open")

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -129,7 +129,7 @@ func TestPebbleIterReuse(t *testing.T) {
 		}
 	}
 
-	iter1 := batch.NewIterator(IterOptions{LowerBound: []byte{40}, UpperBound: []byte{50}})
+	iter1 := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: []byte{40}, UpperBound: []byte{50}})
 	valuesCount := 0
 	// Seek to a value before the lower bound. Identical to seeking to the lower bound.
 	iter1.SeekGE(MVCCKey{Key: []byte{30}})
@@ -157,7 +157,7 @@ func TestPebbleIterReuse(t *testing.T) {
 	// is lower than the previous iterator's lower bound. This should still result
 	// in the right amount of keys being returned; the lower bound from the
 	// previous iterator should get zeroed.
-	iter2 := batch.NewIterator(IterOptions{UpperBound: []byte{10}})
+	iter2 := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: []byte{10}})
 	valuesCount = 0
 	iter1.SeekGE(MVCCKey{Key: []byte{0}})
 	for ; ; iter2.Next() {

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -62,7 +62,8 @@ func (tsdb *DB) findTimeSeries(
 
 	thresholds := tsdb.computeThresholds(now.WallTime)
 
-	iter := snapshot.NewIterator(storage.IterOptions{UpperBound: endKey.AsRawKey()})
+	// NB: timeseries don't have intents.
+	iter := snapshot.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
 	defer iter.Close()
 
 	for iter.SeekGE(next); ; iter.SeekGE(next) {


### PR DESCRIPTION

Also changes all callers to try to appropriately set these parameters.
Note that MVCCKeyAndIntentsIterKind would always be correct, but
where possible, we want to set MVCCKeyIterKind.

Release note: None