### PR TITLE
release-20.2: importccl: return errors in avro input

### DIFF
--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -363,6 +363,11 @@ func (r *avroRecordStream) readNative() {
 		if len(r.buf) > 0 {
 			r.row, remaining, decodeErr = r.decode()
 		}
+		// If we've already read all we can (either to eof or to max size), then
+		// any error during decoding should just be returned as an error.
+		if decodeErr != nil && (r.eof || len(r.buf) > r.maxBufSize) {
+			break
+		}
 	}
 
 	if decodeErr != nil {


### PR DESCRIPTION
Backport 1/1 commits from #55643.

/cc @cockroachdb/release

---

Previously malformed Avro input could cause the reader to loop forever
because the buffer-filling-and-attempt-decoding loop reties after an
error in decoding as it could be that we simply need to read more
to be able to decode (e.g. if it is a long message). However if we
hit eof or the maximum buffer size we should instead assume that it
is malformed input and stop trying to read more and decode again.

Release note (bug fix): Fix a bug where IMPORTs of malformed Avro records could hang forever.
