### PR TITLE
roachprod: add ultra-disk provision iops support

### DIFF
--- a/pkg/cmd/roachprod/vm/azure/flags.go
+++ b/pkg/cmd/roachprod/vm/azure/flags.go
@@ -29,6 +29,7 @@ type providerOpts struct {
 	zone             string
 	networkDiskType  string
 	networkDiskSize  int32
+	ultraDiskIOPS    int64
 	diskCaching      string
 }
 
@@ -59,6 +60,8 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"type of network disk [premium-disk, ultra-disk]. only used if local-ssd is false")
 	flags.Int32Var(&o.networkDiskSize, ProviderName+"-volume-size", 500,
 		"Size in GB of network disk volume, only used if local-ssd=false")
+	flags.Int64Var(&o.ultraDiskIOPS, ProviderName+"-ultra-disk-iops", 5000,
+		"Number of IOPS provisioned for ultra disk, only used if network-disk-type=ultra-disk")
 	flags.StringVar(&o.diskCaching, ProviderName+"-disk-caching", "none",
 		"Disk caching behavior for attached storage.  Valid values are: none, read-only, read-write.  Not applicable to Ultra disks.")
 }


### PR DESCRIPTION
This patch introduces a new flag, `azure-ultra-disk-iops`, which can be
used to configure the amount of ultra disk iops supported by the ultra
disk being attached to the VMs of the cluster. This is only valid if
using an `ultra-disk` as the network disk type. It defaults to 5000
IOPS, which is the Azure default as well.

For some reason, Azure doesn't provide a way to configure IOPS when
creating an ultra disk in the VM request. To make this work, I had to
create an ultra disk separately and then hook it up to the VM being
created. This ultra disk continues to exist under the VM's resource
group.

Release note: None