### PR TITLE
[wip] backupccl: test transaction retryability in backupccl

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/ccl/backupccl/ccl_testing",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",
         "//pkg/clusterversion",
@@ -123,6 +124,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/blobs",
+        "//pkg/ccl/backupccl/ccl_testing",
         "//pkg/ccl/kvccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/backupccl/ccl_testing/BUILD.bazel
+++ b/pkg/ccl/backupccl/ccl_testing/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ccl_testing",
+    srcs = ["testvalues.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/backupccl/ccl_testing",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/ccl/backupccl/ccl_testing/testvalues.go
+++ b/pkg/ccl/backupccl/ccl_testing/testvalues.go
@@ -1,0 +1,24 @@
+package ccl_testing
+
+type testValues struct {
+	values map[string]interface{}
+}
+
+var singleton *testValues
+
+// Get does a get.
+func Get(key string) interface{} {
+	return singleton.values[key]
+}
+
+// Set does a set.
+func Set(key string, value interface{}) {
+	singleton.values[key] = value
+}
+
+// init is called only once.
+func init() {
+	singleton = &testValues{
+		values: make(map[string]interface{}),
+	}
+}

--- a/pkg/ccl/backupccl/main_test.go
+++ b/pkg/ccl/backupccl/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/ccl_testing"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -28,6 +29,7 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	ccl_testing.Set(TXN_RETRY_RATE_KEY, 0.1)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This commit adds a test setting so that backupccl tests exercise the
case where transaction retry during backup/restore.

This is a very early prototype... mainly to gather feedback/thoughts.
Naming and general organization needs to be changed.

Release note: None