### PR TITLE
monitoring: remove faulty prometheus.yaml field

### DIFF
--- a/cloud/kubernetes/prometheus/prometheus.yaml
+++ b/cloud/kubernetes/prometheus/prometheus.yaml
@@ -53,7 +53,6 @@ metadata:
     app: cockroachdb
     prometheus: cockroachdb
 spec:
-  serviceAccountName: prometheus
   selector:
     matchLabels:
       prometheus: cockroachdb


### PR DESCRIPTION
The field `serviceAccountName: prometheus` in the `ServiceMonitor` spec was causing an error:

```
ValidationError(ServiceMonitor.spec): unknown field "serviceAccountName" in com.coreos.monitoring.v1.ServiceMonitor.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

This field doesn't seem to be in the [ServiceMonitorSpec](https://github.com/prometheus-operator/prometheus-operator/blob/v0.43.0/Documentation/api.md#servicemonitorspec), and [others](https://cockroachlabs.slack.com/archives/C9C1Z1LLV/p1597905009000500?thread_ts=1597429926.154100&cid=C9C1Z1LLV) have had to comment out the line, so I've removed it. This configuration works in testing when the line is removed.

Release note: none