### PR TITLE
release-20.2: opt: fix extra column handling when building CTEs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -635,3 +635,15 @@ SELECT * FROM
 8
 9
 10
+
+# Test CTE with order-by projection (#55196).
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1,1),(1,2),(2,1),(2,2);
+
+query I rowsort
+WITH cte AS (SELECT x*10+y FROM xy ORDER BY x+y LIMIT 3) SELECT * FROM cte
+----
+11
+12
+21

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -60,8 +60,12 @@ func (b *Builder) constructProject(input memo.RelExpr, cols []scopeColumn) memo.
 func (b *Builder) dropOrderingAndExtraCols(s *scope) {
 	s.ordering = nil
 	if len(s.extraCols) > 0 {
+		var passthrough opt.ColSet
+		for i := range s.cols {
+			passthrough.Add(s.cols[i].id)
+		}
+		s.expr = b.factory.ConstructProject(s.expr, nil /* projections */, passthrough)
 		s.extraCols = nil
-		s.expr = b.constructProject(s.expr, s.cols)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1515,3 +1515,55 @@ with &1 (t)
            │         └──  y.a:1 => a:8
            └── filters
                 └── x.a:4 = a:8
+
+# Verify that we don't incorrectly project a+1 again (#55196).
+build
+WITH cte AS (SELECT a+1 FROM x ORDER BY a+b LIMIT 10) SELECT * FROM cte
+----
+with &1 (cte)
+ ├── columns: "?column?":7
+ ├── project
+ │    ├── columns: "?column?":5
+ │    └── limit
+ │         ├── columns: "?column?":5 column6:6
+ │         ├── internal-ordering: +6
+ │         ├── sort
+ │         │    ├── columns: "?column?":5 column6:6
+ │         │    ├── ordering: +6
+ │         │    ├── limit hint: 10.00
+ │         │    └── project
+ │         │         ├── columns: "?column?":5 column6:6
+ │         │         ├── scan x
+ │         │         │    └── columns: a:1 b:2 rowid:3!null crdb_internal_mvcc_timestamp:4
+ │         │         └── projections
+ │         │              ├── a:1 + 1 [as="?column?":5]
+ │         │              └── a:1 + b:2 [as=column6:6]
+ │         └── 10
+ └── with-scan &1 (cte)
+      ├── columns: "?column?":7
+      └── mapping:
+           └──  "?column?":5 => "?column?":7
+
+build
+WITH cte AS (SELECT DISTINCT ON (b) a+1 FROM x) SELECT * FROM cte
+----
+with &1 (cte)
+ ├── columns: "?column?":6
+ ├── project
+ │    ├── columns: "?column?":5
+ │    └── distinct-on
+ │         ├── columns: b:2 "?column?":5
+ │         ├── grouping columns: b:2
+ │         ├── project
+ │         │    ├── columns: "?column?":5 b:2
+ │         │    ├── scan x
+ │         │    │    └── columns: a:1 b:2 rowid:3!null crdb_internal_mvcc_timestamp:4
+ │         │    └── projections
+ │         │         └── a:1 + 1 [as="?column?":5]
+ │         └── aggregations
+ │              └── first-agg [as="?column?":5]
+ │                   └── "?column?":5
+ └── with-scan &1 (cte)
+      ├── columns: "?column?":6
+      └── mapping:
+           └──  "?column?":5 => "?column?":6


### PR DESCRIPTION
Backport 1/1 commits from #56030.

/cc @cockroachdb/release

---

In the optbuilder "extra columns" refer to expressions that are used
only as part of ORDER BY or DISTINCT ON clauses. When building CTEs,
we want to project these away. The code was reusing a routine for
creating projections but it incorrectly re-creates the projections
instead of just passing through the columns.

Fixes #55196.

Release note (bug fix): fixed "top-level relational expression cannot
have outer columns" error in some queries that involve WITH.
