### PR TITLE
roachprod,roachtest: use roachprod stage for older cockroach binaries

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -94,6 +94,7 @@ var (
 	sig               = 9
 	waitFlag          = false
 	stageOS           string
+	stageDir          string
 	logsDir           string
 	logsFilter        string
 	logsProgramFilter string
@@ -1324,6 +1325,11 @@ Some examples of usage:
 			return errors.Errorf("cannot stage binary on %s", os)
 		}
 
+		dir := "."
+		if stageDir != "" {
+			dir = stageDir
+		}
+
 		applicationName := args[1]
 		versionArg := ""
 		if len(args) == 3 {
@@ -1332,7 +1338,7 @@ Some examples of usage:
 		switch applicationName {
 		case "cockroach":
 			sha, err := install.StageRemoteBinary(
-				c, applicationName, "cockroach/cockroach", versionArg, debugArch,
+				c, applicationName, "cockroach/cockroach", versionArg, debugArch, dir,
 			)
 			if err != nil {
 				return err
@@ -1347,6 +1353,7 @@ Some examples of usage:
 					sha,
 					debugArch,
 					libExt,
+					dir,
 				); err != nil {
 					return err
 				}
@@ -1354,11 +1361,11 @@ Some examples of usage:
 			return nil
 		case "workload":
 			_, err := install.StageRemoteBinary(
-				c, applicationName, "cockroach/workload", versionArg, "", /* arch */
+				c, applicationName, "cockroach/workload", versionArg, "" /* arch */, dir,
 			)
 			return err
 		case "release":
-			return install.StageCockroachRelease(c, versionArg, releaseArch)
+			return install.StageCockroachRelease(c, versionArg, releaseArch, dir)
 		default:
 			return fmt.Errorf("unknown application %s", applicationName)
 		}
@@ -1736,6 +1743,7 @@ func main() {
 	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
 
 	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
+	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
 
 	logsCmd.Flags().StringVar(
 		&logsFilter, "filter", "", "re to filter log messages")

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1983,6 +1983,28 @@ func (c *cluster) PutLibraries(ctx context.Context, libraryDir string) error {
 	return nil
 }
 
+// Stage stages a binary to the cluster.
+func (c *cluster) Stage(
+	ctx context.Context, l *logger, application, versionOrSHA, dir string, opts ...option,
+) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "cluster.Stage")
+	}
+
+	c.status("staging binary")
+	defer c.status("")
+
+	args := []string{roachprod, "stage", c.makeNodes(opts...), application, versionOrSHA}
+	if dir != "" {
+		args = append(args, fmt.Sprintf("--dir='%s'", dir))
+	}
+	err := execCmd(ctx, c.l, args...)
+	if err != nil {
+		return errors.Wrap(err, "cluster.Stage")
+	}
+	return nil
+}
+
 // Get gets files from remote hosts.
 func (c *cluster) Get(ctx context.Context, l *logger, src, dest string, opts ...option) error {
 	if ctx.Err() != nil {

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -124,11 +125,10 @@ func runDecommissionMixedVersions(
 // cockroachBinaryPath is a shorthand to retrieve the path for a cockroach
 // binary of a given version.
 func cockroachBinaryPath(version string) string {
-	path := "./cockroach"
-	if version != "" {
-		path += "-" + version
+	if version == "" {
+		return "./cockroach"
 	}
-	return path
+	return fmt.Sprintf("./v%s/cockroach", version)
 }
 
 // partialDecommissionStep runs `cockroach node decommission --wait=none` from a

--- a/pkg/util/binfetcher/binfetcher.go
+++ b/pkg/util/binfetcher/binfetcher.go
@@ -140,9 +140,12 @@ var httpClient = httputil.NewClientWithTimeout(300 * time.Second)
 // Download downloads the binary for the given version, and skips the download
 // if the archive is already present in `destDir`.
 //
+// Do not use this to download the cockroach binary. It won't work for v20.2+
+// releases, which include the geos libraries along with the binary. On
+// roachprod, use `roachprod stage` instead.
+//
 // `version` can be:
 //
-// - a release, e.g. v1.0.5 (makes sense only for downloading `cockroach`)
 // - a SHA from the master branch, e.g. bd828feaa309578142fe7ad2d89ee1b70adbd52d
 // - the string "LATEST" for the most recent SHA from the master branch. Note that
 //   caching is disabled in that case.


### PR DESCRIPTION
Previously, the version upgrade roachtests used binfetcher to fetch
older cockroach binaries, which doesn't work as-is with the geos
libraries that are now included with our releases. This was blocking
mixed version 20.2/21.1 testing.

This PR replaces all the uses of binfetcher with `roachprod stage` to
download older cockroach releases in roachtests. It also adds an
optional`--dir` flag to `roachprod stage` to specify the directory to
stage the binary and libraries to, which is needed for the mixed-version
tests because they need to keep the old binaries and libraries around in
order to downgrade.

Closes #55706.

Release note: None