### PR TITLE
release-20.1: backupccl: avoid div-by-zero crash on failed node count

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -146,6 +146,10 @@ func clusterNodeCount(g *gossip.Gossip) int {
 		nodes++
 		return nil
 	})
+	// returning zero will crash.
+	if nodes == 0 {
+		nodes = 1
+	}
 	return nodes
 }
 


### PR DESCRIPTION
Not actually a backport of #55560 since it didn't backport cleanly but same idea.

/cc @cockroachdb/release

---

We've seen a report of a node on a newer version that crashed due to a divide-by-zero
hit during metrics collection, specifically when computing the
throughput-per-node by dividing the backup size by node count.

That crash would be unable to happen in this version as the zero could would 
first make the backup hang forever as the size of its request limited it based on 
the node count. 

The change in #55560 included logging the reason the count failed, however that 
change did not backport cleanly. This change is much more narrow change to just 
make a failure to count fallback to 1. 

Release note (bug fix): avoid hanging when BACKUP is unable to count the total nodes in the cluster.
