### PR TITLE
release-20.2: pgwire: decorate TransactionRetryWithProtoRefreshError with docs URL

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -17,10 +17,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
@@ -267,7 +267,7 @@ func changefeedPlanHook(
 		// `kv.rangefeed.enabled` setting to be true.
 		if !kvserver.RangefeedEnabled.Get(&settings.SV) {
 			return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-				base.DocsURL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+				docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 		}
 		if err := utilccl.CheckEnterpriseEnabled(
 			settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -223,8 +223,8 @@ func (c *cliState) printCliHelp() {
 	}
 	fmt.Printf(helpMessageFmt,
 		demoHelpStr,
-		base.DocsURL("sql-statements.html"),
-		base.DocsURL("use-the-built-in-sql-client.html"),
+		docs.URL("sql-statements.html"),
+		docs.URL("use-the-built-in-sql-client.html"),
 	)
 	fmt.Println()
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -484,7 +485,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 - running the 'cockroach init' command if you are trying to initialize a new cluster.
 
 If problems persist, please see %s.`
-		docLink := base.DocsURL("cluster-setup-troubleshooting.html")
+		docLink := docs.URL("cluster-setup-troubleshooting.html")
 		if !startCtx.inBackground {
 			log.Shoutf(context.Background(), log.Severity_WARNING, msg, docLink)
 		} else {
@@ -1151,7 +1152,7 @@ func setupAndInitializeLoggingAndProfiling(
 				"- %s\n"+
 				"- %s",
 			unimplemented.MakeURL(53404),
-			log.Safe(base.DocsURL("secure-a-cluster.html")),
+			log.Safe(docs.URL("secure-a-cluster.html")),
 		)
 	}
 

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,14 +8,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package base
+package docs
 
 import "github.com/cockroachdb/cockroach/pkg/build"
 
-// DocsURLBase is the root URL for the version of the docs associated with this
+// URLBase is the root URL for the version of the docs associated with this
 // binary.
-var DocsURLBase = "https://www.cockroachlabs.com/docs/" + build.VersionPrefix()
+var URLBase = "https://www.cockroachlabs.com/docs/" + build.VersionPrefix()
 
-// DocsURL generates the URL to pageName in the version of the docs associated
+// URL generates the URL to pageName in the version of the docs associated
 // with this binary.
-func DocsURL(pageName string) string { return DocsURLBase + "/" + pageName }
+func URL(pageName string) string { return URLBase + "/" + pageName }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
@@ -130,7 +130,7 @@ func (r *Replica) RangeFeed(
 ) *roachpb.Error {
 	if !r.isSystemRange() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return roachpb.NewErrorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-			base.DocsURL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	}
 	ctx := r.AnnotateCtx(stream.Context())
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -76,7 +77,7 @@ const (
 
 var productionSettingsWebpage = fmt.Sprintf(
 	"please see %s for more details",
-	base.DocsURL("recommended-production-settings.html"),
+	docs.URL("recommended-production-settings.html"),
 )
 
 // MaxOffsetType stores the configured MaxOffset.

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -204,7 +204,7 @@ func validateInformationSchemaTable(table *descpb.TableDescriptor) error {
 
 var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
 	comment: `roles for which the current user has admin option
-` + base.DocsURL("information-schema.html#administrable_role_authorizations") + `
+` + docs.URL("information-schema.html#administrable_role_authorizations") + `
 https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations.html`,
 	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -236,7 +236,7 @@ https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations
 
 var informationSchemaApplicableRoles = virtualSchemaTable{
 	comment: `roles available to the current user
-` + base.DocsURL("information-schema.html#applicable_roles") + `
+` + docs.URL("information-schema.html#applicable_roles") + `
 https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 	schema: vtable.InformationSchemaApplicableRoles,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -264,7 +264,7 @@ https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 
 var informationSchemaCheckConstraints = virtualSchemaTable{
 	comment: `check constraints
-` + base.DocsURL("information-schema.html#check_constraints") + `
+` + docs.URL("information-schema.html#check_constraints") + `
 https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 	schema: vtable.InformationSchemaCheckConstraints,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -333,7 +333,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 
 var informationSchemaColumnPrivileges = virtualSchemaTable{
 	comment: `column privilege grants (incomplete)
-` + base.DocsURL("information-schema.html#column_privileges") + `
+` + docs.URL("information-schema.html#column_privileges") + `
 https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 	schema: vtable.InformationSchemaColumnPrivileges,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -372,7 +372,7 @@ https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 
 var informationSchemaColumnsTable = virtualSchemaTable{
 	comment: `table and view columns (incomplete)
-` + base.DocsURL("information-schema.html#columns") + `
+` + docs.URL("information-schema.html#columns") + `
 https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 	schema: vtable.InformationSchemaColumns,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -464,7 +464,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 
 var informationSchemaColumnUDTUsage = virtualSchemaTable{
 	comment: `columns with user defined types
-` + base.DocsURL("information-schema.html#column_udt_usage") + `
+` + docs.URL("information-schema.html#column_udt_usage") + `
 https://www.postgresql.org/docs/current/infoschema-column-udt-usage.html`,
 	schema: vtable.InformationSchemaColumnUDTUsage,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -494,7 +494,7 @@ https://www.postgresql.org/docs/current/infoschema-column-udt-usage.html`,
 
 var informationSchemaEnabledRoles = virtualSchemaTable{
 	comment: `roles for the current user
-` + base.DocsURL("information-schema.html#enabled_roles") + `
+` + docs.URL("information-schema.html#enabled_roles") + `
 https://www.postgresql.org/docs/9.5/infoschema-enabled-roles.html`,
 	schema: `
 CREATE TABLE information_schema.enabled_roles (
@@ -690,7 +690,7 @@ CREATE TABLE information_schema.constraint_column_usage (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/key-column-usage-table.html
 var informationSchemaKeyColumnUsageTable = virtualSchemaTable{
 	comment: `column usage by indexes and key constraints
-` + base.DocsURL("information-schema.html#key_column_usage") + `
+` + docs.URL("information-schema.html#key_column_usage") + `
 https://www.postgresql.org/docs/9.5/infoschema-key-column-usage.html`,
 	schema: `
 CREATE TABLE information_schema.key_column_usage (
@@ -838,7 +838,7 @@ func dStringForFKAction(action descpb.ForeignKeyReference_Action) tree.Datum {
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/referential-constraints-table.html
 var informationSchemaReferentialConstraintsTable = virtualSchemaTable{
 	comment: `foreign key constraints
-` + base.DocsURL("information-schema.html#referential_constraints") + `
+` + docs.URL("information-schema.html#referential_constraints") + `
 https://www.postgresql.org/docs/9.5/infoschema-referential-constraints.html`,
 	schema: `
 CREATE TABLE information_schema.referential_constraints (
@@ -899,7 +899,7 @@ CREATE TABLE information_schema.referential_constraints (
 // MySQL:    missing
 var informationSchemaRoleTableGrants = virtualSchemaTable{
 	comment: `privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-` + base.DocsURL("information-schema.html#role_table_grants") + `
+` + docs.URL("information-schema.html#role_table_grants") + `
 https://www.postgresql.org/docs/9.5/infoschema-role-table-grants.html`,
 	schema: `
 CREATE TABLE information_schema.role_table_grants (
@@ -1014,7 +1014,7 @@ CREATE TABLE information_schema.routines (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html
 var informationSchemaSchemataTable = virtualSchemaTable{
 	comment: `database schemas (may contain schemata without permission)
-` + base.DocsURL("information-schema.html#schemata") + `
+` + docs.URL("information-schema.html#schemata") + `
 https://www.postgresql.org/docs/9.5/infoschema-schemata.html`,
 	schema: vtable.InformationSchemaSchemata,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -1038,7 +1038,7 @@ https://www.postgresql.org/docs/9.5/infoschema-schemata.html`,
 // which has one row for each grantee.
 var informationSchemaTypePrivilegesTable = virtualSchemaTable{
 	comment: `type privileges (incomplete; may contain excess users or roles)
-` + base.DocsURL("information-schema.html#type_privileges"),
+` + docs.URL("information-schema.html#type_privileges"),
 	schema: `
 CREATE TABLE information_schema.type_privileges (
 	GRANTEE         STRING NOT NULL,
@@ -1106,7 +1106,7 @@ CREATE TABLE information_schema.type_privileges (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schema-privileges-table.html
 var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 	comment: `schema privileges (incomplete; may contain excess users or roles)
-` + base.DocsURL("information-schema.html#schema_privileges"),
+` + docs.URL("information-schema.html#schema_privileges"),
 	schema: `
 CREATE TABLE information_schema.schema_privileges (
 	GRANTEE         STRING NOT NULL,
@@ -1169,7 +1169,7 @@ func dStringForIndexDirection(dir descpb.IndexDescriptor_Direction) tree.Datum {
 
 var informationSchemaSequences = virtualSchemaTable{
 	comment: `sequences
-` + base.DocsURL("information-schema.html#sequences") + `
+` + docs.URL("information-schema.html#sequences") + `
 https://www.postgresql.org/docs/9.5/infoschema-sequences.html`,
 	schema: `
 CREATE TABLE information_schema.sequences (
@@ -1214,7 +1214,7 @@ CREATE TABLE information_schema.sequences (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/statistics-table.html
 var informationSchemaStatisticsTable = virtualSchemaTable{
 	comment: `index metadata and statistics (incomplete)
-` + base.DocsURL("information-schema.html#statistics"),
+` + docs.URL("information-schema.html#statistics"),
 	schema: `
 CREATE TABLE information_schema.statistics (
 	TABLE_CATALOG STRING NOT NULL,
@@ -1314,7 +1314,7 @@ CREATE TABLE information_schema.statistics (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-constraints-table.html
 var informationSchemaTableConstraintTable = virtualSchemaTable{
 	comment: `table constraints
-` + base.DocsURL("information-schema.html#table_constraints") + `
+` + docs.URL("information-schema.html#table_constraints") + `
 https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html`,
 	schema: `
 CREATE TABLE information_schema.table_constraints (
@@ -1431,7 +1431,7 @@ CREATE TABLE information_schema.user_privileges (
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-privileges-table.html
 var informationSchemaTablePrivileges = virtualSchemaTable{
 	comment: `privileges granted on table or views (incomplete; may contain excess users or roles)
-` + base.DocsURL("information-schema.html#table_privileges") + `
+` + docs.URL("information-schema.html#table_privileges") + `
 https://www.postgresql.org/docs/9.5/infoschema-table-privileges.html`,
 	schema: `
 CREATE TABLE information_schema.table_privileges (
@@ -1487,7 +1487,7 @@ var (
 
 var informationSchemaTablesTable = virtualSchemaTable{
 	comment: `tables and views
-` + base.DocsURL("information-schema.html#tables") + `
+` + docs.URL("information-schema.html#tables") + `
 https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 	schema: vtable.InformationSchemaTables,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -1535,7 +1535,7 @@ func addTablesTableRow(
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/views-table.html
 var informationSchemaViewsTable = virtualSchemaTable{
 	comment: `views (incomplete)
-` + base.DocsURL("information-schema.html#views") + `
+` + docs.URL("information-schema.html#views") + `
 https://www.postgresql.org/docs/9.5/infoschema-views.html`,
 	schema: `
 CREATE TABLE information_schema.views (

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -704,7 +704,7 @@ COMMIT
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1
 
-query error pgcode 40001 restart transaction: crdb_internal.force_retry\(\): TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
+query error pgcode 40001 restart transaction: crdb_internal.force_retry\(\): TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\).*\nHINT:.*transaction-retry-error-reference.html
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 query T

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -98,7 +98,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 		Function: f.String(),
 		HelpMessageBody: HelpMessageBody{
 			Category: d.Category,
-			SeeAlso:  base.DocsURL("functions-and-operators.html"),
+			SeeAlso:  docs.URL("functions-and-operators.html"),
 		},
 	}
 
@@ -172,7 +172,7 @@ var HelpMessages = func(h map[string]HelpMessageBody) map[string]HelpMessageBody
 	reformatSeeAlso := func(seeAlso string) string {
 		return strings.Replace(
 			strings.Replace(seeAlso, ", ", "\n  ", -1),
-			"WEBDOCS", base.DocsURLBase, -1)
+			"WEBDOCS", docs.URLBase, -1)
 	}
 	srcMsg := h["<SOURCE>"]
 	srcMsg.SeeAlso = reformatSeeAlso(strings.TrimSpace(srcMsg.SeeAlso))

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1242,7 +1242,6 @@ func writeErr(
 func writeErrFields(
 	ctx context.Context, sv *settings.Values, err error, msgBuilder *writeBuffer, w io.Writer,
 ) error {
-	// Now send the error to the client.
 	pgErr := pgerror.Flatten(err)
 
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSeverity)

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -27,6 +27,7 @@ func TestDepAllowlist(t *testing.T) {
 			`github.com/cockroachdb/cockroach/pkg/build`,
 			`github.com/cockroachdb/cockroach/pkg/col/coldata`,
 			`github.com/cockroachdb/cockroach/pkg/col/typeconv`,
+			`github.com/cockroachdb/cockroach/pkg/docs`,
 			`github.com/cockroachdb/cockroach/pkg/geo/geopb`,
 			`github.com/cockroachdb/cockroach/pkg/sql/lex`,
 			`github.com/cockroachdb/cockroach/pkg/sql/oidext`,


### PR DESCRIPTION
Backport 2/2 commits from #55197.

/cc @cockroachdb/release

---

Release note (sql change): TransactionRetryWithProtoRefreshError now
have a HINT field that links to a web page containing useful
information to resolve the error.
