### PR TITLE
rowflow: fix illegal row access after it was pushed out

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -701,7 +701,6 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 // in which an UncertaintyError is expected.
 func TestUncertaintyErrorIsReturned(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 56027, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const numNodes = 3


### PR DESCRIPTION
We have recently introduced some memory accounting for the memory used
by rows that are temporarily reside in a row buffer in the router base.
We grow the memory account by the difference between the new row to be
put into the buffer and the old row (that we happen to have the
reference to - if such exists). The old row has already been pushed out,
so it is illegal to access it to get its size which can lead to data
races. This is now fixed by storing the size of the old row in each
position of the row buffer and using that to calculate the delta.

Fixes: #56027.
Fixes: #56043.

Release note: None