### PR TITLE
opt: update test output to convert `inverted-lookup` join to `inverted` join

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -817,7 +817,7 @@ inner-join (lookup geo_table)
  ├── key: (1,5)
  ├── fd: (1)-->(2), (5)-->(6)
  ├── prune: (1,5)
- ├── inner-join (inverted-lookup geo_table@geom_index)
+ ├── inner-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:5
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:6)
@@ -903,7 +903,7 @@ left-join (lookup geo_table)
  ├── key: (1,5)
  ├── fd: (1)-->(2), (5)-->(6)
  ├── prune: (1,5)
- ├── left-join (inverted-lookup geo_table@geom_index)
+ ├── left-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:5 continuation:11
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:6)
@@ -937,7 +937,7 @@ semi-join (lookup geo_table)
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (1)
- ├── inner-join (inverted-lookup geo_table@geom_index)
+ ├── inner-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:5 continuation:11
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:6)
@@ -972,7 +972,7 @@ anti-join (lookup geo_table)
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (1)
- ├── left-join (inverted-lookup geo_table@geom_index)
+ ├── left-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:5 continuation:11
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:6)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -193,7 +193,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		f.Buffer.WriteByte(')')
 
 	case *InvertedJoinExpr:
-		fmt.Fprintf(f.Buffer, "%v (inverted-lookup", t.JoinType)
+		fmt.Fprintf(f.Buffer, "%v (inverted", t.JoinType)
 		FormatPrivate(f, e.Private(), required)
 		f.Buffer.WriteByte(')')
 

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -29,7 +29,7 @@ project
       ├── stats: [rows=9801]
       ├── key: (1,4)
       ├── fd: (1)-->(2), (4)-->(5)
-      ├── inner-join (inverted-lookup rtable@geom_index)
+      ├── inner-join (inverted rtable@geom_index)
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:4(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:5) [type=bool]
@@ -61,7 +61,7 @@ project
       ├── stats: [rows=9801]
       ├── key: (1,4)
       ├── fd: (1)-->(2), (4)-->(5)
-      ├── inner-join (inverted-lookup rtable@geom_index)
+      ├── inner-join (inverted rtable@geom_index)
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:4(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:5) [type=bool]

--- a/pkg/sql/opt/xform/testdata/external/planet-osm
+++ b/pkg/sql/opt/xform/testdata/external/planet-osm
@@ -1757,7 +1757,7 @@ sort
       │         │    ├── immutable
       │         │    ├── stats: [rows=3926737.36, distinct(29)=1, null(29)=0, distinct(69)=2632.05556, null(69)=0, distinct(99)=31, null(99)=1529566.44, distinct(141)=146376, null(141)=0]
       │         │    ├── fd: ()-->(29)
-      │         │    ├── inner-join (inverted-lookup planet_osm_line@planet_osm_line_way_idx [as=l])
+      │         │    ├── inner-join (inverted planet_osm_line@planet_osm_line_way_idx [as=l])
       │         │    │    ├── columns: p.highway:29!null p.way:69 l.rowid:142!null
       │         │    │    ├── inverted-expr
       │         │    │    │    └── st_dwithin(p.way:69, l.way:141, 100.0)

--- a/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
+++ b/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
@@ -265,7 +265,7 @@ sort
            ├── lookup columns are key
            ├── immutable
            ├── fd: ()-->(10)
-           ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=neighborhoods])
+           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=neighborhoods])
            │    ├── columns: neighborhoods.gid:1!null subways.name:10!null subways.geom:22
            │    ├── inverted-expr
            │    │    └── st_coveredby(subways.geom:22, neighborhoods.geom:4)
@@ -324,7 +324,7 @@ sort
       │    │    ├── lookup columns are key
       │    │    ├── immutable
       │    │    ├── fd: ()-->(2)
-      │    │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+      │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
       │    │    │    ├── columns: neighborhoods.boroname:2!null name:3 neighborhoods.geom:4 census.gid:7!null
       │    │    │    ├── inverted-expr
       │    │    │    │    └── st_intersects(neighborhoods.geom:4, census.geom:16)
@@ -380,7 +380,7 @@ project
  │    │    ├── key columns: [1] = [1]
  │    │    ├── lookup columns are key
  │    │    ├── immutable
- │    │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+ │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
  │    │    │    ├── columns: census.gid:1!null routes:23 subways.geom:28
  │    │    │    ├── inverted-expr
  │    │    │    │    └── st_dwithin(subways.geom:28, census.geom:10, 200.0)
@@ -451,7 +451,7 @@ sort
       │    │    │    ├── key columns: [1] = [1]
       │    │    │    ├── lookup columns are key
       │    │    │    ├── immutable
-      │    │    │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+      │    │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
       │    │    │    │    ├── columns: census.gid:1!null routes:23 subways.geom:28
       │    │    │    │    ├── inverted-expr
       │    │    │    │    │    └── st_dwithin(subways.geom:28, census.geom:10, 200.0)
@@ -495,7 +495,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(21)
-      ├── inner-join (inverted-lookup nyc_subway_stations@nyc_subway_stations_geom_idx [as=s])
+      ├── inner-join (inverted nyc_subway_stations@nyc_subway_stations_geom_idx [as=s])
       │    ├── columns: s.gid:1!null n.name:21!null n.geom:22
       │    ├── inverted-expr
       │    │    └── st_contains(n.geom:22, s.geom:16)
@@ -539,7 +539,7 @@ sort
            ├── key columns: [19] = [19]
            ├── lookup columns are key
            ├── immutable
-           ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=n])
+           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=n])
            │    ├── columns: routes:11 s.geom:16 n.gid:19!null
            │    ├── inverted-expr
            │    │    └── st_coveredby(s.geom:16, n.geom:22)
@@ -578,7 +578,7 @@ scalar-group-by
  │    ├── lookup columns are key
  │    ├── immutable
  │    ├── fd: ()-->(3)
- │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
+ │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
  │    │    ├── columns: name:3!null n.geom:4 c.gid:7!null
  │    │    ├── inverted-expr
  │    │    │    └── st_intersects(n.geom:4, c.geom:16)
@@ -631,7 +631,7 @@ project
  │    │    ├── lookup columns are key
  │    │    ├── immutable
  │    │    ├── ordering: +15
- │    │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
+ │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
  │    │    │    ├── columns: c.gid:1!null name:15!null n.geom:16
  │    │    │    ├── inverted-expr
  │    │    │    │    └── st_intersects(n.geom:16, c.geom:10)
@@ -674,7 +674,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(16)
-      ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geom_idx [as=blocks])
+      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=blocks])
       │    ├── columns: blocks.gid:1!null name:16!null subways.geom:28
       │    ├── inverted-expr
       │    │    └── st_coveredby(subways.geom:28, blocks.geom:10)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3625,7 +3625,7 @@ project
  │    │    ├── lookup columns are key
  │    │    ├── immutable
  │    │    ├── fd: (9)==(14), (14)==(9)
- │    │    ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+ │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
  │    │    │    ├── columns: c.gid:1!null n.boroname:14 name:15!null n.geom:16
  │    │    │    ├── inverted-expr
  │    │    │    │    └── st_intersects(n.geom:16, c.geom:10)
@@ -3732,7 +3732,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:16, 50.0)
@@ -3758,7 +3758,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:16, 50.0)
@@ -3783,7 +3783,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -3809,7 +3809,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:16)
@@ -3835,7 +3835,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dwithinexclusive(c.geom:10, n.geom:16, 50.0)
@@ -3861,7 +3861,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:16, 50.0)
@@ -3888,7 +3888,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:16) AND (st_dwithin(c.geom:10, n.geom:16, 50.0) OR st_intersects('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', n.geom:16))
@@ -3914,7 +3914,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dfullywithin(c.geom:10, n.geom:16, 50.0)
@@ -3939,7 +3939,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_dfullywithinexclusive(c.geom:10, n.geom:16, 50.0)
@@ -3966,7 +3966,7 @@ project
       ├── key columns: [1] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
       │    ├── columns: c.gid:1!null name:15 n.geom:16!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(n.geom:16, c.geom:10) AND st_coveredby('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', c.geom:10)
@@ -4015,7 +4015,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(9)
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9!null c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4071,7 +4071,7 @@ semi-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:13!null continuation:19
  │    ├── inverted-expr
  │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4103,7 +4103,7 @@ anti-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── left-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:13 continuation:19
  │    ├── inverted-expr
  │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4135,7 +4135,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── left-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13 continuation:20
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4162,7 +4162,7 @@ left-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1,13)
  ├── fd: (1)-->(2-10), (13)-->(14-16)
- ├── left-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:13 continuation:19
  │    ├── inverted-expr
  │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4216,7 +4216,7 @@ with &1 (q)
       │    │    ├── key columns: [23] = [23]
       │    │    ├── lookup columns are key
       │    │    ├── immutable
-      │    │    ├── left-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      │    │    ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    │    │    ├── columns: geom:22 n.gid:23 continuation:42
       │    │    │    ├── inverted-expr
       │    │    │    │    └── st_intersects(geom:22, n.geom:26)
@@ -4313,7 +4313,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_intersects(c.geom:10::BOX2D::GEOMETRY, n.geom:16)
@@ -4338,7 +4338,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10::BOX2D::GEOMETRY, n.geom:16)
@@ -4363,7 +4363,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10::BOX2D::GEOMETRY, n.geom:16)
@@ -4388,7 +4388,7 @@ project
       ├── key columns: [13] = [13]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:16)
@@ -4430,7 +4430,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(10)
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
       │    ├── columns: c.gid:1!null c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4460,7 +4460,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(14), (1)-->(10)
-      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
       │    ├── columns: c.gid:1!null c.geom:10 n.gid:13!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4490,7 +4490,7 @@ semi-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+ ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:13!null continuation:20
  │    ├── inverted-expr
  │    │    └── st_covers(c.geom:10, n.geom:16)
@@ -4520,7 +4520,7 @@ anti-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── left-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:13 continuation:20
  │    ├── inverted-expr
  │    │    └── st_covers(c.geom:10, n.geom:16)


### PR DESCRIPTION
opt: update test output to convert `inverted-lookup` join to `inverted` join

fixes #55765

Release note: none