### PR TITLE
release-20.1: testutils/passes: add utility for nolint comment, add support in unconvert, descriptormarshal

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -148,6 +148,8 @@ func readBackupManifest(
 		// the ModificationTime for table descriptors. When performing a restore
 		// we no longer have access to that MVCC timestamp but we can set it
 		// to a value we know will be safe.
+		//
+		// nolint:descriptormarshal
 		if t := d.GetTable(); t == nil {
 			continue
 		} else if t.Version == 1 && t.ModificationTime.IsEmpty() {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3483,6 +3483,7 @@ func (desc *Descriptor) GetName() string {
 //
 // A linter should ensure that GetTable() is not called.
 func (desc *Descriptor) Table(ts hlc.Timestamp) *TableDescriptor {
+	// nolint:descriptormarshal
 	t := desc.GetTable()
 	if t != nil {
 		t.maybeSetTimeFromMVCCTimestamp(ts)

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1316,6 +1316,7 @@ func TestKeysPerRow(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
+			// nolint:descriptormarshal
 			keys, err := desc.GetTable().KeysPerRow(test.indexID)
 			if err != nil {
 				t.Fatal(err)
@@ -1381,6 +1382,7 @@ func TestDefaultExprNil(t *testing.T) {
 		}
 		// Test and verify that the default expressions of the column descriptors
 		// are all nil.
+		// nolint:descriptormarshal
 		for _, col := range desc.GetTable().Columns {
 			if col.DefaultExpr != nil {
 				t.Errorf("expected Column Default Expression to be 'nil', got %s instead.", *col.DefaultExpr)

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -18,6 +18,7 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/astutil"
@@ -95,18 +96,8 @@ func isAllowed(obj *types.Func) bool {
 	return false
 }
 
-func findContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
-	fPos := pass.Fset.File(n.Pos())
-	for _, f := range pass.Files {
-		if pass.Fset.File(f.Pos()) == fPos {
-			return f
-		}
-	}
-	panic(fmt.Errorf("cannot file file for %v", n))
-}
-
 func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Func {
-	stack, _ := astutil.PathEnclosingInterval(findContainingFile(pass, n), n.Pos(), n.End())
+	stack, _ := astutil.PathEnclosingInterval(passesutil.FindContainingFile(pass, n), n.Pos(), n.End())
 	for i := len(stack) - 1; i >= 0; i-- {
 		// If we stumble upon a func decl or func lit then we're in an interesting spot
 		funcDecl, ok := stack[i].(*ast.FuncDecl)

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -14,6 +14,7 @@
 package descriptormarshal
 
 import (
+	"fmt"
 	"go/ast"
 	"go/types"
 
@@ -70,9 +71,8 @@ var Analyzer = &analysis.Analyzer{
 				return
 			}
 			pass.Report(analysis.Diagnostic{
-				Pos: n.Pos(),
-				Message: fmt.Sprintf("Illegal call to Descriptor.GetTable() in %s, see Descriptor.Table()",
-					containing.Name()),
+				Pos:     n.Pos(),
+				Message: fmt.Sprintf("Illegal call to Descriptor.GetTable(), see sqlbase.TableFromDescriptor()"),
 			})
 		})
 		return nil, nil

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -14,14 +14,12 @@
 package descriptormarshal
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
@@ -35,10 +33,12 @@ const Doc = `check for correct unmarshaling of sqlbase descriptors`
 
 const sqlbasePkg = "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
+const name = "descriptormarshal"
+
 // Analyzer is a linter that ensures there are no calls to
 // sqlbase.Descriptor.GetTable() except where appropriate.
 var Analyzer = &analysis.Analyzer{
-	Name:     "descriptormarshal",
+	Name:     name,
 	Doc:      Doc,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run: func(pass *analysis.Pass) (interface{}, error) {
@@ -65,8 +65,8 @@ var Analyzer = &analysis.Analyzer{
 			if !isMethodForNamedType(f, "Descriptor") {
 				return
 			}
-			containing := findContainingFunc(pass, n)
-			if isAllowed(containing) {
+
+			if passesutil.HasNolintComment(pass, sel, name) {
 				return
 			}
 			pass.Report(analysis.Diagnostic{
@@ -77,36 +77,6 @@ var Analyzer = &analysis.Analyzer{
 		})
 		return nil, nil
 	},
-}
-
-var allowedFunctions = []string{
-	"(*github.com/cockroachdb/cockroach/pkg/sql/sqlbase.Descriptor).Table",
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase.TestDefaultExprNil",
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase.TestKeysPerRow",
-	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl.readBackupManifest",
-}
-
-func isAllowed(obj *types.Func) bool {
-	str := obj.FullName()
-	for _, allowed := range allowedFunctions {
-		if allowed == str {
-			return true
-		}
-	}
-	return false
-}
-
-func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Func {
-	stack, _ := astutil.PathEnclosingInterval(passesutil.FindContainingFile(pass, n), n.Pos(), n.End())
-	for i := len(stack) - 1; i >= 0; i-- {
-		// If we stumble upon a func decl or func lit then we're in an interesting spot
-		funcDecl, ok := stack[i].(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
-	}
-	return nil
 }
 
 func isMethodForNamedType(f *types.Func, name string) bool {

--- a/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
@@ -15,4 +15,43 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 func F() {
 	var d sqlbase.Descriptor
 	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\) in F, see Descriptor.Table\(\)`
+
+	//nolint:descriptormarshal
+	d.GetTable()
+
+	// nolint:descriptormarshal
+	d.GetTable()
+
+	// nolint:descriptormarshal
+	if t := d.GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t := d.
+		// nolint:descriptormarshal
+		GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t :=
+		// nolint:descriptormarshal
+		d.GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		// nolint:descriptormarshal
+		nil {
+		panic("foo")
+	}
+
+	// It does not work to put the comment as an inline with the preamble to an
+	// if statement.
+	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		panic("foo")
+	}
+
+	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		panic("foo")
+	}
 }

--- a/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
@@ -14,7 +14,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
 func F() {
 	var d sqlbase.Descriptor
-	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\) in F, see Descriptor.Table\(\)`
+	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 
 	//nolint:descriptormarshal
 	d.GetTable()
@@ -39,7 +39,7 @@ func F() {
 		panic("foo")
 	}
 
-	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		// nolint:descriptormarshal
 		nil {
 		panic("foo")
@@ -47,11 +47,11 @@ func F() {
 
 	// It does not work to put the comment as an inline with the preamble to an
 	// if statement.
-	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		panic("foo")
 	}
 
-	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		panic("foo")
 	}
 }

--- a/pkg/testutils/lint/passes/passesutil/passes_util.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package passesutil provides useful functionality for implementing passes.
+package passesutil
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// FindContainingFile finds the file for an ast Node in a Pass.
+func FindContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
+	fPos := pass.Fset.File(n.Pos())
+	for _, f := range pass.Files {
+		if pass.Fset.File(f.Pos()) == fPos {
+			return f
+		}
+	}
+	panic(fmt.Errorf("cannot file file for %v", n))
+}
+
+// HasNolintComment returns true if the comments on the passed node have
+// the comment "nolint:<nolintName>" appearing anywhere in it.
+func HasNolintComment(pass *analysis.Pass, n ast.Node, nolintName string) bool {
+	f := FindContainingFile(pass, n)
+	relevant, containing := findNodesInBlock(f, n)
+	cm := ast.NewCommentMap(pass.Fset, containing, f.Comments)
+	// Check to see if any of the relevant ast nodes contain the relevant comment.
+	nolintComment := "nolint:" + nolintName
+	for _, cn := range relevant {
+		// Ident nodes have all comments on the ident in containing. This may be
+		// too many. Imagine there is a comment on the ident somewhere else in the
+		// decl block, we wouldn't want that to affect a later conversion.
+		//
+		// We want to filter this down to all comments on the ident inside
+		// the relevant statement. To do this we reject comments on idents which
+		// have their slash outside the outermost relevant node. We do this
+		// by inspecting the position of the comment relative to the outermost
+		// relevant node. This is sound because we can't have a comment on an ident
+		// alone as an ident is not a statement.
+		_, isIdent := cn.(*ast.Ident)
+		for _, cg := range cm[cn] {
+			for _, c := range cg.List {
+				if !strings.Contains(c.Text, nolintComment) {
+					continue
+				}
+				outermost := relevant[len(relevant)-1]
+				if isIdent && (cg.Pos() < outermost.Pos() || cg.End() > outermost.End()) {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// findNodesInBlock finds all expressions and statements that occur underneath
+// the block or decl closest to n. The idea is that we want to find comments
+// which occur in in the block or decl which includes the ast node n for
+// filtering. We want to filter the comments down to all comments
+// which are associated with n or any expression up to a statement in the
+// closest encloding block or decl. This is to deal with multi-line
+// expressions or with cases where the relevant expression occurs in an
+// init clause of an if or for and the comment is on the preceding line.
+//
+// For example, imagine that n is the *ast.CallExpr on the method foo in the
+// following snippet:
+//
+//  func nonsense() bool {
+//      if v := (g.foo() + 1) > 2; !v {
+//          return true
+//      }
+//      return false
+//  }
+//
+// This function would return all of the nodes up to the `IfStmt` as relevant
+// and would return the `BlockStmt` of the function nonsense as containing.
+//
+func findNodesInBlock(f *ast.File, n ast.Node) (relevant []ast.Node, containing ast.Node) {
+	stack, _ := astutil.PathEnclosingInterval(f, n.Pos(), n.End())
+	// Add all of the children of n to the set of relevant nodes.
+	ast.Walk(funcVisitor(func(node ast.Node) {
+		relevant = append(relevant, node)
+	}), n)
+	// Reverse the order.
+	for i := 0; i < len(relevant)/2; i++ {
+		relevant[i], relevant[len(relevant)-i-1] = relevant[len(relevant)-i-1], relevant[i]
+	}
+	containing = f // worst-case
+	for _, n := range stack {
+		switch n.(type) {
+		case *ast.GenDecl, *ast.BlockStmt:
+			containing = n
+			return relevant, containing
+		case nil:
+			// Do nothing.
+		default:
+			// Add all of the parents of n up to the containing BlockStmt or GenDecl
+			// to the set of relevant nodes.
+			relevant = append(relevant, n)
+		}
+	}
+	return relevant, containing
+}
+
+type funcVisitor func(node ast.Node)
+
+var _ ast.Visitor = (funcVisitor)(nil)
+
+func (f funcVisitor) Visit(node ast.Node) (w ast.Visitor) {
+	f(node)
+	return f
+}

--- a/pkg/testutils/lint/passes/passesutil/passes_util_test.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util_test.go
@@ -1,1 +1,40 @@
-package passesutil
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package passesutil_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// Use tests from other packages to also test this package. This ensures
+// that if that code changes, somebody will look here. Also it allows for
+// coverage checking here.
+
+func TestDescriptorMarshal(t *testing.T) {
+	skip.UnderStress(t)
+	testdata, err := filepath.Abs(filepath.Join("..", "descriptormarshal", "testdata"))
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, descriptormarshal.Analyzer, "a")
+}
+
+func TestUnconvert(t *testing.T) {
+	skip.UnderStress(t)
+	testdata, err := filepath.Abs(filepath.Join("..", "unconvert", "testdata"))
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, unconvert.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/passesutil/passes_util_test.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util_test.go
@@ -1,0 +1,1 @@
+package passesutil

--- a/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
@@ -12,6 +12,7 @@ package a
 
 import (
 	"errors"
+	"fmt"
 	"log"
 )
 
@@ -55,6 +56,27 @@ func SingleReturn() error {
 	if err != nil {
 		//nolint:returnerrcheck
 		return nil
+	}
+	if err != nil {
+		// nolint:returnerrcheck
+		return nil
+	}
+	if err != nil {
+		return nil // nolint:returnerrcheck
+	}
+
+	// The below nolint comments is not close enough to the return statement.
+
+	// nolint:returnerrcheck
+	if err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+
+	if err != nil {
+		// nolint:returnerrcheck
+		fmt.Println("hmm")
+
+		return nil // want `unexpected nil error return after checking for a non-nil error`
 	}
 	if err != nil {
 		return nil //nolint:returnerrcheck

--- a/pkg/testutils/lint/passes/unconvert/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/unconvert/testdata/src/a/a.go
@@ -14,4 +14,94 @@ var (
 	f  float64 = -1
 	ff         = float64(f) // want `unnecessary conversion`
 	fi         = int(f)
+
+	// nolint:unconvert
+	fff = float64(f)
+
+	// nolint:unconvert
+	_ = float64(f) +
+		float64(f)
+
+	_ = 1 +
+		// nolint:unconvert
+		float64(f) +
+		2
+
+	_ = 1 +
+		2 +
+		float64(f) // nolint:unconvert
+
+	_ = 1 +
+		float64(f) + // nolint:unconvert
+		2
+
+	_ = 1 +
+		float64(f) + 2 // nolint:unconvert
+
+	_ = 1 +
+		float64(f) + 2 + 3 // nolint:unconvert
+
+	_ = 1 +
+		(float64(f) + 2 +
+			3) // nolint:unconvert
+
+	_ = 1 +
+		2 +
+		3 +
+		// nolint:unconvert
+		float64(f)
+
+	// nolint:unconvert
+	_ = 1 +
+		2 +
+		3 +
+		float64(f)
+
+	_ = 1 +
+		(float64(f) /* nolint:unconvert */ + 2 +
+			3)
+
+	// Here the comment does not cover the conversion.
+
+	_ = 1 +
+		// nolint:unconvert
+		2 +
+		3 +
+		float64(f) // want `unnecessary conversion`
+
+	_ = 1 +
+		// nolint:unconvert
+		2 +
+		float64(f) // want `unnecessary conversion`
+
+	_ = 1 +
+		(float64(f) + 2 + // want `unnecessary conversion`
+			3 /* nolint:unconvert */)
+
+	_ = 1 +
+		(float64(f) + 2 /* nolint:unconvert */ + // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		(float64(f) + 2 + /* nolint:unconvert */ // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		(float64(f) + 2 + // nolint:unconvert // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		2 + // nolint:unconvert
+		float64(f) // want `unnecessary conversion`
 )
+
+func foo() {
+	// nolint:unconvert
+	if fff := float64(f); fff > 0 {
+		panic("foo")
+	}
+
+	if fff := float64(f); fff > 0 { // want `unnecessary conversion`
+		panic("foo")
+	}
+}

--- a/pkg/testutils/lint/passes/unconvert/unconvert.go
+++ b/pkg/testutils/lint/passes/unconvert/unconvert.go
@@ -17,6 +17,7 @@ import (
 	"go/token"
 	"go/types"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -25,9 +26,11 @@ import (
 // Doc documents this pass.
 const Doc = `check for unnecessary type conversions`
 
+const name = "unconvert"
+
 // Analyzer defines this pass.
 var Analyzer = &analysis.Analyzer{
-	Name:     "unconvert",
+	Name:     name,
 	Doc:      Doc,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
@@ -80,6 +83,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			if ident.Name == "_cgoCheckPointer" {
 				return
 			}
+		}
+		if passesutil.HasNolintComment(pass, call, name) {
+			return
 		}
 		pass.Reportf(call.Pos(), "unnecessary conversion")
 	})


### PR DESCRIPTION
Backport 5/5 commits from #55218.

/cc @cockroachdb/release

See individual commits. This PR is in support of unblocking #54946.