### PR TITLE
cli: fix username semantics for userfile

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -405,8 +405,8 @@ def go_deps():
         name = "com_github_cockroachdb_datadriven",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/datadriven",
-        sum = "h1:KQqSlwJmTr7NmxtVOl6nPNSZQEk8XuLoLyNDYcmniBo=",
-        version = "v1.0.1-0.20200826112548-92602d883b11",
+        sum = "h1:p4AOBShzCogHTl1n5Ff16j5a24tvk1lc7fzRqduSpKM=",
+        version = "v1.0.1-0.20201022032720-3e27adf87325",
     )
     go_repository(
         name = "com_github_cockroachdb_errors",

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -118,6 +118,7 @@ go_library(
         "//pkg/sql/doctor",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/lex",
+        "//pkg/sql/lexbase:lex",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -51,7 +51,7 @@ const (
 // contains special characters, or the identifier is a reserved SQL
 // keyword.
 func EncodeRestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) {
-	if flags.HasFlags(EncBareIdentifiers) || (!isReservedKeyword(s) && isBareIdentifier(s)) {
+	if flags.HasFlags(EncBareIdentifiers) || (!isReservedKeyword(s) && IsBareIdentifier(s)) {
 		buf.WriteString(s)
 		return
 	}
@@ -62,7 +62,7 @@ func EncodeRestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) {
 // The identifier is only quoted if the flags don't tell otherwise and
 // the identifier contains special characters.
 func EncodeUnrestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) {
-	if flags.HasFlags(EncBareIdentifiers) || isBareIdentifier(s) {
+	if flags.HasFlags(EncBareIdentifiers) || IsBareIdentifier(s) {
 		buf.WriteString(s)
 		return
 	}

--- a/pkg/sql/lexbase/predicates.go
+++ b/pkg/sql/lexbase/predicates.go
@@ -67,9 +67,9 @@ func isReservedKeyword(s string) bool {
 	return ok
 }
 
-// isBareIdentifier returns true if the input string is a permissible bare SQL
+// IsBareIdentifier returns true if the input string is a permissible bare SQL
 // identifier.
-func isBareIdentifier(s string) bool {
+func IsBareIdentifier(s string) bool {
 	if len(s) == 0 || !IsIdentStart(int(s[0])) || (s[0] >= 'A' && s[0] <= 'Z') {
 		return false
 	}

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -86,7 +86,6 @@ func makeFileTableStorage(
 
 	// cfg.User is already a normalized SQL username.
 	username := security.MakeSQLUsernameFromPreNormalizedString(cfg.User)
-
 	executor := filetable.MakeInternalFileToTableExecutor(ie, db)
 	fileToTableSystem, err := filetable.NewFileToTableSystem(ctx,
 		cfg.QualifiedTableName, executor, username)


### PR DESCRIPTION
Previously, userfile would break if a user had a username with special
characters, which is otherwise supported by CRDB.
This is because, unless specified, userfile uses the username to
generate the underlying storage table names.

This change introduces a new name generation scheme which accounts for
all usernames supported by the database. The details are explained in:
https://github.com/cockroachdb/cockroach/issues/55389#issuecomment-712800826

Fixes: #55389

Release note: None