### PR TITLE
release-19.2: release-20.1: testutils/passes: add utility for nolint comment, add support in unconvert, descriptormarshal

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3293,6 +3293,7 @@ func (desc *Descriptor) GetName() string {
 //
 // A linter should ensure that GetTable() is not called.
 func (desc *Descriptor) Table(ts hlc.Timestamp) *TableDescriptor {
+	// nolint:descriptormarshal
 	t := desc.GetTable()
 	if t != nil {
 		t.maybeSetTimeFromMVCCTimestamp(ts)

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -18,20 +18,16 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/gogo/protobuf/proto"
-	"github.com/pmezard/go-difflib/difflib"
 )
 
 // Makes an IndexDescriptor with all columns being ascending.
@@ -1292,6 +1288,7 @@ func TestKeysPerRow(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
+			// nolint:descriptormarshal
 			keys := desc.GetTable().KeysPerRow(test.indexID)
 			if test.expected != keys {
 				t.Errorf("expected %d keys got %d", test.expected, keys)
@@ -2015,6 +2012,7 @@ func TestDefaultExprNil(t *testing.T) {
 		}
 		// Test and verify that the default expressions of the column descriptors
 		// are all nil.
+		// nolint:descriptormarshal
 		for _, col := range desc.GetTable().Columns {
 			if col.DefaultExpr != nil {
 				t.Errorf("expected Column Default Expression to be 'nil', got %s instead.", *col.DefaultExpr)

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -18,6 +18,7 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/astutil"
@@ -95,18 +96,8 @@ func isAllowed(obj *types.Func) bool {
 	return false
 }
 
-func findContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
-	fPos := pass.Fset.File(n.Pos())
-	for _, f := range pass.Files {
-		if pass.Fset.File(f.Pos()) == fPos {
-			return f
-		}
-	}
-	panic(fmt.Errorf("cannot file file for %v", n))
-}
-
 func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Func {
-	stack, _ := astutil.PathEnclosingInterval(findContainingFile(pass, n), n.Pos(), n.End())
+	stack, _ := astutil.PathEnclosingInterval(passesutil.FindContainingFile(pass, n), n.Pos(), n.End())
 	for i := len(stack) - 1; i >= 0; i-- {
 		// If we stumble upon a func decl or func lit then we're in an interesting spot
 		funcDecl, ok := stack[i].(*ast.FuncDecl)

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -71,9 +71,8 @@ var Analyzer = &analysis.Analyzer{
 				return
 			}
 			pass.Report(analysis.Diagnostic{
-				Pos: n.Pos(),
-				Message: fmt.Sprintf("Illegal call to Descriptor.GetTable() in %s, see Descriptor.Table()",
-					containing.Name()),
+				Pos:     n.Pos(),
+				Message: fmt.Sprintf("Illegal call to Descriptor.GetTable(), see sqlbase.TableFromDescriptor()"),
 			})
 		})
 		return nil, nil

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptor_marshal.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
@@ -35,10 +34,12 @@ const Doc = `check for correct unmarshaling of sqlbase descriptors`
 
 const sqlbasePkg = "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
+const name = "descriptormarshal"
+
 // Analyzer is a linter that ensures there are no calls to
 // sqlbase.Descriptor.GetTable() except where appropriate.
 var Analyzer = &analysis.Analyzer{
-	Name:     "descriptormarshal",
+	Name:     name,
 	Doc:      Doc,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run: func(pass *analysis.Pass) (interface{}, error) {
@@ -65,8 +66,8 @@ var Analyzer = &analysis.Analyzer{
 			if !isMethodForNamedType(f, "Descriptor") {
 				return
 			}
-			containing := findContainingFunc(pass, n)
-			if isAllowed(containing) {
+
+			if passesutil.HasNolintComment(pass, sel, name) {
 				return
 			}
 			pass.Report(analysis.Diagnostic{
@@ -77,36 +78,6 @@ var Analyzer = &analysis.Analyzer{
 		})
 		return nil, nil
 	},
-}
-
-var allowedFunctions = []string{
-	"(*github.com/cockroachdb/cockroach/pkg/sql/sqlbase.Descriptor).Table",
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase.TestDefaultExprNil",
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase.TestKeysPerRow",
-	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl.readBackupDescriptor",
-}
-
-func isAllowed(obj *types.Func) bool {
-	str := obj.FullName()
-	for _, allowed := range allowedFunctions {
-		if allowed == str {
-			return true
-		}
-	}
-	return false
-}
-
-func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Func {
-	stack, _ := astutil.PathEnclosingInterval(passesutil.FindContainingFile(pass, n), n.Pos(), n.End())
-	for i := len(stack) - 1; i >= 0; i-- {
-		// If we stumble upon a func decl or func lit then we're in an interesting spot
-		funcDecl, ok := stack[i].(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
-	}
-	return nil
 }
 
 func isMethodForNamedType(f *types.Func, name string) bool {

--- a/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
@@ -15,4 +15,43 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 func F() {
 	var d sqlbase.Descriptor
 	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\) in F, see Descriptor.Table\(\)`
+
+	//nolint:descriptormarshal
+	d.GetTable()
+
+	// nolint:descriptormarshal
+	d.GetTable()
+
+	// nolint:descriptormarshal
+	if t := d.GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t := d.
+		// nolint:descriptormarshal
+		GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t :=
+		// nolint:descriptormarshal
+		d.GetTable(); t != nil {
+		panic("foo")
+	}
+
+	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		// nolint:descriptormarshal
+		nil {
+		panic("foo")
+	}
+
+	// It does not work to put the comment as an inline with the preamble to an
+	// if statement.
+	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		panic("foo")
+	}
+
+	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+		panic("foo")
+	}
 }

--- a/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/testdata/src/a/a.go
@@ -14,7 +14,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
 func F() {
 	var d sqlbase.Descriptor
-	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\) in F, see Descriptor.Table\(\)`
+	d.GetTable() // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 
 	//nolint:descriptormarshal
 	d.GetTable()
@@ -39,7 +39,7 @@ func F() {
 		panic("foo")
 	}
 
-	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		// nolint:descriptormarshal
 		nil {
 		panic("foo")
@@ -47,11 +47,11 @@ func F() {
 
 	// It does not work to put the comment as an inline with the preamble to an
 	// if statement.
-	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != nil { // nolint:descriptormarshal // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		panic("foo")
 	}
 
-	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see descpb.TableFromDescriptor\(\)`
+	if t := d.GetTable(); t != nil { // want `Illegal call to Descriptor.GetTable\(\), see sqlbase.TableFromDescriptor\(\)`
 		panic("foo")
 	}
 }

--- a/pkg/testutils/lint/passes/passesutil/passes_util.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package passesutil provides useful functionality for implementing passes.
+package passesutil
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// FindContainingFile finds the file for an ast Node in a Pass.
+func FindContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
+	fPos := pass.Fset.File(n.Pos())
+	for _, f := range pass.Files {
+		if pass.Fset.File(f.Pos()) == fPos {
+			return f
+		}
+	}
+	panic(fmt.Errorf("cannot file file for %v", n))
+}
+
+// HasNolintComment returns true if the comments on the passed node have
+// the comment "nolint:<nolintName>" appearing anywhere in it.
+func HasNolintComment(pass *analysis.Pass, n ast.Node, nolintName string) bool {
+	f := FindContainingFile(pass, n)
+	relevant, containing := findNodesInBlock(f, n)
+	cm := ast.NewCommentMap(pass.Fset, containing, f.Comments)
+	// Check to see if any of the relevant ast nodes contain the relevant comment.
+	nolintComment := "nolint:" + nolintName
+	for _, cn := range relevant {
+		// Ident nodes have all comments on the ident in containing. This may be
+		// too many. Imagine there is a comment on the ident somewhere else in the
+		// decl block, we wouldn't want that to affect a later conversion.
+		//
+		// We want to filter this down to all comments on the ident inside
+		// the relevant statement. To do this we reject comments on idents which
+		// have their slash outside the outermost relevant node. We do this
+		// by inspecting the position of the comment relative to the outermost
+		// relevant node. This is sound because we can't have a comment on an ident
+		// alone as an ident is not a statement.
+		_, isIdent := cn.(*ast.Ident)
+		for _, cg := range cm[cn] {
+			for _, c := range cg.List {
+				if !strings.Contains(c.Text, nolintComment) {
+					continue
+				}
+				outermost := relevant[len(relevant)-1]
+				if isIdent && (cg.Pos() < outermost.Pos() || cg.End() > outermost.End()) {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// findNodesInBlock finds all expressions and statements that occur underneath
+// the block or decl closest to n. The idea is that we want to find comments
+// which occur in in the block or decl which includes the ast node n for
+// filtering. We want to filter the comments down to all comments
+// which are associated with n or any expression up to a statement in the
+// closest encloding block or decl. This is to deal with multi-line
+// expressions or with cases where the relevant expression occurs in an
+// init clause of an if or for and the comment is on the preceding line.
+//
+// For example, imagine that n is the *ast.CallExpr on the method foo in the
+// following snippet:
+//
+//  func nonsense() bool {
+//      if v := (g.foo() + 1) > 2; !v {
+//          return true
+//      }
+//      return false
+//  }
+//
+// This function would return all of the nodes up to the `IfStmt` as relevant
+// and would return the `BlockStmt` of the function nonsense as containing.
+//
+func findNodesInBlock(f *ast.File, n ast.Node) (relevant []ast.Node, containing ast.Node) {
+	stack, _ := astutil.PathEnclosingInterval(f, n.Pos(), n.End())
+	// Add all of the children of n to the set of relevant nodes.
+	ast.Walk(funcVisitor(func(node ast.Node) {
+		relevant = append(relevant, node)
+	}), n)
+	// Reverse the order.
+	for i := 0; i < len(relevant)/2; i++ {
+		relevant[i], relevant[len(relevant)-i-1] = relevant[len(relevant)-i-1], relevant[i]
+	}
+	containing = f // worst-case
+	for _, n := range stack {
+		switch n.(type) {
+		case *ast.GenDecl, *ast.BlockStmt:
+			containing = n
+			return relevant, containing
+		case nil:
+			// Do nothing.
+		default:
+			// Add all of the parents of n up to the containing BlockStmt or GenDecl
+			// to the set of relevant nodes.
+			relevant = append(relevant, n)
+		}
+	}
+	return relevant, containing
+}
+
+type funcVisitor func(node ast.Node)
+
+var _ ast.Visitor = (funcVisitor)(nil)
+
+func (f funcVisitor) Visit(node ast.Node) (w ast.Visitor) {
+	f(node)
+	return f
+}

--- a/pkg/testutils/lint/passes/passesutil/passes_util_test.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util_test.go
@@ -1,1 +1,40 @@
-package passesutil
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package passesutil_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// Use tests from other packages to also test this package. This ensures
+// that if that code changes, somebody will look here. Also it allows for
+// coverage checking here.
+
+func TestDescriptorMarshal(t *testing.T) {
+	skip.UnderStress(t)
+	testdata, err := filepath.Abs(filepath.Join("..", "descriptormarshal", "testdata"))
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, descriptormarshal.Analyzer, "a")
+}
+
+func TestUnconvert(t *testing.T) {
+	skip.UnderStress(t)
+	testdata, err := filepath.Abs(filepath.Join("..", "unconvert", "testdata"))
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, unconvert.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/passesutil/passes_util_test.go
+++ b/pkg/testutils/lint/passes/passesutil/passes_util_test.go
@@ -1,0 +1,1 @@
+package passesutil

--- a/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck.go
@@ -1,0 +1,213 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package returnerrcheck defines an suite of Analyzers that
+// detects conditionals which check for a non-nil error and then
+// proceed to return a nil error.
+package returnerrcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Doc documents this pass.
+const Doc = `check for return of nil in a conditional which check for non-nil errors`
+
+var errorType = types.Universe.Lookup("error").Type()
+
+const name = "returnerrcheck"
+
+// Analyzer is a linter that ensures that returns from functions which
+// return an error as their last return value which have returns inside
+// the body of if conditionals which check for an error to be non-nil do
+// not return a nil error without a `//nolint:returnerrcheck` comment.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run: func(pass *analysis.Pass) (interface{}, error) {
+		inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		inspect.Preorder([]ast.Node{
+			(*ast.IfStmt)(nil),
+		}, func(n ast.Node) {
+			ifStmt := n.(*ast.IfStmt)
+
+			// Are we inside of a function which returns an error?
+			containing := findContainingFunc(pass, n)
+			if !funcReturnsErrorLast(containing) {
+				return
+			}
+
+			// Now we want to know if the condition in this statement checks if
+			// an error is non-nil.
+			errObj, ok := isNonNilErrCheck(pass, ifStmt.Cond)
+			if !ok {
+				return
+			}
+			for i, n := range ifStmt.Body.List {
+				returnStmt, ok := n.(*ast.ReturnStmt)
+				if !ok {
+					continue
+				}
+				if len(returnStmt.Results) == 0 {
+					continue
+				}
+				lastRes := returnStmt.Results[len(returnStmt.Results)-1]
+				if !pass.TypesInfo.Types[lastRes].IsNil() {
+					continue
+				}
+				if hasAcceptableAction(pass, errObj, ifStmt.Body.List[:i+1]) {
+					continue
+				}
+				if passesutil.HasNolintComment(pass, returnStmt, name) {
+					continue
+				}
+				pass.Report(analysis.Diagnostic{
+					Pos: n.Pos(),
+					Message: fmt.Sprintf("unexpected nil error return after checking for a non-nil error" +
+						"; if this is not a mistake, add a \"//nolint:returnerrcheck\" comment"),
+				})
+			}
+		})
+		return nil, nil
+	},
+}
+
+// hasAcceptableAction determines if there is some action in statements which
+// uses errObj in a way which excuses a nil error return value. Such actions
+// include assigning the error to a value, calling Error() on it, type asserting
+// it, calling a function with the error as an argument, or returning the error
+// in a different return statement.
+func hasAcceptableAction(pass *analysis.Pass, errObj types.Object, statements []ast.Stmt) bool {
+	var seen bool
+	isObj := func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok {
+			if seen = pass.TypesInfo.Uses[id] == errObj; seen {
+				return true
+			}
+		}
+		return false
+	}
+	inspect := func(n ast.Node) (wantMore bool) {
+		switch n := n.(type) {
+		case *ast.CallExpr:
+			// If we call a function with the non-nil error object, we probably know
+			// what we're doing.
+			for _, arg := range n.Args {
+				if isObj(arg) {
+					return false
+				}
+			}
+		case *ast.AssignStmt:
+			// If we assign the error to some value, we probably know what we're
+			// doing.
+			for _, rhs := range n.Rhs {
+				if isObj(rhs) {
+					return false
+				}
+			}
+		case *ast.KeyValueExpr:
+			// If we assign the error to a field or map in a literal, we probably
+			// know what we're doing.
+			if isObj(n.Value) {
+				return false
+			}
+
+		case *ast.SelectorExpr:
+			// If we're selecting something off of the error (i.e. err.Error()) then
+			// we probably know what we're doing.
+			if isObj(n.X) {
+				return false
+			}
+		case *ast.ReturnStmt:
+			// If we return the error, perhaps in a different if statement, we
+			// might know what we're doing. This is good for cases like:
+			//
+			//  if cond || err != nil {
+			//     if err != nil {
+			//         return err
+			//     }
+			//     ...
+			//     return nil
+			//  }
+			//
+			// TODO(ajwerner): ensure that this is returning from the right
+			// function or whether this is a good idea.
+			if numRes := len(n.Results); numRes > 0 && isObj(n.Results[numRes-1]) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, stmt := range statements {
+		if ast.Inspect(stmt, inspect); seen {
+			return true
+		}
+	}
+	return false
+}
+
+func isNonNilErrCheck(pass *analysis.Pass, expr ast.Expr) (errObj types.Object, ok bool) {
+	// TODO(ajwerner): Maybe make this understand !(err == nil) and its variants.
+	binaryExpr, ok := expr.(*ast.BinaryExpr)
+	if !ok {
+		return nil, false
+	}
+	// We care about cases when errors are idents not when they're fields
+	switch binaryExpr.Op {
+	case token.NEQ:
+		var id *ast.Ident
+		if pass.TypesInfo.Types[binaryExpr.X].Type == errorType &&
+			pass.TypesInfo.Types[binaryExpr.Y].IsNil() {
+			id, ok = binaryExpr.X.(*ast.Ident)
+		} else if pass.TypesInfo.Types[binaryExpr.Y].Type == errorType &&
+			pass.TypesInfo.Types[binaryExpr.X].IsNil() {
+			id, ok = binaryExpr.Y.(*ast.Ident)
+		}
+		if ok {
+			errObj, ok := pass.TypesInfo.Uses[id]
+			return errObj, ok
+		}
+	case token.LAND, token.LOR:
+		if errObj, ok := isNonNilErrCheck(pass, binaryExpr.X); ok {
+			return errObj, ok
+		}
+		return isNonNilErrCheck(pass, binaryExpr.Y)
+	}
+	return nil, false
+}
+
+func funcReturnsErrorLast(f *types.Signature) bool {
+	results := f.Results()
+	return results.Len() > 0 &&
+		results.At(results.Len()-1).Type() == errorType
+}
+
+func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Signature {
+	stack, _ := astutil.PathEnclosingInterval(passesutil.FindContainingFile(pass, n), n.Pos(), n.End())
+	for _, n := range stack {
+		if funcDecl, ok := n.(*ast.FuncDecl); ok {
+			return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func).Type().(*types.Signature)
+		}
+		if funcLit, ok := n.(*ast.FuncLit); ok {
+			return pass.TypesInfo.Types[funcLit].Type.(*types.Signature)
+		}
+	}
+	return nil
+}

--- a/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
@@ -1,0 +1,152 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+import (
+	"errors"
+	"fmt"
+	"log"
+)
+
+func noReturn() {
+	err := errors.New("foo")
+	if err != nil {
+		return
+	}
+	_ = func() error {
+		if err != nil {
+			return nil // want `unexpected nil error return after checking for a non-nil error`
+		}
+		return nil
+	}()
+	return
+}
+
+func SingleReturn() error {
+	err := errors.New("foo")
+	if err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil || false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false || err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil && false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false && err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false || err != nil && false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if true && false && err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil {
+		//nolint:returnerrcheck
+		return nil
+	}
+	if err != nil {
+		// nolint:returnerrcheck
+		return nil
+	}
+	if err != nil {
+		return nil // nolint:returnerrcheck
+	}
+
+	// The below nolint comments is not close enough to the return statement.
+
+	// nolint:returnerrcheck
+	if err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+
+	if err != nil {
+		// nolint:returnerrcheck
+		fmt.Println("hmm")
+
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil {
+		return nil //nolint:returnerrcheck
+	}
+	return nil
+}
+
+func MultipleReturns() (int, error) {
+	err := errors.New("foo")
+	if err != nil {
+		if true {
+			return 0, nil
+		}
+		return 0, nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil {
+		//nolint:returnerrcheck
+		return 0, nil
+	}
+	return -1, nil
+}
+
+func AcceptableBehavior() {
+	type structThing struct {
+		err error
+	}
+	_ = func() error {
+		var t structThing
+		// Intentionally don't error if the check is not for an ident directly but
+		// rather is for a field.
+		if t.err != nil {
+			return nil
+		}
+		return nil
+	}
+	_ = func() error {
+		if err := errors.New("foo"); err != nil {
+			log.Printf("%v", err)
+			return nil
+		}
+		return nil
+	}
+	var t structThing
+	_ = func() error {
+		if err := errors.New("foo"); err != nil {
+			t.err = err
+			return nil
+		}
+		return nil
+	}
+	func() error {
+		if err := errors.New("foo"); err != nil {
+			t = structThing{err: err}
+			return nil
+		}
+		return nil
+	}()
+	func() error {
+		if err := errors.New("foo"); err != nil || true {
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		return nil
+	}()
+	func() (string, error) {
+		if err := errors.New("foo"); err != nil {
+			return err.Error(), nil
+		}
+		return "", nil
+	}()
+}

--- a/pkg/testutils/lint/passes/unconvert/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/unconvert/testdata/src/a/a.go
@@ -14,4 +14,94 @@ var (
 	f  float64 = -1
 	ff         = float64(f) // want `unnecessary conversion`
 	fi         = int(f)
+
+	// nolint:unconvert
+	fff = float64(f)
+
+	// nolint:unconvert
+	_ = float64(f) +
+		float64(f)
+
+	_ = 1 +
+		// nolint:unconvert
+		float64(f) +
+		2
+
+	_ = 1 +
+		2 +
+		float64(f) // nolint:unconvert
+
+	_ = 1 +
+		float64(f) + // nolint:unconvert
+		2
+
+	_ = 1 +
+		float64(f) + 2 // nolint:unconvert
+
+	_ = 1 +
+		float64(f) + 2 + 3 // nolint:unconvert
+
+	_ = 1 +
+		(float64(f) + 2 +
+			3) // nolint:unconvert
+
+	_ = 1 +
+		2 +
+		3 +
+		// nolint:unconvert
+		float64(f)
+
+	// nolint:unconvert
+	_ = 1 +
+		2 +
+		3 +
+		float64(f)
+
+	_ = 1 +
+		(float64(f) /* nolint:unconvert */ + 2 +
+			3)
+
+	// Here the comment does not cover the conversion.
+
+	_ = 1 +
+		// nolint:unconvert
+		2 +
+		3 +
+		float64(f) // want `unnecessary conversion`
+
+	_ = 1 +
+		// nolint:unconvert
+		2 +
+		float64(f) // want `unnecessary conversion`
+
+	_ = 1 +
+		(float64(f) + 2 + // want `unnecessary conversion`
+			3 /* nolint:unconvert */)
+
+	_ = 1 +
+		(float64(f) + 2 /* nolint:unconvert */ + // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		(float64(f) + 2 + /* nolint:unconvert */ // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		(float64(f) + 2 + // nolint:unconvert // want `unnecessary conversion`
+			3)
+
+	_ = 1 +
+		2 + // nolint:unconvert
+		float64(f) // want `unnecessary conversion`
 )
+
+func foo() {
+	// nolint:unconvert
+	if fff := float64(f); fff > 0 {
+		panic("foo")
+	}
+
+	if fff := float64(f); fff > 0 { // want `unnecessary conversion`
+		panic("foo")
+	}
+}

--- a/pkg/testutils/lint/passes/unconvert/unconvert.go
+++ b/pkg/testutils/lint/passes/unconvert/unconvert.go
@@ -17,6 +17,7 @@ import (
 	"go/token"
 	"go/types"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/passesutil"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -25,9 +26,11 @@ import (
 // Doc documents this pass.
 const Doc = `check for unnecessary type conversions`
 
+const name = "unconvert"
+
 // Analyzer defines this pass.
 var Analyzer = &analysis.Analyzer{
-	Name:     "unconvert",
+	Name:     name,
 	Doc:      Doc,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
@@ -80,6 +83,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			if ident.Name == "_cgoCheckPointer" {
 				return
 			}
+		}
+		if passesutil.HasNolintComment(pass, call, name) {
+			return
 		}
 		pass.Reportf(call.Pos(), "unnecessary conversion")
 	})


### PR DESCRIPTION
Backport 5/5 commits from #56123.

/cc @cockroachdb/release

---

Backport 5/5 commits from #55218.

/cc @cockroachdb/release

See individual commits. This PR is in support of unblocking #54946.
