### PR TITLE
changefeedccl: support skipping client-side TLS verification of Kafka

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1971,6 +1971,12 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope'`,
 	)
 
+	// Test that a well-formed URI gets as far as unavailable kafka error.
+	sqlDB.ExpectErr(
+		t, `client has run out of available brokers`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=true'`,
+	)
+
 	// kafka_topic_prefix was referenced by an old version of the RFC, it's
 	// "topic_prefix" now.
 	sqlDB.ExpectErr(
@@ -1988,6 +1994,10 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `param tls_enabled must be a bool`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=foo`,
+	)
+	sqlDB.ExpectErr(
+		t, `param insecure_tls_skip_verify must be a bool`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=foo`,
 	)
 	sqlDB.ExpectErr(
 		t, `param ca_cert must be base 64 encoded`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -82,6 +82,7 @@ const (
 	SinkParamFileSize         = `file_size`
 	SinkParamSchemaTopic      = `schema_topic`
 	SinkParamTLSEnabled       = `tls_enabled`
+	SinkParamSkipTLSVerify    = `insecure_tls_skip_verify`
 	SinkParamTopicPrefix      = `topic_prefix`
 	SinkSchemeBuffer          = ``
 	SinkSchemeExperimentalSQL = `experimental-sql`

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -103,6 +103,13 @@ func getSink(
 			}
 		}
 		q.Del(changefeedbase.SinkParamTLSEnabled)
+		if tlsVerifyBool := q.Get(changefeedbase.SinkParamSkipTLSVerify); tlsVerifyBool != `` {
+			var err error
+			if cfg.tlsSkipVerify, err = strconv.ParseBool(tlsVerifyBool); err != nil {
+				return nil, errors.Errorf(`param %s must be a bool: %s`, changefeedbase.SinkParamSkipTLSVerify, err)
+			}
+		}
+		q.Del(changefeedbase.SinkParamSkipTLSVerify)
 		if caCertHex := q.Get(changefeedbase.SinkParamCACert); caCertHex != `` {
 			// TODO(dan): There's a straightforward and unambiguous transformation
 			// between the base 64 encoding defined in RFC 4648 and the URL variant
@@ -290,6 +297,7 @@ func init() {
 type kafkaSinkConfig struct {
 	kafkaTopicPrefix string
 	tlsEnabled       bool
+	tlsSkipVerify    bool
 	caCert           []byte
 	clientCert       []byte
 	clientKey        []byte
@@ -350,6 +358,13 @@ func makeKafkaSink(
 		config.Net.TLS.Enable = true
 	}
 
+	if cfg.tlsEnabled {
+		if config.Net.TLS.Config == nil {
+			config.Net.TLS.Config = &tls.Config{}
+		}
+		config.Net.TLS.Config.InsecureSkipVerify = cfg.tlsSkipVerify
+	}
+
 	if cfg.clientCert != nil {
 		if !cfg.tlsEnabled {
 			return nil, errors.Errorf(`%s requires %s=true`, changefeedbase.SinkParamClientCert, changefeedbase.SinkParamTLSEnabled)
@@ -360,9 +375,6 @@ func makeKafkaSink(
 		cert, err := tls.X509KeyPair(cfg.clientCert, cfg.clientKey)
 		if err != nil {
 			return nil, errors.Errorf(`invalid client certificate data provided: %s`, err)
-		}
-		if config.Net.TLS.Config == nil {
-			config.Net.TLS.Config = &tls.Config{}
 		}
 		config.Net.TLS.Config.Certificates = []tls.Certificate{cert}
 	} else if cfg.clientKey != nil {


### PR DESCRIPTION
We currently force anyone authenticating using TLS to verify the response.
This is a blocker for some test integrations because the hosts provide mismatched certs.
This patch enables the insecure_tls_skip_verify param on sink URIs, which maps to
InsecureSkipVerify in our net client.

Release note (enterprise change): The tls_skip_verify query param may now be set
on changefeed sinks. This disables client-side validation of responses and should
be avoided if possible since it creates man-in-the-middle vulnerabilities.