### PR TITLE
partialidx: add benchmarks for two-variable comparisons

### DIFF
--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -155,6 +155,12 @@ func BenchmarkImplicator(b *testing.B) {
 			pred:    "a > 0 AND a < 100",
 		},
 		{
+			name:    "two-var-comparison",
+			vars:    "a int, b int",
+			filters: "a > b",
+			pred:    "b <= a",
+		},
+		{
 			name:    "single-exact-match-extra-filters",
 			vars:    "a int, b int, c int, d int, e int",
 			filters: "a < 0 AND b > 0 AND c >= 10 AND d = 4 AND @5 = 5",
@@ -177,6 +183,12 @@ func BenchmarkImplicator(b *testing.B) {
 			vars:    "a int, b string",
 			filters: "a >= 10 AND b = 'foo'",
 			pred:    "a >= 0 AND b IN ('foo', 'bar')",
+		},
+		{
+			name:    "multi-column-and-two-var-comparisons",
+			vars:    "a int, b int, c int, d int",
+			filters: "a > b AND c < d",
+			pred:    "b <= a AND c != d",
 		},
 		{
 			name:    "multi-column-or-exact-match",


### PR DESCRIPTION
Two-variable comparison implication performs similarly to other types of
implications.

    BenchmarkImplicator/single-exact-match-16                         76.5 ns/op
    BenchmarkImplicator/single-inexact-match-16                      342 ns/op
    BenchmarkImplicator/range-inexact-match-16                       782 ns/op
    BenchmarkImplicator/two-var-comparison-16                        302 ns/op
    BenchmarkImplicator/single-exact-match-extra-filters-16          310 ns/op
    BenchmarkImplicator/single-inexact-match-extra-filters-16        609 ns/op
    BenchmarkImplicator/multi-column-and-exact-match-16               82.4 ns/op
    BenchmarkImplicator/multi-column-and-inexact-match-16            722 ns/op
    BenchmarkImplicator/multi-column-and-two-var-comparisons-16      611 ns/op
    BenchmarkImplicator/multi-column-or-exact-match-16                76.1 ns/op
    BenchmarkImplicator/multi-column-or-exact-match-reverse-16       595 ns/op
    BenchmarkImplicator/multi-column-or-inexact-match-16            1081 ns/op
    BenchmarkImplicator/in-implies-or-16                             976 ns/op
    BenchmarkImplicator/and-filters-do-not-imply-pred-16            3710 ns/op
    BenchmarkImplicator/or-filters-do-not-imply-pred-16              917 ns/op
    BenchmarkImplicator/many-columns-exact-match10-16                296 ns/op
    BenchmarkImplicator/many-columns-inexact-match10-16             6853 ns/op
    BenchmarkImplicator/many-columns-exact-match100-16             19817 ns/op
    BenchmarkImplicator/many-columns-inexact-match100-16          447894 ns/op

Release note: None