### PR TITLE
sql: permit creation and refreshing of materialized views as of system time

### DIFF
--- a/docs/generated/sql/bnf/refresh_materialized_views.bnf
+++ b/docs/generated/sql/bnf/refresh_materialized_views.bnf
@@ -1,2 +1,2 @@
 refresh_stmt ::=
-	'REFRESH' 'MATERIALIZED' 'VIEW' opt_concurrently view_name opt_clear_data
+	'REFRESH' 'MATERIALIZED' 'VIEW' opt_concurrently view_name opt_clear_data opt_as_of_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -101,7 +101,7 @@ release_stmt ::=
 	'RELEASE' savepoint_name
 
 refresh_stmt ::=
-	'REFRESH' 'MATERIALIZED' 'VIEW' opt_concurrently view_name opt_clear_data
+	'REFRESH' 'MATERIALIZED' 'VIEW' opt_concurrently view_name opt_clear_data opt_as_of_clause
 
 nonpreparable_set_stmt ::=
 	set_transaction_stmt
@@ -343,6 +343,10 @@ opt_clear_data ::=
 	| 'WITH' 'NO' 'DATA'
 	| 
 
+opt_as_of_clause ::=
+	as_of_clause
+	| 
+
 set_transaction_stmt ::=
 	'SET' 'TRANSACTION' transaction_mode_list
 	| 'SET' 'SESSION' 'TRANSACTION' transaction_mode_list
@@ -387,10 +391,6 @@ sconst_or_placeholder ::=
 string_or_placeholder_opt_list ::=
 	string_or_placeholder
 	| '(' string_or_placeholder_list ')'
-
-opt_as_of_clause ::=
-	as_of_clause
-	| 
 
 opt_with_backup_options ::=
 	'WITH' backup_options_list
@@ -1192,6 +1192,9 @@ username_or_sconst ::=
 	non_reserved_word
 	| 'SCONST'
 
+as_of_clause ::=
+	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
+
 transaction_mode_list ::=
 	( transaction_mode ) ( ( opt_comma transaction_mode ) )*
 
@@ -1269,9 +1272,6 @@ role_or_group_or_user ::=
 opt_role_options ::=
 	opt_with role_options
 	| 
-
-as_of_clause ::=
-	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
 
 backup_options_list ::=
 	( backup_options ) ( ( ',' backup_options ) )*

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -546,25 +546,37 @@ func (ex *connExecutor) execStmtInOpenState(
 	// don't return any event unless an error happens.
 
 	if os.ImplicitTxn.Get() {
-		asOfTs, err := p.isAsOf(ctx, stmt.AST)
+		asOfTs, timestampType, err := p.isAsOf(ctx, stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
 		if asOfTs != nil {
-			p.semaCtx.AsOfTimestamp = asOfTs
-			p.extendedEvalCtx.SetTxnTimestamp(asOfTs.GoTime())
-			ex.state.setHistoricalTimestamp(ctx, *asOfTs)
+			switch timestampType {
+			case transactionTimestamp:
+				p.semaCtx.AsOfTimestamp = asOfTs
+				p.extendedEvalCtx.SetTxnTimestamp(asOfTs.GoTime())
+				ex.state.setHistoricalTimestamp(ctx, *asOfTs)
+			case backfillTimestamp:
+				p.semaCtx.AsOfTimestampForBackfill = asOfTs
+			}
 		}
 	} else {
 		// If we're in an explicit txn, we allow AOST but only if it matches with
 		// the transaction's timestamp. This is useful for running AOST statements
 		// using the InternalExecutor inside an external transaction; one might want
 		// to do that to force p.avoidCachedDescriptors to be set below.
-		ts, err := p.isAsOf(ctx, stmt.AST)
+		ts, timestampType, err := p.isAsOf(ctx, stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
 		if ts != nil {
+			if timestampType == backfillTimestamp {
+				// Can't handle this: we don't know how to do a CTAS with a historical
+				// read timestamp and a present write timestamp.
+				err = unimplemented.NewWithIssueDetailf(35712, "historical ctas in explicit txn",
+					"historical CREATE TABLE AS unsupported in explicit transaction")
+				return makeErrEvent(err)
+			}
 			if readTs := ex.state.getReadTimestamp(); *ts != readTs {
 				err = pgerror.Newf(pgcode.Syntax,
 					"inconsistent AS OF SYSTEM TIME timestamp; expected: %s", readTs)
@@ -635,6 +647,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.stmt = &stmt
 	p.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	p.autoCommit = os.ImplicitTxn.Get() && !ex.server.cfg.TestingKnobs.DisableAutoCommit
+
+	// Now actually execute the statement!
 	if err := ex.dispatchToExecutionEngine(ctx, p, res); err != nil {
 		return nil, nil, err
 	}
@@ -775,12 +789,34 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	ex.sessionTracing.TracePlanStart(ctx, stmt.AST.StatementTag())
 	ex.statsCollector.phaseTimes[plannerStartLogicalPlan] = timeutil.Now()
 
+	var originalTxn *kv.Txn
+	if planner.semaCtx.AsOfTimestampForBackfill != nil {
+		// If we've been tasked with backfilling a schema change operation at a
+		// particular system time, it's important that we do planning for the
+		// operation at the timestamp that we're expecting to perform the backfill
+		// at, in case the schema of the objects that we read have changed in
+		// between the present transaction timestamp and the user-defined backfill
+		// timestamp.
+		//
+		// Set the planner's transaction to a new historical transaction pinned at
+		// that timestamp. We'll restore it after planning.
+		historicalTxn := kv.NewTxnWithSteppingEnabled(ctx, ex.transitionCtx.db, ex.transitionCtx.nodeIDOrZero)
+		historicalTxn.SetFixedTimestamp(ctx, *planner.semaCtx.AsOfTimestampForBackfill)
+		originalTxn = planner.txn
+		planner.txn = historicalTxn
+	}
 	// Prepare the plan. Note, the error is processed below. Everything
 	// between here and there needs to happen even if there's an error.
 	err := ex.makeExecPlan(ctx, planner)
 	// We'll be closing the plan manually below after execution; this
 	// defer is a catch-all in case some other return path is taken.
 	defer planner.curPlan.close(ctx)
+
+	if originalTxn != nil {
+		// Reset the planner's transaction to the current-timestamp, original
+		// transaction.
+		planner.txn = originalTxn
+	}
 
 	if planner.autoCommit {
 		planner.curPlan.flags.Set(planFlagImplicitTxn)
@@ -868,7 +904,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	default:
 		planner.curPlan.flags.Set(planFlagNotDistributed)
 	}
+
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
+	// Dispatch the query to the execution engine.
 	stats, err := ex.execWithDistSQLEngine(
 		ctx, planner, stmt.AST.StatementType(), res, distributePlan.WillDistribute(), progAtomic,
 	)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -232,11 +233,17 @@ func (ex *connExecutor) populatePrepared(
 	}
 	p.extendedEvalCtx.PrepareOnly = true
 
-	protoTS, err := p.isAsOf(ctx, stmt.AST)
+	protoTS, timestampType, err := p.isAsOf(ctx, stmt.AST)
 	if err != nil {
 		return 0, err
 	}
 	if protoTS != nil {
+		if timestampType != transactionTimestamp {
+			// Can't handle this: we don't know how to do a CTAS with a historical
+			// read timestamp and a present write timestamp.
+			return 0, unimplemented.NewWithIssueDetailf(35712, "historical prepared backfill",
+				"historical CREATE TABLE AS unsupported in explicit transaction")
+		}
 		p.semaCtx.AsOfTimestamp = protoTS
 		txn.SetFixedTimestamp(ctx, *protoTS)
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -284,6 +284,11 @@ func (n *createTableNode) startExec(params runParams) error {
 			// newTableDescIfAs does it automatically).
 			asCols = asCols[:len(asCols)-1]
 		}
+		// Set creationTime to the AS OF SYSTEM TIME that was stored in our As clause
+		// if there was one.
+		if params.p.semaCtx.AsOfTimestampForBackfill != nil {
+			creationTime = *params.p.semaCtx.AsOfTimestampForBackfill
+		}
 
 		desc, err = newTableDescIfAs(params,
 			n.n, n.dbDesc.GetID(), schemaID, id, creationTime, asCols, privs, params.p.EvalContext())
@@ -380,6 +385,14 @@ func (n *createTableNode) startExec(params runParams) error {
 	// If we are in an explicit txn or the source has placeholders, we execute the
 	// CTAS query synchronously.
 	if n.n.As() && !params.p.ExtendedEvalContext().TxnImplicit {
+		// If we're doing an explicit transaction, we can't do a historical CTAS
+		// so we should bail out.
+		if params.p.semaCtx.AsOfTimestampForBackfill != nil {
+			// We shouldn't get here in normal operation, but we'll check just in
+			// case.
+			return errors.AssertionFailedf("CTAS AS OF timestamp set in explicit txn")
+		}
+
 		err = func() error {
 			// The data fill portion of CREATE AS must operate on a read snapshot,
 			// so that it doesn't end up observing its own writes.
@@ -1098,7 +1111,7 @@ func getFinalSourceQuery(source *tree.Select, evalCtx *tree.EvalContext) string 
 	f.Close()
 
 	// Substitute placeholders with their values.
-	ctx := tree.NewFmtCtx(tree.FmtSerializable)
+	ctx := tree.NewFmtCtx(tree.FmtSerializable | tree.FmtSkipAsOfSystemTimeClauses)
 	ctx.SetPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
 		d, err := placeholder.Eval(evalCtx)
 		if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1124,12 +1124,21 @@ func ParseHLC(s string) (hlc.Timestamp, error) {
 	return tree.DecimalToHLC(dec)
 }
 
+type asOfTimestampType int
+
+const (
+	transactionTimestamp asOfTimestampType = iota + 1
+	backfillTimestamp
+)
+
 // isAsOf analyzes a statement to bypass the logic in newPlan(), since
 // that requires the transaction to be started already. If the returned
 // timestamp is not nil, it is the timestamp to which a transaction
 // should be set. The statements that will be checked are Select,
 // ShowTrace (of a Select statement), Scrub, Export, and CreateStats.
-func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*hlc.Timestamp, error) {
+func (p *planner) isAsOf(
+	ctx context.Context, stmt tree.Statement,
+) (*hlc.Timestamp, asOfTimestampType, error) {
 	var asOf tree.AsOfClause
 	switch s := stmt.(type) {
 	case *tree.Select:
@@ -1142,32 +1151,38 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*hlc.Timesta
 
 		sc, ok := selStmt.(*tree.SelectClause)
 		if !ok {
-			return nil, nil
+			return nil, 0, nil
 		}
 		if sc.From.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 
 		asOf = sc.From.AsOf
 	case *tree.Scrub:
 		if s.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 		asOf = s.AsOf
 	case *tree.Export:
 		return p.isAsOf(ctx, s.Query)
 	case *tree.CreateStats:
 		if s.Options.AsOf.Expr == nil {
-			return nil, nil
+			return nil, 0, nil
 		}
 		asOf = s.Options.AsOf
 	case *tree.Explain:
 		return p.isAsOf(ctx, s.Statement)
+	case *tree.CreateTable:
+		if !s.As() {
+			return nil, 0, nil
+		}
+		ts, _, err := p.isAsOf(ctx, s.AsSource)
+		return ts, backfillTimestamp, err
 	default:
-		return nil, nil
+		return nil, 0, nil
 	}
 	ts, err := p.EvalAsOfTimestamp(ctx, asOf)
-	return &ts, err
+	return &ts, transactionTimestamp, err
 }
 
 // isSavepoint returns true if stmt is a SAVEPOINT statement.

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,3 +1,6 @@
+let $ts
+SELECT now()
+
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 
@@ -40,8 +43,8 @@ forks blue
 forks red
 forks green
 
-statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
+statement error pgcode 42P01 relation "stock" does not exist
+CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns
 CREATE TABLE t2 (col1, col2, col3) AS SELECT * FROM stock
@@ -362,3 +365,70 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Test CTAS as of system time.
+
+statement ok
+CREATE TABLE stockcopy AS SELECT * FROM stock AS OF SYSTEM TIME '-1 ms'
+
+statement count 3
+SELECT * FROM stockcopy
+
+statement ok
+INSERT INTO stock VALUES ('spoons', 10)
+
+# Run a CTAS at a timestamp before we inserted the new value, and make sure
+# that the newly-created table does not contain the new value.
+let $ts
+SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) -
+  '1ms'::interval FROM stock WHERE item = 'spoons';
+
+statement ok
+CREATE TABLE stocknospoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query I
+SELECT COUNT(*) FROM stocknospoons WHERE item = 'spoons'
+----
+0
+
+# Make sure that testing exactly at the timestamp produces a result that
+# includes the new row.
+
+let $ts
+SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp)
+FROM stock WHERE item = 'spoons';
+
+statement ok
+CREATE TABLE stockwithspoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query I
+SELECT COUNT(*) FROM stockwithspoons WHERE item = 'spoons'
+----
+1
+
+statement ok
+ALTER TABLE stock ADD COLUMN newcol INT DEFAULT 1
+
+statement ok
+CREATE TABLE stockafterschemachange AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query error column "newcol" does not exist
+SELECT newcol FROM stockafterschemachange
+
+query I
+SELECT COUNT(*) FROM stockafterschemachange WHERE item = 'spoons'
+----
+1
+
+## Test that CTAS AOST doesn't mix with explicit txns.
+statement ok
+BEGIN
+
+statement error unimplemented: historical CREATE TABLE AS unsupported in explicit transaction
+CREATE TABLE willfail AS SELECT * FROM stock AS OF SYSTEM TIME '-1s'
+
+statement ok
+ROLLBACK
+
+statement error syntax error
+CREATE TABLE willfail (a INT) AS OF SYSTEM TIME '-1s'

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -149,3 +149,28 @@ REFRESH MATERIALIZED VIEW with_options WITH NO DATA
 
 query I
 SELECT * FROM with_options
+
+statement ok
+CREATE TABLE a (a INT, b INT); INSERT INTO a VALUES (1, 2)
+
+let $ts
+SELECT now()
+
+statement ok
+ALTER TABLE a DROP COLUMN b
+
+# TODO (jordan): this should fail. We should not permit creating a
+# materialized view at a timestamp that's before the most recent modification
+# of the tables that it references.
+#
+# Alternatively, we should return an error at planning time of the REFRESH
+# statement, since its backfill query does not match the schema of the table
+# that it's inserting into.
+
+statement ok
+CREATE MATERIALIZED VIEW v5 AS SELECT a, b FROM a AS OF SYSTEM TIME '$ts'
+
+# This statement currently fails in a gross way. It either should not fail, or
+# should fail in a non-gross way.
+statement ok
+REFRESH MATERIALIZED VIEW v5

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -454,7 +454,7 @@ statement ok
 CREATE VIEW v AS SELECT d, t FROM t
 
 statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
+INSERT INTO t SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok
 DROP TABLE t CASCADE

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -58,6 +58,12 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 	}
 
 	outScope = b.allocScope()
+	fmtFlags := tree.FmtParsable
+	if cv.Materialized {
+		// Don't include any AS OF SYSTEM TIME clauses here: our materialized view
+		// shouldn't get refreshed as of a particular time.
+		fmtFlags = fmtFlags | tree.FmtSkipAsOfSystemTimeClauses
+	}
 	outScope.expr = b.factory.ConstructCreateView(
 		&memo.CreateViewPrivate{
 			Schema:       schID,
@@ -66,7 +72,7 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 			Replace:      cv.Replace,
 			Persistence:  cv.Persistence,
 			Materialized: cv.Materialized,
-			ViewQuery:    tree.AsStringWithFlags(cv.AsSource, tree.FmtParsable),
+			ViewQuery:    tree.AsStringWithFlags(cv.AsSource, fmtFlags),
 			Columns:      p,
 			Deps:         b.viewDeps,
 		},

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1299,14 +1299,19 @@ func (b *Builder) validateAsOf(asOf tree.AsOfClause) {
 		panic(err)
 	}
 
-	if b.semaCtx.AsOfTimestamp == nil {
+	if b.semaCtx.AsOfTimestamp != nil {
+		if *b.semaCtx.AsOfTimestamp != ts {
+			panic(unimplementedWithIssueDetailf(35712, "",
+				"cannot specify AS OF SYSTEM TIME with different timestamps"))
+		}
+	} else if b.semaCtx.AsOfTimestampForBackfill != nil {
+		if *b.semaCtx.AsOfTimestampForBackfill != ts {
+			panic(unimplementedWithIssueDetailf(35712, "",
+				"cannot specify AS OF SYSTEM TIME with different timestamps"))
+		}
+	} else {
 		panic(pgerror.Newf(pgcode.Syntax,
 			"AS OF SYSTEM TIME must be provided on a top-level statement"))
-	}
-
-	if *b.semaCtx.AsOfTimestamp != ts {
-		panic(unimplementedWithIssueDetailf(35712, "",
-			"cannot specify AS OF SYSTEM TIME with different timestamps"))
 	}
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2228,12 +2228,13 @@ alter_attribute_action:
 // %Text:
 // REFRESH MATERIALIZED VIEW [CONCURRENTLY] view_name [WITH [NO] DATA]
 refresh_stmt:
-  REFRESH MATERIALIZED VIEW opt_concurrently view_name opt_clear_data
+  REFRESH MATERIALIZED VIEW opt_concurrently view_name opt_clear_data opt_as_of_clause
   {
     $$.val = &tree.RefreshMaterializedView{
       Name: $5.unresolvedObjectName(),
       Concurrently: $4.bool(),
       RefreshDataOption: $6.refreshDataOption(),
+      AsOf: $7.asOfClause(),
     }
   }
 | REFRESH error // SHOW HELP: REFRESH

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1703,6 +1703,7 @@ type RefreshMaterializedView struct {
 	Name              *UnresolvedObjectName
 	Concurrently      bool
 	RefreshDataOption RefreshDataOption
+	AsOf              AsOfClause
 }
 
 // RefreshDataOption corresponds to arguments for the REFRESH MATERIALIZED VIEW

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -137,6 +137,10 @@ const (
 	// rather than string literals. For example, the bytes \x40 will be formatted
 	// as b'\x40' rather than '\x40'.
 	fmtFormatByteLiterals
+
+	// FmtSkipAsOfSystemTimeClauses prevents the formatter from printing AS OF
+	// SYSTEM TIME clauses.
+	FmtSkipAsOfSystemTimeClauses
 )
 
 // Composite/derived flag definitions follow.

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -201,8 +201,10 @@ type AsOfClause struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AsOfClause) Format(ctx *FmtCtx) {
-	ctx.WriteString("AS OF SYSTEM TIME ")
-	ctx.FormatNode(a.Expr)
+	if !ctx.flags.HasFlags(FmtSkipAsOfSystemTimeClauses) {
+		ctx.WriteString("AS OF SYSTEM TIME ")
+		ctx.FormatNode(a.Expr)
+	}
 }
 
 // From represents a FROM clause.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -58,6 +58,12 @@ type SemaContext struct {
 	// globally for the entire txn and this field would not be needed.
 	AsOfTimestamp *hlc.Timestamp
 
+	// AsOfTimestampForBackfill is set to non-nil if the query contains a backfill
+	// operation that is expected to perform at a user-defined timestamp. It's
+	// distinct from AsOfTimestamp above, which is used to denote a user-defined
+	// *transaction* timestamp.
+	AsOfTimestampForBackfill *hlc.Timestamp
+
 	Properties SemaProperties
 }
 


### PR DESCRIPTION
Depends on #55916.

Add the ability to CREATE and REFRESH MATERIALIZED VIEWS, AS OF SYSTEM
TIME. The purpose of this is to allow the expensive backfill operations
to happen at a timestamp in the past to avoid contention.

Currently, this is a little bit broken, because schema changes of the
backing tables of the views can wreak havoc when performed at different
system times.

closes https://github.com/cockroachdb/cockroach/issues/96391

Release note (sql change): add AOST capabilities to materialized views.