### PR TITLE
release-20.2: backupccl: add KMS support to scheduled backups

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -65,6 +65,7 @@ type scheduledBackupEval struct {
 	// backup statement in the schedule.
 	destination          func() ([]string, error)
 	encryptionPassphrase func() (string, error)
+	kmsURIs              func() ([]string, error)
 }
 
 func parseOnError(onError string, details *jobspb.ScheduleDetails) error {
@@ -241,6 +242,20 @@ func doCreateBackupSchedules(
 			return errors.Wrapf(err, "failed to evaluate backup encryption_passphrase")
 		}
 		backupNode.Options.EncryptionPassphrase = tree.NewDString(pw)
+	}
+
+	// Evaluate encryption KMS URIs if set.
+	// Only one of encryption passphrase and KMS URI should be set, but this check
+	// is done during backup planning so we do not need to worry about it here.
+	if eval.kmsURIs != nil {
+		kmsURIs, err := eval.kmsURIs()
+		if err != nil {
+			return errors.Wrapf(err, "failed to evaluate backup kms_uri")
+		}
+		for _, kmsURI := range kmsURIs {
+			backupNode.Options.EncryptionKMSURI = append(backupNode.Options.EncryptionKMSURI,
+				tree.NewDString(kmsURI))
+		}
 	}
 
 	// Evaluate required backup destinations.
@@ -550,6 +565,14 @@ func makeScheduledBackupEval(
 	if schedule.BackupOptions.EncryptionPassphrase != nil {
 		eval.encryptionPassphrase, err =
 			p.TypeAsString(ctx, schedule.BackupOptions.EncryptionPassphrase, scheduleBackupOp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if schedule.BackupOptions.EncryptionKMSURI != nil {
+		eval.kmsURIs, err = p.TypeAsStringArray(ctx, tree.Exprs(schedule.BackupOptions.EncryptionKMSURI),
+			scheduleBackupOp)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #56088.

/cc @cockroachdb/release

---

Previously, the KMS options were not plumbed through during backup
schedule creation, which meant that scheduled backups were not KMS
encrypted.

This change fixes that known limitation.

Fixes: #56082

Release note (bug fix): Scheduled BACKUP now supports KMS encryption.
