### PR TITLE
logictest: skip TestParallel under stressrace

### DIFF
--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -231,6 +231,12 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 func TestParallel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Note: there is special code in teamcity-trigger/main.go to run this package
+	// with less concurrency in the nightly stress runs. If you see problems
+	// please make adjustments there.
+	// As of 6/4/2019, the logic tests never complete under race.
+	skip.UnderStressRace(t, "logic tests and race detector don't mix: #37993")
+
 	glob := *paralleltestdata
 	paths, err := filepath.Glob(glob)
 	if err != nil {


### PR DESCRIPTION
Normal logic tests are skipped under stressrace, and this commit does the
same for TestParallel.

Release note: None

Closes #56041 