### PR TITLE
parser: pin pkg/security as a bazel dep for pkg/parser

### DIFF
--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/docs",
         "//pkg/geo/geopb",  # keep
         "//pkg/roachpb",  # keep
+        "//pkg/security",  # keep
         "//pkg/sql/lex",
         "//pkg/sql/lexbase:lex",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
We picked up a dependency on pkg/security within the parser package
after https://github.com/cockroachdb/cockroach/pull/55398.

We have to pin go dependencies by hand if they're only present in
auto-generated code. It's because it's not otherwise visible to
bazel/gazelle when generating the BUILD files (during the analysis
phase).

Release note: None