### PR TITLE
tracing: rework StartSpan API

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -322,7 +322,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) error {
 	// has completed.
 	// TODO(andrei): we don't close the span on the early returns below.
 	tracer := serverCfg.Settings.Tracer
-	sp := tracer.StartRootSpan("server start", nil /* logTags */, tracing.NonRecordableSpan)
+	sp := tracer.StartSpan("server start")
 	ctx = tracing.ContextWithSpan(ctx, sp)
 
 	// Set up the logging and profiling output.

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -144,7 +144,7 @@ var _ roachpb.InternalClient = &mockInternalClient{}
 func (m *mockInternalClient) Batch(
 	ctx context.Context, in *roachpb.BatchRequest, opts ...grpc.CallOption,
 ) (*roachpb.BatchResponse, error) {
-	sp := m.tr.StartRootSpan("mock", nil /* logTags */, tracing.RecordableSpan)
+	sp := m.tr.StartSpan("mock", tracing.WithForceRealSpan())
 	defer sp.Finish()
 	sp.StartRecording(tracing.SnowballRecording)
 	ctx = tracing.ContextWithSpan(ctx, sp)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -151,7 +151,7 @@ func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 	key := roachpb.Key("a")
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("test", tracing.Recordable)
+	sp := tracer.StartSpan("test", tracing.WithForceRealSpan())
 	sp.StartRecording(tracing.SingleNodeRecording)
 	txnCtx := tracing.ContextWithSpan(context.Background(), sp)
 

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -75,7 +75,6 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//vendor/github.com/cockroachdb/errors",
-        "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/kr/pretty",
         "//vendor/golang.org/x/time/rate",
     ],

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/logtags"
 )
 
 func init() {
@@ -812,9 +811,7 @@ func splitTrigger(
 	ts hlc.Timestamp,
 ) (enginepb.MVCCStats, result.Result, error) {
 	// TODO(andrei): should this span be a child of the ctx's (if any)?
-	sp := rec.ClusterSettings().Tracer.StartRootSpan(
-		"split", logtags.FromContext(ctx), tracing.NonRecordableSpan,
-	)
+	sp := rec.ClusterSettings().Tracer.StartSpan("split", tracing.WithCtxLogTags(ctx))
 	defer sp.Finish()
 	desc := rec.Desc()
 	if !bytes.Equal(desc.StartKey, split.LeftDesc.StartKey) ||

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -885,7 +885,7 @@ func (r *Replica) requestToProposal(
 	return proposal, pErr
 }
 
-// getTraceData extracts the SpanContext of the current span.
+// getTraceData extracts the SpanMeta of the current span.
 func (r *Replica) getTraceData(ctx context.Context) opentracing.TextMapCarrier {
 	sp := tracing.SpanFromContext(ctx)
 	if sp == nil {
@@ -896,9 +896,9 @@ func (r *Replica) getTraceData(ctx context.Context) opentracing.TextMapCarrier {
 	}
 	traceData := opentracing.TextMapCarrier{}
 	if err := r.AmbientContext.Tracer.Inject(
-		sp.Context(), opentracing.TextMap, traceData,
+		sp.Meta(), opentracing.TextMap, traceData,
 	); err != nil {
-		log.Errorf(ctx, "failed to inject sp context (%+v) as trace data: %s", sp.Context(), err)
+		log.Errorf(ctx, "failed to inject sp context (%+v) as trace data: %s", sp.Meta(), err)
 		return nil
 	}
 	return traceData

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -56,8 +56,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/logtags"
-	"github.com/opentracing/opentracing-go"
 	"go.etcd.io/etcd/raft"
 )
 
@@ -297,12 +295,12 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 		// except that one does not currently support FollowsFrom relationships.
 		sp = tr.StartSpan(
 			opName,
-			opentracing.FollowsFrom(parentSp.Context()),
-			tracing.LogTagsFromCtx(parentCtx),
+			tracing.WithParent(parentSp),
+			tracing.WithFollowsFrom(),
+			tracing.WithCtxLogTags(parentCtx),
 		)
 	} else {
-		sp = tr.StartRootSpan(
-			opName, logtags.FromContext(parentCtx), tracing.NonRecordableSpan)
+		sp = tr.StartSpan(opName, tracing.WithCtxLogTags(parentCtx))
 	}
 
 	// Create a new context *without* a timeout. Instead, we multiplex the

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12557,7 +12557,7 @@ func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
 
 	// Hold the RaftLock to encourage the reproposals to occur in the same batch.
 	tc.repl.RaftLock()
-	sp := tracer.StartRootSpan("replica send", logtags.FromContext(ctx), tracing.RecordableSpan)
+	sp := tracer.StartSpan("replica send", tracing.WithCtxLogTags(ctx), tracing.WithForceRealSpan())
 	tracedCtx := tracing.ContextWithSpan(ctx, sp)
 	// Go out of our way to enable recording so that expensive logging is enabled
 	// for this context.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -979,8 +979,8 @@ func (n *Node) setupSpanForIncomingRPC(
 			// If tracing information was passed via gRPC metadata, the gRPC interceptor
 			// should have opened a span for us. If not, open a span now (if tracing is
 			// disabled, this will be a noop span).
-			newSpan = n.storeCfg.AmbientCtx.Tracer.StartRootSpan(
-				opName, n.storeCfg.AmbientCtx.LogTags(), tracing.NonRecordableSpan,
+			newSpan = n.storeCfg.AmbientCtx.Tracer.StartSpan(
+				opName, tracing.WithLogTags(n.storeCfg.AmbientCtx.LogTags()),
 			)
 			ctx = tracing.ContextWithSpan(ctx, newSpan)
 		} else {

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -357,7 +357,6 @@ go_library(
         "//vendor/github.com/gogo/protobuf/proto",
         "//vendor/github.com/lib/pq",
         "//vendor/github.com/lib/pq/oid",
-        "//vendor/github.com/opentracing/opentracing-go",
         "//vendor/github.com/prometheus/client_model/go",
         "//vendor/golang.org/x/net/trace",
         "//vendor/golang.org/x/text/collate",

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -30,9 +30,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//vendor/github.com/cockroachdb/errors",
-        "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/cockroachdb/redact",
-        "//vendor/github.com/opentracing/opentracing-go",
     ],
 )
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -73,7 +73,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
 )
 
 // ClusterOrganization is the organization name.
@@ -1513,21 +1512,19 @@ func (st *SessionTracing) StartTracing(
 	var sp *tracing.Span
 	connCtx := st.ex.ctxHolder.connCtx
 
-	// TODO(andrei): use tracing.EnsureChildSpan() or something more efficient
-	// than StartSpan(). The problem is that the current interface doesn't allow
-	// the Recordable option to be passed.
 	if parentSp := tracing.SpanFromContext(connCtx); parentSp != nil {
 		// Create a child span while recording.
 		sp = parentSp.Tracer().StartSpan(
 			opName,
-			opentracing.ChildOf(parentSp.Context()), tracing.Recordable,
-			tracing.LogTagsFromCtx(connCtx),
+			tracing.WithParent(parentSp),
+			tracing.WithCtxLogTags(connCtx),
+			tracing.WithForceRealSpan(),
 		)
 	} else {
 		// Create a root span while recording.
 		sp = st.ex.server.cfg.AmbientCtx.Tracer.StartSpan(
-			opName, tracing.Recordable,
-			tracing.LogTagsFromCtx(connCtx),
+			opName, tracing.WithForceRealSpan(),
+			tracing.WithCtxLogTags(connCtx),
 		)
 	}
 	sp.StartRecording(recType)

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
 )
 
 // explainDistSQLNode is a planNode that wraps a plan and returns
@@ -168,14 +167,14 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			!parentSp.IsRecording() {
 			tracer := parentSp.Tracer()
 			sp = tracer.StartSpan(
-				"explain-distsql", tracing.Recordable,
-				opentracing.ChildOf(parentSp.Context()),
-				tracing.LogTagsFromCtx(params.ctx))
+				"explain-distsql", tracing.WithForceRealSpan(),
+				tracing.WithParent(parentSp),
+				tracing.WithCtxLogTags(params.ctx))
 		} else {
 			tracer := params.extendedEvalCtx.ExecCfg.AmbientCtx.Tracer
 			sp = tracer.StartSpan(
-				"explain-distsql", tracing.Recordable,
-				tracing.LogTagsFromCtx(params.ctx))
+				"explain-distsql", tracing.WithForceRealSpan(),
+				tracing.WithCtxLogTags(params.ctx))
 		}
 		sp.StartRecording(tracing.SnowballRecording)
 		ctx := tracing.ContextWithSpan(params.ctx, sp)

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -392,7 +392,7 @@ func TestLimitScans(t *testing.T) {
 
 	// Now we're going to run the tableReader and trace it.
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("root", tracing.Recordable)
+	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
 	sp.StartRecording(tracing.SnowballRecording)
 	ctx = tracing.ContextWithSpan(ctx, sp)
 	flowCtx.EvalCtx.Context = ctx

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -752,7 +752,7 @@ func TestRouterDiskSpill(t *testing.T) {
 
 	// Enable stats recording.
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("root", tracing.Recordable)
+	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
 	sp.StartRecording(tracing.SnowballRecording)
 	ctx := tracing.ContextWithSpan(context.Background(), sp)
 

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -47,7 +47,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 
 	// Annotate a context that has an open span.
 
-	sp1 := tracer.StartRootSpan("root", nil /* logTags */, tracing.RecordableSpan)
+	sp1 := tracer.StartSpan("root", tracing.WithForceRealSpan())
 	sp1.StartRecording(tracing.SingleNodeRecording)
 	ctx1 := tracing.ContextWithSpan(context.Background(), sp1)
 	Event(ctx1, "a")

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -65,7 +65,7 @@ func TestTrace(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartRootSpan("s", nil /* logTags */, tracing.RecordableSpan)
+	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
 	sp.StartRecording(tracing.SingleNodeRecording)
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 	Event(ctxWithSpan, "test1")
@@ -94,7 +94,7 @@ func TestTraceWithTags(t *testing.T) {
 	ctx = logtags.AddTag(ctx, "tag", 1)
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartRootSpan("s", nil /* logTags */, tracing.RecordableSpan)
+	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 	sp.StartRecording(tracing.SingleNodeRecording)
 
@@ -180,7 +180,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	VErrEvent(ctxWithEventLog, noLogV(), "testerr")
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartRootSpan("s", nil /* logTags */, tracing.RecordableSpan)
+	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
 	sp.StartRecording(tracing.SingleNodeRecording)
 	ctxWithBoth := tracing.ContextWithSpan(ctxWithEventLog, sp)
 	// Events should only go to the trace.

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "recording.go",
         "shadow.go",
         "span.go",
+        "span_options.go",
         "tags.go",
         "test_utils.go",
         "tracer.go",

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -29,35 +29,35 @@ import (
 	"golang.org/x/net/trace"
 )
 
-// spanMeta stores Span information that is common to Span and SpanContext.
-type spanMeta struct {
-	// A probabilistically unique identifier for a [multi-Span] trace.
-	TraceID uint64
+// SpanMeta is information about a Span that is not local to this
+// process. Typically, SpanMeta is populated from information
+// about a Span on the other end of an RPC, and is used to derive
+// a child span via `Tracer.StartSpan`. For local spans, SpanMeta
+// is not used, as the *Span directly can be derived from.
+//
+// SpanMeta contains the trace and span identifiers of the parent,
+// along with additional metadata. In particular, this specifies
+// whether the child should be recording, in which case the contract
+// is that the recording is to be returned to the caller when the
+// child finishes, so that the caller can inductively construct the
+// entire trace.
+type SpanMeta struct {
+	traceID uint64
+	spanID  uint64
 
-	// A probabilistically unique identifier for a Span.
-	SpanID uint64
-}
-
-// SpanContext is information about a Span, used to derive spans
-// from a parent in a way that's uniform between local and remote
-// parents. For local parents, this generally references their Span
-// to unlock features such as sharing recordings with the parent. For
-// remote parents, it only contains the TraceID and related metadata.
-type SpanContext struct {
-	spanMeta
-
-	// Underlying shadow tracer info and context (optional).
-	shadowTr  *shadowTracer
-	shadowCtx opentracing.SpanContext
+	// Underlying shadow tracer info and span context (optional). This
+	// will only be populated when the remote Span is reporting to an
+	// external opentracing tracer. We hold on to the type of tracer to
+	// avoid mixing spans when the tracer is reconfigured, as impls are
+	// not typically robust to being shown spans they did not create.
+	shadowTracerType string
+	shadowCtx        opentracing.SpanContext
 
 	// If set, all spans derived from this context are being recorded.
+	//
+	// NB: at the time of writing, this is only ever set to SnowballTracing
+	// and only if Baggage[Snowball] is set.
 	recordingType RecordingType
-	// span is set if this context corresponds to a local span. If so, pointing
-	// back to the span is used for registering child spans with their parent.
-	// Children of remote spans act as roots when it comes to recordings - someone
-	// is responsible for calling GetRecording() on them and marshaling the
-	// recording back to the parent (generally an RPC handler does this).
-	span *Span
 
 	// The Span's associated baggage.
 	Baggage map[string]string
@@ -79,19 +79,11 @@ type SpanStats interface {
 	Stats() map[string]string
 }
 
-var _ opentracing.SpanContext = &SpanContext{}
-
-// ForeachBaggageItem is part of the opentracing.SpanContext interface.
-func (sc *SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
-	for k, v := range sc.Baggage {
-		if !handler(k, v) {
-			break
-		}
-	}
-}
-
 type crdbSpan struct {
-	spanMeta
+	// The traceID, probabilistically unique.
+	traceID uint64
+	// The spanID, probabilistically unique.
+	spanID uint64
 
 	parentSpanID uint64
 
@@ -205,7 +197,7 @@ func (s *Span) isNoop() bool {
 	// NB: this is the same as `s` being zero with the exception
 	// of the `tracer` field. However, `Span` is not comparable,
 	// so this can't be expressed easily.
-	return s.isBlackHole() && s.crdb.TraceID == 0
+	return s.isBlackHole() && s.crdb.traceID == 0
 }
 
 // IsRecording returns true if the Span is recording its events.
@@ -246,7 +238,7 @@ func (s *crdbSpan) enableRecording(
 // will be part of the same recording.
 //
 // Recording is not supported by noop spans; to ensure a real Span is always
-// created, use the Recordable option to StartSpan.
+// created, use the WithForceRealSpan option to StartSpan.
 //
 // If recording was already started on this Span (either directly or because a
 // parent Span is recording), the old recording is lost.
@@ -258,7 +250,7 @@ func (s *Span) StartRecording(recType RecordingType) {
 		panic("StartRecording called with NoRecording")
 	}
 	if s.isNoop() {
-		panic("StartRecording called on NoopSpan; use the Recordable option for StartSpan")
+		panic("StartRecording called on NoopSpan; use the WithForceRealSpan option for StartSpan")
 	}
 
 	// If we're already recording (perhaps because the parent was recording when
@@ -330,6 +322,12 @@ func (s *crdbSpan) getRecording() Recording {
 	return result
 }
 
+func (s *crdbSpan) getRecordingType() RecordingType {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.recording.recordingType
+}
+
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;
 // these spans will be part of the result of GetRecording. Used to import
 // recorded traces from other nodes.
@@ -344,7 +342,7 @@ func (s *crdbSpan) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error
 	// Change the root of the remote recording to be a child of this Span. This is
 	// usually already the case, except with DistSQL traces where remote
 	// processors run in spans that FollowFrom an RPC Span that we don't collect.
-	remoteSpans[0].ParentSpanID = s.SpanID
+	remoteSpans[0].ParentSpanID = s.spanID
 
 	s.mu.Lock()
 	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
@@ -364,13 +362,11 @@ func (s *Span) IsBlackHole() bool {
 	return s.isBlackHole()
 }
 
-// IsNoop returns true if the Span context is from a "no-op" Span. If
-// this is true, any Span derived from this context will be a "black hole Span".
-//
-// You should never need to care about this method. It is exported for technical
-// reasons.
-func (sc *SpanContext) IsNoop() bool {
-	return sc.recordingType == NoRecording && sc.shadowTr == nil
+// isNilOrNoop returns true if the Span context is either nil
+// or corresponds to a "no-op" Span. If this is true, any Span
+// derived from this context will be a "black hole Span".
+func (sc *SpanMeta) isNilOrNoop() bool {
+	return sc.recordingType == NoRecording && sc.shadowTracerType == ""
 }
 
 // SetSpanStats sets the stats on a Span. stats.Stats() will also be added to
@@ -407,21 +403,15 @@ func (s *Span) Finish() {
 	}
 }
 
-// Context is part of the opentracing.Span interface.
+// Meta returns the information which needs to be propagated across
+// process boundaries in order to derive child spans from this Span.
 //
-// TODO(andrei, radu): Should this return noopSpanContext for a Recordable Span
+// TODO(andrei, radu): Should this return nil for a WithForceRealSpan Span
 // that's not currently recording? That might save work and allocations when
 // creating child spans.
-func (s *Span) Context() *SpanContext {
+func (s *Span) Meta() *SpanMeta {
 	s.crdb.mu.Lock()
 	defer s.crdb.mu.Unlock()
-	sc := s.SpanContext()
-	return &sc
-}
-
-// SpanContext returns a SpanContext. Note that this returns a value,
-// not a pointer, which the caller can use to avoid heap allocations.
-func (s *Span) SpanContext() SpanContext {
 	n := len(s.crdb.mu.Baggage)
 	// In the common case, we have no baggage, so avoid making an empty map.
 	var baggageCopy map[string]string
@@ -431,20 +421,26 @@ func (s *Span) SpanContext() SpanContext {
 	for k, v := range s.crdb.mu.Baggage {
 		baggageCopy[k] = v
 	}
-	sc := SpanContext{
-		spanMeta: s.crdb.spanMeta,
-		span:     s,
-		Baggage:  baggageCopy,
-	}
+	var shadowTrTyp string
+	var shadowCtx opentracing.SpanContext
 	if s.ot.shadowSpan != nil {
-		sc.shadowTr = s.ot.shadowTr
-		sc.shadowCtx = s.ot.shadowSpan.Context()
+		shadowTrTyp, _ = s.ot.shadowTr.Type()
+		shadowCtx = s.ot.shadowSpan.Context()
 	}
 
+	var recordingType RecordingType
 	if s.crdb.isRecording() {
-		sc.recordingType = s.crdb.mu.recording.recordingType
+		recordingType = s.crdb.mu.recording.recordingType
 	}
-	return sc
+
+	return &SpanMeta{
+		traceID:          s.crdb.traceID,
+		spanID:           s.crdb.spanID,
+		shadowTracerType: shadowTrTyp,
+		shadowCtx:        shadowCtx,
+		recordingType:    recordingType,
+		Baggage:          baggageCopy,
+	}
 }
 
 // SetOperationName is part of the opentracing.Span interface.
@@ -589,8 +585,8 @@ func (s *Span) Tracer() *Tracer {
 // children.
 func (s *crdbSpan) getRecordingLocked() tracingpb.RecordedSpan {
 	rs := tracingpb.RecordedSpan{
-		TraceID:      s.TraceID,
-		SpanID:       s.SpanID,
+		TraceID:      s.traceID,
+		SpanID:       s.spanID,
 		ParentSpanID: s.parentSpanID,
 		Operation:    s.operation,
 		StartTime:    s.startTime,

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -1,0 +1,200 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracing
+
+import (
+	"github.com/cockroachdb/logtags"
+	"github.com/opentracing/opentracing-go"
+)
+
+// spanOptions are the options to `Tracer.StartSpan`. This struct is
+// typically not used directly. Instead, the methods mentioned on each
+// field comment below are invoked as arguments to `Tracer.StartSpan`.
+// See the SpanOption interface for a synopsis.
+type spanOptions struct {
+	Parent            *Span                         // see WithParent
+	RemoteParent      *SpanMeta                     // see WithRemoteParent
+	RefType           opentracing.SpanReferenceType // see WithFollowsFrom
+	LogTags           *logtags.Buffer               // see WithLogTags
+	Tags              map[string]interface{}        // see WithTags
+	SeparateRecording bool                          // see WithSeparateRecording
+	ForceRealSpan     bool                          // see WithForceRealSpan
+}
+
+func (opts *spanOptions) parentTraceID() uint64 {
+	if opts.Parent != nil {
+		return opts.Parent.crdb.traceID
+	} else if opts.RemoteParent != nil {
+		return opts.RemoteParent.traceID
+	}
+	return 0
+}
+
+func (opts *spanOptions) parentSpanID() uint64 {
+	if opts.Parent != nil {
+		return opts.Parent.crdb.spanID
+	} else if opts.RemoteParent != nil {
+		return opts.RemoteParent.spanID
+	}
+	return 0
+}
+
+func (opts *spanOptions) recordingType() RecordingType {
+	var recordingType RecordingType
+	if opts.Parent != nil {
+		recordingType = opts.Parent.crdb.getRecordingType()
+	} else if opts.RemoteParent != nil {
+		recordingType = opts.RemoteParent.recordingType
+	}
+	return recordingType
+}
+
+func (opts *spanOptions) shadowTrTyp() (string, bool) {
+	if opts.Parent != nil {
+		return opts.Parent.ot.shadowTr.Type()
+	} else if opts.RemoteParent != nil {
+		s := opts.RemoteParent.shadowTracerType
+		return s, s != ""
+	}
+	return "", false
+}
+
+// SpanOption is the interface satisfied by options to `Tracer.StartSpan`.
+// A synopsis of the options follows. For details, see their comments.
+//
+// - WithParent: create a child Span from a Span (local span).
+// - WithRemoteParent: create a child Span from a SpanMeta (remote span).
+// - WithFollowsFrom: indicate that child may outlive parent.
+// - WithLogTags: populates the Span tags from a `logtags.Buffer`.
+// - WithCtxLogTags: like WithLogTags, but takes a `context.Context`.
+// - WithTags: adds tags to a Span on creation.
+// - WithSeparateRecording: prevents recording to be shared with local parent span.
+// - WithForceRealSpan: prevents optimizations that can avoid creating a real span.
+type SpanOption interface {
+	apply(spanOptions) spanOptions
+}
+
+type parentOption Span
+
+// WithParent instructs StartSpan to create a child span referring to the
+// given local parent Span.
+//
+// Children of local parents inherit the parent's log tags, and will
+// share their recording with the parent (unless WithSeparateRecording is
+// used). They will also start recording if the parent is recording at
+// the time of child instantiation. If the parent span is not recording,
+// the child could be a "noop span" (depending on whether the Tracer is
+// configured to trace to an external tracing system) which does not support
+// recording, unless the WithForceRealSpan option is passed to StartSpan.
+//
+// By default, children are derived using a ChildOf relationship,
+// which corresponds to the expectation that the parent span will
+// wait for the child to Finish(). If this expectation does not hold,
+// WithFollowsFrom should be added to the StartSpan invocation.
+//
+// When no local Span is available, WithRemoteParent should be used.
+func WithParent(sp *Span) SpanOption {
+	return (*parentOption)(sp)
+}
+
+func (p *parentOption) apply(opts spanOptions) spanOptions {
+	opts.Parent = (*Span)(p)
+	return opts
+}
+
+type remoteParentOption SpanMeta
+
+// WithRemoteParent instructs StartSpan to create child span descending
+// from a parent described via SpanMeta. Since no local parent is
+// available (in contrast to WithParent), this Span will not share a
+// recording with any other Span. Typically RPC middleware ensures that the
+// child's recording is collected and propagated back to the parent Span.
+func WithRemoteParent(parent *SpanMeta) SpanOption {
+	return (*remoteParentOption)(parent)
+}
+
+func (p *remoteParentOption) apply(opts spanOptions) spanOptions {
+	opts.RemoteParent = (*SpanMeta)(p)
+	return opts
+}
+
+type tagsOption []opentracing.Tag
+
+// WithTags is an option to Tracer.StartSpan which populates the
+// tags on the newly created Span.
+func WithTags(tags ...opentracing.Tag) SpanOption {
+	return (tagsOption)(tags)
+}
+
+func (o tagsOption) apply(opts spanOptions) spanOptions {
+	if len(o) == 0 {
+		return opts
+	}
+	if opts.Tags == nil {
+		opts.Tags = map[string]interface{}{}
+	}
+	for _, tag := range o {
+		opts.Tags[tag.Key] = tag.Value
+	}
+	return opts
+}
+
+type followsFromOpt struct{}
+
+// WithFollowsFrom instructs StartSpan to use a FollowsFrom relationship
+// should a child span be created (i.e. should WithParent or WithRemoteParent
+// be supplied as well). A WithFollowsFrom child is expected to, in the common
+// case, outlive the parent span (for example: asynchronous cleanup work),
+// whereas a "regular" child span is not (i.e. the parent span typically
+// waits for the child to Finish()).
+//
+// There is no penalty for getting this wrong, but it can help external
+// trace systems visualize the traces better.
+func WithFollowsFrom() SpanOption {
+	return followsFromOpt{}
+}
+
+func (o followsFromOpt) apply(opts spanOptions) spanOptions {
+	opts.RefType = opentracing.FollowsFromRef
+	return opts
+}
+
+type forceRealSpanOption struct{}
+
+// WithForceRealSpan forces StartSpan to create of a real Span instead of
+// a low-overhead non-recordable noop span.
+//
+// When tracing is disabled all spans are noopSpans; these spans aren't
+// capable of recording, so this option should be passed to StartSpan if the
+// caller wants to be able to call StartRecording on the resulting Span.
+func WithForceRealSpan() SpanOption {
+	return forceRealSpanOption{}
+}
+
+func (forceRealSpanOption) apply(opts spanOptions) spanOptions {
+	opts.ForceRealSpan = true
+	return opts
+}
+
+type withSeparateRecordingOpt struct{}
+
+// WithSeparateRecording instructs StartSpan to configure any child span
+// started via WithParent to *not* share the recording with that parent.
+//
+// See WithParent and WithRemoteParent for details about recording inheritance.
+func WithSeparateRecording() SpanOption {
+	return withSeparateRecordingOpt{}
+}
+
+func (o withSeparateRecordingOpt) apply(opts spanOptions) spanOptions {
+	opts.SeparateRecording = true
+	return opts
+}

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -14,49 +14,28 @@ import (
 	"context"
 
 	"github.com/cockroachdb/logtags"
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // LogTagsOption is a StartSpanOption that uses log tags to populate the Span tags.
 type logTagsOption logtags.Buffer
 
-var _ opentracing.StartSpanOption = &logTagsOption{}
+var _ SpanOption = &logTagsOption{}
 
-// Apply is part of the opentracing.StartSpanOption interface.
-//
-// The tags in the buffer go through the log tag -> Span tag remapping (see
-// tagName()).
-//
-// Note that our tracer does not call Apply() for this options. Instead, it
-// recognizes it as a special case and treats it more efficiently, avoiding
-// allocations for each tag. Apply() is still used by shadow tracers.
-func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
-	if lt == nil {
-		return
-	}
-	tags := (*logtags.Buffer)(lt).Get()
-	if len(tags) == 0 {
-		return
-	}
-	if o.Tags == nil {
-		o.Tags = make(map[string]interface{}, len(tags))
-	}
-	for i := range tags {
-		o.Tags[tagName(tags[i].Key())] = tags[i].ValueStr()
-	}
+func (lt *logTagsOption) apply(opts spanOptions) spanOptions {
+	opts.LogTags = (*logtags.Buffer)(lt)
+	return opts
 }
 
-// LogTags returns a StartSpanOption that sets the Span tags to the given log
+// WithLogTags returns a SpanOption that sets the Span tags to the given log
 // tags. When applied, the returned option will apply any logtag name->Span tag
 // name remapping that has been registered via RegisterTagRemapping.
-func LogTags(tags *logtags.Buffer) opentracing.StartSpanOption {
+func WithLogTags(tags *logtags.Buffer) SpanOption {
 	return (*logTagsOption)(tags)
 }
 
-// LogTagsFromCtx returns a StartSpanOption that sets the Span tags to the log
-// tags in the context.
-func LogTagsFromCtx(ctx context.Context) opentracing.StartSpanOption {
-	return (*logTagsOption)(logtags.FromContext(ctx))
+// WithCtxLogTags returns WithLogTags(logtags.FromContext(ctx)).
+func WithCtxLogTags(ctx context.Context) SpanOption {
+	return WithLogTags(logtags.FromContext(ctx))
 }
 
 // tagRemap is a map that records desired conversions

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -24,7 +24,7 @@ func TestLogTags(t *testing.T) {
 
 	l := logtags.SingleTagBuffer("tag1", "val1")
 	l = l.Add("tag2", "val2")
-	sp1 := tr.StartSpan("foo", Recordable, LogTags(l))
+	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
 	sp1.StartRecording(SingleNodeRecording)
 	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp1.GetRecording(), `
@@ -37,7 +37,7 @@ func TestLogTags(t *testing.T) {
 	RegisterTagRemapping("tag1", "one")
 	RegisterTagRemapping("tag2", "two")
 
-	sp2 := tr.StartSpan("bar", Recordable, LogTags(l))
+	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
 	sp2.StartRecording(SingleNodeRecording)
 	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp2.GetRecording(), `
@@ -47,7 +47,7 @@ func TestLogTags(t *testing.T) {
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
 	shadowTracer.clear()
 
-	sp3 := tr.StartRootSpan("baz", l, RecordableSpan)
+	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
 	sp3.StartRecording(SingleNodeRecording)
 	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp3.GetRecording(), `

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -12,6 +12,7 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -156,101 +157,36 @@ func (t *Tracer) getShadowTracer() *shadowTracer {
 	return (*shadowTracer)(atomic.LoadPointer(&t.shadowTracer))
 }
 
-type recordableOption struct{}
-
-// Apply is part of the opentracing.StartSpanOption interface.
-func (recordableOption) Apply(*opentracing.StartSpanOptions) {}
-
-// Recordable is a StartSpanOption that forces creation of a real Span.
-//
-// When tracing is disabled all spans are noopSpans; these spans aren't
-// capable of recording, so this option should be passed to StartSpan if the
-// caller wants to be able to call StartRecording on the resulting Span.
-var Recordable opentracing.StartSpanOption = recordableOption{}
-
-// StartSpan is part of the opentracing.Tracer interface.
-//
-// Avoid using this method in favor of Tracer.StartRootSpan() or
-// tracing.StartChildSpan() (or higher-level methods like EnsureContext() or
-// AmbientContext.AnnotateCtxWithSpan()) when possible. Those are more efficient
-// because they don't have to use the StartSpanOption interface and so a bunch
-// of allocations are avoided. However, we need to implement this standard
-// StartSpan() too because grpc integrates with a generic opentracing.Tracer.
-func (t *Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) *Span {
+// StartSpan starts a Span. See spanOptions for details.
+func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
 	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
 	// is disabled: if we have no options or a single SpanReference (the common
-	// case) with a noop context, return a noop Span now.
-	if len(opts) == 1 {
-		if o, ok := opts[0].(opentracing.SpanReference); ok {
-			if o.ReferencedContext.(*SpanContext).IsNoop() {
+	// case) with a black hole span, return a noop Span now.
+	if len(os) == 1 {
+		switch o := os[0].(type) {
+		case *parentOption:
+			if (*Span)(o).IsBlackHole() {
+				return t.noopSpan
+			}
+		case *remoteParentOption:
+			if (*SpanMeta)(o).isNilOrNoop() {
 				return t.noopSpan
 			}
 		}
 	}
-
-	if len(opts) == 0 && !t.AlwaysTrace() {
+	if len(os) == 0 && !t.AlwaysTrace() {
 		return t.noopSpan
 	}
 
-	var sso opentracing.StartSpanOptions
-	var recordable RecordableOpt
-	var logTags *logtags.Buffer
-	for _, o := range opts {
-		switch to := o.(type) {
-		case recordableOption:
-			recordable = true
-		case *logTagsOption:
-			// NOTE: calling logTagsOption.Apply() would be functionally equivalent,
-			// but less efficient.
-			logTags = (*logtags.Buffer)(to)
-		default:
-			o.Apply(&sso)
-		}
+	// NB: apply takes and returns a value to avoid forcing
+	// `opts` on the heap here.
+	var opts spanOptions
+	for _, o := range os {
+		opts = o.apply(opts)
 	}
 
-	var parentType opentracing.SpanReferenceType
-	var parentCtx SpanContext
-
-	// Note that the logic around here doesn't support spans with multiple
-	// references. Luckily, we don't have such cases.
-	if len(sso.References) > 1 {
-		panic("multiple references are unsupported")
-	}
-	for _, r := range sso.References {
-		if r.Type != opentracing.ChildOfRef && r.Type != opentracing.FollowsFromRef {
-			continue
-		}
-		if r.ReferencedContext == nil {
-			continue
-		}
-		if r.ReferencedContext.(*SpanContext).IsNoop() {
-			continue
-		}
-		parentType = r.Type
-		parentCtx = *r.ReferencedContext.(*SpanContext)
-		break
-	}
-
-	return t.startSpanGeneric(
-		operationName, parentCtx, parentType, recordable, logTags, false /* separateRecording */, sso.Tags)
+	return t.startSpanGeneric(operationName, opts)
 }
-
-// RecordableOpt specifies whether a Span should be recordable.
-//
-// By default, spans derived from a *recording* (on top of recordable) span
-// are recordable (and recording). Otherwise, they are non-recordable.
-type RecordableOpt bool
-
-const (
-	// RecordableSpan means that a Span will be recordable. This means that
-	// a real Span will be created (and so it carries a cost).
-	RecordableSpan RecordableOpt = true
-	// NonRecordableSpan means that a Span will not be recordable. Using this
-	// option when possible can improve performance.
-	//
-	// TODO(tbg): with always-on tracing, it won't matter.
-	NonRecordableSpan RecordableOpt = false
-)
 
 // AlwaysTrace returns true if operations should be traced regardless of the
 // context.
@@ -259,76 +195,23 @@ func (t *Tracer) AlwaysTrace() bool {
 	return t.useNetTrace() || shadowTracer != nil
 }
 
-// StartRootSpan creates a root Span. This is functionally equivalent to:
-// parentSpan.Tracer().(*Tracer).StartSpan(opName, LogTags(...), [Recordable])
-// Compared to that, it's more efficient, particularly in terms of memory
-// allocations because the opentracing.StartSpanOption interface is not used.
-//
-// logTags can be nil.
-func (t *Tracer) StartRootSpan(
-	opName string, logTags *logtags.Buffer, recordable RecordableOpt,
-) *Span {
-	return t.StartChildSpan(opName, SpanContext{}, logTags, recordable, false /* separateRecording */)
-}
+// startSpanGeneric is the implementation of StartSpan.
+func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
+	if opts.RefType != opentracing.ChildOfRef && opts.RefType != opentracing.FollowsFromRef {
+		panic(fmt.Sprintf("unexpected RefType %v", opts.RefType))
+	}
 
-// StartChildSpan creates a child Span of the given parent Span. This is
-// functionally equivalent to:
-// parentSpan.Tracer().(*Tracer).StartSpan(opName, opentracing.ChildOf(parentSpan.Context()))
-// Compared to that, it's more efficient, particularly in terms of memory
-// allocations; among others, it saves the call to parentSpan.Context.
-//
-// This only works for creating children of local parents (i.e. the caller needs
-// to have a reference to the parent Span).
-//
-// If separateRecording is true and the parent Span is recording, the child's
-// recording will not be part of the parent's recording. This is useful when the
-// child's recording will be reported to a collector separate from the parent's
-// recording; for example DistSQL processors each report their own recording,
-// and we don't want the parent's recording to include a child's because then we
-// might double-report that child.
-//
-// TODO(tbg): I don't think we need separateRecording because children can consume
-// and (atomically) clear their recording to avoid it getting consumed twice.
-func (t *Tracer) StartChildSpan(
-	opName string,
-	parentContext SpanContext,
-	logTags *logtags.Buffer,
-	recordable RecordableOpt,
-	separateRecording bool,
-) *Span {
-	return t.startSpanGeneric(
-		opName,
-		parentContext,
-		opentracing.ChildOfRef,
-		recordable,
-		logTags,
-		separateRecording,
-		nil, /* tags */
-	)
-}
+	if opts.Parent != nil {
+		if opts.RemoteParent != nil {
+			panic("can't specify both Parent and RemoteParent")
+		}
+	}
 
-// startSpanGeneric is the internal workhorse for creating spans. It serves two purposes:
-//
-// 1. creating root spans. In this case, parentContext and parentType are zero. A noop Span
-//    is returned when nothing forces an actual Span to be created, i.e. there is no shadow
-//    tracer and internal tracing active, plus no recordability is requested.
-// 2. creating derived spans. In this case, parentContext and parentType are nonzero. If the
-//    parent is not recording and 'recordable' is zero, and nothing else forces a real Span,
-//    a noopSpan results.
-func (t *Tracer) startSpanGeneric(
-	opName string,
-	parentContext SpanContext,
-	parentType opentracing.SpanReferenceType,
-	recordable RecordableOpt,
-	logTags *logtags.Buffer,
-	separateRecording bool,
-	tags map[string]interface{},
-) *Span {
 	// If tracing is disabled, avoid overhead and return a noop Span.
 	if !t.AlwaysTrace() &&
-		parentContext.TraceID == 0 &&
-		parentContext.recordingType == NoRecording &&
-		recordable == NonRecordableSpan {
+		opts.parentTraceID() == 0 &&
+		opts.recordingType() == NoRecording &&
+		!opts.ForceRealSpan {
 		return t.noopSpan
 	}
 
@@ -337,41 +220,62 @@ func (t *Tracer) startSpanGeneric(
 		crdb: crdbSpan{
 			operation:    opName,
 			startTime:    time.Now(),
-			parentSpanID: parentContext.SpanID,
-			logTags:      logTags,
+			parentSpanID: opts.parentSpanID(),
+			logTags:      opts.LogTags,
 		},
 	}
 	s.crdb.mu.duration = -1 // unfinished
 
-	traceID := parentContext.TraceID
+	traceID := opts.parentTraceID()
 	if traceID == 0 {
 		traceID = uint64(rand.Int63())
 	}
-	s.crdb.TraceID = traceID
-	s.crdb.SpanID = uint64(rand.Int63())
+	s.crdb.traceID = traceID
+	s.crdb.spanID = uint64(rand.Int63())
 
-	// We use the shadowTr from the parent context over that of our
-	// tracer because the tracer's might have changed and be incompatible.
 	shadowTr := t.getShadowTracer()
-	if shadowTr != nil && (parentContext.shadowTr == nil || shadowTr == parentContext.shadowTr) {
-		linkShadowSpan(s, shadowTr, parentContext.shadowCtx, parentType)
+	{
+		// Make sure not to derive spans created using an old
+		// shadow tracer via a new one.
+		typ1, ok1 := opts.shadowTrTyp() // old
+		typ2, ok2 := shadowTr.Type()    // new
+		if ok1 && ok2 && typ1 != typ2 {
+			// If both are set and don't agree, ignore shadow tracer
+			// for the new span. It's fine if the old one isn't set
+			// but the new one is (we won't use it, though we could)
+			// or if the old one is and new one isn't (in which case
+			// the supposedly latest config has no shadow tracing
+			// enabled).
+			shadowTr = nil
+		}
 	}
 
-	// Start recording if necessary.
-	if parentContext.recordingType != NoRecording {
-		var p *crdbSpan
-		if parentContext.span != nil {
-			p = &parentContext.span.crdb
+	if shadowTr != nil {
+		var shadowCtx opentracing.SpanContext
+		if opts.Parent != nil && opts.Parent.ot.shadowSpan != nil {
+			shadowCtx = opts.Parent.ot.shadowSpan.Context()
 		}
-		s.crdb.enableRecording(p, parentContext.recordingType, separateRecording)
+		linkShadowSpan(s, shadowTr, shadowCtx, opts.RefType)
+	}
+
+	// Start recording if necessary. We inherit the recording type of the local parent, if any,
+	// over the remote parent, if any. If neither are specified, we're not recording.
+	recordingType := opts.recordingType()
+
+	if recordingType != NoRecording {
+		var p *crdbSpan
+		if opts.Parent != nil {
+			p = &opts.Parent.crdb
+		}
+		s.crdb.enableRecording(p, recordingType, opts.SeparateRecording)
 	}
 
 	if t.useNetTrace() {
 		s.netTr = trace.New("tracing", opName)
 		s.netTr.SetMaxEvents(maxLogsPerSpan)
-		if logTags != nil {
-			tags := logTags.Get()
-			for i := range logTags.Get() {
+		if opts.LogTags != nil {
+			tags := opts.LogTags.Get()
+			for i := range tags {
 				tag := &tags[i]
 				s.netTr.LazyPrintf("%s:%v", tagName(tag.Key()), tag.Value())
 			}
@@ -381,15 +285,24 @@ func (t *Tracer) startSpanGeneric(
 	// Set initial tags.
 	//
 	// NB: this could be optimized.
-	for k, v := range tags {
+	for k, v := range opts.Tags {
 		s.SetTag(k, v)
 	}
 
 	// Copy baggage from parent.
 	//
 	// NB: this could be optimized.
-	for k, v := range parentContext.Baggage {
-		s.SetBaggageItem(k, v)
+	if opts.Parent != nil {
+		opts.Parent.crdb.mu.Lock()
+		m := opts.Parent.crdb.mu.Baggage
+		for k, v := range m {
+			s.SetBaggageItem(k, v)
+		}
+		opts.Parent.crdb.mu.Unlock()
+	} else if opts.RemoteParent != nil {
+		for k, v := range opts.RemoteParent.Baggage {
+			s.SetBaggageItem(k, v)
+		}
 	}
 
 	return s
@@ -405,10 +318,8 @@ func (fn textMapWriterFn) Set(key, val string) {
 }
 
 // Inject is part of the opentracing.Tracer interface.
-func (t *Tracer) Inject(
-	osc opentracing.SpanContext, format interface{}, carrier interface{},
-) error {
-	if osc.(*SpanContext).IsNoop() {
+func (t *Tracer) Inject(sc *SpanMeta, format interface{}, carrier interface{}) error {
+	if sc.isNilOrNoop() {
 		// Fast path when tracing is disabled. Extract will accept an empty map as a
 		// noop context.
 		return nil
@@ -424,25 +335,27 @@ func (t *Tracer) Inject(
 		return opentracing.ErrInvalidCarrier
 	}
 
-	sc, ok := osc.(*SpanContext)
-	if !ok {
-		return opentracing.ErrInvalidSpanContext
-	}
-
-	mapWriter.Set(fieldNameTraceID, strconv.FormatUint(sc.TraceID, 16))
-	mapWriter.Set(fieldNameSpanID, strconv.FormatUint(sc.SpanID, 16))
+	mapWriter.Set(fieldNameTraceID, strconv.FormatUint(sc.traceID, 16))
+	mapWriter.Set(fieldNameSpanID, strconv.FormatUint(sc.spanID, 16))
 
 	for k, v := range sc.Baggage {
 		mapWriter.Set(prefixBaggage+k, v)
 	}
 
-	if sc.shadowTr != nil {
-		mapWriter.Set(fieldNameShadowType, sc.shadowTr.Typ())
-		// Encapsulate the shadow text map, prepending a prefix to the keys.
-		if err := sc.shadowTr.Inject(sc.shadowCtx, format, textMapWriterFn(func(key, val string) {
-			mapWriter.Set(prefixShadow+key, val)
-		})); err != nil {
-			return err
+	shadowTr := t.getShadowTracer()
+	if shadowTr != nil {
+		// Don't use a different shadow tracer than the one that created the parent span
+		// to put information on the wire. If something changes out from under us, forget
+		// about shadow tracing.
+		curTyp, _ := shadowTr.Type()
+		if typ := sc.shadowTracerType; typ == curTyp {
+			mapWriter.Set(fieldNameShadowType, sc.shadowTracerType)
+			// Encapsulate the shadow text map, prepending a prefix to the keys.
+			if err := shadowTr.Inject(sc.shadowCtx, format, textMapWriterFn(func(key, val string) {
+				mapWriter.Set(prefixShadow+key, val)
+			})); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -458,12 +371,12 @@ func (fn textMapReaderFn) ForeachKey(handler func(key, val string) error) error 
 	return fn(handler)
 }
 
-var noopSpanContext = &SpanContext{}
+var noopSpanContext = &SpanMeta{}
 
 // Extract is part of the opentracing.Tracer interface.
 // It always returns a valid context, even in error cases (this is assumed by the
 // grpc-opentracing interceptor).
-func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanContext, error) {
+func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanMeta, error) {
 	// We only support the HTTPHeaders/TextMap format.
 	if format != opentracing.HTTPHeaders && format != opentracing.TextMap {
 		return noopSpanContext, opentracing.ErrUnsupportedFormat
@@ -474,21 +387,26 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanContext,
 		return noopSpanContext, opentracing.ErrInvalidCarrier
 	}
 
-	var sc SpanContext
 	var shadowType string
 	var shadowCarrier opentracing.TextMapCarrier
 
+	var traceID uint64
+	var spanID uint64
+	var baggage map[string]string
+
+	// TODO(tbg): ForeachKey forces things on the heap. We can do better
+	// by using an explicit carrier.
 	err := mapReader.ForeachKey(func(k, v string) error {
 		switch k = strings.ToLower(k); k {
 		case fieldNameTraceID:
 			var err error
-			sc.TraceID, err = strconv.ParseUint(v, 16, 64)
+			traceID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return opentracing.ErrSpanContextCorrupted
 			}
 		case fieldNameSpanID:
 			var err error
-			sc.SpanID, err = strconv.ParseUint(v, 16, 64)
+			spanID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return opentracing.ErrSpanContextCorrupted
 			}
@@ -496,10 +414,10 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanContext,
 			shadowType = v
 		default:
 			if strings.HasPrefix(k, prefixBaggage) {
-				if sc.Baggage == nil {
-					sc.Baggage = make(map[string]string)
+				if baggage == nil {
+					baggage = make(map[string]string)
 				}
-				sc.Baggage[strings.TrimPrefix(k, prefixBaggage)] = v
+				baggage[strings.TrimPrefix(k, prefixBaggage)] = v
 			} else if strings.HasPrefix(k, prefixShadow) {
 				if shadowCarrier == nil {
 					shadowCarrier = make(opentracing.TextMapCarrier)
@@ -513,29 +431,45 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanContext,
 	if err != nil {
 		return noopSpanContext, err
 	}
-	if sc.TraceID == 0 && sc.SpanID == 0 {
+	if traceID == 0 && spanID == 0 {
 		return noopSpanContext, nil
 	}
 
-	if sc.Baggage[Snowball] != "" {
-		sc.recordingType = SnowballRecording
+	var recordingType RecordingType
+	if baggage[Snowball] != "" {
+		recordingType = SnowballRecording
 	}
 
+	var shadowCtx opentracing.SpanContext
 	if shadowType != "" {
-		// Using a shadow tracer only works if all hosts use the same shadow tracer.
-		// If that's not the case, ignore the shadow context.
-		if shadowTr := t.getShadowTracer(); shadowTr != nil &&
-			strings.EqualFold(shadowType, shadowTr.Typ()) {
-			sc.shadowTr = shadowTr
+		shadowTr := t.getShadowTracer()
+		curShadowTyp, _ := shadowTr.Type()
+
+		if shadowType != curShadowTyp {
+			// If either the incoming context or tracer disagree on which
+			// shadow tracer (if any) is active, scrub shadow tracing from
+			// consideration.
+			shadowType = ""
+		} else {
+			// Shadow tracing is active on this node and the incoming information
+			// was created using the same type of tracer.
+			//
 			// Extract the shadow context using the un-encapsulated textmap.
-			sc.shadowCtx, err = shadowTr.Extract(format, shadowCarrier)
+			shadowCtx, err = shadowTr.Extract(format, shadowCarrier)
 			if err != nil {
 				return noopSpanContext, err
 			}
 		}
 	}
 
-	return &sc, nil
+	return &SpanMeta{
+		traceID:          traceID,
+		spanID:           spanID,
+		shadowTracerType: shadowType,
+		shadowCtx:        shadowCtx,
+		recordingType:    recordingType,
+		Baggage:          baggage,
+	}, nil
 }
 
 // ForkCtxSpan checks if ctx has a Span open; if it does, it creates a new Span
@@ -553,11 +487,7 @@ func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
 			return ctx, sp
 		}
 		tr := sp.Tracer()
-		if sp.IsBlackHole() {
-			ns := tr.noopSpan
-			return ContextWithSpan(ctx, ns), ns
-		}
-		newSpan := tr.StartSpan(opName, opentracing.FollowsFrom(sp.Context()), LogTagsFromCtx(ctx))
+		newSpan := tr.StartSpan(opName, WithParent(sp), WithCtxLogTags(ctx))
 		return ContextWithSpan(ctx, newSpan), newSpan
 	}
 	return ctx, nil
@@ -570,18 +500,16 @@ func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
 // Returns the new context and the new Span (if any). The Span should be
 // closed via FinishSpan.
 func ChildSpan(ctx context.Context, opName string) (context.Context, *Span) {
-	return childSpan(ctx, opName, false /* separateRecording */)
+	return childSpan(ctx, opName, spanOptions{})
 }
 
 // ChildSpanSeparateRecording is like ChildSpan but the new Span has separate
 // recording (see StartChildSpan).
 func ChildSpanSeparateRecording(ctx context.Context, opName string) (context.Context, *Span) {
-	return childSpan(ctx, opName, true /* separateRecording */)
+	return childSpan(ctx, opName, spanOptions{SeparateRecording: true})
 }
 
-func childSpan(
-	ctx context.Context, opName string, separateRecording bool,
-) (context.Context, *Span) {
+func childSpan(ctx context.Context, opName string, opts spanOptions) (context.Context, *Span) {
 	sp := SpanFromContext(ctx)
 	if sp == nil || sp.isNoop() {
 		// Optimization: avoid ContextWithSpan call if tracing is disabled.
@@ -592,7 +520,9 @@ func childSpan(
 		ns := tr.noopSpan
 		return ContextWithSpan(ctx, ns), ns
 	}
-	newSpan := tr.StartChildSpan(opName, sp.SpanContext(), logtags.FromContext(ctx), NonRecordableSpan, separateRecording)
+	opts.LogTags = logtags.FromContext(ctx)
+	opts.Parent = sp
+	newSpan := tr.startSpanGeneric(opName, opts)
 	return ContextWithSpan(ctx, newSpan), newSpan
 }
 
@@ -605,7 +535,7 @@ func childSpan(
 // even if the current context's log tags are different from that Span's tags.
 func EnsureContext(ctx context.Context, tracer *Tracer, opName string) (context.Context, func()) {
 	if SpanFromContext(ctx) == nil {
-		sp := tracer.StartRootSpan(opName, logtags.FromContext(ctx), NonRecordableSpan)
+		sp := tracer.StartSpan(opName, WithCtxLogTags(ctx))
 		return ContextWithSpan(ctx, sp), sp.Finish
 	}
 	return ctx, func() {}
@@ -618,7 +548,7 @@ func EnsureContext(ctx context.Context, tracer *Tracer, opName string) (context.
 // The caller is responsible for closing the Span (via Span.Finish).
 func EnsureChildSpan(ctx context.Context, tracer *Tracer, name string) (context.Context, *Span) {
 	if SpanFromContext(ctx) == nil {
-		sp := tracer.StartRootSpan(name, logtags.FromContext(ctx), NonRecordableSpan)
+		sp := tracer.StartSpan(name, WithCtxLogTags(ctx))
 		return ContextWithSpan(ctx, sp), sp
 	}
 	return ChildSpan(ctx, name)
@@ -650,12 +580,12 @@ func StartSnowballTrace(
 	ctx context.Context, tracer *Tracer, opName string,
 ) (context.Context, *Span) {
 	var span *Span
-	if parentSpan := SpanFromContext(ctx); parentSpan != nil {
-		span = parentSpan.Tracer().StartSpan(
-			opName, opentracing.ChildOf(parentSpan.Context()), Recordable, LogTagsFromCtx(ctx),
+	if sp := SpanFromContext(ctx); sp != nil {
+		span = sp.Tracer().StartSpan(
+			opName, WithParent(sp), WithForceRealSpan(), WithCtxLogTags(ctx),
 		)
 	} else {
-		span = tracer.StartSpan(opName, Recordable, LogTagsFromCtx(ctx))
+		span = tracer.StartSpan(opName, WithForceRealSpan(), WithCtxLogTags(ctx))
 	}
 	span.StartRecording(SnowballRecording)
 	return ContextWithSpan(ctx, span), span
@@ -672,7 +602,7 @@ func ContextWithRecordingSpan(
 	ctx context.Context, opName string,
 ) (retCtx context.Context, getRecording func() Recording, cancel func()) {
 	tr := NewTracer()
-	sp := tr.StartSpan(opName, Recordable, LogTagsFromCtx(ctx))
+	sp := tr.StartSpan(opName, WithForceRealSpan(), WithCtxLogTags(ctx))
 	sp.StartRecording(SnowballRecording)
 	ctx, cancelCtx := context.WithCancel(ctx)
 	ctx = ContextWithSpan(ctx, sp)


### PR DESCRIPTION
The tracer previously offered three APIs for starting spans. First, there was `StartSpan`, mandated by the `opentracing` interfaces, which was unnecessarily allocation-heavy, in particular when the caller was holding on to a span directly (rather than having received information about a parent span from the RPC). Offsetting the inefficiencies, we had added two separate methods, `StartRootSpan` and `StartChildSpan`, that took in various options directly (and which were not conforming to the `opentracing` specs). These latter two in particular had become a hodge podge of settings that were added organically over time.

Now, with the opentracing interfaces out of the picture, it was time to make some clarifications. The key change in this PR is that StartSpan now becomes the *only* way to start traces, and allows doing so efficiently in all cases. In particular, we provide two separate options that specify a parent span:

- `WithParent`, for the case in which the caller has a `*Span` at their disposal, i.e. we're creating a new trace span locally, and
- `WithRemoteParent`, for the case in which a span is to be derived from metadata about a parent span on the other side of an RPC.

The implementations are now deliberate about which case they're in, which I have found greatly helps the clarity of the implementation. In particular, `*SpanContext`, which was previously used for both local and remote parents, and as a result was only partially populated in the remote case, now only contains the fields corresponding to data coming in over the wire, and is only ever used in the remote case. Reflecting this, it was renamed to `RemoteSpan`. Its usage has decreased dramatically due to the `WithParent` option, with only a single call site to `WithRemoteParent` remaining outside of the `tracing` package (to propagate trace information on the Raft streams, something difficult to wrap in an RPC middleware due to batching).

The explicit distinction between remote and local parents has also clarified the current semantics of recording inheritance. Remember that (explicit opt-out aside) a child span created from a local parent shares its recording with that parent (which transitively shares with any local grandparent). "Obviously" this does not work across RPC boundaries without an additional mechanism to feed the spans back into the caller's span, but in the old API there really wasn't an obvious way to simulate the "remote" case (since calling `.Context()` on a local span and deriving from that locally would correspond to what is now `WithParent(span)`, i.e. the local case). Now, in tests such as `TestRecordingInRecording`, we clearly see the distinction in behavior.
As an aside, the current thinking is to do away with the concept of sharing recordings and also the concept of inserting a recording into an existing span. Instead, we will endow the tracer with a registry that is handed any recordings received from remote RPCs. The registry is in charge of maintaining the partial trace tree and releasing it the moment the local span is `Finished()`, and allows retrieving the aggregate recording before this point in time. This is both conceptually simpler (spans never share recordings, so in particular the knob to control the behavior goes away), and also allows for straightforward generalizations towards true distributed tracing.

The `Recordable` option was renamed to `WithForceRealSpan` for clarity. While technically the old name was apt, the dichotomy between noopSpan vs recordable span has been hard for me to internalize and I assume this holds for others as well. "real span" vs "noop span" is a more natural dichotomy to remember. Of course, ultimately the goal of moving to always-on tracing means that the concept of a noop span goes away (or at least stops being the case to optimize for), so more changes here will take place in the future.

There is still cruft in the interfaces, but with PR we're within striking distance and will be able to adapt the semantics to the requirements of always-on tracing soon.

Also, we are probably allocating more than we were before. However,
there's nothing we can't fix. I am planning to polish #54738 soon
and carry out a first round of improvements within.

Release note: None