### PR TITLE
opt: updated normalization rules for folding is expressions with null predicate

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -360,10 +360,10 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1000 (missing stats)
-│ render 0: (a, b) IS NOT DISTINCT FROM NULL
+│ render 0: false
 │
 └── • scan
-      columns: (a, b)
+      columns: ()
       estimated row count: 1000 (missing stats)
       table: t@primary
       spans: FULL SCAN
@@ -445,10 +445,10 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1000 (missing stats)
-│ render 0: (a, b) IS DISTINCT FROM NULL
+│ render 0: true
 │
 └── • scan
-      columns: (a, b)
+      columns: ()
       estimated row count: 1000 (missing stats)
       table: t@primary
       spans: FULL SCAN

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -168,7 +168,7 @@ func (c *CustomFuncs) AllowNullArgs(op opt.Operator, left, right opt.ScalarExpr)
 // tuples.
 func (c *CustomFuncs) IsListOfConstants(elems memo.ScalarListExpr) bool {
 	for _, elem := range elems {
-		if !c.IsConstValueOrTuple(elem) {
+		if !c.IsConstValueOrGroupOfConstValues(elem) {
 			return false
 		}
 	}
@@ -192,10 +192,21 @@ func (c *CustomFuncs) FoldArray(elems memo.ScalarListExpr, typ *types.T) opt.Sca
 	return c.f.ConstructConst(a, typ)
 }
 
-// IsConstValueOrTuple returns true if the input is a constant or a tuple of
-// constants.
-func (c *CustomFuncs) IsConstValueOrTuple(input opt.ScalarExpr) bool {
+// IsConstValueOrGroupOfConstValues returns true if the input is a constant,
+// or an array or tuple with only constant elements.
+func (c *CustomFuncs) IsConstValueOrGroupOfConstValues(input opt.ScalarExpr) bool {
 	return memo.CanExtractConstDatum(input)
+}
+
+// IsNeverNull returns true if the input is a non-null constant value,
+// any tuple, or any array.
+func (c *CustomFuncs) IsNeverNull(input opt.ScalarExpr) bool {
+	switch input.Op() {
+	case opt.TrueOp, opt.FalseOp, opt.ConstOp, opt.TupleOp, opt.ArrayOp:
+		return true
+	}
+
+	return false
 }
 
 // HasNullElement returns true if the input tuple has at least one constant,

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -127,7 +127,7 @@
 
 # FoldNonNullIsNull replaces x IS NULL with False where x is a non-Null constant.
 [FoldNonNullIsNull, Normalize]
-(Is $left:^(Null) & (IsConstValueOrTuple $left) (Null))
+(Is $left:(IsNeverNull $left) (Null))
 =>
 (False)
 
@@ -153,7 +153,7 @@
 
 # FoldNonNullIsNotNull replaces x IS NOT NULL with True where x is a non-Null constant.
 [FoldNonNullIsNotNull, Normalize]
-(IsNot $left:^(Null) & (IsConstValueOrTuple $left) (Null))
+(IsNot $left:(IsNeverNull $left) (Null))
 =>
 (True)
 
@@ -198,7 +198,7 @@
     $right:(ConstValue) &
         (IsTimestampTZ $right) &
         (IsTimestamp $ts:(SecondScalarListExpr $args)) &
-        ^(IsConstValueOrTuple $ts)
+        ^(IsConstValueOrGroupOfConstValues $ts)
 )
 =>
 ((OpName)
@@ -227,7 +227,7 @@
     $right:(ConstValue) &
         (IsTimestamp $right) &
         (IsTimestampTZ $tz:(SecondScalarListExpr $args)) &
-        ^(IsConstValueOrTuple $tz)
+        ^(IsConstValueOrGroupOfConstValues $tz)
 )
 =>
 ((OpName)

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -79,9 +79,9 @@
 # should not be triggered.
 [FoldBinary, Normalize]
 (Binary
-    $left:* & (IsConstValueOrTuple $left)
+    $left:* & (IsConstValueOrGroupOfConstValues $left)
     $right:* &
-        (IsConstValueOrTuple $right) &
+        (IsConstValueOrGroupOfConstValues $right) &
         (Succeeded $result:(FoldBinary (OpName) $left $right))
 )
 =>
@@ -93,7 +93,7 @@ $result
 [FoldUnary, Normalize]
 (Unary
     $input:* &
-        (IsConstValueOrTuple $input) &
+        (IsConstValueOrGroupOfConstValues $input) &
         (Succeeded $result:(FoldUnary (OpName) $input))
 )
 =>
@@ -104,9 +104,9 @@ $result
 # evaluation would not cause an error.
 [FoldComparison, Normalize]
 (Comparison
-    $left:* & (IsConstValueOrTuple $left)
+    $left:* & (IsConstValueOrGroupOfConstValues $left)
     $right:* &
-        (IsConstValueOrTuple $right) &
+        (IsConstValueOrGroupOfConstValues $right) &
         (Succeeded
             $result:(FoldComparison (OpName) $left $right)
         )
@@ -121,7 +121,7 @@ $result
 (Cast
     $input:*
     $typ:* &
-        (IsConstValueOrTuple $input) &
+        (IsConstValueOrGroupOfConstValues $input) &
         (Succeeded $result:(FoldCast $input $typ))
 )
 =>
@@ -138,7 +138,7 @@ $result
 (Indirection
     $input:*
     $index:* &
-        (IsConstValueOrTuple $index) &
+        (IsConstValueOrGroupOfConstValues $index) &
         (Succeeded $result:(FoldIndirection $input $index))
 )
 =>

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -49,7 +49,12 @@ $item
 # operand is a constant, replaces with that constant. Note that ConstValue
 # matches nulls as well as other constants.
 [SimplifyCoalesce, Normalize]
-(Coalesce $args:[ $arg:* & (IsConstValueOrTuple $arg) ... ])
+(Coalesce
+    $args:[
+        $arg:* & (IsConstValueOrGroupOfConstValues $arg)
+        ...
+    ]
+)
 =>
 (SimplifyCoalesce $args)
 

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -83,7 +83,7 @@ func (c *CustomFuncs) SimplifyCoalesce(args memo.ScalarListExpr) opt.ScalarExpr 
 
 		// If item is not a constant value, then its value may turn out to be
 		// null, so no more folding. Return operands from then on.
-		if !c.IsConstValueOrTuple(item) {
+		if !c.IsConstValueOrGroupOfConstValues(item) {
 			return c.f.ConstructCoalesce(args[i:])
 		}
 

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -367,6 +367,36 @@ values
  ├── fd: ()-->(1)
  └── (false,)
 
+norm expect=FoldNonNullIsNull
+SELECT (i,f) IS NOT DISTINCT FROM NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
+ ├── scan a
+ └── projections
+      └── false [as="?column?":8]
+
+norm expect=FoldNonNullIsNull
+SELECT ARRAY[k,i] IS NOT DISTINCT FROM NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
+ ├── scan a
+ └── projections
+      └── false [as="?column?":8]
+
+norm expect-not=FoldNonNullIsNull
+SELECT (i,f) IS NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── scan a
+ │    └── columns: i:2 f:3
+ └── projections
+      └── (i:2, f:3) IS NULL [as="?column?":8, outer=(2,3)]
+
 # --------------------------------------------------
 # FoldNullTupleIsTupleNull
 # --------------------------------------------------
@@ -528,6 +558,36 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── (true,)
+
+norm expect=FoldNonNullIsNotNull
+SELECT (i,f) IS DISTINCT FROM NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
+ ├── scan a
+ └── projections
+      └── true [as="?column?":8]
+
+norm expect=FoldNonNullIsNotNull
+SELECT ARRAY[k,i] IS DISTINCT FROM NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
+ ├── scan a
+ └── projections
+      └── true [as="?column?":8]
+
+norm expect-not=FoldNonNullIsNotNull
+SELECT (i,f) IS NOT NULL FROM a
+----
+project
+ ├── columns: "?column?":8!null
+ ├── scan a
+ │    └── columns: i:2 f:3
+ └── projections
+      └── (i:2, f:3) IS NOT NULL [as="?column?":8, outer=(2,3)]
 
 # --------------------------------------------------
 # FoldNonNullTupleIsTupleNotNull


### PR DESCRIPTION
opt: updated normalization rules for folding is expressions with null predicate

Previously, for statements such as `SELECT (foo,bar) IS DISTINCT FROM NULL FROM a_table`,
the expression `(foo,bar) IS DISTINCT FROM NULL` would not be normalized to `true`.
Similarly, if `IS NOT DISTINCT FROM NULL` were used, then the expression would not be
normalized to `false`. The previous statement would only normalize if the tuple/array in
the statement contained only constants. Given the updates in this commit, normalization
will be applied when any arrays or tuples are provided in this situation.

Release note: None