### PR TITLE
kvserver: replace multiTestContext with TestCluster in client_merge_test

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -209,9 +209,9 @@ const (
 	// If ReplicationAuto is used, StartTestCluster() blocks until the initial
 	// ranges are fully replicated.
 	ReplicationAuto TestClusterReplicationMode = iota
-	// ReplicationManual means that the split and replication queues of all
-	// servers are stopped, and the test must manually control splitting and
-	// replication through the TestServer.
+	// ReplicationManual means that the split, merge and replication queues of all
+	// servers are stopped, and the test must manually control splitting, merging
+	// and  replication through the TestServer.
 	// Note that the server starts with a number of system ranges,
 	// all with a single replica on node 1.
 	ReplicationManual

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -1664,9 +1664,14 @@ func verifyRangeStats(
 func verifyRecomputedStats(
 	reader storage.Reader, d *roachpb.RangeDescriptor, expMS enginepb.MVCCStats, nowNanos int64,
 ) error {
-	if ms, err := rditer.ComputeStatsForRange(d, reader, nowNanos); err != nil {
+	ms, err := rditer.ComputeStatsForRange(d, reader, nowNanos)
+	if err != nil {
 		return err
-	} else if expMS != ms {
+	}
+	// When used with a real wall clock these will not be the same, since it
+	// takes time to load stats.
+	expMS.AgeTo(ms.LastUpdateNanos)
+	if expMS != ms {
 		return fmt.Errorf("expected range's stats to agree with recomputation: got\n%+v\nrecomputed\n%+v", expMS, ms)
 	}
 	return nil

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -686,6 +686,15 @@ func (tc *TestCluster) TransferRangeLease(
 	return nil
 }
 
+// TransferRangeLeaseOrFatal is a convenience version of TransferRangeLease
+func (tc *TestCluster) TransferRangeLeaseOrFatal(
+	t testing.TB, rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
+) {
+	if err := tc.TransferRangeLease(rangeDesc, dest); err != nil {
+		t.Fatalf(`could transfer lease for range %s error is %+v`, rangeDesc, err)
+	}
+}
+
 // FindRangeLease is similar to FindRangeLeaseHolder but returns a Lease proto
 // without verifying if the lease is still active. Instead, it returns a time-
 // stamp taken off the queried node's clock.


### PR DESCRIPTION
Makes progress on #8299

multiTestContext is a legacy construct that is deprecated in favor of running
tests via TestCluster. This is one PR out of many to remove the usage of
multiTestContext in the client_merge test cases. This does not remove
all the usages of mtc in this file and just focuses on the simple ones.
The more complex cases that rely on lease expiration and unreliableRaftHandler
will be tackled in a future PR.

Release note: None