### PR TITLE
storage: changes to the Writer and Batch interfaces

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -241,7 +241,7 @@ func TestPebbleEncryption(t *testing.T) {
 	t.Logf("EnvStats:\n%+v\n\n", *stats)
 
 	batch := db.NewWriteOnlyBatch()
-	require.NoError(t, batch.Put(storage.MVCCKey{Key: roachpb.Key("a")}, []byte("a")))
+	require.NoError(t, batch.PutUnversioned(roachpb.Key("a"), []byte("a")))
 	require.NoError(t, batch.Commit(true))
 	require.NoError(t, db.Flush())
 	val, err := db.MVCCGet(storage.MVCCKey{Key: roachpb.Key("a")})

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -127,7 +127,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	// adjusted accordingly.
 	const numInitialEntries = 100
 	for i := 0; i < numInitialEntries; i++ {
-		if err := e.Put(storage.MVCCKey{Key: append([]byte("b"), byte(i))}, nil); err != nil {
+		if err := e.PutUnversioned(append([]byte("b"), byte(i)), nil); err != nil {
 			t.Fatalf("%+v", err)
 		}
 	}

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -184,10 +184,10 @@ func runSyncer(
 			}
 		}()
 
-		k, v := storage.MakeMVCCMetadataKey(key()), []byte("payload")
+		k, v := key(), []byte("payload")
 		switch seq % 2 {
 		case 0:
-			if err := db.Put(k, v); err != nil {
+			if err := db.PutUnversioned(k, v); err != nil {
 				seq--
 				return seq, err
 			}
@@ -197,7 +197,7 @@ func runSyncer(
 			}
 		default:
 			b := db.NewBatch()
-			if err := b.Put(k, v); err != nil {
+			if err := b.PutUnversioned(k, v); err != nil {
 				seq--
 				return seq, err
 			}

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -127,9 +127,9 @@ func TestOpenReadOnlyStore(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			key := storage.MakeMVCCMetadataKey(roachpb.Key("key"))
+			key := roachpb.Key("key")
 			val := []byte("value")
-			err = db.Put(key, val)
+			err = db.PutUnversioned(key, val)
 			if !testutils.IsError(err, test.expErr) {
 				t.Fatalf("wanted %s but got %v", test.expErr, err)
 			}

--- a/pkg/cli/syncbench/syncbench.go
+++ b/pkg/cli/syncbench/syncbench.go
@@ -93,7 +93,7 @@ func (w *worker) run(wg *sync.WaitGroup) {
 			for j := 0; j < 5; j++ {
 				block := randBlock(60, 80)
 				key := encoding.EncodeUint32Ascending(buf, rand.Uint32())
-				if err := b.Put(storage.MakeMVCCMetadataKey(key), block); err != nil {
+				if err := b.PutUnversioned(key, block); err != nil {
 					log.Fatalf(ctx, "%v", err)
 				}
 				buf = key[:0]

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -342,7 +342,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 				{"e", 1, "e"},
 				{"z", 2, "zzzzzz"},
 			}) {
-				if err := e.Put(kv.Key, kv.Value); err != nil {
+				if err := e.PutMVCC(kv.Key, kv.Value); err != nil {
 					t.Fatalf("%+v", err)
 				}
 			}
@@ -499,7 +499,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				{"y", 5, "yyy"},
 				{"z", 2, "zz"},
 			}) {
-				if err := e.Put(kv.Key, kv.Value); err != nil {
+				if err := e.PutMVCC(kv.Key, kv.Value); err != nil {
 					t.Fatalf("%+v", err)
 				}
 			}
@@ -974,7 +974,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				// ingesting the perfectly shadowing KVs (same ts and same value) in the
 				// second SST.
 				for _, kv := range sstKVs {
-					if err := e.Put(kv.Key, kv.Value); err != nil {
+					if err := e.PutMVCC(kv.Key, kv.Value); err != nil {
 						t.Fatalf("%+v", err)
 					}
 				}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -33,14 +33,37 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) Clear(key storage.MVCCKey) error {
+// TODO(sbhola): narrow the calls where we increment counters to
+// make this test stricter.
+
+func (wb *wrappedBatch) ClearMVCC(key storage.MVCCKey) error {
 	wb.clearCount++
-	return wb.Batch.Clear(key)
+	return wb.Batch.ClearMVCC(key)
 }
 
-func (wb *wrappedBatch) ClearRange(start, end storage.MVCCKey) error {
+func (wb *wrappedBatch) ClearUnversioned(key roachpb.Key) error {
+	wb.clearCount++
+	return wb.Batch.ClearUnversioned(key)
+}
+
+func (wb *wrappedBatch) ClearIntent(key roachpb.Key) error {
+	wb.clearCount++
+	return wb.Batch.ClearIntent(key)
+}
+
+func (wb *wrappedBatch) ClearRawRange(start, end roachpb.Key) error {
 	wb.clearRangeCount++
-	return wb.Batch.ClearRange(start, end)
+	return wb.Batch.ClearRawRange(start, end)
+}
+
+func (wb *wrappedBatch) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {
+	wb.clearRangeCount++
+	return wb.Batch.ClearMVCCRangeAndIntents(start, end)
+}
+
+func (wb *wrappedBatch) ClearMVCCRange(start, end storage.MVCCKey) error {
+	wb.clearRangeCount++
+	return wb.Batch.ClearMVCCRange(start, end)
 }
 
 // TestCmdClearRangeBytesThreshold verifies that clear range resorts to

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3065,7 +3065,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		for _, r := range keyRanges {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(sstFile)
-			if err := sst.ClearRange(r.Start, r.End); err != nil {
+			if err := sst.ClearRawRange(r.Start.Key, r.End.Key); err != nil {
 				return err
 			}
 
@@ -3098,7 +3098,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			sst := storage.MakeIngestionSSTWriter(sstFile)
 			defer sst.Close()
 			r := rditer.MakeRangeIDLocalKeyRange(rangeID, false /* replicatedOnly */)
-			if err := sst.ClearRange(r.Start, r.End); err != nil {
+			if err := sst.ClearRawRange(r.Start.Key, r.End.Key); err != nil {
 				return err
 			}
 			tombstoneKey := keys.RangeTombstoneKey(rangeID)

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -49,7 +49,11 @@ func (ds dataDistribution) setupTest(
 			break
 		}
 		if txn == nil {
-			require.NoError(t, eng.Put(kv.Key, kv.Value))
+			if kv.Key.Timestamp.IsEmpty() {
+				require.NoError(t, eng.PutUnversioned(kv.Key.Key, kv.Value))
+			} else {
+				require.NoError(t, eng.PutMVCC(kv.Key, kv.Value))
+			}
 		} else {
 			// TODO(ajwerner): Decide if using MVCCPut is worth it.
 			ts := kv.Key.Timestamp

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -18,6 +18,8 @@ import (
 )
 
 // KeyRange is a helper struct for the ReplicaDataIterator.
+// TODO(sumeer): change these to roachpb.Key since the timestamp is
+// always empty.
 type KeyRange struct {
 	Start, End storage.MVCCKey
 }
@@ -34,6 +36,8 @@ type KeyRange struct {
 // This is problematic as it requires of every user careful tracking of when
 // to call that method; some just never call it and pull the whole replica
 // into memory. Use of an allocator should be opt-in.
+//
+// TODO(sumeer): Should return EngineKeys, to handle separated lock table.
 type ReplicaDataIterator struct {
 	curIndex int
 	ranges   []KeyRange

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1693,7 +1693,7 @@ func handleTruncatedStateBelowRaft(
 		// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to
 		// avoid allocating when constructing Raft log keys (16 bytes).
 		unsafeKey := prefixBuf.RaftLogKey(idx)
-		if err := readWriter.Clear(storage.MakeMVCCMetadataKey(unsafeKey)); err != nil {
+		if err := readWriter.ClearUnversioned(unsafeKey); err != nil {
 			return false, errors.Wrapf(err, "unable to clear truncated Raft entries for %+v", newTruncatedState)
 		}
 	}

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -150,7 +150,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(sstFile)
 			defer sst.Close()
-			err := sst.ClearRange(r.Start, r.End)
+			err := sst.ClearRawRange(r.Start.Key, r.End.Key)
 			require.NoError(t, err)
 			err = sst.Finish()
 			require.NoError(t, err)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2126,7 +2126,7 @@ func TestOptimizePuts(t *testing.T) {
 			t.Errorf("%d: expected %+v; got %+v", i, c.expBlind, blind)
 		}
 		if c.exKey != nil {
-			if err := tc.engine.Clear(storage.MakeMVCCMetadataKey(c.exKey)); err != nil {
+			if err := tc.engine.ClearUnversioned(c.exKey); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1598,7 +1598,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		keys.StoreSuggestedCompactionKeyPrefix().PrefixEnd(),
 		storage.MVCCKeyIterKind,
 		func(res storage.MVCCKeyValue) error {
-			return s.engine.Clear(res.Key)
+			return s.engine.ClearUnversioned(res.Key.Key)
 		})
 	if err != nil {
 		log.Warningf(ctx, "error when clearing compactor keys: %s", err)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -520,7 +520,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
 
 	// Put some random garbage into the engine.
-	require.NoError(t, eng.Put(storage.MakeMVCCMetadataKey(roachpb.Key("foo")), []byte("bar")))
+	require.NoError(t, eng.PutUnversioned(roachpb.Key("foo"), []byte("bar")))
 
 	cfg := TestStoreConfig(nil)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -73,32 +73,32 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 			}
 			defer b.Close()
 
-			if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
+			if err := b.PutUnversioned(mvccKey("a").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
 			// Write an engine value to be deleted.
-			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Clear(mvccKey("b")); err != nil {
+			if err := b.ClearUnversioned(mvccKey("b").Key); err != nil {
 				t.Fatal(err)
 			}
 			// Write an engine value to be merged.
-			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+			if err := e.PutUnversioned(mvccKey("c").Key, appender("foo")); err != nil {
 				t.Fatal(err)
 			}
 			if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
 				t.Fatal(err)
 			}
 			// Write a key with an empty value.
-			if err := b.Put(mvccKey("e"), nil); err != nil {
+			if err := b.PutUnversioned(mvccKey("e").Key, nil); err != nil {
 				t.Fatal(err)
 			}
 			// Write an engine value to be single deleted.
-			if err := e.Put(mvccKey("d"), []byte("before")); err != nil {
+			if err := e.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClear(mvccKey("d")); err != nil {
+			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -234,35 +234,34 @@ func TestReadOnlyBasics(t *testing.T) {
 			// For a read-only ReadWriter, all Writer methods should panic.
 			failureTestCases := []func(){
 				func() { _ = ro.ApplyBatchRepr(nil, false) },
-				func() { _ = ro.Clear(a) },
-				func() { _ = ro.SingleClear(a) },
-				func() { _ = ro.ClearRange(a, a) },
+				func() { _ = ro.ClearUnversioned(a.Key) },
+				func() { _ = ro.ClearRawRange(a.Key, a.Key) },
 				func() { _ = ro.Merge(a, nil) },
-				func() { _ = ro.Put(a, nil) },
+				func() { _ = ro.PutUnversioned(a.Key, nil) },
 			}
 			for i, f := range failureTestCases {
 				shouldPanic(t, f, string(i), "not implemented")
 			}
 
-			if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("a").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Clear(mvccKey("b")); err != nil {
+			if err := e.ClearUnversioned(mvccKey("b").Key); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+			if err := e.PutUnversioned(mvccKey("c").Key, appender("foo")); err != nil {
 				t.Fatal(err)
 			}
 			if err := e.Merge(mvccKey("c"), appender("bar")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Put(mvccKey("d"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("d").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.SingleClear(mvccKey("d")); err != nil {
+			if err := e.ClearUnversioned(mvccKey("d").Key); err != nil {
 				t.Fatal(err)
 			}
 
@@ -368,7 +367,7 @@ func TestApplyBatchRepr(t *testing.T) {
 				b1 := e.NewBatch()
 				defer b1.Close()
 
-				if err := b1.Put(mvccKey("lost"), []byte("update")); err != nil {
+				if err := b1.PutUnversioned(mvccKey("lost").Key, []byte("update")); err != nil {
 					t.Fatal(err)
 				}
 
@@ -394,7 +393,7 @@ func TestApplyBatchRepr(t *testing.T) {
 				key := mvccKey("phantom")
 				val := []byte("phantom")
 
-				if err := b3.Put(key, val); err != nil {
+				if err := b3.PutUnversioned(key.Key, val); err != nil {
 					t.Fatal(err)
 				}
 
@@ -433,29 +432,29 @@ func TestBatchGet(t *testing.T) {
 			defer b.Close()
 
 			// Write initial values, then write to batch.
-			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+			if err := e.PutUnversioned(mvccKey("c").Key, appender("foo")); err != nil {
 				t.Fatal(err)
 			}
 			// Write batch values.
-			if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
+			if err := b.PutUnversioned(mvccKey("a").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Clear(mvccKey("b")); err != nil {
+			if err := b.ClearUnversioned(mvccKey("b").Key); err != nil {
 				t.Fatal(err)
 			}
 			if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Put(mvccKey("d"), []byte("before")); err != nil {
+			if err := b.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClear(mvccKey("d")); err != nil {
+			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Put(mvccKey("d"), []byte("after")); err != nil {
+			if err := b.PutUnversioned(mvccKey("d").Key, []byte("after")); err != nil {
 				t.Fatal(err)
 			}
 
@@ -502,10 +501,10 @@ func TestBatchMerge(t *testing.T) {
 			defer b.Close()
 
 			// Write batch put, delete & merge.
-			if err := b.Put(mvccKey("a"), appender("a-value")); err != nil {
+			if err := b.PutUnversioned(mvccKey("a").Key, appender("a-value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Clear(mvccKey("b")); err != nil {
+			if err := b.ClearUnversioned(mvccKey("b").Key); err != nil {
 				t.Fatal(err)
 			}
 			if err := b.Merge(mvccKey("c"), appender("c-value")); err != nil {
@@ -564,7 +563,7 @@ func TestBatchProto(t *testing.T) {
 			defer b.Close()
 
 			val := roachpb.MakeValueFromString("value")
-			if _, _, err := PutProto(b, mvccKey("proto"), &val); err != nil {
+			if _, _, err := PutProto(b, mvccKey("proto").Key, &val); err != nil {
 				t.Fatal(err)
 			}
 			getVal := &roachpb.Value{}
@@ -633,7 +632,7 @@ func TestBatchScan(t *testing.T) {
 				{Key: mvccKey("m"), Value: []byte("13")},
 			}
 			for _, kv := range existingVals {
-				if err := e.Put(kv.Key, kv.Value); err != nil {
+				if err := e.PutUnversioned(kv.Key.Key, kv.Value); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -651,7 +650,7 @@ func TestBatchScan(t *testing.T) {
 				{Key: mvccKey("jj"), Value: []byte("b10")},
 			}
 			for _, kv := range batchVals {
-				if err := b.Put(kv.Key, kv.Value); err != nil {
+				if err := b.PutUnversioned(kv.Key.Key, kv.Value); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -716,10 +715,10 @@ func TestBatchScanWithDelete(t *testing.T) {
 			defer b.Close()
 
 			// Write initial value, then delete via batch.
-			if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
+			if err := e.PutUnversioned(mvccKey("a").Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Clear(mvccKey("a")); err != nil {
+			if err := b.ClearUnversioned(mvccKey("a").Key); err != nil {
 				t.Fatal(err)
 			}
 			kvs, err := Scan(b, roachpb.KeyMin, roachpb.KeyMax, 0)
@@ -749,14 +748,14 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 			defer b.Close()
 
 			// Write two values.
-			if err := e.Put(mvccKey("a"), []byte("value1")); err != nil {
+			if err := e.PutUnversioned(mvccKey("a").Key, []byte("value1")); err != nil {
 				t.Fatal(err)
 			}
-			if err := e.Put(mvccKey("b"), []byte("value2")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("value2")); err != nil {
 				t.Fatal(err)
 			}
 			// Now, delete "a" in batch.
-			if err := b.Clear(mvccKey("a")); err != nil {
+			if err := b.ClearUnversioned(mvccKey("a").Key); err != nil {
 				t.Fatal(err)
 			}
 			// A scan with max=1 should scan "b".
@@ -799,7 +798,7 @@ func TestBatchConcurrency(t *testing.T) {
 				t.Error("mismatch of \"a\"")
 			}
 			// Write an engine value.
-			if err := e.Put(mvccKey("a"), appender("foo")); err != nil {
+			if err := e.PutUnversioned(mvccKey("a").Key, appender("foo")); err != nil {
 				t.Fatal(err)
 			}
 			// Now, read again and verify that the merge happens on top of the mod.
@@ -827,7 +826,7 @@ func TestBatchDistinctAfterApplyBatchRepr(t *testing.T) {
 				batch := e.NewBatch()
 				defer batch.Close()
 
-				if err := batch.Put(mvccKey("batchkey"), []byte("b")); err != nil {
+				if err := batch.PutUnversioned(mvccKey("batchkey").Key, []byte("b")); err != nil {
 					t.Fatal(err)
 				}
 
@@ -861,17 +860,17 @@ func TestBatchDistinct(t *testing.T) {
 			e := engineImpl.create()
 			defer e.Close()
 
-			if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("b")); err != nil {
 				t.Fatal(err)
 			}
 
 			batch := e.NewBatch()
 			defer batch.Close()
 
-			if err := batch.Put(mvccKey("a"), []byte("a")); err != nil {
+			if err := batch.PutUnversioned(mvccKey("a").Key, []byte("a")); err != nil {
 				t.Fatal(err)
 			}
-			if err := batch.Clear(mvccKey("b")); err != nil {
+			if err := batch.ClearUnversioned(mvccKey("b").Key); err != nil {
 				t.Fatal(err)
 			}
 
@@ -907,7 +906,7 @@ func TestBatchDistinct(t *testing.T) {
 			}
 			iter.Close()
 
-			if err := distinct.Put(mvccKey("c"), []byte("c")); err != nil {
+			if err := distinct.PutUnversioned(mvccKey("c").Key, []byte("c")); err != nil {
 				t.Fatal(err)
 			}
 			if v, err := distinct.MVCCGet(mvccKey("c")); err != nil {
@@ -950,10 +949,10 @@ func TestWriteOnlyBatchDistinct(t *testing.T) {
 			e := engineImpl.create()
 			defer e.Close()
 
-			if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
+			if err := e.PutUnversioned(mvccKey("b").Key, []byte("b")); err != nil {
 				t.Fatal(err)
 			}
-			if _, _, err := PutProto(e, mvccKey("c"), &roachpb.Value{}); err != nil {
+			if _, _, err := PutProto(e, mvccKey("c").Key, &roachpb.Value{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1008,10 +1007,10 @@ func TestBatchDistinctPanics(t *testing.T) {
 			// while the distinct batch is open.
 			a := mvccKey("a")
 			testCases := []func(){
-				func() { _ = batch.Put(a, nil) },
+				func() { _ = batch.PutUnversioned(a.Key, nil) },
 				func() { _ = batch.Merge(a, nil) },
-				func() { _ = batch.Clear(a) },
-				func() { _ = batch.SingleClear(a) },
+				func() { _ = batch.ClearUnversioned(a.Key) },
+				func() { _ = batch.SingleClearEngine(EngineKey{Key: a.Key}) },
 				func() { _ = batch.ApplyBatchRepr(nil, false) },
 				func() { _, _ = batch.MVCCGet(a) },
 				func() { _, _, _, _ = batch.MVCCGetProto(a, nil) },
@@ -1052,13 +1051,13 @@ func TestBatchIteration(t *testing.T) {
 			v1 := []byte("value1")
 			v2 := []byte("value2")
 
-			if err := b.Put(k1, v1); err != nil {
+			if err := b.PutUnversioned(k1.Key, v1); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Put(k2, v2); err != nil {
+			if err := b.PutUnversioned(k2.Key, v2); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Put(k3, []byte("doesn't matter")); err != nil {
+			if err := b.PutUnversioned(k3.Key, []byte("doesn't matter")); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1164,7 +1163,7 @@ func TestBatchCombine(t *testing.T) {
 						k := fmt.Sprint(v)
 
 						b := e.NewWriteOnlyBatch()
-						if err := b.Put(mvccKey(k), []byte(k)); err != nil {
+						if err := b.PutUnversioned(mvccKey(k).Key, []byte(k)); err != nil {
 							errs <- errors.Wrap(err, "put failed")
 							return
 						}
@@ -1211,8 +1210,14 @@ func TestDecodeKey(t *testing.T) {
 		t.Run(test.String(), func(t *testing.T) {
 			b := e.NewBatch()
 			defer b.Close()
-			if err := b.Put(test, nil); err != nil {
-				t.Fatalf("%+v", err)
+			if test.Timestamp.IsEmpty() {
+				if err := b.PutUnversioned(test.Key, nil); err != nil {
+					t.Fatalf("%+v", err)
+				}
+			} else {
+				if err := b.PutMVCC(test, nil); err != nil {
+					t.Fatalf("%+v", err)
+				}
 			}
 			repr := b.Repr()
 

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -306,11 +306,11 @@ func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
 	}
 }
 
-func BenchmarkClearRange_Pebble(b *testing.B) {
+func BenchmarkClearMVCCRange_Pebble(b *testing.B) {
 	skip.UnderShort(b)
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
-		return batch.ClearRange(start, end)
+		return batch.ClearMVCCRange(start, end)
 	})
 }
 

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1047,7 +1047,7 @@ func runExportToSst(
 		key = encoding.EncodeUint32Ascending(key, uint32(i))
 
 		for j := 0; j < numRevisions; j++ {
-			err := batch.Put(MVCCKey{Key: key, Timestamp: hlc.Timestamp{WallTime: int64(j + 1), Logical: 0}}, []byte("foobar"))
+			err := batch.PutMVCC(MVCCKey{Key: key, Timestamp: hlc.Timestamp{WallTime: int64(j + 1), Logical: 0}}, []byte("foobar"))
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -587,9 +587,9 @@ type clearRangeOp struct {
 }
 
 func (c clearRangeOp) run(ctx context.Context) string {
-	// All ClearRange calls in Cockroach usually happen with metadata keys, so
-	// mimic the same behavior here.
-	err := c.m.engine.ClearRange(storage.MakeMVCCMetadataKey(c.key), storage.MakeMVCCMetadataKey(c.endKey))
+	// ClearRange calls in Cockroach usually happen with boundaries demarcated
+	// using unversioned keys, so mimic the same behavior here.
+	err := c.m.engine.ClearRawRange(c.key, c.endKey)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err.Error())
 	}

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -100,8 +100,14 @@ func TestMultiIterator(t *testing.T) {
 						v = []byte{input[i+1]}
 					}
 					i += 2
-					if err := batch.Put(MVCCKey{Key: k, Timestamp: ts}, v); err != nil {
-						t.Fatalf("%+v", err)
+					if ts.IsEmpty() {
+						if err := batch.PutUnversioned(k, v); err != nil {
+							t.Fatalf("%+v", err)
+						}
+					} else {
+						if err := batch.PutMVCC(MVCCKey{Key: k, Timestamp: ts}, v); err != nil {
+							t.Fatalf("%+v", err)
+						}
 					}
 				}
 				iter := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -536,10 +536,7 @@ func cmdCheckIntent(e *evalCtx) error {
 
 func cmdClearRange(e *evalCtx) error {
 	key, endKey := e.getKeyRange()
-	return e.engine.ClearRange(
-		MVCCKey{Key: key},
-		MVCCKey{Key: endKey},
-	)
+	return e.engine.ClearRawRange(key, endKey)
 }
 
 func cmdCPut(e *evalCtx) error {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1593,7 +1593,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 
 			// Write a MVCC metadata key where the value is not an encoded MVCCMetadata
 			// protobuf.
-			if err := engine.Put(mvccKey(roachpb.Key("garbage")), []byte("garbage")); err != nil {
+			if err := engine.PutUnversioned(roachpb.Key("garbage"), []byte("garbage")); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -1361,23 +1361,23 @@ func TestMVCCPutAfterBatchIterCreate(t *testing.T) {
 			engine := engineImpl.create()
 			defer engine.Close()
 
-			err := engine.Put(MVCCKey{testKey1, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			err := engine.PutMVCC(MVCCKey{testKey1, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = engine.Put(MVCCKey{testKey2, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			err = engine.PutMVCC(MVCCKey{testKey2, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = engine.Put(MVCCKey{testKey2, hlc.Timestamp{WallTime: 3}}, []byte("foobar"))
+			err = engine.PutMVCC(MVCCKey{testKey2, hlc.Timestamp{WallTime: 3}}, []byte("foobar"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = engine.Put(MVCCKey{testKey3, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			err = engine.PutMVCC(MVCCKey{testKey3, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = engine.Put(MVCCKey{testKey4, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			err = engine.PutMVCC(MVCCKey{testKey4, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -124,7 +124,7 @@ func TestPebbleIterReuse(t *testing.T) {
 	batch := eng.NewBatch()
 	for i := 0; i < 100; i++ {
 		key := MVCCKey{[]byte{byte(i)}, hlc.Timestamp{WallTime: 100}}
-		if err := batch.Put(key, []byte("foo")); err != nil {
+		if err := batch.PutMVCC(key, []byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
These are in preparation for the separated lock table.
The Clear, ClearRange, Put methods are split into
many methods so we can differentiate the purpose of
the caller. A SingleClearEngine is added to Batch,
which will replace the Writer.SingleClear method -
this is a low-level method that we don't want anyone
outside storage to call.

There are many TODOs which will get fixed in future
PRs when we introduce new functionality.

Informs #41720

Release note: None