### PR TITLE
sql: add barebones live cluster checks for creating DB regions

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -136,6 +136,7 @@ go_library(
         "reassign_owned_by.go",
         "recursive_cte.go",
         "refresh_materialized_view.go",
+        "region_util.go",
         "relocate.go",
         "rename_column.go",
         "rename_database.go",

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -77,10 +77,6 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 		)
 	}
 
-	if n.Regions != nil {
-		return nil, unimplemented.New("create database with region", "implementation pending")
-	}
-
 	if n.Survive != tree.SurviveDefault {
 		return nil, unimplemented.New("create database survive", "implementation pending")
 	}

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -9,7 +9,16 @@ test2   {test2-az1,test2-az2,test2-az3}
 test3   {test3-az1,test3-az2,test3-az3}
 
 statement error implementation pending
-CREATE DATABASE new_db REGION "us-west-1"
+CREATE DATABASE region_test_db REGION "test1"
+
+statement error implementation pending
+CREATE DATABASE multi_region_test_db REGIONS "test1", "test2"
+
+statement error region "region_no_exists" does not exist\nHINT:.*valid regions: test1, test2, test3
+CREATE DATABASE invalid_region_db REGION "region_no_exists"
+
+statement error region "test1" defined multiple times
+CREATE DATABASE duplicate_region_name_db REGIONS "test1", "test1"
 
 statement error implementation pending
 CREATE DATABASE new_db SURVIVE AVAILABILITY ZONE FAILURE

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/errors"
+)
+
+type liveClusterRegions map[string]struct{}
+
+func (s *liveClusterRegions) isActive(region string) bool {
+	_, ok := (*s)[region]
+	return ok
+}
+
+func (s *liveClusterRegions) toStrings() []string {
+	ret := make([]string, 0, len(*s))
+	for region := range *s {
+		ret = append(ret, region)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i] < ret[j]
+	})
+	return ret
+}
+
+// getLiveClusterRegions returns a set of live region names in the cluster.
+// A region name is deemed active if there is at least one alive node
+// in the cluster in with locality set to a given region.
+func (p *planner) getLiveClusterRegions() (liveClusterRegions, error) {
+	nodes, err := getAllNodeDescriptors(p)
+	if err != nil {
+		return nil, err
+	}
+	var ret liveClusterRegions = make(map[string]struct{})
+	for _, node := range nodes {
+		for _, tier := range node.Locality.Tiers {
+			if tier.Key == "region" {
+				ret[tier.Value] = struct{}{}
+				break
+			}
+		}
+	}
+	return ret, nil
+}
+
+// checkLiveClusterRegion checks whether a region can be added to a database
+// based on whether the cluster regions are alive.
+func checkLiveClusterRegion(liveClusterRegions liveClusterRegions, region string) error {
+	if !liveClusterRegions.isActive(region) {
+		return errors.WithHintf(
+			pgerror.Newf(
+				pgcode.InvalidName,
+				"region %q does not exist",
+				region,
+			),
+			"valid regions: %s",
+			strings.Join(liveClusterRegions.toStrings(), ", "),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
This can be moved at any point, but the live cluster checks seem
helpful. This is not yet persisted yet anywhere because we have not
decided to do this yet.

Release note: None