### PR TITLE
sql: add non-persistent NULL histogram bucket when parsing statistics

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -460,11 +460,6 @@ ALTER TABLE hist INJECT STATISTICS '[
 ]'
 ----
 
-# TODO(mgartner): The distinct(2) stat for the partial index scan should be 5.454545
-# not 6.454545. It is currently one more than it should be because
-# updateDistinctCountFromHistogram increments the distinct count before the null
-# count has been set to zero.
-
 exec-ddl
 CREATE INDEX idx ON hist (s) WHERE i > 100 AND i <= 150
 ----
@@ -474,7 +469,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 150
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string)
- ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ ├── stats: [rows=43.6363636, distinct(2)=3.09090909, null(2)=0]
  │   histogram(2)=  0   0   41.818 1.8182
  │                <--- 125 -------- 149 -
  ├── key: (1)
@@ -486,7 +481,7 @@ select
  │    ├── fd: (1)-->(2,3)
  │    └── scan hist@idx,partial
  │         ├── columns: k:1(int!null) s:3(string)
- │         ├── stats: [rows=90.9090909, distinct(2)=6.45454545, null(2)=0]
+ │         ├── stats: [rows=90.9090909, distinct(2)=5.45454545, null(2)=0]
  │         │   histogram(2)=  0   0   89.091 1.8182
  │         │                <--- 100 -------- 150 -
  │         ├── key: (1)
@@ -509,7 +504,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 150
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string)
- ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ ├── stats: [rows=43.6363636, distinct(2)=3.09090909, null(2)=0]
  │   histogram(2)=  0   0   41.818 1.8182
  │                <--- 125 -------- 149 -
  ├── key: (1)
@@ -517,7 +512,7 @@ index-join hist
  └── scan hist@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/126 - /149]
-      ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+      ├── stats: [rows=43.6363636, distinct(2)=3.09090909, null(2)=0]
       │   histogram(2)=  0   0   41.818 1.8182
       │                <--- 125 -------- 149 -
       ├── key: (1)
@@ -528,7 +523,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 150
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string)
- ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ ├── stats: [rows=43.6363636, distinct(2)=3.09090909, null(2)=0]
  │   histogram(2)=  0   0   41.818 1.8182
  │                <--- 125 -------- 149 -
  ├── key: (1)
@@ -542,7 +537,7 @@ index-join hist
       ├── fd: (1)-->(2)
       ├── scan hist@idx,partial
       │    ├── columns: k:1(int!null) i:2(int!null)
-      │    ├── stats: [rows=190, distinct(1)=190, null(1)=0, distinct(2)=11, null(2)=0]
+      │    ├── stats: [rows=190, distinct(1)=190, null(1)=0, distinct(2)=10, null(2)=0]
       │    │   histogram(2)=  0   0   180  10
       │    │                <--- 100 ----- 200
       │    ├── key: (1)
@@ -555,7 +550,7 @@ SELECT * FROM hist WHERE (i > 100 AND i < 125) OR (i > 150 AND i < 175)
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string)
- ├── stats: [rows=87.2727273, distinct(2)=7.18181818, null(2)=0]
+ ├── stats: [rows=87.2727273, distinct(2)=6.18181818, null(2)=0]
  │   histogram(2)=  0   0   41.818 1.8182 0   0   41.818 1.8182
  │                <--- 100 -------- 124 ---- 150 -------- 174 -
  ├── key: (1)
@@ -565,7 +560,7 @@ index-join hist
       ├── constraint: /2/1
       │    ├── [/101 - /124]
       │    └── [/151 - /174]
-      ├── stats: [rows=87.2727273, distinct(2)=7.18181818, null(2)=0]
+      ├── stats: [rows=87.2727273, distinct(2)=6.18181818, null(2)=0]
       │   histogram(2)=  0   0   41.818 1.8182 0   0   41.818 1.8182
       │                <--- 100 -------- 124 ---- 150 -------- 174 -
       ├── key: (1)
@@ -587,7 +582,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mang
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ ├── stats: [rows=4.60955951, distinct(2)=1.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=3.81818182, null(2,3)=0]
  │   histogram(2)=  0   0   3.4572 1.1524
  │                <--- 125 -------- 129 -
  │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
@@ -597,7 +592,7 @@ index-join hist
  └── scan hist@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/126 - /129]
-      ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+      ├── stats: [rows=4.60955951, distinct(2)=1.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=3.81818182, null(2,3)=0]
       │   histogram(2)=  0   0   3.4572 1.1524
       │                <--- 125 -------- 129 -
       │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
@@ -610,7 +605,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=2.30477976, distinct(2)=2.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=2.27272727, null(2,3)=0]
+ ├── stats: [rows=2.30477976, distinct(2)=1.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1.27272727, null(2,3)=0]
  │   histogram(2)=  0   0   1.7286 0.57619
  │                <--- 125 --------- 129 -
  │   histogram(3)=  0  2.3048
@@ -625,7 +620,7 @@ select
  │    └── scan hist@idx,partial
  │         ├── columns: k:1(int!null) i:2(int!null)
  │         ├── constraint: /2/1: [/126 - /129]
- │         ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │         ├── stats: [rows=4.60955951, distinct(2)=1.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=3.81818182, null(2,3)=0]
  │         │   histogram(2)=  0   0   3.4572 1.1524
  │         │                <--- 125 -------- 129 -
  │         │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
@@ -653,7 +648,7 @@ select
  │         ├── constraint: /2/1
  │         │    ├── [/100 - /100]
  │         │    └── [/200 - /200]
- │         ├── stats: [rows=12.6762887, distinct(2)=3, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=9, null(2,3)=0]
+ │         ├── stats: [rows=12.6762887, distinct(2)=2, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=6, null(2,3)=0]
  │         │   histogram(2)=  0 6.3381 0 6.3381
  │         │                <--- 100 ---- 200 -
  │         │   histogram(3)=  0   3.1691   0   3.1691   0  6.3381
@@ -679,7 +674,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 150 AND s = 'banana'
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=6.91433927, distinct(2)=4.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=4.09090909, null(2,3)=0]
+ ├── stats: [rows=6.91433927, distinct(2)=3.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=3.09090909, null(2,3)=0]
  │   histogram(2)=  0   0   6.6262 0.2881
  │                <--- 125 -------- 149 -
  │   histogram(3)=  0   6.9143
@@ -689,7 +684,7 @@ index-join hist
  └── scan hist@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/126 - /149]
-      ├── stats: [rows=6.91433927, distinct(2)=4.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=4.09090909, null(2,3)=0]
+      ├── stats: [rows=6.91433927, distinct(2)=3.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=3.09090909, null(2,3)=0]
       │   histogram(2)=  0   0   6.6262 0.2881
       │                <--- 125 -------- 149 -
       │   histogram(3)=  0   6.9143
@@ -714,7 +709,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mang
 scan hist@idx,partial
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  ├── constraint: /2/3/1: [/126 - /129]
- ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ ├── stats: [rows=4.60955951, distinct(2)=1.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=3.81818182, null(2,3)=0]
  │   histogram(2)=  0   0   3.4572 1.1524
  │                <--- 125 -------- 129 -
  │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
@@ -727,7 +722,7 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=2.30477976, distinct(2)=2.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=2.27272727, null(2,3)=0]
+ ├── stats: [rows=2.30477976, distinct(2)=1.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1.27272727, null(2,3)=0]
  │   histogram(2)=  0   0   1.7286 0.57619
  │                <--- 125 --------- 129 -
  │   histogram(3)=  0  2.3048
@@ -737,7 +732,7 @@ select
  ├── scan hist@idx,partial
  │    ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  │    ├── constraint: /2/3/1: [/126/'mango' - /129/'mango']
- │    ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │    ├── stats: [rows=4.60955951, distinct(2)=1.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=3.81818182, null(2,3)=0]
  │    │   histogram(2)=  0   0   3.4572 1.1524
  │    │                <--- 125 -------- 129 -
  │    │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
@@ -1539,7 +1534,7 @@ project
  └── select
       ├── columns: k:1(int!null) g:2(geometry!null) s:3(string!null)
       ├── immutable
-      ├── stats: [rows=22.2222222, distinct(2)=7, null(2)=0, distinct(3)=3, null(3)=0]
+      ├── stats: [rows=22.2222222, distinct(2)=7, null(2)=0, distinct(3)=2, null(3)=0]
       │   histogram(3)=  0   11.111   0   11.111
       │                <--- 'banana' --- 'cherry'
       ├── key: (1)
@@ -1589,7 +1584,7 @@ project
  └── select
       ├── columns: k:1(int!null) g:2(geometry!null) s:3(string!null)
       ├── immutable
-      ├── stats: [rows=11.1111111, distinct(2)=7, null(2)=0, distinct(3)=2, null(3)=0]
+      ├── stats: [rows=11.1111111, distinct(2)=7, null(2)=0, distinct(3)=1, null(3)=0]
       │   histogram(3)=  0   11.111
       │                <--- 'banana'
       ├── key: (1)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1041,14 +1041,14 @@ project
  ├── fd: ()-->(5)
  ├── index-join t47742
  │    ├── columns: a:1(int) t47742.b:2(bool!null)
- │    ├── stats: [rows=2640.64496, distinct(2)=2.00246926, null(2)=0]
+ │    ├── stats: [rows=2640.64496, distinct(2)=1.00246926, null(2)=0]
  │    │   histogram(2)=  0    0    0.0021284 2640.6
  │    │                <--- false ----------- true
  │    ├── fd: ()-->(2)
  │    └── scan t47742@b_idx
  │         ├── columns: t47742.b:2(bool!null) rowid:3(int!null)
  │         ├── constraint: /-2/3: [/true - /true]
- │         ├── stats: [rows=2640.64496, distinct(2)=2.00246926, null(2)=0]
+ │         ├── stats: [rows=2640.64496, distinct(2)=1.00246926, null(2)=0]
  │         │   histogram(2)=  0    0    0.0021284 2640.6
  │         │                <--- false ----------- true
  │         ├── key: (3)
@@ -1800,23 +1800,23 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=8.09111244, distinct(1)=1, null(1)=0, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=8.09111244, null(5)=0, distinct(6)=8.09111244, null(6)=0, distinct(1,3,4)=1, null(1,3,4)=0, distinct(1-6)=8.09111244, null(1-6)=0]
- │   histogram(2)=  0 8.0911
+ ├── stats: [rows=16.1809855, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=16.1809855, null(6)=0, distinct(1-4)=1, null(1-4)=0, distinct(1-6)=16.1809855, null(1-6)=0]
+ │   histogram(2)=  0 16.181
  │                <--- true
- │   histogram(4)=  0 8.0911
+ │   histogram(4)=  0 16.181
  │                <--- 'foo'
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=8.09114009]
+ │    ├── stats: [rows=16.1810131]
  │    ├── fd: ()-->(1-4)
  │    └── scan multi_col@abcde_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) rowid:7(int!null)
  │         ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/11 - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/20]
- │         ├── stats: [rows=8.09114009, distinct(1)=1, null(1)=0, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=8.09114009, null(5)=0, distinct(1,3,4)=1, null(1,3,4)=0, distinct(1-5)=8.09114009, null(1-5)=0]
- │         │   histogram(2)=  0 8.0911
+ │         ├── stats: [rows=16.1810131, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=10, null(5)=0, distinct(1-4)=1, null(1-4)=0, distinct(1-5)=10, null(1-5)=0]
+ │         │   histogram(2)=  0 16.181
  │         │                <--- true
- │         │   histogram(4)=  0 8.0911
+ │         │   histogram(4)=  0 16.181
  │         │                <--- 'foo'
  │         ├── key: (7)
  │         └── fd: ()-->(1-4), (7)-->(5)
@@ -1833,8 +1833,8 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=81.87, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=5, null(5)=0, distinct(6)=81.87, null(6)=0, distinct(2,3,5,6)=81.87, null(2,3,5,6)=0]
- │   histogram(2)=  0 81.87
+ ├── stats: [rows=55.6195503, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=5, null(5)=0, distinct(6)=55.6195503, null(6)=0, distinct(2,3)=1, null(2,3)=0, distinct(2,3,5,6)=55.6195503, null(2,3,5,6)=0]
+ │   histogram(2)=  0 55.62
  │                <--- true
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
@@ -1866,13 +1866,13 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=81.87, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=5, null(5)=0, distinct(6)=81.87, null(6)=0, distinct(2,3,5,6)=81.87, null(2,3,5,6)=0]
- │   histogram(2)=  0 81.87
+ ├── stats: [rows=55.6195503, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=5, null(5)=0, distinct(6)=55.6195503, null(6)=0, distinct(2,3)=1, null(2,3)=0, distinct(2,3,5,6)=55.6195503, null(2,3,5,6)=0]
+ │   histogram(2)=  0 55.62
  │                <--- true
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=416.509091]
+ │    ├── stats: [rows=394.208847]
  │    ├── fd: ()-->(2)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
@@ -1883,8 +1883,8 @@ select
  │         │    ├── [/true/7/5e-324 - /true/7]
  │         │    └── [/true/9/5e-324 - /true/9]
  │         ├── flags: force-index=bef_idx
- │         ├── stats: [rows=416.509091, distinct(2)=2, null(2)=0, distinct(5)=5, null(5)=0, distinct(6)=416.509091, null(6)=0, distinct(2,5,6)=416.509091, null(2,5,6)=0]
- │         │   histogram(2)=  0 416.51
+ │         ├── stats: [rows=394.208847, distinct(2)=1, null(2)=0, distinct(5)=5, null(5)=0, distinct(6)=394.208847, null(6)=0, distinct(2,5,6)=394.208847, null(2,5,6)=0]
+ │         │   histogram(2)=  0 394.21
  │         │                <--- true
  │         ├── key: (7)
  │         └── fd: ()-->(2), (7)-->(5,6)
@@ -1904,23 +1904,23 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=8.09028187, distinct(1)=1, null(1)=0, distinct(2)=2, null(2)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(1,4-6)=1, null(1,4-6)=0, distinct(1,2,4-6)=2, null(1,2,4-6)=0]
- │   histogram(2)=  0 8.0903
+ ├── stats: [rows=17.9784037, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(1,2,4-6)=1, null(1,2,4-6)=0]
+ │   histogram(2)=  0 17.978
  │                <--- true
- │   histogram(4)=  0 8.0903
+ │   histogram(4)=  0 17.978
  │                <--- 'foo'
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.811629073]
+ │    ├── stats: [rows=1.99072309]
  │    ├── fd: ()-->(2,5,6)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
  │         ├── constraint: /2/5/6/7: [/true/5/0.0 - /true/5/0.0]
  │         ├── flags: force-index=bef_idx
- │         ├── stats: [rows=0.811629073, distinct(2)=0.811629073, null(2)=0, distinct(5)=0.811629073, null(5)=0, distinct(6)=0.811629073, null(6)=0, distinct(5,6)=0.811629073, null(5,6)=0, distinct(2,5,6)=0.811629073, null(2,5,6)=0]
- │         │   histogram(2)=  0 0.81163
- │         │                <--- true -
+ │         ├── stats: [rows=1.99072309, distinct(2)=1, null(2)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(2,5,6)=1, null(2,5,6)=0]
+ │         │   histogram(2)=  0 1.9907
+ │         │                <--- true
  │         ├── key: (7)
  │         └── fd: ()-->(2,5,6)
  └── filters
@@ -1937,29 +1937,27 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.000809838025, distinct(1)=0.000809838025, null(1)=0, distinct(2)=0.000809838025, null(2)=0, distinct(4)=0.000809838025, null(4)=0, distinct(5)=0.000809838025, null(5)=0, distinct(6)=0.000809838025, null(6)=0, distinct(1,4-6)=0.000809838025, null(1,4-6)=0, distinct(1,2,4-6)=0.000809838025, null(1,2,4-6)=0]
- │   histogram(2)=  0 0.00080984
- │                <----- true --
- │   histogram(4)=  0 0.00080984
- │                <---- 'bar' --
+ ├── stats: [rows=0.00179964001, distinct(1)=0.00179964001, null(1)=0, distinct(2)=0.00179964001, null(2)=0, distinct(4)=0.00179964001, null(4)=0, distinct(5)=0.00179964001, null(5)=0, distinct(6)=0.00179964001, null(6)=0, distinct(1,2,4-6)=0.00179964001, null(1,2,4-6)=0]
+ │   histogram(2)=  0 0.0017996
+ │                <---- true --
+ │   histogram(4)=  0 0.0017996
+ │                <---- 'bar' -
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.0008238352]
- │    ├── fd: ()-->(1,2,4)
- │    └── scan multi_col@bad_idx
- │         ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) rowid:7(int!null)
- │         ├── constraint: /2/-1/4/7: [/true/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar' - /true/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar']
- │         ├── stats: [rows=0.0008238352, distinct(1)=0.0008238352, null(1)=0, distinct(2)=0.0008238352, null(2)=0, distinct(4)=0.0008238352, null(4)=0, distinct(1,4)=0.0008238352, null(1,4)=0, distinct(1,2,4)=0.0008238352, null(1,2,4)=0]
- │         │   histogram(2)=  0 0.00082384
- │         │                <----- true --
- │         │   histogram(4)=  0 0.00082384
+ │    ├── stats: [rows=0.000900180036]
+ │    ├── fd: ()-->(4-6)
+ │    └── scan multi_col@def_idx
+ │         ├── columns: d:4(string!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
+ │         ├── constraint: /4/5/6/7: [/'bar'/5/0.0 - /'bar'/5/0.0]
+ │         ├── stats: [rows=0.000900180036, distinct(4)=0.000900180036, null(4)=0, distinct(5)=0.000900180036, null(5)=0, distinct(6)=0.000900180036, null(6)=0, distinct(4-6)=0.000900180036, null(4-6)=0]
+ │         │   histogram(4)=  0 0.00090018
  │         │                <---- 'bar' --
  │         ├── key: (7)
- │         └── fd: ()-->(1,2,4)
+ │         └── fd: ()-->(4-6)
  └── filters
-      ├── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
-      └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
+      ├── a:1 = '37685f26-4b07-40ba-9bbf-42916ed9bc61' [type=bool, outer=(1), constraints=(/1: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61' - /'37685f26-4b07-40ba-9bbf-42916ed9bc61']; tight), fd=()-->(1)]
+      └── b:2 = true [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
 
 opt
 SELECT * FROM multi_col
@@ -1971,24 +1969,24 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=1.62000005e-07, distinct(1)=1.62000005e-07, null(1)=0, distinct(2)=1.62000005e-07, null(2)=0, distinct(4)=1.62000005e-07, null(4)=0, distinct(5)=1.62000005e-07, null(5)=0, distinct(6)=1.62000005e-07, null(6)=0, distinct(1,4-6)=1.62000005e-07, null(1,4-6)=0, distinct(1,2,4-6)=1.62000005e-07, null(1,2,4-6)=0]
- │   histogram(2)=  0 1.62e-07
- │                <--- false -
- │   histogram(4)=  0 1.62e-07
- │                <--- 'bar' -
+ ├── stats: [rows=3.60000002e-07, distinct(1)=3.60000002e-07, null(1)=0, distinct(2)=3.60000002e-07, null(2)=0, distinct(4)=3.60000002e-07, null(4)=0, distinct(5)=3.60000002e-07, null(5)=0, distinct(6)=3.60000002e-07, null(6)=0, distinct(1,2,4-6)=3.60000002e-07, null(1,2,4-6)=0]
+ │   histogram(2)=  0 3.6e-07
+ │                <--- false
+ │   histogram(4)=  0 3.6e-07
+ │                <--- 'bar'
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=1.648e-07]
+ │    ├── stats: [rows=3.61e-07]
  │    ├── fd: ()-->(1,2,4)
  │    └── scan multi_col@bad_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) rowid:7(int!null)
  │         ├── constraint: /2/-1/4/7: [/false/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar' - /false/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar']
- │         ├── stats: [rows=1.648e-07, distinct(1)=1.648e-07, null(1)=0, distinct(2)=1.648e-07, null(2)=0, distinct(4)=1.648e-07, null(4)=0, distinct(1,4)=1.648e-07, null(1,4)=0, distinct(1,2,4)=1.648e-07, null(1,2,4)=0]
- │         │   histogram(2)=  0 1.648e-07
- │         │                <---- false -
- │         │   histogram(4)=  0 1.648e-07
- │         │                <---- 'bar' -
+ │         ├── stats: [rows=3.61e-07, distinct(1)=3.61e-07, null(1)=0, distinct(2)=3.61e-07, null(2)=0, distinct(4)=3.61e-07, null(4)=0, distinct(1,2,4)=3.61e-07, null(1,2,4)=0]
+ │         │   histogram(2)=  0 3.61e-07
+ │         │                <--- false -
+ │         │   histogram(4)=  0 3.61e-07
+ │         │                <--- 'bar' -
  │         ├── key: (7)
  │         └── fd: ()-->(1,2,4)
  └── filters
@@ -2005,21 +2003,21 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.00161838005, distinct(1)=0.00161838005, null(1)=0, distinct(2)=0.00161838005, null(2)=0, distinct(4)=0.00161838005, null(4)=0, distinct(5)=0.00161838005, null(5)=0, distinct(6)=0.00161838005, null(6)=0, distinct(1,4-6)=0.00161838005, null(1,4-6)=0, distinct(1,2,4-6)=0.00161838005, null(1,2,4-6)=0]
- │   histogram(2)=  0 0.0016184
+ ├── stats: [rows=0.00359640002, distinct(1)=0.00359640002, null(1)=0, distinct(2)=0.00359640002, null(2)=0, distinct(4)=0.00359640002, null(4)=0, distinct(5)=0.00359640002, null(5)=0, distinct(6)=0.00359640002, null(6)=0, distinct(1,2,4-6)=0.00359640002, null(1,2,4-6)=0]
+ │   histogram(2)=  0 0.0035964
  │                <---- false -
- │   histogram(4)=  0 0.0016184
+ │   histogram(4)=  0 0.0035964
  │                <---- 'foo' -
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.000162358286]
+ │    ├── stats: [rows=0.000398224263]
  │    ├── fd: ()-->(2,5,6)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
  │         ├── constraint: /2/5/6/7: [/false/5/0.0 - /false/5/0.0]
- │         ├── stats: [rows=0.000162358286, distinct(2)=0.000162358286, null(2)=0, distinct(5)=0.000162358286, null(5)=0, distinct(6)=0.000162358286, null(6)=0, distinct(5,6)=0.000162358286, null(5,6)=0, distinct(2,5,6)=0.000162358286, null(2,5,6)=0]
- │         │   histogram(2)=  0 0.00016236
+ │         ├── stats: [rows=0.000398224263, distinct(2)=0.000398224263, null(2)=0, distinct(5)=0.000398224263, null(5)=0, distinct(6)=0.000398224263, null(6)=0, distinct(2,5,6)=0.000398224263, null(2,5,6)=0]
+ │         │   histogram(2)=  0 0.00039822
  │         │                <---- false --
  │         ├── key: (7)
  │         └── fd: ()-->(2,5,6)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1196,7 +1196,7 @@ except-all
       └── select
            ├── save-table-name: consistency_08_select_4
            ├── columns: o_id:5(int!null) o_d_id:6(int!null) o_w_id:7(int!null) o_carrier_id:10(int)
-           ├── stats: [rows=90000, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0, distinct(10)=2, null(10)=90000]
+           ├── stats: [rows=90000, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0, distinct(10)=1, null(10)=90000]
            │   histogram(10)=
            ├── key: (5-7)
            ├── fd: ()-->(10)
@@ -1258,7 +1258,7 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           2.00                2.00 <==            90000.00        1.00
+{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
 {o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
 {o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
 {o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
@@ -1298,7 +1298,7 @@ except-all
  │    └── select
  │         ├── save-table-name: consistency_09_select_3
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=2, null(6)=90000]
+ │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
  │         │   histogram(6)=
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
@@ -1360,7 +1360,7 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           2.00                2.00 <==            90000.00        1.00
+{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
 {o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
 {o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
 {o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
@@ -1650,7 +1650,7 @@ scalar-group-by
  │    │    │    └── select
  │    │    │         ├── save-table-name: consistency_12_select_5
  │    │    │         ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_delivery_d:16(timestamp)
- │    │    │         ├── stats: [rows=899134, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0, distinct(16)=2, null(16)=899134]
+ │    │    │         ├── stats: [rows=899134, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0, distinct(16)=1, null(16)=899134]
  │    │    │         │   histogram(16)=
  │    │    │         ├── fd: ()-->(16)
  │    │    │         ├── scan order_line
@@ -1675,7 +1675,7 @@ scalar-group-by
  │    │    │    └── select
  │    │    │         ├── save-table-name: consistency_12_select_8
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=2, null(6)=90000]
+ │    │    │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
  │    │    │         │   histogram(6)=
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
@@ -1765,7 +1765,7 @@ column_names     row_count  distinct_count  null_count
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {ol_d_id}        899134.00      1.00           10.00               1.00                0.00            1.00
-{ol_delivery_d}  899134.00      1.00           2.00                2.00 <==            899134.00       1.00
+{ol_delivery_d}  899134.00      1.00           1.00                1.00                899134.00       1.00
 {ol_o_id}        899134.00      1.00           2999.00             3.33 <==            0.00            1.00
 {ol_w_id}        899134.00      1.00           10.00               1.00                0.00            1.00
 
@@ -1801,7 +1801,7 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           2.00                2.00 <==            90000.00        1.00
+{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
 {o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
 {o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
 {o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -144,7 +144,7 @@ func (s *Statistics) String() string {
 // maintaining statistics on a few columns and column sets that are frequently
 // used in predicates, group by columns, etc.
 //
-// ColumnStatistiscs can be copied by value.
+// ColumnStatistics can be copied by value.
 type ColumnStatistic struct {
 	// Cols is the set of columns whose data are summarized by this
 	// ColumnStatistic struct. The ColSet is never modified in-place.

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -415,8 +415,6 @@ func (sc *TableStatisticsCache) parseStats(
 			return nil, err
 		}
 
-		// Decode the histogram data so that it's usable by the opt catalog.
-		res.Histogram = make([]cat.HistogramBucket, len(res.HistogramData.Buckets))
 		// Hydrate the type in case any user defined types are present.
 		// There are cases where typ is nil, so don't do anything if so.
 		if typ := res.HistogramData.ColumnType; typ != nil && typ.UserDefined() {
@@ -441,9 +439,30 @@ func (sc *TableStatisticsCache) parseStats(
 				return nil, err
 			}
 		}
+
+		var offset int
+		if res.NullCount > 0 {
+			// A bucket for NULL is not persisted, but we create a fake one to
+			// make histograms easier to work with. The length of res.Histogram
+			// is therefore 1 greater than the length of the histogram data
+			// buckets.
+			res.Histogram = make([]cat.HistogramBucket, len(res.HistogramData.Buckets)+1)
+			res.Histogram[0] = cat.HistogramBucket{
+				NumEq:         float64(res.NullCount),
+				NumRange:      0,
+				DistinctRange: 0,
+				UpperBound:    tree.DNull,
+			}
+			offset = 1
+		} else {
+			res.Histogram = make([]cat.HistogramBucket, len(res.HistogramData.Buckets))
+			offset = 0
+		}
+
+		// Decode the histogram data so that it's usable by the opt catalog.
 		var a rowenc.DatumAlloc
-		for i := range res.Histogram {
-			bucket := &res.HistogramData.Buckets[i]
+		for i := offset; i < len(res.Histogram); i++ {
+			bucket := &res.HistogramData.Buckets[i-offset]
 			datum, _, err := rowenc.DecodeTableKey(&a, res.HistogramData.ColumnType, bucket.UpperBound, encoding.Ascending)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
All parsed table statistics now include a histogram bucket for Null
values. This bucket is not persisted. It is populated via the NullCount
statistic when the table statistics are parsed.

By including a histogram bucket for Null, the statistics builder logic
can be simplified. In particular, `updateDistinctCountFromHistogram` no
longer needs to increment a column statistic `DisctinctCount` if the
`NullCount` is greater than 0. This avoids a chicken-and-the-egg type
problem (should the NullCount be set to 0 before or after the
DistinctCount is incremented) which resulted in a bug where some
distinct counts were 1 greater than they should have been. This bug is
now fixed.

Thanks to @rytaft for the inspiration.

Release note: None